### PR TITLE
feat(useFetch): new feature createFetch, close #352

### DIFF
--- a/packages/core/useAsyncState/index.md
+++ b/packages/core/useAsyncState/index.md
@@ -72,7 +72,7 @@ export declare function useAsyncState<T>(
       }
     | undefined
   >
-  execute: (delay?: number) => void
+  execute: (delay?: number) => Promise<void>
 }
 ```
 

--- a/packages/core/useFetch/demo.vue
+++ b/packages/core/useFetch/demo.vue
@@ -9,8 +9,6 @@ const refetch = ref(false)
 
 const toggleRefetch = useToggle(refetch)
 
-// const { isFinished, canAbort, isFetching, statusCode, error, data, execute, abort } = useFetch(url, { immediate: false, refetch })
-
 const {
   data,
   error,
@@ -20,7 +18,7 @@ const {
   isFinished,
   canAbort,
   execute,
-} = useFetch(url, { immediate: false, refetch }).get()
+} = useFetch(url, { refetch }).get()
 
 const text = stringify(reactive({
   isFinished,

--- a/packages/core/useFetch/index.md
+++ b/packages/core/useFetch/index.md
@@ -70,9 +70,10 @@ setTimeout(() => {
 }, 5000)
 ```
 
-Create a custom useFetch instance with default values
+Create a custom `useFetch` instance with default values
 
 ```ts
+// foo.ts
 import { createFetch } from '@vueuse/core'
 
 export const useMyFetch = createFetch({
@@ -81,6 +82,14 @@ export const useMyFetch = createFetch({
     Authorization: 'my-token',
   }
 })
+```
+
+```ts
+// bar.ts
+import { useMyFetch } from './foo'
+
+// will request `https://my-api.com/posts` with token
+const { data } = useFetch('/posts')
 ```
 
 <!--FOOTER_STARTS-->
@@ -160,6 +169,23 @@ export interface UseFetchOptions {
    */
   refetch?: MaybeRef<boolean>
 }
+export interface CreateFetchOptions {
+  /**
+   * The base URL that will be prefixed to all urls
+   */
+  baseUrl?: MaybeRef<string>
+  /**
+   * Default Options for the useFetch function
+   */
+  options?: UseFetchOptions
+  /**
+   * Options for the fetch request
+   */
+  fetchOptions?: RequestInit
+}
+export declare function createFetch(
+  config?: CreateFetchOptions
+): typeof useFetch
 export declare function useFetch<T>(url: MaybeRef<string>): UseFetchReturn<T>
 export declare function useFetch<T>(
   url: MaybeRef<string>,

--- a/packages/core/useFetch/index.md
+++ b/packages/core/useFetch/index.md
@@ -70,6 +70,18 @@ setTimeout(() => {
 }, 5000)
 ```
 
+Create a custom useFetch instance with default values
+
+```ts
+import { createFetch } from '@vueuse/core'
+
+export const useMyFetch = createFetch({
+  baseUrl: 'https://my-api.com',
+  headers: {
+    Authorization: 'my-token',
+  }
+})
+```
 
 <!--FOOTER_STARTS-->
 ## Type Declarations

--- a/packages/core/useFetch/index.test.ts
+++ b/packages/core/useFetch/index.test.ts
@@ -1,4 +1,4 @@
-import { useFetch } from '.'
+import { useFetch, createFetch } from '.'
 import fetchMock from 'jest-fetch-mock'
 import { when } from '@vueuse/shared'
 import { nextTick, ref } from 'vue-demi'
@@ -32,7 +32,7 @@ describe('useFetch', () => {
   })
 
   test('should have an error on 400', async() => {
-    fetchMock.mockResponse('Hello World', { status: 400 })
+    fetchMock.mockResponse('', { status: 400 })
 
     const { error, statusCode, isFinished } = useFetch('https://example.com')
 
@@ -54,7 +54,7 @@ describe('useFetch', () => {
   })
 
   test('should not call if immediate is false', async() => {
-    fetchMock.mockResponse('Hello World')
+    fetchMock.mockResponse('')
 
     useFetch('https://example.com', { immediate: false })
     await nextTick()
@@ -63,7 +63,7 @@ describe('useFetch', () => {
   })
 
   test('should refetch if refetch is set to true', async() => {
-    fetchMock.mockResponse('Hello World')
+    fetchMock.mockResponse('')
 
     const url = ref('https://example.com')
     const { isFinished } = useFetch(url, { refetch: true })
@@ -74,5 +74,19 @@ describe('useFetch', () => {
     await when(isFinished).toBe(true)
 
     expect(fetchMock).toBeCalledTimes(2)
+  })
+
+  test('should create an instance of useFetch with a base url', async() => {
+    fetchMock.mockResponse('')
+
+    const useMyFetch = createFetch({ baseUrl: 'https://example.com', fetchOptions: { headers: { Authorization: 'test' } } })
+    const { isFinished } = useMyFetch('test', { headers: { 'Accept-Language': 'en-US' } })
+
+    await when(isFinished).toBe(true)
+
+    console.log(fetchMock.mock.calls[0][1])
+
+    expect(fetchMock.mock.calls[0][1]!.headers).toMatchObject({ Authorization: 'test', 'Accept-Language': 'en-US' })
+    expect(fetchMock.mock.calls[0][0]).toEqual('https://example.com/test')
   })
 })

--- a/packages/core/useFetch/index.test.ts
+++ b/packages/core/useFetch/index.test.ts
@@ -84,8 +84,6 @@ describe('useFetch', () => {
 
     await when(isFinished).toBe(true)
 
-    console.log(fetchMock.mock.calls[0][1])
-
     expect(fetchMock.mock.calls[0][1]!.headers).toMatchObject({ Authorization: 'test', 'Accept-Language': 'en-US' })
     expect(fetchMock.mock.calls[0][0]).toEqual('https://example.com/test')
   })

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -296,14 +296,6 @@ export function createFetch(config: CreateFetchOptions) {
   let options = config.options || {}
   let fetchOptions = config.fetchOptions || {}
 
-  /**
-   * The types here are a little complicated to get working properly
-   * Let me know if you have any ideas on how to simplify this.
-   */
-  function useFactoryFetch<T>(url: MaybeRef<string>): UseFetchReturn<T>
-  function useFactoryFetch<T>(url: MaybeRef<string>, useFetchOptions: UseFetchOptions): UseFetchReturn<T>
-  function useFactoryFetch<T>(url: MaybeRef<string>, options: RequestInit, useFetchOptions?: UseFetchOptions): UseFetchReturn<T>
-
   function useFactoryFetch(url: MaybeRef<string>, ...args: any[]) {
     const computedUrl = computed(() => joinPaths(unref(config.baseUrl), unref(url)))
 

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -1,6 +1,5 @@
 import { Ref, ref, unref, watch, computed, ComputedRef, shallowRef } from 'vue-demi'
-import { Fn, MaybeRef } from '@vueuse/shared'
-import { containsProp } from '@vueuse/shared/utils'
+import { Fn, MaybeRef, containsProp } from '@vueuse/shared/utils'
 
 interface UseFetchReturnBase<T> {
   /**
@@ -308,16 +307,17 @@ export function createFetch(config: CreateFetchOptions = {}) {
   let fetchOptions = config.fetchOptions || {}
 
   function useFactoryFetch(url: MaybeRef<string>, ...args: any[]) {
-    const computedUrl = computed(() => config.baseUrl 
-      ? joinPaths(unref(config.baseUrl), unref(url)) 
-      : unref(URL)
+    const computedUrl = computed(() => config.baseUrl
+      ? joinPaths(unref(config.baseUrl), unref(url))
+      : unref(URL),
     )
 
     // Merge properties into a single object
     if (args.length > 0) {
-      if (isFetchOptions(args[0])) { 
-        options = { ...options, ...args[0] } 
-      } else {
+      if (isFetchOptions(args[0])) {
+        options = { ...options, ...args[0] }
+      }
+      else {
         fetchOptions = {
           ...fetchOptions,
           ...args[0],

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -330,5 +330,5 @@ export function createFetch(config: CreateFetchOptions) {
     return useFetch(computedUrl, fetchOptions, options)
   }
 
-  return useFactoryFetch
+  return useFactoryFetch as typeof useFetch
 }

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -308,12 +308,16 @@ export function createFetch(config: CreateFetchOptions = {}) {
   let fetchOptions = config.fetchOptions || {}
 
   function useFactoryFetch(url: MaybeRef<string>, ...args: any[]) {
-    const computedUrl = computed(() => config.baseUrl ? joinPaths(unref(config.baseUrl), unref(url)) : unref(url))
+    const computedUrl = computed(() => config.baseUrl 
+      ? joinPaths(unref(config.baseUrl), unref(url)) 
+      : unref(URL)
+    )
 
     // Merge properties into a single object
     if (args.length > 0) {
-      if (isFetchOptions(args[0])) { options = { ...options, ...args[0] } }
-      else {
+      if (isFetchOptions(args[0])) { 
+        options = { ...options, ...args[0] } 
+      } else {
         fetchOptions = {
           ...fetchOptions,
           ...args[0],

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -1,5 +1,6 @@
 import { Ref, ref, unref, watch, computed, ComputedRef, shallowRef } from 'vue-demi'
 import { Fn, MaybeRef } from '@vueuse/shared'
+import { containsProp } from '@vueuse/shared/utils'
 
 interface UseFetchReturnBase<T> {
   /**
@@ -106,6 +107,16 @@ export interface CreateFetchOptions {
   fetchOptions?: RequestInit
 }
 
+/**
+ * !!!IMPORTANT!!!
+ *
+ * If you update the UseFetchOptions interface, be sure to update this object
+ * to include the new options
+ */
+function isFetchOptions(obj: object): obj is UseFetchOptions {
+  return containsProp(obj, 'immediate', 'refetch')
+}
+
 export function useFetch<T>(url: MaybeRef<string>): UseFetchReturn<T>
 export function useFetch<T>(url: MaybeRef<string>, useFetchOptions: UseFetchOptions): UseFetchReturn<T>
 export function useFetch<T>(url: MaybeRef<string>, options: RequestInit, useFetchOptions?: UseFetchOptions): UseFetchReturn<T>
@@ -124,14 +135,14 @@ export function useFetch<T>(url: MaybeRef<string>, ...args: any[]): UseFetchRetu
   let initialized = false
 
   if (args.length > 0) {
-    if ('immediate' in args[0] || 'refetch' in args[0])
+    if (isFetchOptions(args[0]))
       options = { ...options, ...args[0] }
     else
       fetchOptions = args[0]
   }
 
   if (args.length > 1) {
-    if ('immediate' in args[1] || 'refetch' in args[1])
+    if (isFetchOptions(args[1]))
       options = { ...options, ...args[1] }
   }
 
@@ -301,7 +312,7 @@ export function createFetch(config: CreateFetchOptions = {}) {
 
     // Merge properties into a single object
     if (args.length > 0) {
-      if ('immediate' in args[0] || 'refetch' in args[0]) { options = { ...options, ...args[0] } }
+      if (isFetchOptions(args[0])) { options = { ...options, ...args[0] } }
       else {
         fetchOptions = {
           ...fetchOptions,
@@ -315,7 +326,7 @@ export function createFetch(config: CreateFetchOptions = {}) {
     }
 
     if (args.length > 1) {
-      if ('immediate' in args[1] || 'refetch' in args[1])
+      if (isFetchOptions(args[1]))
         options = { ...options, ...args[1] }
     }
 

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -93,7 +93,7 @@ export interface CreateFetchOptions {
   /**
    * The base URL that will be prefixed to all urls
    */
-  baseUrl: MaybeRef<string>
+  baseUrl?: MaybeRef<string>
 
   /**
    * Default Options for the useFetch function
@@ -297,7 +297,7 @@ export function createFetch(config: CreateFetchOptions) {
   let fetchOptions = config.fetchOptions || {}
 
   function useFactoryFetch(url: MaybeRef<string>, ...args: any[]) {
-    const computedUrl = computed(() => joinPaths(unref(config.baseUrl), unref(url)))
+    const computedUrl = computed(() => config.baseUrl ? joinPaths(unref(config.baseUrl), unref(url)) : unref(url))
 
     // Merge properties into a single object
     if (args.length > 0) {

--- a/packages/shared/utils/index.ts
+++ b/packages/shared/utils/index.ts
@@ -18,3 +18,7 @@ export function promiseTimeout(
 export function invoke<T>(fn: () => T): T {
   return fn()
 }
+
+export function containsProp(obj: object, ...props: string[]) {
+  return props.some(k => k in obj)
+}


### PR DESCRIPTION
Basic implementation of `createFetch` as mentioned in issue #352. Adds new test for the `createFetch` function.

I was also thinking it might be interesting to have some hooks on the `createFetch` object like `beforeRequest` and possibly `afterRequest`. These would return a promise which would allow one to do something like get an authorization token and attach it to the headers but the implementation of something like that might be a bit more difficult. So before doing anything like that I thought it would be better to discuss it.

Also I had to copy the function overloads to the `createFetch` function, if you have a better idea on how to do this let me know!