### PR TITLE
fix(useFirestore): sub-collection is wrongly detected as a document

### DIFF
--- a/packages/firebase/useFirestore/index.test.ts
+++ b/packages/firebase/useFirestore/index.test.ts
@@ -1,0 +1,25 @@
+import { useFirestore } from './index'
+import type firebase from 'firebase'
+
+describe('useFirestore', () => {
+  const expectArrayRef = (path: string, initialValue: any, result: boolean) => {
+    // @ts-ignore
+    const docRef: firebase.firestore.DocumentReference<firebase.firestore.DocumentData> = {
+      path,
+      onSnapshot: jest.fn(),
+    }
+
+    const ref = useFirestore(docRef, initialValue)
+
+    expect(Array.isArray(ref.value)).toBe(result)
+  }
+
+  it('should return an array ref when applied on a (sub-)collection', () => {
+    expectArrayRef('users', [], true)
+    expectArrayRef('users/foo/todos', [], true)
+  })
+
+  it('should not return an array ref object when applied on a document', () => {
+    expectArrayRef('users/foo', {}, false)
+  })
+})

--- a/packages/firebase/useFirestore/index.ts
+++ b/packages/firebase/useFirestore/index.ts
@@ -27,7 +27,7 @@ function getData<T>(
 }
 
 function isDocumentReference<T>(docRef: any): docRef is firebase.firestore.DocumentReference<T> {
-  return Boolean(docRef.parent)
+  return (docRef.path.match(/\//g) || []).length % 2 !== 0
 }
 
 export function useFirestore<T extends firebase.firestore.DocumentData> (


### PR DESCRIPTION
This PR fixes #365.

I modified the `isDocumentReference` which now checks the number of slash (`/`) occurences in the path:
* even -> collection
* odd -> document