### PR TITLE
fix: useResizeObserver and useIntersectionObserver only working on initial page loads

### DIFF
--- a/packages/core/useIntersectionObserver/index.ts
+++ b/packages/core/useIntersectionObserver/index.ts
@@ -65,7 +65,7 @@ export function useIntersectionObserver(
       )
       observer!.observe(newValue)
     }
-  })
+  }, { immediate: true, flush: 'post' })
 
   const stop = () => {
     cleanup()

--- a/packages/core/useResizeObserver/index.ts
+++ b/packages/core/useResizeObserver/index.ts
@@ -68,7 +68,7 @@ export function useResizeObserver(
       observer = new window.ResizeObserver(callback)
       observer!.observe(newValue, observerOptions)
     }
-  }, { immediate: true })
+  }, { immediate: true, flush: 'post' })
 
   const stop = () => {
     cleanup()


### PR DESCRIPTION
Currently there is a bug where [useResizeObserver](https://vueuse.js.org/core/useresizeobserver/) and [useIntersectionObserver](https://vueuse.js.org/core/useintersectionobserver/) will only work on the initial page load but will break if navigating to the page from a different route.

This PR addresses this(also see issue #300) by adding `flush: 'post'` to the `watch` functions in the `useResizeObserver` and `useIntersectionObserver` which seems to be the correct way to handle accessing dom refs according to [the Vue 3 documentation on Effect Flush Timing](https://v3.vuejs.org/guide/reactivity-computed-watchers.html#effect-flush-timing)