### PR TITLE
fix(useAuth): fix imports to use only needed SDK & fixed typo in docs

### DIFF
--- a/packages/firebase/useAuth/index.md
+++ b/packages/firebase/useAuth/index.md
@@ -32,7 +32,7 @@ const signIn = () => auth().signInWithPopup(new GoogleAuthProvider())
 </template>
 ```
 
-Using a different firebaes auth instance
+Using a different firebase auth instance
 ```ts
 import firebase from 'firebase'
 const { isAuthenticated, user } = useAuth(firebase.auth) // or userAuth(firebase.auth())

--- a/packages/firebase/useAuth/index.ts
+++ b/packages/firebase/useAuth/index.ts
@@ -1,5 +1,6 @@
 import { computed, ComputedRef, ref, Ref } from 'vue-demi'
-import firebase from 'firebase'
+import firebase from 'firebase/app'
+import 'firebase/auth'
 
 export interface FirebaseAuthOptions {
   isAuthenticated: ComputedRef<boolean>

--- a/packages/firebase/useAuth/index.ts
+++ b/packages/firebase/useAuth/index.ts
@@ -1,6 +1,5 @@
 import { computed, ComputedRef, ref, Ref } from 'vue-demi'
 import firebase from 'firebase/app'
-import 'firebase/auth'
 
 export interface FirebaseAuthOptions {
   isAuthenticated: ComputedRef<boolean>


### PR DESCRIPTION
This fixes an issue with the `useAuth` function where it would import more from firebase than needed causing warnings in the console. It also fixes a small type in the docs for `useAuth`

The console error looked like this
![image](https://user-images.githubusercontent.com/7064956/108801401-9cee3100-7563-11eb-8a9e-30d2745c8086.png)
