### PR TITLE
docs: fix missing ref from target

### DIFF
--- a/packages/core/useMouseInElement/index.md
+++ b/packages/core/useMouseInElement/index.md
@@ -21,9 +21,9 @@ import { useMouseInElement } from '@vueuse/core'
 
 export default {
   setup() {
-    const el = ref(null)
+    const target = ref(null)
 
-    const { x, y, isOutside } = useMouseInElement(el)
+    const { x, y, isOutside } = useMouseInElement(target)
 
     return { x, y, isOutside }
   }


### PR DESCRIPTION
Template used `ref="target"` but the setup function used `const el`.