### PR TITLE
Update `useFetch` to allow more calls

### DIFF
--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -227,9 +227,13 @@ export function useFetch<T>(url: MaybeRef<string>, ...args: any[]): UseFetchRetu
       controller.abort()
   }
 
+  const loading = (isLoading: boolean) => {
+    isFetching.value = isLoading
+    isFinished.value = !isLoading
+  }
+
   const execute = async() => {
-    isFetching.value = true
-    isFinished.value = false
+    loading(true)
     error.value = null
     statusCode.value = null
     aborted.value = false
@@ -269,8 +273,10 @@ export function useFetch<T>(url: MaybeRef<string>, ...args: any[]): UseFetchRetu
     if (options.beforeFetch)
       Object.assign(context, await options.beforeFetch(context))
 
-    if (isCanceled || !fetch)
+    if (isCanceled || !fetch) {
+      loading(false)
       return Promise.resolve()
+    }
 
     return new Promise((resolve) => {
       fetch(
@@ -300,8 +306,7 @@ export function useFetch<T>(url: MaybeRef<string>, ...args: any[]): UseFetchRetu
           error.value = fetchError.message || fetchError.name
         })
         .finally(() => {
-          isFinished.value = true
-          isFetching.value = false
+          loading(false)
         })
     })
   }

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -57,21 +57,19 @@ interface UseFetchReturnBase<T> {
 type DataType = 'text' | 'json' | 'blob' | 'arrayBuffer' | 'formData'
 type PayloadType = 'text' | 'json' | 'formData'
 
-interface UseFetchReturnMethodConfigured<T> extends UseFetchReturnBase<T> {
+export interface UseFetchReturn<T> extends UseFetchReturnBase<T> {
   // type
-  json<JSON = any>(): UseFetchReturnBase<JSON>
-  text(): UseFetchReturnBase<string>
-  blob(): UseFetchReturnBase<Blob>
-  arrayBuffer(): UseFetchReturnBase<ArrayBuffer>
-  formData(): UseFetchReturnBase<FormData>
-}
+  json<JSON = any>(): UseFetchReturn<JSON>
+  text(): UseFetchReturn<string>
+  blob(): UseFetchReturn<Blob>
+  arrayBuffer(): UseFetchReturn<ArrayBuffer>
+  formData(): UseFetchReturn<FormData>
 
-export interface UseFetchReturn<T> extends UseFetchReturnMethodConfigured<T> {
   // methods
-  get(): UseFetchReturnMethodConfigured<T>
-  post(payload?: unknown, type?: PayloadType): UseFetchReturnMethodConfigured<T>
-  put(payload?: unknown, type?: PayloadType): UseFetchReturnMethodConfigured<T>
-  delete(payload?: unknown, type?: PayloadType): UseFetchReturnMethodConfigured<T>
+  get(): UseFetchReturn<T>
+  post(payload?: unknown, type?: PayloadType): UseFetchReturn<T>
+  put(payload?: unknown, type?: PayloadType): UseFetchReturn<T>
+  delete(payload?: unknown, type?: PayloadType): UseFetchReturn<T>
 }
 
 export interface BeforeFetchContext {
@@ -195,7 +193,6 @@ export function useFetch<T>(url: MaybeRef<string>, ...args: any[]): UseFetchRetu
     payload: undefined as unknown,
     payloadType: 'json' as PayloadType,
   }
-  let initialized = false
 
   if (args.length > 0) {
     if (isFetchOptions(args[0]))
@@ -231,7 +228,6 @@ export function useFetch<T>(url: MaybeRef<string>, ...args: any[]): UseFetchRetu
   }
 
   const execute = async() => {
-    initialized = true
     isFetching.value = true
     isFinished.value = false
     error.value = null
@@ -349,7 +345,7 @@ export function useFetch<T>(url: MaybeRef<string>, ...args: any[]): UseFetchRetu
 
   function setMethod(method: string) {
     return (payload?: unknown, payloadType?: PayloadType) => {
-      if (!initialized) {
+      if (!isFetching.value) {
         config.method = method
         config.payload = payload
         config.payloadType = payloadType || typeof payload === 'string' ? 'text' : 'json'
@@ -361,9 +357,9 @@ export function useFetch<T>(url: MaybeRef<string>, ...args: any[]): UseFetchRetu
 
   function setType(type: DataType) {
     return () => {
-      if (!initialized) {
+      if (!isFetching.value) {
         config.type = type
-        return base as any
+        return shell as any
       }
       return undefined
     }


### PR DESCRIPTION
fixes #442 

Now there is only one interface `UseFetchReturn` that is returned, when you call `useFetch` the first time, set the method or update the type. Of course you cannot change the method or the type while it's making a request.

In addition this fixes (unless it was intended) the loading state when the request is cancelled in `beforeFetch` .

I didn't touch the tests nor the docs. before let me know what you think about this approach.