### PR TITLE
fix(useUrlSearchParams): wrong parsing of hash url without params

### DIFF
--- a/packages/core/useUrlSearchParams/index.test.ts
+++ b/packages/core/useUrlSearchParams/index.test.ts
@@ -89,4 +89,16 @@ describe('useUrlSearchParams', () => {
       })
     })
   })
+
+  test('hash url without params', () => {
+    useSetup(() => {
+      window.location.hash = '#/test/'
+      const params = useUrlSearchParams('hash')
+      expect(params).toEqual({})
+
+      const newHash = '#/change/?foo=bar'
+      window.location.hash = newHash
+      expect(window.location.hash).toBe(newHash)
+    })
+  })
 })

--- a/packages/core/useUrlSearchParams/index.ts
+++ b/packages/core/useUrlSearchParams/index.ts
@@ -31,7 +31,7 @@ export function useUrlSearchParams<T extends Record<string, any> = UrlParams>(
     if (mode === 'hash') {
       const hash = window.location.hash || ''
       const index = hash.indexOf('?')
-      return new URLSearchParams(index ? hash.substring(index + 1) : '')
+      return new URLSearchParams(index >= 0 ? hash.substring(index + 1) : '')
     }
     else {
       return new URLSearchParams(window.location.search || '')


### PR DESCRIPTION
Hello @antfu,

unfortunately I found another issue in the `useUrlSearchParams` function 😭.

Kind regards,
Lukas