### PR TITLE
feat(onClickOutside): default to just pointerDown 

### DIFF
--- a/packages/core/onClickOutside/demo.vue
+++ b/packages/core/onClickOutside/demo.vue
@@ -22,6 +22,7 @@ onClickOutside(
     console.log(event)
     dropdown.value = false
   },
+  { event: 'mousedown' },
 )
 </script>
 

--- a/packages/core/onClickOutside/index.ts
+++ b/packages/core/onClickOutside/index.ts
@@ -7,7 +7,7 @@ const events = ['mousedown', 'touchstart', 'pointerdown'] as const
 type EventType = WindowEventMap[(typeof events)[number]]
 
 export interface OnClickOutsideOptions extends ConfigurableWindow {
-  events: ('mousedown' | 'touchstart' | 'pointerdown')[]
+  events: string[]
 }
 
 /**

--- a/packages/core/onClickOutside/index.ts
+++ b/packages/core/onClickOutside/index.ts
@@ -6,6 +6,10 @@ import { ConfigurableWindow, defaultWindow } from '../_configurable'
 const events = ['mousedown', 'touchstart', 'pointerdown'] as const
 type EventType = WindowEventMap[(typeof events)[number]]
 
+export interface OnClickOutsideOptions extends ConfigurableWindow {
+  events: ('mousedown' | 'touchstart' | 'pointerdown')[]
+}
+
 /**
  * Listen for clicks outside of an element.
  *
@@ -17,7 +21,9 @@ type EventType = WindowEventMap[(typeof events)[number]]
 export function onClickOutside(
   target: MaybeElementRef,
   handler: (evt: EventType) => void,
-  options: ConfigurableWindow = {},
+  options: OnClickOutsideOptions = {
+    events: ['pointerdown'],
+  },
 ) {
   const { window = defaultWindow } = options
 
@@ -35,7 +41,7 @@ export function onClickOutside(
     handler(event)
   }
 
-  let disposables: Fn[] = events
+  let disposables: Fn[] = options.events
     .map(event => useEventListener(window, event, listener, { passive: true }))
 
   const stop = () => {

--- a/packages/core/onClickOutside/index.ts
+++ b/packages/core/onClickOutside/index.ts
@@ -5,7 +5,7 @@ import { ConfigurableWindow, defaultWindow } from '../_configurable'
 
 export type AllowedEvents = Pick<WindowEventMap, 'mousedown' | 'mouseup' | 'touchstart' | 'touchend' | 'pointerdown' | 'pointerup'>
 export interface OnClickOutsideOptions<E extends keyof AllowedEvents> extends ConfigurableWindow {
-  event: E
+  event?: E
 }
 
 /**
@@ -19,11 +19,9 @@ export interface OnClickOutsideOptions<E extends keyof AllowedEvents> extends Co
 export function onClickOutside<E extends keyof AllowedEvents = 'pointerdown'>(
   target: MaybeElementRef,
   handler: (evt: AllowedEvents[E]) => void,
-  options: OnClickOutsideOptions<E> = {
-    event: 'pointerdown' as E,
-  },
+  options: OnClickOutsideOptions<E> = {},
 ) {
-  const { window = defaultWindow } = options
+  const { window = defaultWindow, event = 'pointerdown' } = options
 
   if (!window)
     return
@@ -39,7 +37,7 @@ export function onClickOutside<E extends keyof AllowedEvents = 'pointerdown'>(
     handler(event)
   }
 
-  const stop = useEventListener(window, options.event, listener, { passive: true })
+  const stop = useEventListener(window, event, listener, { passive: true })
 
   tryOnUnmounted(stop)
 

--- a/packages/core/onClickOutside/index.ts
+++ b/packages/core/onClickOutside/index.ts
@@ -3,8 +3,8 @@ import { MaybeElementRef, unrefElement } from '../unrefElement'
 import { useEventListener } from '../useEventListener'
 import { ConfigurableWindow, defaultWindow } from '../_configurable'
 
-export type AllowedEvents = Pick<WindowEventMap, 'mousedown' | 'mouseup' | 'touchstart' | 'touchend' | 'pointerdown' | 'pointerup'>
-export interface OnClickOutsideOptions<E extends keyof AllowedEvents> extends ConfigurableWindow {
+export type OnClickOutsideEvents = Pick<WindowEventMap, 'mousedown' | 'mouseup' | 'touchstart' | 'touchend' | 'pointerdown' | 'pointerup'>
+export interface OnClickOutsideOptions<E extends keyof OnClickOutsideEvents> extends ConfigurableWindow {
   event?: E
 }
 
@@ -16,9 +16,9 @@ export interface OnClickOutsideOptions<E extends keyof AllowedEvents> extends Co
  * @param handler
  * @param options
  */
-export function onClickOutside<E extends keyof AllowedEvents = 'pointerdown'>(
+export function onClickOutside<E extends keyof OnClickOutsideEvents = 'pointerdown'>(
   target: MaybeElementRef,
-  handler: (evt: AllowedEvents[E]) => void,
+  handler: (evt: OnClickOutsideEvents[E]) => void,
   options: OnClickOutsideOptions<E> = {},
 ) {
   const { window = defaultWindow, event = 'pointerdown' } = options
@@ -26,7 +26,7 @@ export function onClickOutside<E extends keyof AllowedEvents = 'pointerdown'>(
   if (!window)
     return
 
-  const listener = (event: AllowedEvents[E]) => {
+  const listener = (event: OnClickOutsideEvents[E]) => {
     const el = unrefElement(target)
     if (!el)
       return


### PR DESCRIPTION
default to just pointerDown and add option to include more events. Closes #451 