### PR TITLE
useFullscreen demo: replace toogle with enter

### DIFF
--- a/packages/core/useFullscreen/demo.vue
+++ b/packages/core/useFullscreen/demo.vue
@@ -3,7 +3,7 @@ import { ref } from 'vue-demi'
 import { useFullscreen } from '.'
 
 const el = ref(null)
-const { toggle } = useFullscreen(el)
+const { enter } = useFullscreen(el)
 </script>
 
 <template>
@@ -17,7 +17,7 @@ const { toggle } = useFullscreen(el)
     />
     <br>
     <br>
-    <button @click="toggle">
+    <button @click="enter">
       Go Fullscreen
     </button>
   </div>


### PR DESCRIPTION
after the first "run" toggle will only work every second click. Using enter makes more sense.
Steps to reproduce toggle bug:
- Click "Go Fullscreen"
- Fullscreen is enabled
- Click ESC
- Fullscreen is disabled
- Click "Go Fullscreen"
- Nothing happens (toggle set's value to false)
- Click "Go Fullscreen"
- Fullscreen is enabled
- Click ESC
- ...