### PR TITLE
docs: replaced `@link` to `@see` in jsdoc

### DIFF
--- a/packages/core/asyncComputed/index.md
+++ b/packages/core/asyncComputed/index.md
@@ -107,7 +107,7 @@ export declare type AsyncComputedOptions = {
 /**
  * Create an asynchronous computed dependency.
  *
- * @link https://vueuse.org/asyncComputed
+ * @see https://vueuse.org/asyncComputed
  * @param evaluationCallback     The promise-returning callback which generates the computed value
  * @param initialState           The initial state, used until the first evaluation finishes
  * @param optionsOrRef           Additional options or a ref passed to receive the updates of the async evaluation

--- a/packages/core/asyncComputed/index.ts
+++ b/packages/core/asyncComputed/index.ts
@@ -22,7 +22,7 @@ export type AsyncComputedOptions = {
 /**
  * Create an asynchronous computed dependency.
  *
- * @link https://vueuse.org/asyncComputed
+ * @see https://vueuse.org/asyncComputed
  * @param evaluationCallback     The promise-returning callback which generates the computed value
  * @param initialState           The initial state, used until the first evaluation finishes
  * @param optionsOrRef           Additional options or a ref passed to receive the updates of the async evaluation

--- a/packages/core/autoResetRef/index.md
+++ b/packages/core/autoResetRef/index.md
@@ -27,7 +27,7 @@ const setMessage = () => {
 /**
  * Create a ref which will be reset to the default value after some time.
  *
- * @link https://vueuse.org/autoResetRef
+ * @see https://vueuse.org/autoResetRef
  * @param defaultValue The value which will be set.
  * @param afterMs      A zero-or-greater delay in milliseconds.
  */

--- a/packages/core/autoResetRef/index.ts
+++ b/packages/core/autoResetRef/index.ts
@@ -4,7 +4,7 @@ import { MaybeRef } from '@vueuse/shared'
 /**
  * Create a ref which will be reset to the default value after some time.
  *
- * @link https://vueuse.org/autoResetRef
+ * @see https://vueuse.org/autoResetRef
  * @param defaultValue The value which will be set.
  * @param afterMs      A zero-or-greater delay in milliseconds.
  */

--- a/packages/core/createGlobalState/index.md
+++ b/packages/core/createGlobalState/index.md
@@ -37,7 +37,7 @@ export default defineComponent({
 /**
  * Keep states in the global scope to be reusable across Vue instances.
  *
- * @link https://vueuse.org/createGlobalState
+ * @see https://vueuse.org/createGlobalState
  * @param stateFactory A factory function to create the state
  */
 export declare function createGlobalState<T extends object>(

--- a/packages/core/createGlobalState/index.ts
+++ b/packages/core/createGlobalState/index.ts
@@ -25,7 +25,7 @@ function withScope<T extends object>(factory: () => T): T {
 /**
  * Keep states in the global scope to be reusable across Vue instances.
  *
- * @link https://vueuse.org/createGlobalState
+ * @see https://vueuse.org/createGlobalState
  * @param stateFactory A factory function to create the state
  */
 export function createGlobalState<T extends object>(

--- a/packages/core/onClickOutside/index.md
+++ b/packages/core/onClickOutside/index.md
@@ -44,7 +44,7 @@ declare type EventType = WindowEventMap[typeof events[number]]
 /**
  * Listen for clicks outside of an element.
  *
- * @link https://vueuse.org/onClickOutside
+ * @see https://vueuse.org/onClickOutside
  * @param target
  * @param handler
  * @param options

--- a/packages/core/onClickOutside/index.ts
+++ b/packages/core/onClickOutside/index.ts
@@ -9,7 +9,7 @@ type EventType = WindowEventMap[(typeof events)[number]]
 /**
  * Listen for clicks outside of an element.
  *
- * @link https://vueuse.org/onClickOutside
+ * @see https://vueuse.org/onClickOutside
  * @param target
  * @param handler
  * @param options

--- a/packages/core/onKeyStroke/index.md
+++ b/packages/core/onKeyStroke/index.md
@@ -62,7 +62,7 @@ export declare type KeyStrokeOptions = {
 /**
  * Listen for keyboard keys being stroked.
  *
- * @link https://vueuse.org/onKeyStroke
+ * @see https://vueuse.org/onKeyStroke
  * @param key
  * @param handler
  * @param options
@@ -75,7 +75,7 @@ export declare function onKeyStroke(
 /**
  * Listen to the keydown event of the given key.
  *
- * @link https://vueuse.org/onKeyStroke
+ * @see https://vueuse.org/onKeyStroke
  * @param key
  * @param handler
  * @param options
@@ -88,7 +88,7 @@ export declare function onKeyDown(
 /**
  * Listen to the keypress event of the given key.
  *
- * @link https://vueuse.org/onKeyStroke
+ * @see https://vueuse.org/onKeyStroke
  * @param key
  * @param handler
  * @param options
@@ -101,7 +101,7 @@ export declare function onKeyPressed(
 /**
  * Listen to the keyup event of the given key.
  *
- * @link https://vueuse.org/onKeyStroke
+ * @see https://vueuse.org/onKeyStroke
  * @param key
  * @param handler
  * @param options

--- a/packages/core/onKeyStroke/index.ts
+++ b/packages/core/onKeyStroke/index.ts
@@ -23,7 +23,7 @@ const createKeyPredicate = (keyFilter: KeyFilter): KeyPredicate =>
 /**
  * Listen for keyboard keys being stroked.
  *
- * @link https://vueuse.org/onKeyStroke
+ * @see https://vueuse.org/onKeyStroke
  * @param key
  * @param handler
  * @param options
@@ -42,7 +42,7 @@ export function onKeyStroke(key: KeyFilter, handler: (event: KeyboardEvent) => v
 /**
  * Listen to the keydown event of the given key.
  *
- * @link https://vueuse.org/onKeyStroke
+ * @see https://vueuse.org/onKeyStroke
  * @param key
  * @param handler
  * @param options
@@ -54,7 +54,7 @@ export function onKeyDown(key: KeyFilter, handler: (event: KeyboardEvent) => voi
 /**
  * Listen to the keypress event of the given key.
  *
- * @link https://vueuse.org/onKeyStroke
+ * @see https://vueuse.org/onKeyStroke
  * @param key
  * @param handler
  * @param options
@@ -66,7 +66,7 @@ export function onKeyPressed(key: KeyFilter, handler: (event: KeyboardEvent) => 
 /**
  * Listen to the keyup event of the given key.
  *
- * @link https://vueuse.org/onKeyStroke
+ * @see https://vueuse.org/onKeyStroke
  * @param key
  * @param handler
  * @param options

--- a/packages/core/onStartTyping/index.md
+++ b/packages/core/onStartTyping/index.md
@@ -39,7 +39,7 @@ export default {
 /**
  * Fires when users start typing on non-editable elements.
  *
- * @link https://vueuse.org/onStartTyping
+ * @see https://vueuse.org/onStartTyping
  * @param callback
  * @param options
  */

--- a/packages/core/onStartTyping/index.ts
+++ b/packages/core/onStartTyping/index.ts
@@ -47,7 +47,7 @@ const isTypedCharValid = ({
 /**
  * Fires when users start typing on non-editable elements.
  *
- * @link https://vueuse.org/onStartTyping
+ * @see https://vueuse.org/onStartTyping
  * @param callback
  * @param options
  */

--- a/packages/core/templateRef/index.md
+++ b/packages/core/templateRef/index.md
@@ -64,7 +64,7 @@ const target = ref<HTMLElement | null>(null)
 /**
  * Shorthand for binding ref to template element.
  *
- * @link https://vueuse.org/templateRef
+ * @see https://vueuse.org/templateRef
  * @param key
  * @param initialValue
  */

--- a/packages/core/templateRef/index.ts
+++ b/packages/core/templateRef/index.ts
@@ -3,7 +3,7 @@ import { getCurrentInstance, onMounted, onUpdated, customRef, Ref } from 'vue-de
 /**
  * Shorthand for binding ref to template element.
  *
- * @link https://vueuse.org/templateRef
+ * @see https://vueuse.org/templateRef
  * @param key
  * @param initialValue
  */

--- a/packages/core/toRefs/index.md
+++ b/packages/core/toRefs/index.md
@@ -60,7 +60,7 @@ export default {
 /**
  * Extended `toRefs` that also accepts refs of an object.
  *
- * @link https://vueuse.org/toRefs
+ * @see https://vueuse.org/toRefs
  * @param objectRef A ref or normal object or array.
  */
 export declare function toRefs<T extends object>(

--- a/packages/core/toRefs/index.ts
+++ b/packages/core/toRefs/index.ts
@@ -4,7 +4,7 @@ import { MaybeRef } from '@vueuse/shared'
 /**
  * Extended `toRefs` that also accepts refs of an object.
  *
- * @link https://vueuse.org/toRefs
+ * @see https://vueuse.org/toRefs
  * @param objectRef A ref or normal object or array.
  */
 export function toRefs<T extends object>(

--- a/packages/core/useActiveElement/index.md
+++ b/packages/core/useActiveElement/index.md
@@ -25,7 +25,7 @@ watch(activeElement, (el) => {
 /**
  * Reactive `document.activeElement`
  *
- * @link https://vueuse.org/useActiveElement
+ * @see https://vueuse.org/useActiveElement
  * @param options
  */
 export declare function useActiveElement<T extends HTMLElement>(

--- a/packages/core/useActiveElement/index.ts
+++ b/packages/core/useActiveElement/index.ts
@@ -5,7 +5,7 @@ import { ConfigurableWindow, defaultWindow } from '../_configurable'
 /**
  * Reactive `document.activeElement`
  *
- * @link https://vueuse.org/useActiveElement
+ * @see https://vueuse.org/useActiveElement
  * @param options
  */
 export function useActiveElement<T extends HTMLElement>(options: ConfigurableWindow = {}) {

--- a/packages/core/useAsyncState/index.md
+++ b/packages/core/useAsyncState/index.md
@@ -50,7 +50,7 @@ export interface AsyncStateOptions {
  * Reactive async state. Will not block your setup function and will triggers changes once
  * the promise is ready.
  *
- * @link https://vueuse.org/useAsyncState
+ * @see https://vueuse.org/useAsyncState
  * @param promise         The promise / async function to be resolved
  * @param initialState    The initial state, used until the first evaluation finishes
  * @param options

--- a/packages/core/useAsyncState/index.ts
+++ b/packages/core/useAsyncState/index.ts
@@ -29,7 +29,7 @@ export interface AsyncStateOptions {
  * Reactive async state. Will not block your setup function and will triggers changes once
  * the promise is ready.
  *
- * @link https://vueuse.org/useAsyncState
+ * @see https://vueuse.org/useAsyncState
  * @param promise         The promise / async function to be resolved
  * @param initialState    The initial state, used until the first evaluation finishes
  * @param options

--- a/packages/core/useBattery/index.md
+++ b/packages/core/useBattery/index.md
@@ -44,7 +44,7 @@ export interface BatteryManager extends EventTarget {
 /**
  * Reactive Battery Status API.
  *
- * @link https://vueuse.org/useBattery
+ * @see https://vueuse.org/useBattery
  * @param options
  */
 export declare function useBattery({

--- a/packages/core/useBattery/index.ts
+++ b/packages/core/useBattery/index.ts
@@ -18,7 +18,7 @@ type NavigatorWithBattery = Navigator & {
 /**
  * Reactive Battery Status API.
  *
- * @link https://vueuse.org/useBattery
+ * @see https://vueuse.org/useBattery
  * @param options
  */
 export function useBattery({ navigator = defaultNavigator }: ConfigurableNavigator = {}) {

--- a/packages/core/useBreakpoints/breakpoints.ts
+++ b/packages/core/useBreakpoints/breakpoints.ts
@@ -1,7 +1,7 @@
 /**
  * Breakpoints from Tailwind V2
  *
- * @link https://tailwindcss.com/docs/breakpoints
+ * @see https://tailwindcss.com/docs/breakpoints
  */
 export const breakpointsTailwind = {
   'sm': 640,
@@ -14,7 +14,7 @@ export const breakpointsTailwind = {
 /**
  * Breakpoints from Bootstrap V5
  *
- * @link https://getbootstrap.com/docs/5.0/layout/breakpoints
+ * @see https://getbootstrap.com/docs/5.0/layout/breakpoints
  */
 export const breakpointsBootstrapV5 = {
   sm: 576,
@@ -27,7 +27,7 @@ export const breakpointsBootstrapV5 = {
 /**
  * Breakpoints from Vuetify V2
  *
- * @link https://vuetifyjs.com/en/features/breakpoints
+ * @see https://vuetifyjs.com/en/features/breakpoints
  */
 export const breakpointsVuetify = {
   xs: 600,
@@ -39,7 +39,7 @@ export const breakpointsVuetify = {
 /**
  * Breakpoints from Ant Design
  *
- * @link https://ant.design/components/layout/#breakpoint-width
+ * @see https://ant.design/components/layout/#breakpoint-width
  */
 export const breakpointsAntDesign = {
   xs: 480,

--- a/packages/core/useBreakpoints/index.md
+++ b/packages/core/useBreakpoints/index.md
@@ -41,7 +41,7 @@ export declare type Breakpoints<K extends string = string> = Record<
 /**
  * Reactively viewport breakpoints
  *
- * @link https://vueuse.org/useBreakpoints
+ * @see https://vueuse.org/useBreakpoints
  * @param options
  */
 export declare function useBreakpoints<K extends string>(

--- a/packages/core/useBreakpoints/index.ts
+++ b/packages/core/useBreakpoints/index.ts
@@ -8,7 +8,7 @@ export type Breakpoints<K extends string = string> = Record<K, number | string>
 /**
  * Reactively viewport breakpoints
  *
- * @link https://vueuse.org/useBreakpoints
+ * @see https://vueuse.org/useBreakpoints
  * @param options
  */
 export function useBreakpoints<K extends string>(breakpoints: Breakpoints<K>, options: ConfigurableWindow = {}) {

--- a/packages/core/useBrowserLocation/index.md
+++ b/packages/core/useBrowserLocation/index.md
@@ -36,7 +36,7 @@ export interface BrowserLocationState {
 /**
  * Reactive browser location.
  *
- * @link https://vueuse.org/useBrowserLocation
+ * @see https://vueuse.org/useBrowserLocation
  * @param options
  */
 export declare function useBrowserLocation({

--- a/packages/core/useBrowserLocation/index.ts
+++ b/packages/core/useBrowserLocation/index.ts
@@ -22,7 +22,7 @@ export interface BrowserLocationState {
 /**
  * Reactive browser location.
  *
- * @link https://vueuse.org/useBrowserLocation
+ * @see https://vueuse.org/useBrowserLocation
  * @param options
  */
 export function useBrowserLocation({ window = defaultWindow }: ConfigurableWindow = {}) {

--- a/packages/core/useClipboard/index.md
+++ b/packages/core/useClipboard/index.md
@@ -56,7 +56,7 @@ export interface ClipboardReturn<Optional> {
 /**
  * Reactive Clipboard API.
  *
- * @link https://vueuse.org/useClipboard
+ * @see https://vueuse.org/useClipboard
  * @param options
  */
 export declare function useClipboard(

--- a/packages/core/useClipboard/index.ts
+++ b/packages/core/useClipboard/index.ts
@@ -36,7 +36,7 @@ export interface ClipboardReturn<Optional> {
 /**
  * Reactive Clipboard API.
  *
- * @link https://vueuse.org/useClipboard
+ * @see https://vueuse.org/useClipboard
  * @param options
  */
 export function useClipboard(options?: ClipboardOptions<undefined>): ClipboardReturn<false>

--- a/packages/core/useCssVar/index.md
+++ b/packages/core/useCssVar/index.md
@@ -23,7 +23,7 @@ const color = useCssVar('--color', el)
 /**
  * Manipulate CSS variables.
  *
- * @link https://vueuse.org/useCssVar
+ * @see https://vueuse.org/useCssVar
  * @param prop
  * @param el
  * @param options

--- a/packages/core/useCssVar/index.ts
+++ b/packages/core/useCssVar/index.ts
@@ -5,7 +5,7 @@ import { MaybeElementRef, unrefElement } from '../unrefElement'
 /**
  * Manipulate CSS variables.
  *
- * @link https://vueuse.org/useCssVar
+ * @see https://vueuse.org/useCssVar
  * @param prop
  * @param el
  * @param options

--- a/packages/core/useDark/index.md
+++ b/packages/core/useDark/index.md
@@ -126,7 +126,7 @@ export declare type ColorSchemes = "light" | "dark" | "auto"
 /**
  * Reactive dark mode with auto data persistence.
  *
- * @link https://vueuse.org/useDark
+ * @see https://vueuse.org/useDark
  * @param options
  */
 export declare function useDark(

--- a/packages/core/useDark/index.ts
+++ b/packages/core/useDark/index.ts
@@ -63,7 +63,7 @@ export type ColorSchemes = 'light' | 'dark' | 'auto'
 /**
  * Reactive dark mode with auto data persistence.
  *
- * @link https://vueuse.org/useDark
+ * @see https://vueuse.org/useDark
  * @param options
  */
 export function useDark(options: UseDarkOptions = {}) {

--- a/packages/core/useDeviceLight/index.md
+++ b/packages/core/useDeviceLight/index.md
@@ -26,7 +26,7 @@ const light = useDeviceLight()
 /**
  * Reactive DeviceLightEvent.
  *
- * @link https://vueuse.org/useDeviceLight
+ * @see https://vueuse.org/useDeviceLight
  * @param options
  */
 export declare function useDeviceLight({

--- a/packages/core/useDeviceLight/index.ts
+++ b/packages/core/useDeviceLight/index.ts
@@ -7,7 +7,7 @@ import { ConfigurableWindow, defaultWindow } from '../_configurable'
 /**
  * Reactive DeviceLightEvent.
  *
- * @link https://vueuse.org/useDeviceLight
+ * @see https://vueuse.org/useDeviceLight
  * @param options
  */
 export function useDeviceLight({ window = defaultWindow }: ConfigurableWindow = {}) {

--- a/packages/core/useDeviceMotion/index.md
+++ b/packages/core/useDeviceMotion/index.md
@@ -39,7 +39,7 @@ interface DeviceMotionOptions
 /**
  * Reactive DeviceMotionEvent.
  *
- * @link https://vueuse.org/useDeviceMotion
+ * @see https://vueuse.org/useDeviceMotion
  * @param options
  */
 export declare function useDeviceMotion(

--- a/packages/core/useDeviceMotion/index.ts
+++ b/packages/core/useDeviceMotion/index.ts
@@ -10,7 +10,7 @@ interface DeviceMotionOptions extends ConfigurableWindow, ConfigurableEventFilte
 /**
  * Reactive DeviceMotionEvent.
  *
- * @link https://vueuse.org/useDeviceMotion
+ * @see https://vueuse.org/useDeviceMotion
  * @param options
  */
 export function useDeviceMotion(options: DeviceMotionOptions = {}) {

--- a/packages/core/useDeviceOrientation/index.md
+++ b/packages/core/useDeviceOrientation/index.md
@@ -36,7 +36,7 @@ You can find [more information about the state on the MDN](https://developer.moz
 /**
  * Reactive DeviceOrientationEvent.
  *
- * @link https://vueuse.org/useDeviceOrientation
+ * @see https://vueuse.org/useDeviceOrientation
  * @param options
  */
 export declare function useDeviceOrientation(

--- a/packages/core/useDeviceOrientation/index.ts
+++ b/packages/core/useDeviceOrientation/index.ts
@@ -7,7 +7,7 @@ import { ConfigurableWindow, defaultWindow } from '../_configurable'
 /**
  * Reactive DeviceOrientationEvent.
  *
- * @link https://vueuse.org/useDeviceOrientation
+ * @see https://vueuse.org/useDeviceOrientation
  * @param options
  */
 export function useDeviceOrientation(options: ConfigurableWindow = {}) {

--- a/packages/core/useDevicePixelRatio/index.md
+++ b/packages/core/useDevicePixelRatio/index.md
@@ -30,7 +30,7 @@ export default {
 /**
  * Reactively track `window.devicePixelRatio`.
  *
- * @link https://vueuse.org/useDevicePixelRatio
+ * @see https://vueuse.org/useDevicePixelRatio
  * @param options
  */
 export declare function useDevicePixelRatio({

--- a/packages/core/useDevicePixelRatio/index.ts
+++ b/packages/core/useDevicePixelRatio/index.ts
@@ -21,7 +21,7 @@ const DEVICE_PIXEL_RATIO_SCALES = [
 /**
  * Reactively track `window.devicePixelRatio`.
  *
- * @link https://vueuse.org/useDevicePixelRatio
+ * @see https://vueuse.org/useDevicePixelRatio
  * @param options
  */
 export function useDevicePixelRatio({

--- a/packages/core/useDevicesList/index.md
+++ b/packages/core/useDevicesList/index.md
@@ -48,7 +48,7 @@ export interface UseDevicesListReturn {
 /**
  * Reactive `enumerateDevices` listing avaliable input/output devices
  *
- * @link https://vueuse.org/useDevicesList
+ * @see https://vueuse.org/useDevicesList
  * @param options
  */
 export declare function useDevicesList(

--- a/packages/core/useDevicesList/index.ts
+++ b/packages/core/useDevicesList/index.ts
@@ -32,7 +32,7 @@ export interface UseDevicesListReturn {
 /**
  * Reactive `enumerateDevices` listing avaliable input/output devices
  *
- * @link https://vueuse.org/useDevicesList
+ * @see https://vueuse.org/useDevicesList
  * @param options
  */
 export function useDevicesList(options: UseDevicesListOptions = {}): UseDevicesListReturn {

--- a/packages/core/useDocumentVisibility/index.md
+++ b/packages/core/useDocumentVisibility/index.md
@@ -22,7 +22,7 @@ const visibility = useDocumentVisibility()
 /**
  * Reactively track `document.visibilityState`.
  *
- * @link https://vueuse.org/useDocumentVisibility
+ * @see https://vueuse.org/useDocumentVisibility
  * @param options
  */
 export declare function useDocumentVisibility({

--- a/packages/core/useDocumentVisibility/index.ts
+++ b/packages/core/useDocumentVisibility/index.ts
@@ -5,7 +5,7 @@ import { ConfigurableDocument, defaultDocument } from '../_configurable'
 /**
  * Reactively track `document.visibilityState`.
  *
- * @link https://vueuse.org/useDocumentVisibility
+ * @see https://vueuse.org/useDocumentVisibility
  * @param options
  */
 export function useDocumentVisibility({ document = defaultDocument }: ConfigurableDocument = {}): Ref<VisibilityState> {

--- a/packages/core/useElementBounding/index.md
+++ b/packages/core/useElementBounding/index.md
@@ -39,7 +39,7 @@ export default {
 /**
  * Reactive size of an HTML element.
  *
- * @link https://vueuse.org/useElementSize
+ * @see https://vueuse.org/useElementSize
  * @param target
  * @param callback
  * @param options

--- a/packages/core/useElementBounding/index.ts
+++ b/packages/core/useElementBounding/index.ts
@@ -5,7 +5,7 @@ import { ResizeObserverOptions, useResizeObserver } from '../useResizeObserver'
 /**
  * Reactive size of an HTML element.
  *
- * @link https://vueuse.org/useElementSize
+ * @see https://vueuse.org/useElementSize
  * @param target
  * @param callback
  * @param options

--- a/packages/core/useElementSize/index.md
+++ b/packages/core/useElementSize/index.md
@@ -49,7 +49,7 @@ export interface ElementSize {
 /**
  * Reactive size of an HTML element.
  *
- * @link https://vueuse.org/useElementSize
+ * @see https://vueuse.org/useElementSize
  * @param target
  * @param callback
  * @param options

--- a/packages/core/useElementSize/index.ts
+++ b/packages/core/useElementSize/index.ts
@@ -10,7 +10,7 @@ export interface ElementSize {
 /**
  * Reactive size of an HTML element.
  *
- * @link https://vueuse.org/useElementSize
+ * @see https://vueuse.org/useElementSize
  * @param target
  * @param callback
  * @param options

--- a/packages/core/useElementVisibility/index.md
+++ b/packages/core/useElementVisibility/index.md
@@ -44,7 +44,7 @@ export interface VisibilityScrollTargetOptions extends ConfigurableWindow {
 /**
  * Tracks the visibility of an element within the viewport.
  *
- * @link https://vueuse.org/useElementVisibility
+ * @see https://vueuse.org/useElementVisibility
  * @param element
  * @param options
  */

--- a/packages/core/useElementVisibility/index.ts
+++ b/packages/core/useElementVisibility/index.ts
@@ -10,7 +10,7 @@ export interface VisibilityScrollTargetOptions extends ConfigurableWindow {
 /**
  * Tracks the visibility of an element within the viewport.
  *
- * @link https://vueuse.org/useElementVisibility
+ * @see https://vueuse.org/useElementVisibility
  * @param element
  * @param options
  */

--- a/packages/core/useEventListener/index.md
+++ b/packages/core/useEventListener/index.md
@@ -39,7 +39,7 @@ export declare type GeneralEventListener<E = Event> = {
  *
  * Overload 1: Omitted Window target
  *
- * @link https://vueuse.org/useEventListener
+ * @see https://vueuse.org/useEventListener
  * @param event
  * @param listener
  * @param options
@@ -54,7 +54,7 @@ export declare function useEventListener<E extends keyof WindowEventMap>(
  *
  * Overload 2: Explicitly Window target
  *
- * @link https://vueuse.org/useEventListener
+ * @see https://vueuse.org/useEventListener
  * @param target
  * @param event
  * @param listener
@@ -71,7 +71,7 @@ export declare function useEventListener<E extends keyof WindowEventMap>(
  *
  * Overload 3: Explicitly Document target
  *
- * @link https://vueuse.org/useEventListener
+ * @see https://vueuse.org/useEventListener
  * @param target
  * @param event
  * @param listener
@@ -88,7 +88,7 @@ export declare function useEventListener<E extends keyof DocumentEventMap>(
  *
  * Overload 4: Custom event target with event type infer
  *
- * @link https://vueuse.org/useEventListener
+ * @see https://vueuse.org/useEventListener
  * @param target
  * @param event
  * @param listener
@@ -108,7 +108,7 @@ export declare function useEventListener<
  *
  * Overload 5: Custom event target fallback
  *
- * @link https://vueuse.org/useEventListener
+ * @see https://vueuse.org/useEventListener
  * @param target
  * @param event
  * @param listener

--- a/packages/core/useEventListener/index.ts
+++ b/packages/core/useEventListener/index.ts
@@ -19,7 +19,7 @@ export type GeneralEventListener<E = Event> = {
  *
  * Overload 1: Omitted Window target
  *
- * @link https://vueuse.org/useEventListener
+ * @see https://vueuse.org/useEventListener
  * @param event
  * @param listener
  * @param options
@@ -31,7 +31,7 @@ export function useEventListener<E extends keyof WindowEventMap>(event: E, liste
  *
  * Overload 2: Explicitly Window target
  *
- * @link https://vueuse.org/useEventListener
+ * @see https://vueuse.org/useEventListener
  * @param target
  * @param event
  * @param listener
@@ -44,7 +44,7 @@ export function useEventListener<E extends keyof WindowEventMap>(target: Window,
  *
  * Overload 3: Explicitly Document target
  *
- * @link https://vueuse.org/useEventListener
+ * @see https://vueuse.org/useEventListener
  * @param target
  * @param event
  * @param listener
@@ -57,7 +57,7 @@ export function useEventListener<E extends keyof DocumentEventMap>(target: Docum
  *
  * Overload 4: Custom event target with event type infer
  *
- * @link https://vueuse.org/useEventListener
+ * @see https://vueuse.org/useEventListener
  * @param target
  * @param event
  * @param listener
@@ -70,7 +70,7 @@ export function useEventListener<Names extends string, EventType = Event>(target
  *
  * Overload 5: Custom event target fallback
  *
- * @link https://vueuse.org/useEventListener
+ * @see https://vueuse.org/useEventListener
  * @param target
  * @param event
  * @param listener

--- a/packages/core/useEventSource/index.md
+++ b/packages/core/useEventSource/index.md
@@ -33,7 +33,7 @@ const { status, data, error, close } = useEventSource('https://event-source-url'
  * Reactive wrapper for EventSource.
  *
  * @see https://vueuse.org/useEventSource
- * @link https://developer.mozilla.org/en-US/docs/Web/API/EventSource/EventSource|EventSource
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/EventSource/EventSource EventSource
  * @param url
  * @param events
  */

--- a/packages/core/useEventSource/index.md
+++ b/packages/core/useEventSource/index.md
@@ -32,7 +32,7 @@ const { status, data, error, close } = useEventSource('https://event-source-url'
 /**
  * Reactive wrapper for EventSource.
  *
- * @link https://vueuse.org/useEventSource
+ * @see https://vueuse.org/useEventSource
  * @link https://developer.mozilla.org/en-US/docs/Web/API/EventSource/EventSource|EventSource
  * @param url
  * @param events

--- a/packages/core/useEventSource/index.ts
+++ b/packages/core/useEventSource/index.ts
@@ -5,7 +5,7 @@ import { tryOnMounted, tryOnUnmounted } from '@vueuse/shared'
 /**
  * Reactive wrapper for EventSource.
  *
- * @link https://vueuse.org/useEventSource
+ * @see https://vueuse.org/useEventSource
  * @link https://developer.mozilla.org/en-US/docs/Web/API/EventSource/EventSource|EventSource
  * @param url
  * @param events

--- a/packages/core/useEventSource/index.ts
+++ b/packages/core/useEventSource/index.ts
@@ -6,7 +6,7 @@ import { tryOnMounted, tryOnUnmounted } from '@vueuse/shared'
  * Reactive wrapper for EventSource.
  *
  * @see https://vueuse.org/useEventSource
- * @link https://developer.mozilla.org/en-US/docs/Web/API/EventSource/EventSource|EventSource
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/EventSource/EventSource EventSource
  * @param url
  * @param events
  */

--- a/packages/core/useFavicon/index.md
+++ b/packages/core/useFavicon/index.md
@@ -52,7 +52,7 @@ export interface FaviconOptions extends ConfigurableDocument {
 /**
  * Reactive favicon.
  *
- * @link https://vueuse.org/useFavicon
+ * @see https://vueuse.org/useFavicon
  * @param newIcon
  * @param options
  */

--- a/packages/core/useFavicon/index.ts
+++ b/packages/core/useFavicon/index.ts
@@ -10,7 +10,7 @@ export interface FaviconOptions extends ConfigurableDocument {
 /**
  * Reactive favicon.
  *
- * @link https://vueuse.org/useFavicon
+ * @see https://vueuse.org/useFavicon
  * @param newIcon
  * @param options
  */

--- a/packages/core/useFullscreen/index.md
+++ b/packages/core/useFullscreen/index.md
@@ -34,7 +34,7 @@ const { isFullscreen, enter, exit, toggle } = useFullscreen(el)
 /**
  * Reactive Fullscreen API.
  *
- * @link https://vueuse.org/useFullscreen
+ * @see https://vueuse.org/useFullscreen
  * @param target
  * @param options
  */

--- a/packages/core/useFullscreen/index.ts
+++ b/packages/core/useFullscreen/index.ts
@@ -63,7 +63,7 @@ const functionsMap: FunctionMap[] = [
 /**
  * Reactive Fullscreen API.
  *
- * @link https://vueuse.org/useFullscreen
+ * @see https://vueuse.org/useFullscreen
  * @param target
  * @param options
  */

--- a/packages/core/useGeolocation/index.md
+++ b/packages/core/useGeolocation/index.md
@@ -35,7 +35,7 @@ export interface GeolocationOptions
 /**
  * Reactive Geolocation API.
  *
- * @link https://vueuse.org/useGeolocation
+ * @see https://vueuse.org/useGeolocation
  * @param options
  */
 export declare function useGeolocation(

--- a/packages/core/useGeolocation/index.ts
+++ b/packages/core/useGeolocation/index.ts
@@ -9,7 +9,7 @@ export interface GeolocationOptions extends Partial<PositionOptions>, Configurab
 /**
  * Reactive Geolocation API.
  *
- * @link https://vueuse.org/useGeolocation
+ * @see https://vueuse.org/useGeolocation
  * @param options
  */
 export function useGeolocation(options: GeolocationOptions = {}) {

--- a/packages/core/useIdle/index.md
+++ b/packages/core/useIdle/index.md
@@ -46,7 +46,7 @@ export interface IdleOptions
 /**
  * Tracks whether the user is being inactive.
  *
- * @link https://vueuse.org/useIdle
+ * @see https://vueuse.org/useIdle
  * @param timeout default to 1 minute
  * @param options IdleOptions
  */

--- a/packages/core/useIdle/index.ts
+++ b/packages/core/useIdle/index.ts
@@ -30,7 +30,7 @@ export interface IdleOptions extends ConfigurableWindow, ConfigurableEventFilter
 /**
  * Tracks whether the user is being inactive.
  *
- * @link https://vueuse.org/useIdle
+ * @see https://vueuse.org/useIdle
  * @param timeout default to 1 minute
  * @param options IdleOptions
  */

--- a/packages/core/useIntersectionObserver/index.md
+++ b/packages/core/useIntersectionObserver/index.md
@@ -62,7 +62,7 @@ export interface IntersectionObserverOptions extends ConfigurableWindow {
 /**
  * Detects that a target element's visibility.
  *
- * @link https://vueuse.org/useIntersectionObserver
+ * @see https://vueuse.org/useIntersectionObserver
  * @param target
  * @param callback
  * @param options

--- a/packages/core/useIntersectionObserver/index.ts
+++ b/packages/core/useIntersectionObserver/index.ts
@@ -23,7 +23,7 @@ export interface IntersectionObserverOptions extends ConfigurableWindow {
 /**
  * Detects that a target element's visibility.
  *
- * @link https://vueuse.org/useIntersectionObserver
+ * @see https://vueuse.org/useIntersectionObserver
  * @param target
  * @param callback
  * @param options

--- a/packages/core/useLocalStorage/index.ts
+++ b/packages/core/useLocalStorage/index.ts
@@ -11,7 +11,7 @@ export function useLocalStorage<T = unknown> (key: string, defaultValue: null, o
 /**
  * Reactive LocalStorage.
  *
- * @link https://vueuse.org/useLocalStorage
+ * @see https://vueuse.org/useLocalStorage
  * @param key
  * @param defaultValue
  * @param options

--- a/packages/core/useMagicKeys/index.md
+++ b/packages/core/useMagicKeys/index.md
@@ -199,7 +199,7 @@ export interface MagicKeysInternal {
    * A Set of currently pressed keys,
    * Stores raw keyCodes.
    *
-   * @link https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode
    */
   current: Set<string>
 }
@@ -215,7 +215,7 @@ export declare type MagicKeys<Reactive extends Boolean> = Readonly<
 /**
  * Reactive keys pressed state, with magical keys combination support.
  *
- * @link https://vueuse.org/useMagicKeys
+ * @see https://vueuse.org/useMagicKeys
  */
 export declare function useMagicKeys(
   options?: UseMagicKeysOptions<false>

--- a/packages/core/useMagicKeys/index.ts
+++ b/packages/core/useMagicKeys/index.ts
@@ -49,7 +49,7 @@ export interface MagicKeysInternal {
    * A Set of currently pressed keys,
    * Stores raw keyCodes.
    *
-   * @link https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode
    */
   current: Set<string>
 }
@@ -66,7 +66,7 @@ export type MagicKeys<Reactive extends Boolean> =
 /**
  * Reactive keys pressed state, with magical keys combination support.
  *
- * @link https://vueuse.org/useMagicKeys
+ * @see https://vueuse.org/useMagicKeys
  */
 export function useMagicKeys(options?: UseMagicKeysOptions<false>): MagicKeys<false>
 export function useMagicKeys(options: UseMagicKeysOptions<true>): MagicKeys<true>

--- a/packages/core/useManualRefHistory/index.md
+++ b/packages/core/useManualRefHistory/index.md
@@ -187,7 +187,7 @@ export interface UseManualRefHistoryReturn<Raw, Serialized> {
 /**
  * Track the change history of a ref, also provides undo and redo functionality.
  *
- * @link https://vueuse.org/useManualRefHistory
+ * @see https://vueuse.org/useManualRefHistory
  * @param source
  * @param options
  */

--- a/packages/core/useManualRefHistory/index.ts
+++ b/packages/core/useManualRefHistory/index.ts
@@ -115,7 +115,7 @@ function defaultParse<R, S>(clone?: boolean | CloneFn<R>) {
 /**
  * Track the change history of a ref, also provides undo and redo functionality.
  *
- * @link https://vueuse.org/useManualRefHistory
+ * @see https://vueuse.org/useManualRefHistory
  * @param source
  * @param options
  */

--- a/packages/core/useMediaQuery/index.md
+++ b/packages/core/useMediaQuery/index.md
@@ -23,7 +23,7 @@ const isPreferredDark = useMediaQuery('(prefers-color-scheme: dark)')
 /**
  * Reactive Media Query.
  *
- * @link https://vueuse.org/useMediaQuery
+ * @see https://vueuse.org/useMediaQuery
  * @param query
  * @param options
  */

--- a/packages/core/useMediaQuery/index.ts
+++ b/packages/core/useMediaQuery/index.ts
@@ -7,7 +7,7 @@ import { ConfigurableWindow, defaultWindow } from '../_configurable'
 /**
  * Reactive Media Query.
  *
- * @link https://vueuse.org/useMediaQuery
+ * @see https://vueuse.org/useMediaQuery
  * @param query
  * @param options
  */

--- a/packages/core/useMouse/index.md
+++ b/packages/core/useMouse/index.md
@@ -51,7 +51,7 @@ export declare type MouseSourceType = "mouse" | "touch" | null
 /**
  * Reactive mouse position.
  *
- * @link https://vueuse.org/useMouse
+ * @see https://vueuse.org/useMouse
  * @param options
  */
 export declare function useMouse(

--- a/packages/core/useMouse/index.ts
+++ b/packages/core/useMouse/index.ts
@@ -28,7 +28,7 @@ export type MouseSourceType = 'mouse' | 'touch' | null
 /**
  * Reactive mouse position.
  *
- * @link https://vueuse.org/useMouse
+ * @see https://vueuse.org/useMouse
  * @param options
  */
 export function useMouse(options: MouseOptions = {}) {

--- a/packages/core/useMouseInElement/index.md
+++ b/packages/core/useMouseInElement/index.md
@@ -42,7 +42,7 @@ export interface MouseInElementOptions extends MouseOptions {
 /**
  * Reactive mouse position related to an element.
  *
- * @link https://vueuse.org/useMouseInElement
+ * @see https://vueuse.org/useMouseInElement
  * @param target
  * @param options
  */

--- a/packages/core/useMouseInElement/index.ts
+++ b/packages/core/useMouseInElement/index.ts
@@ -10,7 +10,7 @@ export interface MouseInElementOptions extends MouseOptions {
 /**
  * Reactive mouse position related to an element.
  *
- * @link https://vueuse.org/useMouseInElement
+ * @see https://vueuse.org/useMouseInElement
  * @param target
  * @param options
  */

--- a/packages/core/useMousePressed/index.md
+++ b/packages/core/useMousePressed/index.md
@@ -75,7 +75,7 @@ export interface MousePressedOptions extends ConfigurableWindow {
 /**
  * Reactive mouse position.
  *
- * @link https://vueuse.org/useMousePressed
+ * @see https://vueuse.org/useMousePressed
  * @param options
  */
 export declare function useMousePressed(

--- a/packages/core/useMousePressed/index.ts
+++ b/packages/core/useMousePressed/index.ts
@@ -28,7 +28,7 @@ export interface MousePressedOptions extends ConfigurableWindow {
 /**
  * Reactive mouse position.
  *
- * @link https://vueuse.org/useMousePressed
+ * @see https://vueuse.org/useMousePressed
  * @param options
  */
 export function useMousePressed(options: MousePressedOptions = {}) {

--- a/packages/core/useMutationObserver/index.md
+++ b/packages/core/useMutationObserver/index.md
@@ -46,7 +46,7 @@ export interface MutationObserverOptions
  * Watch for changes being made to the DOM tree.
  *
  * @see https://vueuse.org/useMutationObserver
- * @link https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver|MutationObserver MDN
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver MutationObserver MDN
  * @param target
  * @param callback
  * @param options

--- a/packages/core/useMutationObserver/index.md
+++ b/packages/core/useMutationObserver/index.md
@@ -45,7 +45,7 @@ export interface MutationObserverOptions
 /**
  * Watch for changes being made to the DOM tree.
  *
- * @link https://vueuse.org/useMutationObserver
+ * @see https://vueuse.org/useMutationObserver
  * @link https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver|MutationObserver MDN
  * @param target
  * @param callback

--- a/packages/core/useMutationObserver/index.ts
+++ b/packages/core/useMutationObserver/index.ts
@@ -8,7 +8,7 @@ export interface MutationObserverOptions extends MutationObserverInit, Configura
 /**
  * Watch for changes being made to the DOM tree.
  *
- * @link https://vueuse.org/useMutationObserver
+ * @see https://vueuse.org/useMutationObserver
  * @link https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver|MutationObserver MDN
  * @param target
  * @param callback

--- a/packages/core/useMutationObserver/index.ts
+++ b/packages/core/useMutationObserver/index.ts
@@ -9,7 +9,7 @@ export interface MutationObserverOptions extends MutationObserverInit, Configura
  * Watch for changes being made to the DOM tree.
  *
  * @see https://vueuse.org/useMutationObserver
- * @link https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver|MutationObserver MDN
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver MutationObserver MDN
  * @param target
  * @param callback
  * @param options

--- a/packages/core/useNetwork/index.md
+++ b/packages/core/useNetwork/index.md
@@ -81,7 +81,7 @@ export interface NetworkState {
 /**
  * Reactive Network status.
  *
- * @link https://vueuse.org/useNetwork
+ * @see https://vueuse.org/useNetwork
  * @param options
  */
 export declare function useNetwork(options?: ConfigurableWindow): NetworkState

--- a/packages/core/useNetwork/index.ts
+++ b/packages/core/useNetwork/index.ts
@@ -43,7 +43,7 @@ export interface NetworkState {
 /**
  * Reactive Network status.
  *
- * @link https://vueuse.org/useNetwork
+ * @see https://vueuse.org/useNetwork
  * @param options
  */
 export function useNetwork(options: ConfigurableWindow = {}): NetworkState {

--- a/packages/core/useNow/index.md
+++ b/packages/core/useNow/index.md
@@ -30,7 +30,7 @@ export interface UseNowOptions {
 /**
  * Reactive current timestamp.
  *
- * @link https://vueuse.org/useNow
+ * @see https://vueuse.org/useNow
  * @param options
  */
 export declare function useNow(

--- a/packages/core/useNow/index.ts
+++ b/packages/core/useNow/index.ts
@@ -14,7 +14,7 @@ export interface UseNowOptions {
 /**
  * Reactive current timestamp.
  *
- * @link https://vueuse.org/useNow
+ * @see https://vueuse.org/useNow
  * @param options
  */
 export function useNow(options: UseNowOptions = {}) {

--- a/packages/core/useOnline/index.md
+++ b/packages/core/useOnline/index.md
@@ -22,7 +22,7 @@ const online = useOnline()
 /**
  * Reactive online state.
  *
- * @link https://vueuse.org/useOnline
+ * @see https://vueuse.org/useOnline
  * @param options
  */
 export declare function useOnline(options?: ConfigurableWindow): Ref<boolean>

--- a/packages/core/useOnline/index.ts
+++ b/packages/core/useOnline/index.ts
@@ -4,7 +4,7 @@ import { ConfigurableWindow } from '../_configurable'
 /**
  * Reactive online state.
  *
- * @link https://vueuse.org/useOnline
+ * @see https://vueuse.org/useOnline
  * @param options
  */
 export function useOnline(options: ConfigurableWindow = {}) {

--- a/packages/core/usePageLeave/index.md
+++ b/packages/core/usePageLeave/index.md
@@ -22,7 +22,7 @@ const isLeft = usePageLeave()
 /**
  * Reactive state to show whether mouse leaves the page.
  *
- * @link https://vueuse.org/usePageLeave
+ * @see https://vueuse.org/usePageLeave
  * @param options
  */
 export declare function usePageLeave(options?: ConfigurableWindow): Ref<boolean>

--- a/packages/core/usePageLeave/index.ts
+++ b/packages/core/usePageLeave/index.ts
@@ -5,7 +5,7 @@ import { ConfigurableWindow, defaultWindow } from '../_configurable'
 /**
  * Reactive state to show whether mouse leaves the page.
  *
- * @link https://vueuse.org/usePageLeave
+ * @see https://vueuse.org/usePageLeave
  * @param options
  */
 export function usePageLeave(options: ConfigurableWindow = {}) {

--- a/packages/core/usePermission/index.md
+++ b/packages/core/usePermission/index.md
@@ -48,7 +48,7 @@ export interface UsePermissionReturnWithControls {
 /**
  * Reactive Permissions API.
  *
- * @link https://vueuse.org/usePermission
+ * @see https://vueuse.org/usePermission
  */
 export declare function usePermission(
   permissionDesc:

--- a/packages/core/usePermission/index.ts
+++ b/packages/core/usePermission/index.ts
@@ -31,7 +31,7 @@ export interface UsePermissionReturnWithControls {
 /**
  * Reactive Permissions API.
  *
- * @link https://vueuse.org/usePermission
+ * @see https://vueuse.org/usePermission
  */
 export function usePermission(
   permissionDesc: GeneralPermissionDescriptor | GeneralPermissionDescriptor['name'],

--- a/packages/core/usePreferredColorScheme/index.md
+++ b/packages/core/usePreferredColorScheme/index.md
@@ -23,7 +23,7 @@ export declare type ColorSchemeType = "dark" | "light" | "no-preference"
 /**
  * Reactive prefers-color-scheme media query.
  *
- * @link https://vueuse.org/usePreferredColorScheme
+ * @see https://vueuse.org/usePreferredColorScheme
  * @param [options]
  */
 export declare function usePreferredColorScheme(

--- a/packages/core/usePreferredColorScheme/index.ts
+++ b/packages/core/usePreferredColorScheme/index.ts
@@ -7,7 +7,7 @@ export type ColorSchemeType = 'dark' | 'light' | 'no-preference'
 /**
  * Reactive prefers-color-scheme media query.
  *
- * @link https://vueuse.org/usePreferredColorScheme
+ * @see https://vueuse.org/usePreferredColorScheme
  * @param [options]
  */
 export function usePreferredColorScheme(options?: ConfigurableWindow) {

--- a/packages/core/usePreferredDark/index.md
+++ b/packages/core/usePreferredDark/index.md
@@ -22,7 +22,7 @@ const isDark = usePreferredDark()
 /**
  * Reactive dark theme preference.
  *
- * @link https://vueuse.org/usePreferredDark
+ * @see https://vueuse.org/usePreferredDark
  * @param [options]
  */
 export declare function usePreferredDark(

--- a/packages/core/usePreferredDark/index.ts
+++ b/packages/core/usePreferredDark/index.ts
@@ -4,7 +4,7 @@ import { ConfigurableWindow } from '../_configurable'
 /**
  * Reactive dark theme preference.
  *
- * @link https://vueuse.org/usePreferredDark
+ * @see https://vueuse.org/usePreferredDark
  * @param [options]
  */
 export function usePreferredDark(options?: ConfigurableWindow) {

--- a/packages/core/usePreferredLanguages/index.md
+++ b/packages/core/usePreferredLanguages/index.md
@@ -22,7 +22,7 @@ const languages = usePreferredLanguages()
 /**
  * Reactive Navigator Languages.
  *
- * @link https://vueuse.org/usePreferredLanguages
+ * @see https://vueuse.org/usePreferredLanguages
  * @param options
  */
 export declare function usePreferredLanguages(

--- a/packages/core/usePreferredLanguages/index.ts
+++ b/packages/core/usePreferredLanguages/index.ts
@@ -5,7 +5,7 @@ import { ConfigurableWindow, defaultWindow } from '../_configurable'
 /**
  * Reactive Navigator Languages.
  *
- * @link https://vueuse.org/usePreferredLanguages
+ * @see https://vueuse.org/usePreferredLanguages
  * @param options
  */
 export function usePreferredLanguages(options: ConfigurableWindow = {}): Ref<readonly string[]> {

--- a/packages/core/useRafFn/index.md
+++ b/packages/core/useRafFn/index.md
@@ -46,7 +46,7 @@ export interface RafFnReturn extends Pausable {
 /**
  * Call function on every `requestAnimationFrame`. With controls of pausing and resuming.
  *
- * @link https://vueuse.org/useRafFn
+ * @see https://vueuse.org/useRafFn
  * @param fn
  * @param options
  */

--- a/packages/core/useRafFn/index.ts
+++ b/packages/core/useRafFn/index.ts
@@ -26,7 +26,7 @@ export interface RafFnReturn extends Pausable {
 /**
  * Call function on every `requestAnimationFrame`. With controls of pausing and resuming.
  *
- * @link https://vueuse.org/useRafFn
+ * @see https://vueuse.org/useRafFn
  * @param fn
  * @param options
  */

--- a/packages/core/useRefHistory/index.md
+++ b/packages/core/useRefHistory/index.md
@@ -299,7 +299,7 @@ export interface UseRefHistoryReturn<Raw, Serialized> {
 /**
  * Track the change history of a ref, also provides undo and redo functionality.
  *
- * @link https://vueuse.org/useRefHistory
+ * @see https://vueuse.org/useRefHistory
  * @param source
  * @param options
  */

--- a/packages/core/useRefHistory/index.ts
+++ b/packages/core/useRefHistory/index.ts
@@ -138,7 +138,7 @@ export interface UseRefHistoryReturn<Raw, Serialized> {
 /**
  * Track the change history of a ref, also provides undo and redo functionality.
  *
- * @link https://vueuse.org/useRefHistory
+ * @see https://vueuse.org/useRefHistory
  * @param source
  * @param options
  */

--- a/packages/core/useResizeObserver/index.md
+++ b/packages/core/useResizeObserver/index.md
@@ -79,7 +79,7 @@ declare class ResizeObserver {
 /**
  * Reports changes to the dimensions of an Element's content or the border-box
  *
- * @link https://vueuse.org/useResizeObserver
+ * @see https://vueuse.org/useResizeObserver
  * @param target
  * @param callback
  * @param options

--- a/packages/core/useResizeObserver/index.ts
+++ b/packages/core/useResizeObserver/index.ts
@@ -39,7 +39,7 @@ declare class ResizeObserver {
 /**
  * Reports changes to the dimensions of an Element's content or the border-box
  *
- * @link https://vueuse.org/useResizeObserver
+ * @see https://vueuse.org/useResizeObserver
  * @param target
  * @param callback
  * @param options

--- a/packages/core/useScriptTag/index.md
+++ b/packages/core/useScriptTag/index.md
@@ -87,7 +87,7 @@ export interface UseScriptTagOptions extends ConfigurableDocument {
 /**
  * Async script tag loading.
  *
- * @link https://vueuse.org/useScriptTag
+ * @see https://vueuse.org/useScriptTag
  * @param src
  */
 export declare function useScriptTag(

--- a/packages/core/useScriptTag/index.ts
+++ b/packages/core/useScriptTag/index.ts
@@ -40,7 +40,7 @@ export interface UseScriptTagOptions extends ConfigurableDocument {
 /**
  * Async script tag loading.
  *
- * @link https://vueuse.org/useScriptTag
+ * @see https://vueuse.org/useScriptTag
  * @param src
  */
 export function useScriptTag(

--- a/packages/core/useSessionStorage/index.ts
+++ b/packages/core/useSessionStorage/index.ts
@@ -11,7 +11,7 @@ export function useSessionStorage<T = unknown> (key: string, defaultValue: null,
 /**
  * Reactive SessionStorage.
  *
- * @link https://vueuse.org/useSessionStorage
+ * @see https://vueuse.org/useSessionStorage
  * @param key
  * @param defaultValue
  * @param options

--- a/packages/core/useShare/index.md
+++ b/packages/core/useShare/index.md
@@ -55,7 +55,7 @@ export interface ShareOptions {
 /**
  * Reactive Web Share API.
  *
- * @use   {@link https://vueuse.org/useShare}
+ * @use   {@see https://vueuse.org/useShare}
  * @param shareOptions
  * @param options
  */

--- a/packages/core/useShare/index.md
+++ b/packages/core/useShare/index.md
@@ -55,7 +55,7 @@ export interface ShareOptions {
 /**
  * Reactive Web Share API.
  *
- * @use   {@see https://vueuse.org/useShare}
+ * @use   {@link https://vueuse.org/useShare}
  * @param shareOptions
  * @param options
  */

--- a/packages/core/useShare/index.ts
+++ b/packages/core/useShare/index.ts
@@ -17,7 +17,7 @@ interface NavigatorWithShare {
 /**
  * Reactive Web Share API.
  *
- * @use   {@see https://vueuse.org/useShare}
+ * @use   {@link https://vueuse.org/useShare}
  * @param shareOptions
  * @param options
  */

--- a/packages/core/useShare/index.ts
+++ b/packages/core/useShare/index.ts
@@ -17,7 +17,7 @@ interface NavigatorWithShare {
 /**
  * Reactive Web Share API.
  *
- * @use   {@link https://vueuse.org/useShare}
+ * @use   {@see https://vueuse.org/useShare}
  * @param shareOptions
  * @param options
  */

--- a/packages/core/useSpeechRecognition/index.md
+++ b/packages/core/useSpeechRecognition/index.md
@@ -64,7 +64,7 @@ export interface SpeechRecognitionOptions extends ConfigurableWindow {
  * Reactive SpeechRecognition.
  *
  * @see https://vueuse.org/useSpeechRecognition
- * @link https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition|SpeechRecognition
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition SpeechRecognition
  * @param options
  */
 export declare function useSpeechRecognition(

--- a/packages/core/useSpeechRecognition/index.md
+++ b/packages/core/useSpeechRecognition/index.md
@@ -63,7 +63,7 @@ export interface SpeechRecognitionOptions extends ConfigurableWindow {
 /**
  * Reactive SpeechRecognition.
  *
- * @link https://vueuse.org/useSpeechRecognition
+ * @see https://vueuse.org/useSpeechRecognition
  * @link https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition|SpeechRecognition
  * @param options
  */

--- a/packages/core/useSpeechRecognition/index.ts
+++ b/packages/core/useSpeechRecognition/index.ts
@@ -30,7 +30,7 @@ export interface SpeechRecognitionOptions extends ConfigurableWindow {
  * Reactive SpeechRecognition.
  *
  * @see https://vueuse.org/useSpeechRecognition
- * @link https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition|SpeechRecognition
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition SpeechRecognition
  * @param options
  */
 export function useSpeechRecognition(options: SpeechRecognitionOptions = {}) {

--- a/packages/core/useSpeechRecognition/index.ts
+++ b/packages/core/useSpeechRecognition/index.ts
@@ -29,7 +29,7 @@ export interface SpeechRecognitionOptions extends ConfigurableWindow {
 /**
  * Reactive SpeechRecognition.
  *
- * @link https://vueuse.org/useSpeechRecognition
+ * @see https://vueuse.org/useSpeechRecognition
  * @link https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition|SpeechRecognition
  * @param options
  */

--- a/packages/core/useStorage/index.ts
+++ b/packages/core/useStorage/index.ts
@@ -53,7 +53,7 @@ export function useStorage<T = unknown> (key: string, defaultValue: null, storag
 /**
  * Reactive LocalStorage/SessionStorage.
  *
- * @link https://vueuse.org/useStorage
+ * @see https://vueuse.org/useStorage
  * @param key
  * @param defaultValue
  * @param storage

--- a/packages/core/useSwipe/index.md
+++ b/packages/core/useSwipe/index.md
@@ -79,7 +79,7 @@ export interface SwipeReturn {
 /**
  * Reactive swipe detection.
  *
- * @link https://vueuse.org/useSwipe
+ * @see https://vueuse.org/useSwipe
  * @param target
  * @param options
  */

--- a/packages/core/useSwipe/index.ts
+++ b/packages/core/useSwipe/index.ts
@@ -61,7 +61,7 @@ export interface SwipeReturn {
 /**
  * Reactive swipe detection.
  *
- * @link https://vueuse.org/useSwipe
+ * @see https://vueuse.org/useSwipe
  * @param target
  * @param options
  */
@@ -169,7 +169,7 @@ export function useSwipe(
 
 /**
  * This is a polyfill for passive event support detection
- * @link https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md
+ * @see https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md
  */
 function checkPassiveEventSupport(document?: Document) {
   if (!document)

--- a/packages/core/useTimeAgo/index.md
+++ b/packages/core/useTimeAgo/index.md
@@ -68,7 +68,7 @@ export interface TimeAgoOptions {
 /**
  * Reactive time ago formatter.
  *
- * @link https://vueuse.org/useTimeAgo
+ * @see https://vueuse.org/useTimeAgo
  * @param options
  */
 export declare function useTimeAgo(

--- a/packages/core/useTimeAgo/index.ts
+++ b/packages/core/useTimeAgo/index.ts
@@ -93,7 +93,7 @@ const DEFAULT_FORMATTER = (date: Date) => date.toISOString().slice(0, 10)
 /**
  * Reactive time ago formatter.
  *
- * @link https://vueuse.org/useTimeAgo
+ * @see https://vueuse.org/useTimeAgo
  * @param options
  */
 export function useTimeAgo(

--- a/packages/core/useTimestamp/index.md
+++ b/packages/core/useTimestamp/index.md
@@ -36,7 +36,7 @@ export interface TimestampOptions {
 /**
  * Reactive current timestamp.
  *
- * @link https://vueuse.org/useTimestamp
+ * @see https://vueuse.org/useTimestamp
  * @param options
  */
 export declare function useTimestamp(

--- a/packages/core/useTimestamp/index.ts
+++ b/packages/core/useTimestamp/index.ts
@@ -21,7 +21,7 @@ export interface TimestampOptions {
 /**
  * Reactive current timestamp.
  *
- * @link https://vueuse.org/useTimestamp
+ * @see https://vueuse.org/useTimestamp
  * @param options
  */
 export function useTimestamp(options: TimestampOptions = {}) {

--- a/packages/core/useTitle/index.md
+++ b/packages/core/useTitle/index.md
@@ -44,7 +44,7 @@ useTitle(title) // document title will match with the ref "title"
 /**
  * Reactive document title.
  *
- * @link https://vueuse.org/useTitle
+ * @see https://vueuse.org/useTitle
  * @param newTitle
  * @param options
  */

--- a/packages/core/useTitle/index.ts
+++ b/packages/core/useTitle/index.ts
@@ -5,7 +5,7 @@ import { ConfigurableDocument, defaultDocument } from '../_configurable'
 /**
  * Reactive document title.
  *
- * @link https://vueuse.org/useTitle
+ * @see https://vueuse.org/useTitle
  * @param newTitle
  * @param options
  */

--- a/packages/core/useTransition/index.md
+++ b/packages/core/useTransition/index.md
@@ -109,13 +109,13 @@ interface TransitionOptions {
 /**
  * Common transitions
  *
- * @link https://easings.net
+ * @see https://easings.net
  */
 export declare const TransitionPresets: Record<string, CubicBezierPoints>
 /**
  * Transition between values.
  *
- * @link https://vueuse.org/useTransition
+ * @see https://vueuse.org/useTransition
  * @param source
  * @param options
  */

--- a/packages/core/useTransition/index.ts
+++ b/packages/core/useTransition/index.ts
@@ -54,7 +54,7 @@ function createEasingFunction([p0, p1, p2, p3]: CubicBezierPoints): EasingFuncti
 /**
  * Common transitions
  *
- * @link https://easings.net
+ * @see https://easings.net
  */
 export const TransitionPresets: Record<string, CubicBezierPoints> = {
   linear: [0, 0, 1, 1],
@@ -85,7 +85,7 @@ export const TransitionPresets: Record<string, CubicBezierPoints> = {
 /**
  * Transition between values.
  *
- * @link https://vueuse.org/useTransition
+ * @see https://vueuse.org/useTransition
  * @param source
  * @param options
  */

--- a/packages/core/useUrlSearchParams/index.md
+++ b/packages/core/useUrlSearchParams/index.md
@@ -40,7 +40,7 @@ export declare type UrlParams = Record<string, string[] | string>
 /**
  * Reactive URLSearchParams
  *
- * @link https://vueuse.org/useUrlSearchParams
+ * @see https://vueuse.org/useUrlSearchParams
  * @param mode
  * @param options
  */

--- a/packages/core/useUrlSearchParams/index.ts
+++ b/packages/core/useUrlSearchParams/index.ts
@@ -8,7 +8,7 @@ export type UrlParams = Record<string, string[] | string>
 /**
  * Reactive URLSearchParams
  *
- * @link https://vueuse.org/useUrlSearchParams
+ * @see https://vueuse.org/useUrlSearchParams
  * @param mode
  * @param options
  */

--- a/packages/core/useUserMedia/index.md
+++ b/packages/core/useUserMedia/index.md
@@ -88,7 +88,7 @@ export interface UseUserMediaOptions extends ConfigurableNavigator {
 /**
  * Reactive `mediaDevices.getUserMedia` streaming
  *
- * @link https://vueuse.org/useUserMedia
+ * @see https://vueuse.org/useUserMedia
  * @param options
  */
 export declare function useUserMedia(

--- a/packages/core/useUserMedia/index.ts
+++ b/packages/core/useUserMedia/index.ts
@@ -39,7 +39,7 @@ export interface UseUserMediaOptions extends ConfigurableNavigator {
 /**
  * Reactive `mediaDevices.getUserMedia` streaming
  *
- * @link https://vueuse.org/useUserMedia
+ * @see https://vueuse.org/useUserMedia
  * @param options
  */
 export function useUserMedia(options: UseUserMediaOptions = {}) {

--- a/packages/core/useVModel/index.md
+++ b/packages/core/useVModel/index.md
@@ -38,7 +38,7 @@ export interface VModelOptions {
 /**
  * Shorthand for v-model binding, props + emit -> ref
  *
- * @link https://vueuse.org/useVModel
+ * @see https://vueuse.org/useVModel
  * @param props
  * @param key (default 'value' in Vue 2 and 'modelValue' in Vue 3)
  * @param emit

--- a/packages/core/useVModel/index.ts
+++ b/packages/core/useVModel/index.ts
@@ -13,7 +13,7 @@ export interface VModelOptions {
 /**
  * Shorthand for v-model binding, props + emit -> ref
  *
- * @link https://vueuse.org/useVModel
+ * @see https://vueuse.org/useVModel
  * @param props
  * @param key (default 'value' in Vue 2 and 'modelValue' in Vue 3)
  * @param emit

--- a/packages/core/useVModels/index.md
+++ b/packages/core/useVModels/index.md
@@ -37,7 +37,7 @@ export default {
 /**
  * Shorthand for props v-model binding. Think like `toRefs(props)` but changes will also emit out.
  *
- * @link https://vueuse.org/useVModels
+ * @see https://vueuse.org/useVModels
  * @param props
  * @param emit
  */

--- a/packages/core/useVModels/index.ts
+++ b/packages/core/useVModels/index.ts
@@ -4,7 +4,7 @@ import { useVModel, VModelOptions } from '../useVModel'
 /**
  * Shorthand for props v-model binding. Think like `toRefs(props)` but changes will also emit out.
  *
- * @link https://vueuse.org/useVModels
+ * @see https://vueuse.org/useVModels
  * @param props
  * @param emit
  */

--- a/packages/core/useWebSocket/index.md
+++ b/packages/core/useWebSocket/index.md
@@ -155,7 +155,7 @@ export interface WebSocketResult<T> {
 /**
  * Reactive WebSocket client.
  *
- * @link https://vueuse.org/useWebSocket
+ * @see https://vueuse.org/useWebSocket
  * @param url
  */
 export declare function useWebSocket<Data = any>(

--- a/packages/core/useWebSocket/index.ts
+++ b/packages/core/useWebSocket/index.ts
@@ -104,7 +104,7 @@ function resolveNestedOptions<T>(options: T | true): T {
 /**
  * Reactive WebSocket client.
  *
- * @link https://vueuse.org/useWebSocket
+ * @see https://vueuse.org/useWebSocket
  * @param url
  */
 export function useWebSocket<Data = any>(

--- a/packages/core/useWebWorker/index.md
+++ b/packages/core/useWebWorker/index.md
@@ -37,7 +37,7 @@ const { data, post, terminate } = useWebWorker('/path/to/worker.js')
 /**
  * Simple Web Workers registration and communication.
  *
- * @link https://vueuse.org/useWebWorker
+ * @see https://vueuse.org/useWebWorker
  * @param url
  * @param workerOptions
  * @param options

--- a/packages/core/useWebWorker/index.ts
+++ b/packages/core/useWebWorker/index.ts
@@ -7,7 +7,7 @@ import { ConfigurableWindow, defaultWindow } from '../_configurable'
 /**
  * Simple Web Workers registration and communication.
  *
- * @link https://vueuse.org/useWebWorker
+ * @see https://vueuse.org/useWebWorker
  * @param url
  * @param workerOptions
  * @param options

--- a/packages/core/useWebWorkerFn/index.md
+++ b/packages/core/useWebWorkerFn/index.md
@@ -69,7 +69,7 @@ export interface WebWorkerOptions extends ConfigurableWindow {
 /**
  * Run expensive function without blocking the UI, using a simple syntax that makes use of Promise.
  *
- * @link https://vueuse.org/useWebWorkerFn
+ * @see https://vueuse.org/useWebWorkerFn
  * @param fn
  * @param options
  */

--- a/packages/core/useWebWorkerFn/index.ts
+++ b/packages/core/useWebWorkerFn/index.ts
@@ -28,7 +28,7 @@ export interface WebWorkerOptions extends ConfigurableWindow {
 /**
  * Run expensive function without blocking the UI, using a simple syntax that makes use of Promise.
  *
- * @link https://vueuse.org/useWebWorkerFn
+ * @see https://vueuse.org/useWebWorkerFn
  * @param fn
  * @param options
  */

--- a/packages/core/useWindowScroll/index.md
+++ b/packages/core/useWindowScroll/index.md
@@ -22,7 +22,7 @@ const { x, y } = useWindowScroll()
 /**
  * Reactive window scroll.
  *
- * @link https://vueuse.org/useWindowScroll
+ * @see https://vueuse.org/useWindowScroll
  * @param options
  */
 export declare function useWindowScroll({

--- a/packages/core/useWindowScroll/index.ts
+++ b/packages/core/useWindowScroll/index.ts
@@ -5,7 +5,7 @@ import { ConfigurableWindow, defaultWindow } from '../_configurable'
 /**
  * Reactive window scroll.
  *
- * @link https://vueuse.org/useWindowScroll
+ * @see https://vueuse.org/useWindowScroll
  * @param options
  */
 export function useWindowScroll({ window = defaultWindow }: ConfigurableWindow = {}) {

--- a/packages/core/useWindowSize/index.md
+++ b/packages/core/useWindowSize/index.md
@@ -26,7 +26,7 @@ export interface WindowSizeOptions extends ConfigurableWindow {
 /**
  * Reactive window size.
  *
- * @link https://vueuse.org/useWindowSize
+ * @see https://vueuse.org/useWindowSize
  * @param options
  */
 export declare function useWindowSize({

--- a/packages/core/useWindowSize/index.ts
+++ b/packages/core/useWindowSize/index.ts
@@ -10,7 +10,7 @@ export interface WindowSizeOptions extends ConfigurableWindow {
 /**
  * Reactive window size.
  *
- * @link https://vueuse.org/useWindowSize
+ * @see https://vueuse.org/useWindowSize
  * @param options
  */
 export function useWindowSize({ window = defaultWindow, initialWidth = Infinity, initialHeight = Infinity }: WindowSizeOptions = {}) {

--- a/packages/firebase/useFirestore/index.ts
+++ b/packages/firebase/useFirestore/index.ts
@@ -57,7 +57,7 @@ export function useFirestore<T extends firebase.firestore.DocumentData> (
  * Reactive Firestore binding. Making it straightforward to always keep your
  * local data in sync with remotes databases.
  *
- * @link https://vueuse.org/useFirestore
+ * @see https://vueuse.org/useFirestore
  * @param docRef
  * @param initialValue
  * @param options

--- a/packages/integrations/useAxios/index.ts
+++ b/packages/integrations/useAxios/index.ts
@@ -17,7 +17,7 @@ export function useAxios<T = any>(url: string, config: AxiosRequestConfig, insta
 /**
  * Wrapper for axios.
  *
- * @link https://vueuse.org/useAxios
+ * @see https://vueuse.org/useAxios
  * @param url
  * @param config
  */

--- a/packages/integrations/useCookies/index.md
+++ b/packages/integrations/useCookies/index.md
@@ -99,7 +99,7 @@ Create a `universal-cookie` instance using request (default is window.document.c
 /**
  * Creates a new {@link useCookies} function
  * @param {Object} req - incoming http request (for SSR)
- * @link https://github.com/reactivestack/cookies/tree/master/packages/universal-cookie|universal-cookie
+ * @see https://github.com/reactivestack/cookies/tree/master/packages/universal-cookie universal-cookie
  * @description Creates universal-cookie instance using request (default is window.document.cookie) and returns {@link useCookies} function with provided universal-cookie instance
  */
 export declare function createCookies(

--- a/packages/integrations/useCookies/index.ts
+++ b/packages/integrations/useCookies/index.ts
@@ -10,7 +10,7 @@ type RawCookies = {
 /**
  * Creates a new {@link useCookies} function
  * @param {Object} req - incoming http request (for SSR)
- * @link https://github.com/reactivestack/cookies/tree/master/packages/universal-cookie|universal-cookie
+ * @see https://github.com/reactivestack/cookies/tree/master/packages/universal-cookie universal-cookie
  * @description Creates universal-cookie instance using request (default is window.document.cookie) and returns {@link useCookies} function with provided universal-cookie instance
  */
 export function createCookies(req?: IncomingMessage) {

--- a/packages/integrations/useFocusTrap/index.md
+++ b/packages/integrations/useFocusTrap/index.md
@@ -73,34 +73,34 @@ export interface UseFocusTrapReturn {
   /**
    * Activate the focus trap
    *
-   * @link https://github.com/focus-trap/focus-trap#trapactivateactivateoptions
+   * @see https://github.com/focus-trap/focus-trap#trapactivateactivateoptions
    * @param opts Activate focus trap options
    */
   activate: (opts?: ActivateOptions) => void
   /**
    * Deactivate the focus trap
    *
-   * @link https://github.com/focus-trap/focus-trap#trapdeactivatedeactivateoptions
+   * @see https://github.com/focus-trap/focus-trap#trapdeactivatedeactivateoptions
    * @param opts Deactivate focus trap options
    */
   deactivate: (opts?: DeactivateOptions) => void
   /**
    * Pause the focus trap
    *
-   * @link https://github.com/focus-trap/focus-trap#trappause
+   * @see https://github.com/focus-trap/focus-trap#trappause
    */
   pause: Fn
   /**
    * Unpauses the focus trap
    *
-   * @link https://github.com/focus-trap/focus-trap#trapunpause
+   * @see https://github.com/focus-trap/focus-trap#trapunpause
    */
   unpause: Fn
 }
 /**
  * Reactive focus-trap
  *
- * @link https://vueuse.org/useFocusTrap
+ * @see https://vueuse.org/useFocusTrap
  * @param target The target element to trap focus within
  * @param options Focus trap options
  * @param autoFocus Focus trap automatically when mounted

--- a/packages/integrations/useFocusTrap/index.ts
+++ b/packages/integrations/useFocusTrap/index.ts
@@ -23,7 +23,7 @@ export interface UseFocusTrapReturn {
   /**
    * Activate the focus trap
    *
-   * @link https://github.com/focus-trap/focus-trap#trapactivateactivateoptions
+   * @see https://github.com/focus-trap/focus-trap#trapactivateactivateoptions
    * @param opts Activate focus trap options
    */
   activate: (opts?: ActivateOptions) => void
@@ -31,7 +31,7 @@ export interface UseFocusTrapReturn {
   /**
    * Deactivate the focus trap
    *
-   * @link https://github.com/focus-trap/focus-trap#trapdeactivatedeactivateoptions
+   * @see https://github.com/focus-trap/focus-trap#trapdeactivatedeactivateoptions
    * @param opts Deactivate focus trap options
    */
   deactivate: (opts?: DeactivateOptions) => void
@@ -39,14 +39,14 @@ export interface UseFocusTrapReturn {
   /**
    * Pause the focus trap
    *
-   * @link https://github.com/focus-trap/focus-trap#trappause
+   * @see https://github.com/focus-trap/focus-trap#trappause
    */
   pause: Fn
 
   /**
    * Unpauses the focus trap
    *
-   * @link https://github.com/focus-trap/focus-trap#trapunpause
+   * @see https://github.com/focus-trap/focus-trap#trapunpause
    */
   unpause: Fn
 }
@@ -54,7 +54,7 @@ export interface UseFocusTrapReturn {
 /**
  * Reactive focus-trap
  *
- * @link https://vueuse.org/useFocusTrap
+ * @see https://vueuse.org/useFocusTrap
  * @param target The target element to trap focus within
  * @param options Focus trap options
  * @param autoFocus Focus trap automatically when mounted

--- a/packages/integrations/useJwt/index.md
+++ b/packages/integrations/useJwt/index.md
@@ -52,7 +52,7 @@ export interface JwtResult<Payload, Header, Fallback> {
 /**
  * Reactive decoded jwt token.
  *
- * @link https://vueuse.org/useJwt
+ * @see https://vueuse.org/useJwt
  * @param jwt
  */
 export declare function useJwt<

--- a/packages/integrations/useJwt/index.ts
+++ b/packages/integrations/useJwt/index.ts
@@ -24,7 +24,7 @@ export interface JwtResult<Payload, Header, Fallback> {
 /**
  * Reactive decoded jwt token.
  *
- * @link https://vueuse.org/useJwt
+ * @see https://vueuse.org/useJwt
  * @param jwt
  */
 export function useJwt<

--- a/packages/integrations/useNProgress/index.md
+++ b/packages/integrations/useNProgress/index.md
@@ -57,7 +57,7 @@ useNProgress(null, {
 /**
  * Reactive progress bar.
  *
- * @link https://vueuse.org/useNProgress
+ * @see https://vueuse.org/useNProgress
  * @param currentProgress
  * @param options
  */

--- a/packages/integrations/useNProgress/index.ts
+++ b/packages/integrations/useNProgress/index.ts
@@ -5,7 +5,7 @@ import { ref, isRef, watchEffect, computed } from 'vue-demi'
 /**
  * Reactive progress bar.
  *
- * @link https://vueuse.org/useNProgress
+ * @see https://vueuse.org/useNProgress
  * @param currentProgress
  * @param options
  */

--- a/packages/integrations/useQRCode/index.md
+++ b/packages/integrations/useQRCode/index.md
@@ -44,7 +44,7 @@ const qrcode = useQRCode(text)
 /**
  * Wrapper for qrcode.
  *
- * @link https://vueuse.org/useQRCode
+ * @see https://vueuse.org/useQRCode
  * @param text
  * @param options
  */

--- a/packages/integrations/useQRCode/index.ts
+++ b/packages/integrations/useQRCode/index.ts
@@ -5,7 +5,7 @@ import QRCode from 'qrcode'
 /**
  * Wrapper for qrcode.
  *
- * @link https://vueuse.org/useQRCode
+ * @see https://vueuse.org/useQRCode
  * @param text
  * @param options
  */

--- a/packages/shared/and/index.md
+++ b/packages/shared/and/index.md
@@ -32,7 +32,7 @@ whenever(and(a, b), () => {
 /**
  * `AND` conditions for refs.
  *
- * @link https://vueuse.org/and
+ * @see https://vueuse.org/and
  */
 export declare function and(...args: MaybeRef<any>[]): ComputedRef<boolean>
 ```

--- a/packages/shared/and/index.ts
+++ b/packages/shared/and/index.ts
@@ -4,7 +4,7 @@ import { computed, ComputedRef, unref } from 'vue-demi'
 /**
  * `AND` conditions for refs.
  *
- * @link https://vueuse.org/and
+ * @see https://vueuse.org/and
  */
 export function and(...args: MaybeRef<any>[]): ComputedRef<boolean> {
   return computed(() => args.every(i => unref(i)))

--- a/packages/shared/not/index.md
+++ b/packages/shared/not/index.md
@@ -31,7 +31,7 @@ whenever(not(a), () => {
 /**
  * `NOT` conditions for refs.
  *
- * @link https://vueuse.org/not
+ * @see https://vueuse.org/not
  */
 export declare function not(v: MaybeRef<any>): ComputedRef<boolean>
 ```

--- a/packages/shared/not/index.ts
+++ b/packages/shared/not/index.ts
@@ -4,7 +4,7 @@ import { computed, ComputedRef, unref } from 'vue-demi'
 /**
  * `NOT` conditions for refs.
  *
- * @link https://vueuse.org/not
+ * @see https://vueuse.org/not
  */
 export function not(v: MaybeRef<any>): ComputedRef<boolean> {
   return computed(() => !unref(v))

--- a/packages/shared/or/index.md
+++ b/packages/shared/or/index.md
@@ -32,7 +32,7 @@ whenever(or(a, b), () => {
 /**
  * `OR` conditions for refs.
  *
- * @link https://vueuse.org/or
+ * @see https://vueuse.org/or
  */
 export declare function or(...args: MaybeRef<any>[]): ComputedRef<boolean>
 ```

--- a/packages/shared/or/index.ts
+++ b/packages/shared/or/index.ts
@@ -4,7 +4,7 @@ import { computed, ComputedRef, unref } from 'vue-demi'
 /**
  * `OR` conditions for refs.
  *
- * @link https://vueuse.org/or
+ * @see https://vueuse.org/or
  */
 export function or(...args: MaybeRef<any>[]): ComputedRef<boolean> {
   return computed(() => args.some(i => unref(i)))

--- a/packages/shared/reactivePick/index.md
+++ b/packages/shared/reactivePick/index.md
@@ -80,7 +80,7 @@ const size = reactivePick(useElementBounding(), 'height', 'width')
 /**
  * Reactively pick fields from a reactive object
  *
- * @link https://vueuse.js.org/reactivePick
+ * @see https://vueuse.js.org/reactivePick
  */
 export declare function reactivePick<T extends object, K extends keyof T>(
   obj: T,

--- a/packages/shared/reactivePick/index.ts
+++ b/packages/shared/reactivePick/index.ts
@@ -3,7 +3,7 @@ import { reactive, toRef, UnwrapRef } from 'vue-demi'
 /**
  * Reactively pick fields from a reactive object
  *
- * @link https://vueuse.js.org/reactivePick
+ * @see https://vueuse.js.org/reactivePick
  */
 export function reactivePick<T extends object, K extends keyof T>(
   obj: T,

--- a/packages/shared/until/index.md
+++ b/packages/shared/until/index.md
@@ -131,7 +131,7 @@ export interface UntilArrayInstance<T> extends UntilBaseInstance<T> {
 /**
  * Promised one-time watch for changes
  *
- * @link https://vueuse.org/until
+ * @see https://vueuse.org/until
  * @example
  * ```
  * const { count } = useCounter()

--- a/packages/shared/until/index.ts
+++ b/packages/shared/until/index.ts
@@ -60,7 +60,7 @@ export interface UntilArrayInstance<T> extends UntilBaseInstance<T> {
 /**
  * Promised one-time watch for changes
  *
- * @link https://vueuse.org/until
+ * @see https://vueuse.org/until
  * @example
  * ```
  * const { count } = useCounter()

--- a/packages/shared/useCounter/index.md
+++ b/packages/shared/useCounter/index.md
@@ -22,7 +22,7 @@ const { count, inc, dec, set, reset } = useCounter()
 /**
  * Basic counter with utility functions.
  *
- * @link https://vueuse.org/useCounter
+ * @see https://vueuse.org/useCounter
  * @param [initialValue=0]
  */
 export declare function useCounter(

--- a/packages/shared/useCounter/index.ts
+++ b/packages/shared/useCounter/index.ts
@@ -3,7 +3,7 @@ import { ref } from 'vue-demi'
 /**
  * Basic counter with utility functions.
  *
- * @link https://vueuse.org/useCounter
+ * @see https://vueuse.org/useCounter
  * @param [initialValue=0]
  */
 export function useCounter(initialValue = 0) {

--- a/packages/shared/useLastChanged/index.md
+++ b/packages/shared/useLastChanged/index.md
@@ -33,7 +33,7 @@ export interface UseLastChangedOptions<
 /**
  * Records the timestamp of the last change
  *
- * @link https://vueuse.org/useLastChanged
+ * @see https://vueuse.org/useLastChanged
  */
 export declare function useLastChanged(
   source: WatchSource,

--- a/packages/shared/useLastChanged/index.ts
+++ b/packages/shared/useLastChanged/index.ts
@@ -11,7 +11,7 @@ export interface UseLastChangedOptions<
 /**
  * Records the timestamp of the last change
  *
- * @link https://vueuse.org/useLastChanged
+ * @see https://vueuse.org/useLastChanged
  */
 export function useLastChanged(source: WatchSource, options?: UseLastChangedOptions<false>): Ref<number | null>
 export function useLastChanged(source: WatchSource, options: UseLastChangedOptions<true>): Ref<number>

--- a/packages/shared/useToggle/index.md
+++ b/packages/shared/useToggle/index.md
@@ -30,7 +30,7 @@ const toggleDark = useToggle(isDark)
 /**
  * A boolean ref with a toggler
  *
- * @link https://vueuse.org/useToggle
+ * @see https://vueuse.org/useToggle
  * @param [initialValue=false]
  */
 export declare function useToggle(value: Ref<boolean>): () => boolean

--- a/packages/shared/useToggle/index.ts
+++ b/packages/shared/useToggle/index.ts
@@ -3,7 +3,7 @@ import { isRef, Ref, ref } from 'vue-demi'
 /**
  * A boolean ref with a toggler
  *
- * @link https://vueuse.org/useToggle
+ * @see https://vueuse.org/useToggle
  * @param [initialValue=false]
  */
 export function useToggle(value: Ref<boolean>): () => boolean

--- a/packages/shared/whenever/index.md
+++ b/packages/shared/whenever/index.md
@@ -63,7 +63,7 @@ whenever(
 /**
  * Shorthand for watching value to be truthy
  *
- * @link https://vueuse.js.org/whenever
+ * @see https://vueuse.js.org/whenever
  */
 export declare function whenever<T = boolean>(
   source: WatchSource<T>,

--- a/packages/shared/whenever/index.ts
+++ b/packages/shared/whenever/index.ts
@@ -4,7 +4,7 @@ import { Fn } from '../utils'
 /**
  * Shorthand for watching value to be truthy
  *
- * @link https://vueuse.js.org/whenever
+ * @see https://vueuse.js.org/whenever
  */
 export function whenever<T = boolean>(source: WatchSource<T>, cb: Fn, options?: WatchOptions) {
   return watch(


### PR DESCRIPTION
`@link` is **inline** directive. Therefore, using it as
```js
/**
 * @link https://...
 */
```
 is actually a wrong syntax. As a result, some editors do not handle links correctly:

![зображення](https://user-images.githubusercontent.com/1662812/116373059-8a5ed500-a7fc-11eb-81bd-3a92bef59139.png)
Note that the link is `https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver|MutationObserver`.

Also, in rendered mode `@link` are not parsed at all, 
![зображення](https://user-images.githubusercontent.com/1662812/116373126-9a76b480-a7fc-11eb-92fe-5a86c0311320.png)

Because the `@link` is used as a block directive, I replaced it with the `@see` directive, and changed the syntax for anchors in some places. Now:

![зображення](https://user-images.githubusercontent.com/1662812/116373194-a6fb0d00-a7fc-11eb-9177-f6052e026f59.png)
![зображення](https://user-images.githubusercontent.com/1662812/116373276-b37f6580-a7fc-11eb-92f1-798bc519e668.png)

Alternatively, you could use the link directive, but in an inline mode:
```js
/**
 * {@link https://...}
 */
```