### PR TITLE
fix(useFetch): abort controller would only works on first request

### DIFF
--- a/packages/core/useFetch/index.test.ts
+++ b/packages/core/useFetch/index.test.ts
@@ -45,7 +45,14 @@ describe('useFetch', () => {
   test('should abort request and set aborted to true', async() => {
     fetchMock.mockResponse(() => new Promise(resolve => setTimeout(() => resolve({ body: 'ok' }), 1000)))
 
-    const { aborted, abort, isFinished } = useFetch('https://example.com')
+    const { aborted, abort, isFinished, execute } = useFetch('https://example.com')
+
+    setTimeout(() => abort(), 0)
+
+    await when(isFinished).toBe(true)
+    expect(aborted.value).toBe(true)
+
+    execute()
 
     setTimeout(() => abort(), 0)
 

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -194,10 +194,8 @@ export function useFetch<T>(url: MaybeRef<string>, ...args: any[]): UseFetchRetu
   let controller: AbortController | undefined
 
   const abort = () => {
-    if (supportsAbort && controller) {
-      aborted.value = true
+    if (supportsAbort && controller)
       controller.abort()
-    }
   }
 
   const execute = () => {
@@ -211,6 +209,7 @@ export function useFetch<T>(url: MaybeRef<string>, ...args: any[]): UseFetchRetu
 
     if (supportsAbort) {
       controller = new AbortController()
+      controller.signal.onabort = () => aborted.value = true
       fetchOptions = {
         ...fetchOptions,
         signal: controller.signal,

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -212,8 +212,8 @@ export function useFetch<T>(url: MaybeRef<string>, ...args: any[]): UseFetchRetu
     if (supportsAbort) {
       controller = new AbortController()
       fetchOptions = {
-        signal: controller.signal,
         ...fetchOptions,
+        signal: controller.signal,
       }
     }
 


### PR DESCRIPTION
**Problem**
Noticed this as I was working on `beforeFetch` hooks for the useFetch function. Basically the problem is that we end up reassigning the `fetchOptions` when we run the first fetch after we attach the signal. The problem comes with the second fetch though. Since the `fetchOptions` object now already contains a signal, it will overwrite our new signal with the old one.

```ts
if (supportsAbort) {
  controller = new AbortController()
  fetchOptions = {
    signal: controller.signal,
    ...fetchOptions,
  }
}
```

**Solution**
I ended up just moving the signal below where we spread out our fetchOptions which will overwrite the old signal.
```ts
if (supportsAbort) {
  controller = new AbortController()
  fetchOptions = {
    ...fetchOptions,
    signal: controller.signal,
  }
}
```