### PR TITLE
fix(useSwipe): exceed threshold in between

### DIFF
--- a/packages/core/useSwipe/index.test.ts
+++ b/packages/core/useSwipe/index.test.ts
@@ -34,8 +34,10 @@ describe('useSwipe', () => {
 
   const mockTouchEvents = (target: EventTarget, coords: Array<number[]>) => {
     coords.forEach(([x, y], i) => {
-      if (i === 0) target.dispatchEvent(mockTouchStart(x, y))
-      else if (i === coords.length - 1) target.dispatchEvent(mockTouchEnd(x, y))
+      if (i === 0)
+        target.dispatchEvent(mockTouchStart(x, y))
+      else if (i === coords.length - 1)
+        target.dispatchEvent(mockTouchEnd(x, y))
       else
         target.dispatchEvent(mockTouchMove(x, y))
     })
@@ -72,13 +74,25 @@ describe('useSwipe', () => {
     })
   })
 
+  it('threshold exceeded in between', () => {
+    useSetup(() => {
+      useSwipe(target, { threshold, onSwipe, onSwipeEnd })
+
+      mockTouchEvents(target, [[0, 0], [threshold / 2, 0], [threshold, 0], [threshold - 1, 0], [threshold - 1, 0]])
+
+      expect(onSwipe.mock.calls.length).toBe(2)
+      expect(onSwipeEnd.mock.calls.length).toBe(1)
+      expect(onSwipeEnd.mock.calls[0][1]).toBe(SwipeDirection.NONE)
+    })
+  })
+
   it('reactivity', () => {
     useSetup(() => {
       const { isSwiping, direction, lengthX, lengthY } = useSwipe(target, { threshold, onSwipe, onSwipeEnd })
 
       target.dispatchEvent(mockTouchStart(0, 0))
       expect(isSwiping.value).toBeFalsy()
-      expect(direction.value).toBeNull()
+      expect(direction.value).toBe(SwipeDirection.NONE)
       expect(lengthX.value).toBe(0)
       expect(lengthY.value).toBe(0)
 
@@ -101,10 +115,10 @@ describe('useSwipe', () => {
     useSetup(() => {
       const { direction } = useSwipe(target, { threshold, onSwipe, onSwipeEnd })
 
-      mockTouchEvents(target, [[0, 2 * threshold], [0, threshold], [0, threshold]])
+      mockTouchEvents(target, coords)
 
-      expect(direction.value).toBe(SwipeDirection.UP)
-      expect(onSwipeEnd.mock.calls[0][1]).toBe(SwipeDirection.UP)
+      expect(direction.value).toBe(expected)
+      expect(onSwipeEnd.mock.calls[0][1]).toBe(expected)
     })
   })
 })

--- a/packages/core/useSwipe/index.ts
+++ b/packages/core/useSwipe/index.ts
@@ -8,7 +8,8 @@ export enum SwipeDirection {
   UP = 'UP',
   RIGHT = 'RIGHT',
   DOWN = 'DOWN',
-  LEFT = 'LEFT'
+  LEFT = 'LEFT',
+  NONE = 'NONE',
 }
 
 export interface SwipeOptions extends ConfigurableWindow {
@@ -90,7 +91,7 @@ export function useSwipe(
 
   const direction = computed(() => {
     if (!isThresholdExceeded.value)
-      return null
+      return SwipeDirection.NONE
 
     if (abs(diffX.value) > abs(diffY.value)) {
       return diffX.value > 0
@@ -138,16 +139,17 @@ export function useSwipe(
     useEventListener(target, 'touchmove', (e: TouchEvent) => {
       const [x, y] = getTouchEventCoords(e)
       updateCoordsEnd(x, y)
-      if (direction.value) {
+      if (!isSwiping.value && isThresholdExceeded.value)
         isSwiping.value = true
+      if (isSwiping.value)
         onSwipe?.(e)
-      }
     }, listenerOptions),
 
     useEventListener(target, 'touchend', (e: TouchEvent) => {
-      isSwiping.value = false
-      if (direction.value)
+      if (isSwiping.value)
         onSwipeEnd?.(e, direction.value)
+
+      isSwiping.value = false
     }, listenerOptions),
   ]
 


### PR DESCRIPTION
`onSwipeEnd` should be called at the end of any swipe, as soon as the threshold was exceeded during the swipe. I also added a test case for this scenario. I introduced an additional enum value `NONE` for this case.

Closes #390 