### PR TITLE
chore: clear demo log within sync

### DIFF
--- a/packages/shared/ignorableWatch/demo.vue
+++ b/packages/shared/ignorableWatch/demo.vue
@@ -9,11 +9,12 @@ const source = ref(0)
 const { ignoreUpdates } = ignorableWatch(
   source,
   v => (log.value += `Changed to "${v}"\n`),
+  { flush: 'sync' },
 )
 
 const clear = () => {
-  log.value = ''
   source.value = 0
+  log.value = ''
 }
 const update = () => {
   source.value++
@@ -34,7 +35,7 @@ const ignoredUpdate = () => {
     Ignored Update
   </button>
   <button @click="clear">
-    Clear Log
+    Reset
   </button>
 
   <br>


### PR DESCRIPTION
Currently `Clear Log` button first clears log and resets counter to `0` then logs it. To really clear the log we have to click again. I fixed it by setting `flush: sync`.