### PR TITLE
fix: Change `onMediaError` to `onSourceError`

### DIFF
--- a/packages/core/useMediaControls/index.ts
+++ b/packages/core/useMediaControls/index.ts
@@ -381,6 +381,15 @@ export function useMediaControls(target: MaybeRef<HTMLMediaElement | null | unde
     el.load()
   })
 
+  // Remove source error listeners
+  tryOnUnmounted(() => {
+    const el = unref(target)
+    if (!el)
+      return
+
+    el.querySelectorAll('source').forEach(e => e.removeEventListener('error', sourceErrorEvent.trigger))
+  })
+
   /**
    * Watch volume and change player volume when volume prop changes
    */

--- a/packages/core/useMediaControls/index.ts
+++ b/packages/core/useMediaControls/index.ts
@@ -236,7 +236,7 @@ export function useMediaControls(target: MaybeRef<HTMLMediaElement | null | unde
   const supportsPictureInPicture = document && 'pictureInPictureEnabled' in document
 
   // Events
-  const mediaErrorEvent = createEventHook<Event>()
+  const sourceErrorEvent = createEventHook<Event>()
 
   /**
    * Disables the specified track. If no track is specified then
@@ -369,6 +369,8 @@ export function useMediaControls(target: MaybeRef<HTMLMediaElement | null | unde
       source.setAttribute('src', src)
       source.setAttribute('type', type || '')
 
+      useEventListener(source, 'error', sourceErrorEvent.trigger)
+
       el.appendChild(source)
     })
 
@@ -465,7 +467,6 @@ export function useMediaControls(target: MaybeRef<HTMLMediaElement | null | unde
   useEventListener(target, 'play', () => ignorePlayingUpdates(() => playing.value = true))
   useEventListener(target, 'enterpictureinpicture', () => isPictureInPicture.value = true)
   useEventListener(target, 'leavepictureinpicture', () => isPictureInPicture.value = false)
-  useEventListener(target, 'error', mediaErrorEvent.trigger)
 
   /**
    * The following listeners need to listen to a nested
@@ -513,6 +514,6 @@ export function useMediaControls(target: MaybeRef<HTMLMediaElement | null | unde
     isPictureInPicture,
 
     // Events
-    onMediaError: mediaErrorEvent.on,
+    onSourceError: sourceErrorEvent.on,
   }
 }

--- a/packages/core/useMediaControls/index.ts
+++ b/packages/core/useMediaControls/index.ts
@@ -360,7 +360,10 @@ export function useMediaControls(target: MaybeRef<HTMLMediaElement | null | unde
       sources = [src]
 
     // Clear the sources
-    el.querySelectorAll('source').forEach(e => e.remove())
+    el.querySelectorAll('source').forEach((e) => {
+      e.removeEventListener('error', sourceErrorEvent.trigger)
+      e.remove()
+    })
 
     // Add new sources
     sources.forEach(({ src, type }) => {
@@ -369,7 +372,7 @@ export function useMediaControls(target: MaybeRef<HTMLMediaElement | null | unde
       source.setAttribute('src', src)
       source.setAttribute('type', type || '')
 
-      useEventListener(source, 'error', sourceErrorEvent.trigger)
+      source.addEventListener('error', sourceErrorEvent.trigger)
 
       el.appendChild(source)
     })


### PR DESCRIPTION
@wheatjs 

https://github.com/vueuse/vueuse/blob/87a464dbfc2bd489eb412a022df4b4b425b0bd43/packages/core/useMediaControls/index.ts#L468

The listener of `error` events on the media element mostly does not make sense.
`Error` never will be triggered on `<video>` or `<audio>` with `<source>` tag inside. This will be triggered directly on the `<source>` tag whose resource could not be loaded. And this event will not pop up. Check console in [simple demo](https://codepen.io/cawa-93/pen/wvJMZdK?editors=1010).
 
