### PR TITLE
fix(useFirestore): optional Chaining on isDocumentReference

### DIFF
--- a/packages/firebase/useFirestore/index.ts
+++ b/packages/firebase/useFirestore/index.ts
@@ -27,7 +27,7 @@ function getData<T>(
 }
 
 function isDocumentReference<T>(docRef: any): docRef is firebase.firestore.DocumentReference<T> {
-  return (docRef.path.match(/\//g) || []).length % 2 !== 0
+  return (docRef.path?.match(/\//g) || []).length % 2 !== 0
 }
 
 export function useFirestore<T extends firebase.firestore.DocumentData> (


### PR DESCRIPTION
Fixes #447 