### PR TITLE
feat(useTransition): support for vectors

### DIFF
--- a/packages/core/useTransition/demo.vue
+++ b/packages/core/useTransition/demo.vue
@@ -1,8 +1,13 @@
 <script setup lang="ts">
+import { rand } from '@vueuse/shared'
 import { ref } from 'vue-demi'
 import { useTransition } from '.'
 
+const duration = 1500
+
 const baseNumber = ref(0)
+
+const baseVector = ref([50, 50])
 
 const easeOutElastic = (n: number) => {
   return n === 0
@@ -13,17 +18,20 @@ const easeOutElastic = (n: number) => {
 }
 
 const cubicBezierNumber = useTransition(baseNumber, {
-  duration: 1500,
+  duration,
   transition: [0.75, 0, 0.25, 1],
 })
 
 const customFnNumber = useTransition(baseNumber, {
-  duration: 1500,
+  duration,
   transition: easeOutElastic,
 })
 
+const transitionedVector = useTransition(baseVector, { duration })
+
 const toggle = () => {
   baseNumber.value = baseNumber.value === 100 ? 0 : 100
+  baseVector.value = [rand(0, 100), rand(0, 100)]
 }
 </script>
 
@@ -56,6 +64,10 @@ const toggle = () => {
         <div class="sled" :style="{ left: customFnNumber + '%' }" />
       </div>
     </div>
+
+    <p class="mt-2">
+      Vector: <b>[{{ transitionedVector[0].toFixed(2) }}, {{ transitionedVector[1].toFixed(2) }}]</b>
+    </p>
   </div>
 </template>
 

--- a/packages/core/useTransition/demo.vue
+++ b/packages/core/useTransition/demo.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
 import { rand } from '@vueuse/shared'
 import { ref } from 'vue-demi'
-import { useTransition } from '.'
+import { useTransition, TransitionPresets } from '.'
 
 const duration = 1500
 
 const baseNumber = ref(0)
 
-const baseVector = ref([50, 50])
+const baseVector = ref([0, 0])
 
 const easeOutElastic = (n: number) => {
   return n === 0
@@ -27,7 +27,10 @@ const customFnNumber = useTransition(baseNumber, {
   transition: easeOutElastic,
 })
 
-const transitionedVector = useTransition(baseVector, { duration })
+const vector = useTransition(baseVector, {
+  duration,
+  transition: TransitionPresets.easeOutExpo,
+})
 
 const toggle = () => {
   baseNumber.value = baseNumber.value === 100 ? 0 : 100
@@ -42,14 +45,10 @@ const toggle = () => {
     </button>
 
     <p class="mt-2">
-      Base number: <b>{{ baseNumber }}</b>
-    </p>
-
-    <p class="mt-2">
       Cubic bezier curve: <b>{{ cubicBezierNumber.toFixed(2) }}</b>
     </p>
 
-    <div class="track">
+    <div class="track number">
       <div class="relative">
         <div class="sled" :style="{ left: cubicBezierNumber + '%' }" />
       </div>
@@ -59,26 +58,29 @@ const toggle = () => {
       Custom function: <b>{{ customFnNumber.toFixed(2) }}</b>
     </p>
 
-    <div class="track">
+    <div class="track number">
       <div class="relative">
         <div class="sled" :style="{ left: customFnNumber + '%' }" />
       </div>
     </div>
 
     <p class="mt-2">
-      Vector: <b>[{{ transitionedVector[0].toFixed(2) }}, {{ transitionedVector[1].toFixed(2) }}]</b>
+      Vector: <b>[{{ vector[0].toFixed(2) }}, {{ vector[1].toFixed(2) }}]</b>
     </p>
+
+    <div class="track vector">
+      <div class="relative">
+        <div class="sled" :style="{ left: vector[0] + '%', top: vector[1] + '%' }" />
+      </div>
+    </div>
   </div>
 </template>
 
 <style scoped>
 .track {
   background: rgba(125, 125, 125, 0.3);
-  border-radius: 1rem;
-  height: 1rem;
-  margin: 0.5rem 0;
+  border-radius: 0.5rem;
   max-width: 20rem;
-  padding: 0 0.5rem;
   width: 100%;
 }
 
@@ -87,7 +89,28 @@ const toggle = () => {
   border-radius: 50%;
   height: 1rem;
   position: absolute;
-  transform: translateX(-50%);
   width: 1rem;
+}
+
+.number.track {
+  height: 1rem;
+  margin: 0.5rem 0;
+  padding: 0 0.5rem;
+}
+
+.number.track .sled {
+  transform: translateX(-50%);
+}
+
+.vector.track {
+  padding: 0.5rem;
+}
+
+.vector.track .relative {
+  padding-bottom: 56.25%;
+}
+
+.vector.track .sled {
+  transform: translateX(-50%) translateY(-50%);
 }
 </style>

--- a/packages/core/useTransition/index.md
+++ b/packages/core/useTransition/index.md
@@ -11,7 +11,7 @@ Transition between values
 ```js
 import { useTransition, TransitionPresets } from '@vueuse/core'
 
-useTransition(baseNumber, {
+useTransition(source, {
   duration: 1000,
   transition: TransitionPresets.easeInOutCubic,
 })
@@ -46,8 +46,7 @@ The following transitions are available via the `TransitionPresets` constant.
 Custom transitions can be defined using cubic bezier curves. Transitions defined this way work the same as [CSS easing functions](https://developer.mozilla.org/en-US/docs/Web/CSS/easing-function).
 
 ```js
-useTransition(baseNumber, {
-  duration: 1000,
+useTransition(source, {
   transition: [0.75, 0, 0.25, 1],
 })
 ```
@@ -63,8 +62,7 @@ const easeOutElastic = (n) => {
       : (2 ** (-10 * n)) * Math.sin((n * 10 - 0.75) * ((2 * Math.PI) / 3)) + 1
 }
 
-useTransition(baseNumber, {
-  duration: 1000,
+useTransition(source, {
   transition: easeOutElastic,
 })
 ```
@@ -72,9 +70,7 @@ useTransition(baseNumber, {
 To choreograph behavior around a transition, define `onStarted` or `onFinished` callbacks.
 
 ```js
-useTransition(baseNumber, {
-  duration: 1000,
-  transition: easeOutElastic,
+useTransition(source, {
   onStarted() {
     // called after the transition starts
   },
@@ -119,10 +115,10 @@ export declare const TransitionPresets: Record<string, CubicBezierPoints>
  * @param source
  * @param options
  */
-export declare function useTransition(
-  source: Ref<number>,
+export declare function useTransition<T extends Ref<number | number[]>>(
+  source: T,
   options?: TransitionOptions
-): Ref<number>
+): ComputedRef<UnwrapRef<T>>
 export {}
 ```
 

--- a/packages/core/useTransition/index.test.ts
+++ b/packages/core/useTransition/index.test.ts
@@ -188,4 +188,32 @@ describe('useTransition', () => {
     expect(onStarted.mock.calls.length).toBe(1)
     expect(onFinished.mock.calls.length).toBe(1)
   })
+
+  it('transitions between vectors', async() => {
+    const vm = useSetup(() => {
+      const baseVector = ref([0, 0])
+
+      const transitionedVector = useTransition(baseVector, {
+        duration: 100,
+      })
+
+      return {
+        baseVector,
+        transitionedVector,
+      }
+    })
+
+    expect(vm.transitionedVector).toEqual([0, 0])
+
+    vm.baseVector = [1, 1]
+
+    await promiseTimeout(50)
+
+    expect(vm.transitionedVector[0] > 0 && vm.transitionedVector[0] < 1).toBe(true)
+    expect(vm.transitionedVector[1] > 0 && vm.transitionedVector[1] < 1).toBe(true)
+
+    await promiseTimeout(100)
+
+    expect(vm.transitionedVector).toEqual([1, 1])
+  })
 })

--- a/packages/core/useTransition/index.test.ts
+++ b/packages/core/useTransition/index.test.ts
@@ -215,5 +215,15 @@ describe('useTransition', () => {
     await promiseTimeout(100)
 
     expect(vm.transitionedVector).toEqual([1, 1])
+
+    vm.baseVector[0] = 0
+
+    await promiseTimeout(50)
+
+    expect(vm.transitionedVector[0] > 0 && vm.transitionedVector[0] < 1).toBe(true)
+
+    await promiseTimeout(100)
+
+    expect(vm.transitionedVector).toEqual([0, 1])
   })
 })

--- a/packages/core/useTransition/index.test.ts
+++ b/packages/core/useTransition/index.test.ts
@@ -208,22 +208,18 @@ describe('useTransition', () => {
     vm.baseVector = [1, 1]
 
     await promiseTimeout(50)
-
     expect(vm.transitionedVector[0] > 0 && vm.transitionedVector[0] < 1).toBe(true)
     expect(vm.transitionedVector[1] > 0 && vm.transitionedVector[1] < 1).toBe(true)
 
     await promiseTimeout(100)
-
     expect(vm.transitionedVector).toEqual([1, 1])
 
-    vm.baseVector[0] = 0
+    vm.baseVector.splice(0, 1, 0)
 
     await promiseTimeout(50)
-
     expect(vm.transitionedVector[0] > 0 && vm.transitionedVector[0] < 1).toBe(true)
 
     await promiseTimeout(100)
-
     expect(vm.transitionedVector).toEqual([0, 1])
   })
 })

--- a/packages/core/useTransition/index.ts
+++ b/packages/core/useTransition/index.ts
@@ -135,7 +135,7 @@ export function useTransition<T extends Ref<number | number[]>>(source: T, optio
 
     resume()
     onStarted()
-  })
+  }, { deep: true })
 
   return Array.isArray(source.value)
     ? computed(() => outputVector.value as UnwrapRef<T>)

--- a/packages/core/useTransition/index.ts
+++ b/packages/core/useTransition/index.ts
@@ -1,5 +1,5 @@
 import { useRafFn } from '../useRafFn'
-import { computed, Ref, ref, unref, watch } from 'vue-demi'
+import { computed, Ref, ref, unref, UnwrapRef, watch } from 'vue-demi'
 import { clamp, isFunction, MaybeRef, noop } from '@vueuse/shared'
 
 /**
@@ -89,7 +89,7 @@ export const TransitionPresets: Record<string, CubicBezierPoints> = {
  * @param source
  * @param options
  */
-export function useTransition(source: Ref<number | number[]>, options: TransitionOptions = {}) {
+export function useTransition<T extends Ref<number | number[]>>(source: T, options: TransitionOptions = {}) {
   const {
     duration = 500,
     onFinished = noop,
@@ -137,5 +137,7 @@ export function useTransition(source: Ref<number | number[]>, options: Transitio
     onStarted()
   })
 
-  return computed(() => Array.isArray(source.value) ? outputVector.value : outputVector.value[0])
+  return Array.isArray(source.value)
+    ? computed(() => outputVector.value as UnwrapRef<T>)
+    : computed(() => outputVector.value[0] as UnwrapRef<T>)
 }

--- a/packages/shared/utils/is.ts
+++ b/packages/shared/utils/is.ts
@@ -16,3 +16,8 @@ export const now = () => Date.now()
 export const timestamp = () => +Date.now()
 export const clamp = (n: number, min: number, max: number) => Math.min(max, Math.max(min, n))
 export const noop = () => {}
+export const rand = (min: number, max: number) => {
+  min = Math.ceil(min)
+  max = Math.floor(max)
+  return Math.floor(Math.random() * (max - min + 1)) + min
+}

--- a/packages/shared/utils/is.ts
+++ b/packages/shared/utils/is.ts
@@ -16,8 +16,4 @@ export const now = () => Date.now()
 export const timestamp = () => +Date.now()
 export const clamp = (n: number, min: number, max: number) => Math.min(max, Math.max(min, n))
 export const noop = () => {}
-export const rand = (min: number, max: number) => {
-  min = Math.ceil(min)
-  max = Math.floor(max)
-  return Math.floor(Math.random() * (max - min + 1)) + min
-}
+export const rand = (min: number, max: number) => Math.floor(Math.random() * (max - min + 1)) + min

--- a/packages/shared/utils/is.ts
+++ b/packages/shared/utils/is.ts
@@ -16,4 +16,8 @@ export const now = () => Date.now()
 export const timestamp = () => +Date.now()
 export const clamp = (n: number, min: number, max: number) => Math.min(max, Math.max(min, n))
 export const noop = () => {}
-export const rand = (min: number, max: number) => Math.floor(Math.random() * (max - min + 1)) + min
+export const rand = (min: number, max: number) => {
+  min = Math.ceil(min)
+  max = Math.floor(max)
+  return Math.floor(Math.random() * (max - min + 1)) + min
+}


### PR DESCRIPTION
This is the first of several PRs to implement features being designed in #364

There is a small breaking change here. The returned value is now a `ComputedRef` instead of a `Ref`, meaning anyone who manually set the value of a transitioned ref would no longer be able to do so. This was never part of the documented API though, so I'm not sure how much to worry about it. I think just making a mention in the release notes would be sufficient.

Vectors support any number of dimensions, and there is a quick track/sled example added to the demo.
