### PR TITLE
docs: fix accessibility issues. Add serve docs command & theme color to head

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "clean": "rimraf dist types packages/*/dist",
     "dev": "nr docs",
     "docs": "vitepress dev packages",
+    "docs:serve": "vitepress serve packages",
     "docs:build": "nr update:full && vitepress build packages && nr build:redirects && esno scripts/post-docs.ts",
     "lint": "eslint './{packages,scripts,meta}/**/*.{js,ts,tsx,vue,md}'",
     "lint:fix": "nr lint --fix",

--- a/packages/.vitepress/config.js
+++ b/packages/.vitepress/config.js
@@ -21,6 +21,7 @@ const categoriesOrder = [
 const config = {
   title: 'VueUse',
   description: 'Collection of essential Vue Composition Utilities',
+  lang: 'en-US',
   themeConfig: {
     logo: '/favicon.svg',
     repo: 'vueuse/vueuse',
@@ -88,6 +89,7 @@ const config = {
     },
   },
   head: [
+    ['meta', { name: 'theme-color', content: '#ffffff' }],
     ['link', { rel: 'icon', href: '/favicon-32x32.png', type: 'image/png' }],
     ['link', { rel: 'icon', href: '/favicon.svg', type: 'image/svg+xml' }],
     ['meta', { name: 'author', content: 'Anthony Fu' }],

--- a/packages/.vitepress/theme/components/DarkModeSwitch.vue
+++ b/packages/.vitepress/theme/components/DarkModeSwitch.vue
@@ -1,5 +1,5 @@
 <template>
-  <button class="icon-button" @click="toggle">
+  <button aria-label="Toggle Theme" class="icon-button" @click="toggle">
     <carbon-moon v-show="isDark" />
     <carbon-sun v-show="!isDark" />
   </button>

--- a/packages/.vitepress/theme/components/NavBar.vue
+++ b/packages/.vitepress/theme/components/NavBar.vue
@@ -12,7 +12,7 @@
 
     <div class="nav-icons">
       <div v-if="repo" class="item">
-        <a class="icon-button" :href="repo.link" target="_blank" aria-label="View Github Repo">
+        <a class="icon-button" :href="repo.link" target="_blank" aria-label="View GitHub Repo">
           <carbon-logo-github />
         </a>
       </div>

--- a/packages/.vitepress/theme/components/NavBar.vue
+++ b/packages/.vitepress/theme/components/NavBar.vue
@@ -12,7 +12,7 @@
 
     <div class="nav-icons">
       <div v-if="repo" class="item">
-        <a class="icon-button" :href="repo.link" target="_blank">
+        <a class="icon-button" :href="repo.link" target="_blank" aria-label="View Github Repo">
           <carbon-logo-github />
         </a>
       </div>


### PR DESCRIPTION
This just fixes some accessibility issues and adds the theme colors to the head since lighthouse was warning about it.

Also noticed lighthouse complaining about the service worker
![image](https://user-images.githubusercontent.com/7064956/114112661-cf04e980-98aa-11eb-8689-d99870f3dc68.png)
![image](https://user-images.githubusercontent.com/7064956/114112697-e5ab4080-98aa-11eb-9b2f-af0e9a8eadbb.png)
