### PR TITLE
fix: bug in useMouseInElement demo causing the demo to not work

### DIFF
--- a/packages/.vitepress/utils.ts
+++ b/packages/.vitepress/utils.ts
@@ -1,4 +1,4 @@
 import { reactify } from '@vueuse/shared'
 import YAML from 'js-yaml'
 
-export const stringify = reactify(YAML.dump)
+export const stringify = reactify(input => YAML.dump(input, { skipInvalid: true }))

--- a/packages/core/useMouseInElement/demo.vue
+++ b/packages/core/useMouseInElement/demo.vue
@@ -5,7 +5,7 @@ import { useMouseInElement } from '.'
 
 const demo = ref(null)
 const mouse = reactive(useMouseInElement(demo))
-const tesxt = stringify(mouse)
+const text = stringify(mouse)
 </script>
 
 <template>


### PR DESCRIPTION
**Problem**
The [`useMouseInElement` demo](https://vueuse.js.org/core/useMouseInElement/) was not working due to two issues. The first issue was a simple typo: `tesxt` instead of `text`. 
The second problem was caused by the `stringify` function used by the docs. This function uses the `YAML.dump` function but this happens to throw an error in this demo due to that fact that the `useMouseInElement` function returns a `stop` function which `YMAL.dump` considers an invalid type. 

**Solution**
To solve this  I added the `skipInvalid: true` option which according to [the docs](https://github.com/nodeca/js-yaml#dump-object---options-) will not throw errors on invalid types