### PR TITLE
fix(useAsyncState): fix delay and option for disabling state reset

### DIFF
--- a/packages/core/useAsyncState/demo.vue
+++ b/packages/core/useAsyncState/demo.vue
@@ -3,16 +3,22 @@ import axios from 'axios'
 import YAML from 'js-yaml'
 import { useAsyncState } from '.'
 
-const { state, ready } = useAsyncState(
-  axios.get('https://jsonplaceholder.typicode.com/todos/1').then(t => t.data),
+const { state, isReady, execute } = useAsyncState(
+  () => axios.get('https://jsonplaceholder.typicode.com/todos/1').then(t => t.data),
   {},
-  2000,
+  {
+    delay: 2000,
+    resetOnExecute: false,
+  },
 )
 </script>
 
 <template>
   <div>
-    <note>Ready: {{ ready.toString() }}</note>
+    <note>Ready: {{ isReady.toString() }}</note>
     <pre lang="json" class="ml-2">{{ YAML.dump(state) }}</pre>
+    <button @click="execute(2000)">
+      Execute
+    </button>
   </div>
 </template>

--- a/packages/core/useAsyncState/index.ts
+++ b/packages/core/useAsyncState/index.ts
@@ -23,6 +23,17 @@ export interface AsyncStateOptions {
    * Callback when error is caught.
    */
   onError?: (e: Error) => void
+
+  /**
+   * Sets the state to initialState before executing the promise.
+   *
+   * This can be useful when calling the execute function more than once (for
+   * example, to refresh data). When set to false, the current state remains
+   * unchanged until the promise resolves.
+   *
+   * @default true
+   */
+  resetOnExecute?: boolean
 }
 
 /**
@@ -43,6 +54,7 @@ export function useAsyncState<T>(
     immediate = true,
     delay = 0,
     onError = noop,
+    resetOnExecute = true,
   } = options
 
   const state = shallowRef(initialState)
@@ -50,7 +62,9 @@ export function useAsyncState<T>(
   const error = ref<Error | undefined>(undefined)
 
   async function execute(delay = 0) {
-    state.value = initialState
+    if (resetOnExecute)
+      state.value = initialState
+
     error.value = undefined
     isReady.value = false
 

--- a/packages/core/useAsyncState/index.ts
+++ b/packages/core/useAsyncState/index.ts
@@ -54,7 +54,7 @@ export function useAsyncState<T>(
     error.value = undefined
     isReady.value = false
 
-    if (!delay)
+    if (delay > 0)
       await promiseTimeout(delay)
 
     const _promise = typeof promise === 'function'


### PR DESCRIPTION
Implements the suggestion in https://github.com/vueuse/vueuse/issues/480. I added it as an option in order to avoid breaking existing code.

In addition, the delay option was not working (`!delay` is false when delay is non-zero). This PR fixes it as well.