### PR TITLE
fix(useDebounce): make return type readonly, close #407

### DIFF
--- a/packages/shared/useDebounce/index.ts
+++ b/packages/shared/useDebounce/index.ts
@@ -1,7 +1,7 @@
 import { ref, Ref, watch } from 'vue-demi'
 import { useDebounceFn } from '../useDebounceFn'
 
-export function useDebounce<T>(value: Ref<T>, ms = 200): Ref<T> {
+export function useDebounce<T>(value: Ref<T>, ms = 200): Readonly<Ref<T>> {
   if (ms <= 0)
     return value
 


### PR DESCRIPTION
This is to address the discussion in #407. From what I understand the goal was just to change the return type to a readonly, correct? Wasn't really clear if any of the other changes discussed in there should be implemented, if they should let me know

closes #407 