### PR TITLE
fix(useMediaControls): Removes tracks that have been inserted in html

### DIFF
--- a/packages/core/useMediaControls/index.ts
+++ b/packages/core/useMediaControls/index.ts
@@ -384,7 +384,7 @@ export function useMediaControls(target: MaybeRef<HTMLMediaElement | null | unde
     const textTracks = unref(options.tracks)
     const el = unref(target)
 
-    if (!textTracks || !el)
+    if (!textTracks || !textTracks.length || !el)
       return
 
     /**


### PR DESCRIPTION
By default, `textTracks` are an empty array.

https://github.com/vueuse/vueuse/blob/ecd649621c4f7a6703f3cf2d897eb81a2f47a5db/packages/core/useMediaControls/index.ts#L387-L395

If you insert tracks not in the parameters but directly into the template like `<track>`, they will be deleted because `!textTracks` is `false` by default.