### PR TITLE
feat(useWebSocket)!: rework useWebSocket

### DIFF
--- a/indexes.json
+++ b/indexes.json
@@ -685,7 +685,7 @@
       "package": "core",
       "docs": "https://vueuse.js.org/core/useWebSocket/",
       "category": "Misc",
-      "description": "reactive simple [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/WebSocket) client"
+      "description": "reactive [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/WebSocket) client"
     },
     {
       "name": "useWebWorker",

--- a/packages/functions.md
+++ b/packages/functions.md
@@ -38,7 +38,7 @@
 
 ### Misc
   - [`useEventSource`](https://vueuse.js.org/core/useEventSource/) — an [EventSource](https://developer.mozilla.org/en-US/docs/Web/API/EventSource) or [Server-Sent-Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events) instance opens a persistent connection to an HTTP server
-  - [`useWebSocket`](https://vueuse.js.org/core/useWebSocket/) — reactive simple [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/WebSocket) client
+  - [`useWebSocket`](https://vueuse.js.org/core/useWebSocket/) — reactive [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/WebSocket) client
   - [`useWebWorker`](https://vueuse.js.org/core/useWebWorker/) — simple [Web Workers](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers) registration and communication
   - [`useWebWorkerFn`](https://vueuse.js.org/core/useWebWorkerFn/) — run expensive function without blocking the UI
 


### PR DESCRIPTION
BREAKING CHANGES:
- the `ws` option in the return of `useWebSocket` is not a ref instead of plain WebSocket instance
- `useWebSocket`'s `send` will now buffers data before the connection established instead of discarding sliently
- `useWebSocket`'s returned `state` is renamed to `status`

----

Continued from the work in #325 by @shuperry. Close #283.

> Note: This PR will be held until v4.2