### PR TITLE
fix(useAxios): export UseAxiosReturn type

### DIFF
--- a/packages/integrations/useAxios/index.ts
+++ b/packages/integrations/useAxios/index.ts
@@ -1,7 +1,7 @@
 import { Ref, ref } from 'vue-demi'
 import axios, { AxiosError, AxiosRequestConfig, AxiosResponse, CancelTokenSource, AxiosInstance } from 'axios'
 
-interface UseAxiosReturn<T> {
+export interface UseAxiosReturn<T> {
   response: Ref<AxiosResponse<T> | undefined>
   data: Ref<T | undefined>
   finished: Ref<boolean>


### PR DESCRIPTION
sometimes we need to extend or use this interface and in my opnion don't be bad if we export that.