### PR TITLE
feat(useFetch): add beforeFetch option

### DIFF
--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -92,7 +92,7 @@ export interface UseFetchOptions {
   /**
    * Will run immediately before the fetch request is dispatched
    */
-  beforeFetch?: (ctx: Context, abort: Fn) => Promise<Partial<Context>> | Partial<Context>
+  beforeFetch?: (ctx: Context) => Promise<Partial<Context>> | Partial<Context>
 }
 
 export interface CreateFetchOptions {
@@ -241,20 +241,20 @@ export function useFetch<T>(url: MaybeRef<string>, ...args: any[]): UseFetchRetu
       }
     }
 
-    let context = { url: unref(url), options: fetchOptions, cancel: abort }
+    const context = { url: unref(url), options: fetchOptions, cancel: abort }
 
     if (options.beforeFetch)
       Object.assign(context, await options.beforeFetch(context))
 
     return new Promise((resolve) => {
       fetch(
-        _url,
+        context.url,
         {
           ...defaultFetchOptions,
-          ..._fetchOptions,
+          ...context.options,
           headers: {
             ...defaultFetchOptions.headers,
-            ..._fetchOptions?.headers,
+            ...context.options?.headers,
           },
         },
       )

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -55,7 +55,7 @@ interface UseFetchReturnBase<T> {
 
 type DataType = 'text' | 'json' | 'blob' | 'arrayBuffer' | 'formData'
 type PayloadType = 'text' | 'json' | 'formData'
-type Context = { url: string; options: RequestInit }
+type Context = { url: string; options: RequestInit, cancel: () => void }
 
 interface UseFetchReturnMethodConfigured<T> extends UseFetchReturnBase<T> {
   // type

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -92,7 +92,7 @@ export interface UseFetchOptions {
   /**
    * Will run immediately before the fetch request is dispatched
    */
-  beforeFetch?: (ctx: Context, abort: Fn) => Promise<Context> | Context
+  beforeFetch?: (ctx: Context, abort: Fn) => Promise<Partial<Context>> | Partial<Context>
 }
 
 export interface CreateFetchOptions {
@@ -244,8 +244,12 @@ export function useFetch<T>(url: MaybeRef<string>, ...args: any[]): UseFetchRetu
     let _url = unref(url)
     let _fetchOptions = fetchOptions
 
-    if (options.beforeFetch)
-      ({ url: _url, options: _fetchOptions } = await options.beforeFetch({ url: _url, options: _fetchOptions }, abort))
+    if (options.beforeFetch) {
+      const { url: maybeUrl, options: maybeOptions } = await options.beforeFetch({ url: _url, options: _fetchOptions }, abort)
+
+      _url = maybeUrl || _url
+      _fetchOptions = maybeOptions || _fetchOptions
+    }
 
     return new Promise((resolve) => {
       fetch(

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -241,13 +241,13 @@ export function useFetch<T>(url: MaybeRef<string>, ...args: any[]): UseFetchRetu
       }
     }
 
-    const isCanceled = ref(false)
-    const context = { url: unref(url), options: fetchOptions, cancel: () => { isCanceled.value = true } }
+    let isCanceled = false
+    const context = { url: unref(url), options: fetchOptions, cancel: () => { isCanceled = true } }
 
     if (options.beforeFetch)
       Object.assign(context, await options.beforeFetch(context))
 
-    if (isCanceled.value)
+    if (isCanceled)
       return Promise.resolve()
 
     return new Promise((resolve) => {

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -241,15 +241,10 @@ export function useFetch<T>(url: MaybeRef<string>, ...args: any[]): UseFetchRetu
       }
     }
 
-    let _url = unref(url)
-    let _fetchOptions = fetchOptions
+    let context = { url: unref(url), options: fetchOptions, cancel: abort }
 
-    if (options.beforeFetch) {
-      const { url: maybeUrl, options: maybeOptions } = await options.beforeFetch({ url: _url, options: _fetchOptions }, abort)
-
-      _url = maybeUrl || _url
-      _fetchOptions = maybeOptions || _fetchOptions
-    }
+    if (options.beforeFetch)
+      Object.assign(context, await options.beforeFetch(context))
 
     return new Promise((resolve) => {
       fetch(

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -55,6 +55,7 @@ interface UseFetchReturnBase<T> {
 
 type DataType = 'text' | 'json' | 'blob' | 'arrayBuffer' | 'formData'
 type PayloadType = 'text' | 'json' | 'formData'
+type Context = { url: string; options: RequestInit }
 
 interface UseFetchReturnMethodConfigured<T> extends UseFetchReturnBase<T> {
   // type
@@ -91,7 +92,7 @@ export interface UseFetchOptions {
   /**
    * Will run immediately before the fetch request is dispatched
    */
-  beforeFetch?: (url: string, options: RequestInit, abort: Fn) => Promise<{ url: string; options: RequestInit }> | ({ url: string; options: RequestInit })
+  beforeFetch?: (ctx: Context, abort: Fn) => Promise<Context> | Context
 }
 
 export interface CreateFetchOptions {
@@ -244,7 +245,7 @@ export function useFetch<T>(url: MaybeRef<string>, ...args: any[]): UseFetchRetu
     let _fetchOptions = fetchOptions
 
     if (options.beforeFetch)
-      ({ url: _url, options: _fetchOptions } = await options.beforeFetch(_url, _fetchOptions, abort))
+      ({ url: _url, options: _fetchOptions } = await options.beforeFetch({ url: _url, options: _fetchOptions }, abort))
 
     return new Promise((resolve) => {
       fetch(

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -241,10 +241,14 @@ export function useFetch<T>(url: MaybeRef<string>, ...args: any[]): UseFetchRetu
       }
     }
 
-    const context = { url: unref(url), options: fetchOptions, cancel: abort }
+    const isCanceled = ref(false)
+    const context = { url: unref(url), options: fetchOptions, cancel: () => { isCanceled.value = true } }
 
     if (options.beforeFetch)
       Object.assign(context, await options.beforeFetch(context))
+
+    if (isCanceled.value)
+      return Promise.resolve()
 
     return new Promise((resolve) => {
       fetch(

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -55,7 +55,6 @@ interface UseFetchReturnBase<T> {
 
 type DataType = 'text' | 'json' | 'blob' | 'arrayBuffer' | 'formData'
 type PayloadType = 'text' | 'json' | 'formData'
-type Context = { url: string; options: RequestInit, cancel: () => void }
 
 interface UseFetchReturnMethodConfigured<T> extends UseFetchReturnBase<T> {
   // type
@@ -72,6 +71,23 @@ export interface UseFetchReturn<T> extends UseFetchReturnMethodConfigured<T> {
   post(payload?: unknown, type?: PayloadType): UseFetchReturnMethodConfigured<T>
   put(payload?: unknown, type?: PayloadType): UseFetchReturnMethodConfigured<T>
   delete(payload?: unknown, type?: PayloadType): UseFetchReturnMethodConfigured<T>
+}
+
+export interface BeforeFetchContext {
+  /**
+   * The computed url of the current request
+   */
+  url: string
+
+  /**
+   * The requset options of the current request
+   */
+  options: RequestInit
+
+  /**
+   * Cancels the current requset
+   */
+  cancel: Fn
 }
 
 export interface UseFetchOptions {
@@ -92,7 +108,7 @@ export interface UseFetchOptions {
   /**
    * Will run immediately before the fetch request is dispatched
    */
-  beforeFetch?: (ctx: Context) => Promise<Partial<Context>> | Partial<Context>
+  beforeFetch?: (ctx: BeforeFetchContext) => Promise<Partial<BeforeFetchContext>> | Partial<BeforeFetchContext>
 }
 
 export interface CreateFetchOptions {
@@ -242,7 +258,7 @@ export function useFetch<T>(url: MaybeRef<string>, ...args: any[]): UseFetchRetu
     }
 
     let isCanceled = false
-    const context = { url: unref(url), options: fetchOptions, cancel: () => { isCanceled = true } }
+    const context: BeforeFetchContext = { url: unref(url), options: fetchOptions, cancel: () => { isCanceled = true } }
 
     if (options.beforeFetch)
       Object.assign(context, await options.beforeFetch(context))

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -88,7 +88,10 @@ export interface UseFetchOptions {
    */
   refetch?: MaybeRef<boolean>
 
-  beforeFetch?: (url: string, options: RequestInit) => Promise<{ url: string; options: RequestInit }>
+  /**
+   * Will run immediately before the fetch request is dispatched
+   */
+  beforeFetch?: (url: string, options: RequestInit, abort: Fn) => Promise<{ url: string; options: RequestInit }> | ({ url: string; options: RequestInit })
 }
 
 export interface CreateFetchOptions {
@@ -241,7 +244,7 @@ export function useFetch<T>(url: MaybeRef<string>, ...args: any[]): UseFetchRetu
     let _fetchOptions = fetchOptions
 
     if (options.beforeFetch)
-      ({ url: _url, options: _fetchOptions } = await options.beforeFetch(_url, _fetchOptions))
+      ({ url: _url, options: _fetchOptions } = await options.beforeFetch(_url, _fetchOptions, abort))
 
     return new Promise((resolve) => {
       fetch(


### PR DESCRIPTION
Hey @antfu this is the initial implementation of the `beforeFetch` feature I had in mind for useFetch. It isn't too complicated. This adds a new option to the `useFetch` options called `beforeFetch`. This new options accepts a promise that returns the url and request options. The basic usage would be as follows

```ts
useFetch('/api/me', {
  beforeFetch: async(url, options) => {
    options.headers = {
      ...options.headers,
      Authorization: `Bearer ${await getAuthToken()}`,
    }

    return {
      url,
      options,
    }
  },
})
```
Of course this option would also apply to the `createFetch` function, where it would be more likely to be used.

Let me know what you think about this API. If you like it I'll go ahead and write some tests and add docs, otherwise we can refactor 😄 