### PR TITLE
fix(useEventListener): return cleanup fn

### DIFF
--- a/packages/core/useEventListener/index.ts
+++ b/packages/core/useEventListener/index.ts
@@ -110,7 +110,7 @@ export function useEventListener(...args: any[]) {
     { immediate: true },
   )
 
-  tryOnUnmounted(stop)
+  tryOnUnmounted(cleanup)
 
-  return stop
+  return cleanup
 }


### PR DESCRIPTION
useEventListener return stop fn, which is not defined. see #332