### PR TITLE
fix: bug in useMediaQuery demo causing demo to not work properly

### DIFF
--- a/packages/core/useMediaQuery/demo.vue
+++ b/packages/core/useMediaQuery/demo.vue
@@ -3,8 +3,8 @@ import { computed, reactive } from 'vue-demi'
 import { useMediaQuery } from '.'
 import YAML from 'js-yaml'
 
-const isLargeScreen = useMediaQuery('(min-width = 1024px)')
-const prefersDark = useMediaQuery('(prefers-color-scheme = dark)')
+const isLargeScreen = useMediaQuery('(min-width: 1024px)')
+const prefersDark = useMediaQuery('(prefers-color-scheme: dark)')
 
 const code = computed(() => YAML.dump(reactive({
   isLargeScreen,

--- a/packages/core/useMediaQuery/index.md
+++ b/packages/core/useMediaQuery/index.md
@@ -4,7 +4,7 @@ category: Browser
 
 # useMediaQuery
 
-Reactive [Media Query]((https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Testing_media_queries)). Once you've created a MediaQueryList object, you can check the result of the query or receive notifications when the result changes.
+Reactive [Media Query](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Testing_media_queries). Once you've created a MediaQueryList object, you can check the result of the query or receive notifications when the result changes.
 
 ## Usage
 


### PR DESCRIPTION
There currently exists a bug in the [`useMediaQuery` demo](https://vueuse.js.org/core/useMediaQuery/) that causes the demo to not work properly.

This pull request fixes the bug by changing the media query from `(min-width = 1024px)` to `(min-width: 1024px)` and `(prefers-color-scheme = dark)` to `(prefers-color-scheme: dark)`. It also fixes a typo in the `useMediaQuery` documentation that causes the link to the `Media Query` MDN documentation link to not work.