### PR TITLE
feat(filters): use number/ref with debounce & throttle filters

### DIFF
--- a/packages/shared/debouncedWatch/index.ts
+++ b/packages/shared/debouncedWatch/index.ts
@@ -1,9 +1,9 @@
 import { WatchSource, WatchOptions, WatchStopHandle, WatchCallback } from 'vue-demi'
-import { debounceFilter, MapOldSources, MapSources } from '../utils'
+import { debounceFilter, MapOldSources, MapSources, MaybeRef } from '../utils'
 import { watchWithFilter } from '../watchWithFilter'
 
 export interface DebouncedWatchOptions<Immediate> extends WatchOptions<Immediate> {
-  debounce?: number
+  debounce?: MaybeRef<number>
 }
 
 // overlads

--- a/packages/shared/throttledWatch/index.ts
+++ b/packages/shared/throttledWatch/index.ts
@@ -1,9 +1,9 @@
 import { WatchSource, WatchOptions, WatchStopHandle, WatchCallback } from 'vue-demi'
-import { MapOldSources, MapSources, throttleFilter } from '../utils'
+import { MapOldSources, MapSources, throttleFilter, MaybeRef } from '../utils'
 import { watchWithFilter } from '../watchWithFilter'
 
 export interface ThrottledWatchOptions<Immediate> extends WatchOptions<Immediate> {
-  throttle?: number
+  throttle?: MaybeRef<number>
 }
 
 // overlads

--- a/packages/shared/useDebounceFn/index.ts
+++ b/packages/shared/useDebounceFn/index.ts
@@ -1,4 +1,4 @@
-import { createFilterWrapper, debounceFilter, FunctionArgs } from '../utils'
+import { createFilterWrapper, debounceFilter, FunctionArgs, MaybeRef } from '../utils'
 
 /**
  * Debounce execution of a function.
@@ -8,7 +8,7 @@ import { createFilterWrapper, debounceFilter, FunctionArgs } from '../utils'
  *
  * @return A new, debounce, function.
  */
-export function useDebounceFn<T extends FunctionArgs>(fn: T, ms = 200): T {
+export function useDebounceFn<T extends FunctionArgs>(fn: T, ms: MaybeRef<number> = 200): T {
   return createFilterWrapper(
     debounceFilter(ms),
     fn,

--- a/packages/shared/useThrottleFn/index.ts
+++ b/packages/shared/useThrottleFn/index.ts
@@ -1,4 +1,4 @@
-import { createFilterWrapper, FunctionArgs, throttleFilter } from '../utils'
+import { createFilterWrapper, FunctionArgs, throttleFilter, MaybeRef } from '../utils'
 
 /**
  * Throttle execution of a function. Especially useful for rate limiting
@@ -10,7 +10,7 @@ import { createFilterWrapper, FunctionArgs, throttleFilter } from '../utils'
  *
  * @return  A new, throttled, function.
  */
-export function useThrottleFn<T extends FunctionArgs>(fn: T, ms = 200, trailing = true): T {
+export function useThrottleFn<T extends FunctionArgs>(fn: T, ms: MaybeRef<number> = 200, trailing = true): T {
   return createFilterWrapper(
     throttleFilter(ms, trailing),
     fn,

--- a/packages/shared/utils/filters.ts
+++ b/packages/shared/utils/filters.ts
@@ -42,13 +42,15 @@ export function debounceFilter(ms: MaybeRef<number>) {
   let timer: ReturnType<typeof setTimeout> | undefined
 
   const filter: EventFilter = (invoke) => {
+    const duration = unref(ms)
+
     if (timer)
       clearTimeout(timer)
 
-    if (unref(ms) <= 0)
+    if (duration <= 0)
       return invoke()
 
-    timer = setTimeout(invoke, unref(ms))
+    timer = setTimeout(invoke, duration)
   }
 
   return filter
@@ -72,14 +74,17 @@ export function throttleFilter(ms: MaybeRef<number>, trailing = true) {
   }
 
   const filter: EventFilter = (invoke) => {
+    const duration = unref(ms)
     const elapsed = Date.now() - lastExec
 
     clear()
 
-    if (unref(ms) <= 0)
+    if (duration <= 0) {
+      lastExec = Date.now()
       return invoke()
+    }
 
-    if (elapsed > ms) {
+    if (elapsed > duration) {
       lastExec = Date.now()
       invoke()
     }
@@ -87,7 +92,7 @@ export function throttleFilter(ms: MaybeRef<number>, trailing = true) {
       timer = setTimeout(() => {
         clear()
         invoke()
-      }, unref(ms))
+      }, duration)
     }
   }
 

--- a/packages/shared/utils/filters.ts
+++ b/packages/shared/utils/filters.ts
@@ -39,12 +39,12 @@ export const bypassFilter: EventFilter = (invoke) => {
  * @param ms
  */
 export function debounceFilter(ms: MaybeRef<number>) {
-  if (unref(ms) <= 0)
-    return bypassFilter
-
   let timer: ReturnType<typeof setTimeout> | undefined
 
-  const filter: EventFilter = (invoke) => {
+  const filter: EventFilter = (invoke, args) => {
+    if (unref(ms) <= 0)
+      return bypassFilter(invoke, args)
+
     if (timer)
       clearTimeout(timer)
 
@@ -61,9 +61,6 @@ export function debounceFilter(ms: MaybeRef<number>) {
  * @param [trailing=true]
  */
 export function throttleFilter(ms: MaybeRef<number>, trailing = true) {
-  if (unref(ms) <= 0)
-    return bypassFilter
-
   let lastExec = 0
   let timer: ReturnType<typeof setTimeout> | undefined
 
@@ -74,10 +71,13 @@ export function throttleFilter(ms: MaybeRef<number>, trailing = true) {
     }
   }
 
-  const filter: EventFilter = (invoke) => {
+  const filter: EventFilter = (invoke, args) => {
     const elapsed = Date.now() - lastExec
 
     clear()
+
+    if (unref(ms) <= 0)
+      return bypassFilter(invoke, args)
 
     if (elapsed > ms) {
       lastExec = Date.now()

--- a/packages/shared/utils/filters.ts
+++ b/packages/shared/utils/filters.ts
@@ -1,5 +1,5 @@
-import { ref } from 'vue-demi'
-import { Fn, Pausable } from './types'
+import { ref, unref } from 'vue-demi'
+import { Fn, Pausable, MaybeRef } from './types'
 
 export type FunctionArgs<Args extends any[] = any[], Return = void> = (...args: Args) => Return
 
@@ -38,8 +38,8 @@ export const bypassFilter: EventFilter = (invoke) => {
  *
  * @param ms
  */
-export function debounceFilter(ms: number) {
-  if (ms <= 0)
+export function debounceFilter(ms: MaybeRef<number>) {
+  if (unref(ms) <= 0)
     return bypassFilter
 
   let timer: ReturnType<typeof setTimeout> | undefined
@@ -48,7 +48,7 @@ export function debounceFilter(ms: number) {
     if (timer)
       clearTimeout(timer)
 
-    timer = setTimeout(invoke, ms)
+    timer = setTimeout(invoke, unref(ms))
   }
 
   return filter
@@ -60,8 +60,8 @@ export function debounceFilter(ms: number) {
  * @param ms
  * @param [trailing=true]
  */
-export function throttleFilter(ms: number, trailing = true) {
-  if (ms <= 0)
+export function throttleFilter(ms: MaybeRef<number>, trailing = true) {
+  if (unref(ms) <= 0)
     return bypassFilter
 
   let lastExec = 0
@@ -87,7 +87,7 @@ export function throttleFilter(ms: number, trailing = true) {
       timer = setTimeout(() => {
         clear()
         invoke()
-      }, ms)
+      }, unref(ms))
     }
   }
 

--- a/packages/shared/utils/filters.ts
+++ b/packages/shared/utils/filters.ts
@@ -41,7 +41,7 @@ export const bypassFilter: EventFilter = (invoke) => {
 export function debounceFilter(ms: MaybeRef<number>) {
   let timer: ReturnType<typeof setTimeout> | undefined
 
-  const filter: EventFilter = (invoke, args) => {
+  const filter: EventFilter = (invoke) => {
     if (timer)
       clearTimeout(timer)
 

--- a/packages/shared/utils/filters.ts
+++ b/packages/shared/utils/filters.ts
@@ -42,11 +42,11 @@ export function debounceFilter(ms: MaybeRef<number>) {
   let timer: ReturnType<typeof setTimeout> | undefined
 
   const filter: EventFilter = (invoke, args) => {
-    if (unref(ms) <= 0)
-      return bypassFilter(invoke, args)
-
     if (timer)
       clearTimeout(timer)
+
+    if (unref(ms) <= 0)
+      return invoke()
 
     timer = setTimeout(invoke, unref(ms))
   }
@@ -71,13 +71,13 @@ export function throttleFilter(ms: MaybeRef<number>, trailing = true) {
     }
   }
 
-  const filter: EventFilter = (invoke, args) => {
+  const filter: EventFilter = (invoke) => {
     const elapsed = Date.now() - lastExec
 
     clear()
 
     if (unref(ms) <= 0)
-      return bypassFilter(invoke, args)
+      return invoke()
 
     if (elapsed > ms) {
       lastExec = Date.now()

--- a/packages/shared/utils/index.test.ts
+++ b/packages/shared/utils/index.test.ts
@@ -1,4 +1,5 @@
-import { increaseWithUnit } from '.'
+import { ref, nextTick } from 'vue-demi'
+import { increaseWithUnit, debounceFilter, throttleFilter, createFilterWrapper } from '.'
 
 describe('utils', () => {
   it('increaseWithUnit', () => {
@@ -10,5 +11,95 @@ describe('utils', () => {
     expect(increaseWithUnit('0.5vw', 1.5)).toEqual('2vw')
     expect(increaseWithUnit('100 %', 10)).toEqual('110 %')
     expect(increaseWithUnit('var(--cool)', -5)).toEqual('var(--cool)')
+  })
+})
+
+describe('filters', () => {
+  beforeEach(() => jest.useFakeTimers())
+  afterEach(() => jest.clearAllTimers())
+
+  it('should debounce', () => {
+    let called = 0
+    const filter = createFilterWrapper(debounceFilter(1000), () => called++)
+
+    setTimeout(filter, 200)
+    setTimeout(filter, 500)
+
+    jest.runAllTimers()
+
+    expect(called).toBe(1)
+  })
+
+  it('should debounce twice', () => {
+    let called = 0
+    const filter = createFilterWrapper(debounceFilter(500), () => called++)
+
+    setTimeout(filter, 500)
+    setTimeout(filter, 1000)
+
+    jest.runAllTimers()
+
+    expect(called).toBe(2)
+  })
+
+  it('should debounce with ref', () => {
+    const debounceTime = ref(0)
+
+    let called = 0
+    const filter = createFilterWrapper(debounceFilter(debounceTime), () => called++)
+
+    filter()
+    debounceTime.value = 500
+    filter()
+    setTimeout(filter, 200)
+
+    jest.runAllTimers()
+
+    expect(called).toBe(2)
+  })
+
+  it('should throttle', () => {
+    let called = 0
+    const filter = createFilterWrapper(throttleFilter(1000), () => called++)
+
+    setTimeout(filter, 500)
+    setTimeout(filter, 500)
+    setTimeout(filter, 500)
+    setTimeout(filter, 500)
+
+    jest.runAllTimers()
+
+    expect(called).toBe(2)
+  })
+
+  it('should throttle', () => {
+    let called = 0
+    const filter = createFilterWrapper(throttleFilter(1000), () => called++)
+
+    setTimeout(filter, 500)
+    setTimeout(filter, 500)
+    setTimeout(filter, 500)
+    setTimeout(filter, 500)
+
+    jest.runAllTimers()
+
+    expect(called).toBe(2)
+  })
+
+  it('should throttle with ref', async() => {
+    const throttle = ref(0)
+    let called = 0
+    const filter = createFilterWrapper(throttleFilter(throttle), () => called++)
+
+    filter()
+    throttle.value = 1000
+    await nextTick()
+    setTimeout(filter, 300)
+    setTimeout(filter, 600)
+    setTimeout(filter, 900)
+
+    jest.runAllTimers()
+
+    expect(called).toBe(2)
   })
 })


### PR DESCRIPTION
Adds option to use `Ref<number>` for debounce and throttle filter along with functions that wrap those filters. Would resolve #409 