### PR TITLE
feat(useAxios): axios instance support, close #273

### DIFF
--- a/packages/integrations/useAxios/demo.vue
+++ b/packages/integrations/useAxios/demo.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { stringify } from '@vueuse/docs-utils'
-import { defineComponent } from 'vue-demi'
 import { useAxios } from '.'
 
 const { data, finished } = useAxios(

--- a/packages/integrations/useAxios/index.md
+++ b/packages/integrations/useAxios/index.md
@@ -20,6 +20,31 @@ import { useAxios } from '@vueuse/integrations'
 const { data, finished } = useAxios('/api/posts')
 ```
 
+or use an instance of axios
+
+```ts
+import axios from 'axios'
+import { useAxios } from '@vueuse/integrations'
+
+const instance = axios.create({
+  baseUrl: '/api'
+})
+
+const { data, finished } = useAxios('/posts', instance)
+```
+
+use an instance of axios with config options
+
+```ts
+import axios from 'axios'
+import { useAxios } from '@vueuse/integrations'
+
+const instance = axios.create({
+  baseUrl: '/api'
+})
+
+const { data, finished } = useAxios('/posts', { method: 'POST' }, instance)
+```
 
 <!--FOOTER_STARTS-->
 ## Type Declarations

--- a/packages/integrations/useAxios/index.ts
+++ b/packages/integrations/useAxios/index.ts
@@ -1,5 +1,17 @@
 import { Ref, ref } from 'vue-demi'
-import axios, { AxiosError, AxiosRequestConfig, AxiosResponse, CancelTokenSource } from 'axios'
+import axios, { AxiosError, AxiosRequestConfig, AxiosResponse, CancelTokenSource, AxiosInstance } from 'axios'
+
+interface UseAxiosReturn<T> {
+  response: Ref<AxiosResponse<T> | undefined>
+  data: Ref<T | undefined>
+  finished: Ref<boolean>
+  canceled: Ref<boolean>
+  error: Ref<AxiosError<T> | undefined>
+}
+
+export function useAxios<T = any>(url: string, config?: AxiosRequestConfig): UseAxiosReturn<T>
+export function useAxios<T = any>(url: string, instance?: AxiosInstance): UseAxiosReturn<T>
+export function useAxios<T = any>(url: string, config: AxiosRequestConfig, instance: AxiosInstance): UseAxiosReturn<T>
 
 /**
  * Wrapper for axios.
@@ -8,10 +20,22 @@ import axios, { AxiosError, AxiosRequestConfig, AxiosResponse, CancelTokenSource
  * @param url
  * @param config
  */
-export function useAxios<T = any>(
-  url: string,
-  config?: AxiosRequestConfig,
-) {
+export function useAxios<T = any>(url: string, ...args: any[]) {
+  let config: AxiosRequestConfig = {}
+  let instance: AxiosInstance = axios
+
+  if (args.length > 0) {
+    if ('request' in args[0])
+      instance = args[0]
+    else
+      config = args[0]
+  }
+
+  if (args.length > 1) {
+    if ('request' in args[1])
+      instance = args[1]
+  }
+
   const response = ref<any>(null) as Ref<AxiosResponse<T> | undefined>
   const data = ref<any>(undefined) as Ref<T | undefined>
   const finished = ref(false)
@@ -24,7 +48,7 @@ export function useAxios<T = any>(
     canceled.value = true
   }
 
-  axios(url, { ...config, cancelToken: cancelToken.token })
+  instance(url, { ...config, cancelToken: cancelToken.token })
     .then((r: AxiosResponse<T>) => {
       response.value = r
       data.value = r.data

--- a/packages/integrations/useAxios/index.ts
+++ b/packages/integrations/useAxios/index.ts
@@ -25,6 +25,11 @@ export function useAxios<T = any>(url: string, ...args: any[]) {
   let instance: AxiosInstance = axios
 
   if (args.length > 0) {
+    /**
+     * Unable to use `instanceof` here becuase of (https://github.com/axios/axios/issues/737)
+     * so instead we are checking if there is a `requset` on the object to see if it is an
+     * axios instance
+     */
     if ('request' in args[0])
       instance = args[0]
     else


### PR DESCRIPTION
Adds support for Axios instances as mentioned in issue #273. 

Uses the following overrides so that it works with the existing API without breaking it.

```ts
export function useAxios<T = any>(url: string, config?: AxiosRequestConfig): UseAxiosReturn<T>
export function useAxios<T = any>(url: string, instance?: AxiosInstance): UseAxiosReturn<T>
export function useAxios<T = any>(url: string, config: AxiosRequestConfig, instance: AxiosInstance): UseAxiosReturn<T>
```