### PR TITLE
refactor(useMediaControls): Deprecate options that can simply be set as attributes

### DIFF
--- a/packages/core/useMediaControls/demo.vue
+++ b/packages/core/useMediaControls/demo.vue
@@ -10,9 +10,9 @@ import { useMediaControls } from '.'
 
 const video = ref<HTMLVideoElement>()
 const loop = ref(false)
+const poster = 'https://bitmovin.com/wp-content/uploads/2016/06/sintel-poster.jpg'
 
 const controls = useMediaControls(video, {
-  loop,
   src: {
     src: 'https://upload.wikimedia.org/wikipedia/commons/transcoded/f/f1/Sintel_movie_4K.webm/Sintel_movie_4K.webm.1080p.vp9.webm',
     type: 'video/webm',
@@ -32,7 +32,6 @@ const controls = useMediaControls(video, {
       srcLang: 'fr',
     },
   ],
-  poster: 'https://bitmovin.com/wp-content/uploads/2016/06/sintel-poster.jpg',
 })
 
 const {
@@ -66,7 +65,14 @@ const formatDuration = (seconds: number) => new Date(1000 * seconds).toISOString
     @keydown.left="currentTime -= 10"
   >
     <div class="relative bg-black">
-      <video ref="video" crossorigin="anonymous" class="w-full block" @click="playing = !playing" />
+      <video
+        ref="video"
+        crossorigin="anonymous"
+        class="w-full block"
+        :poster="poster"
+        :loop="loop"
+        @click="playing = !playing"
+      />
       <div v-if="waiting" class="absolute inset-0 grid place-items-center pointer-events-none bg-black bg-opacity-20">
         <Spinner />
       </div>

--- a/packages/core/useMediaControls/demo.vue
+++ b/packages/core/useMediaControls/demo.vue
@@ -12,7 +12,6 @@ const video = ref<HTMLVideoElement>()
 const loop = ref(false)
 
 const controls = useMediaControls(video, {
-  controls: true,
   loop,
   src: {
     src: 'https://upload.wikimedia.org/wikipedia/commons/transcoded/f/f1/Sintel_movie_4K.webm/Sintel_movie_4K.webm.1080p.vp9.webm',

--- a/packages/core/useMediaControls/demo.vue
+++ b/packages/core/useMediaControls/demo.vue
@@ -9,11 +9,10 @@ import { stringify } from '@vueuse/docs-utils'
 import { useMediaControls } from '.'
 
 const video = ref<HTMLVideoElement>()
-const muted = ref(false)
 const loop = ref(false)
 
 const controls = useMediaControls(video, {
-  muted,
+  controls: true,
   loop,
   src: {
     src: 'https://upload.wikimedia.org/wikipedia/commons/transcoded/f/f1/Sintel_movie_4K.webm/Sintel_movie_4K.webm.1080p.vp9.webm',
@@ -46,6 +45,7 @@ const {
   waiting,
   selectedTrack,
   volume,
+  muted,
   isPictureInPicture,
   supportsPictureInPicture,
   togglePictureInPicture,

--- a/packages/core/useMediaControls/index.md
+++ b/packages/core/useMediaControls/index.md
@@ -15,10 +15,8 @@ import { ref } from 'vue'
 import { useMediaControls } from '@vueuse/core'
 
 const video = ref()
-const loop = ref(false)
 const { playing, currentTime, duration } = useMediaControls(video, { 
   src: 'video.mp4',
-  loop,
 })
 </script>
 
@@ -26,7 +24,6 @@ const { playing, currentTime, duration } = useMediaControls(video, {
   <video ref="video" />
   <button @click="playing = !playing">Play / Pause</button>
   <span>{{ currentTime }} / {{ duration }}</span>
-  <button @click="loop = !loop">Toggle Loop</button>
 </template>
 ```
 

--- a/packages/core/useMediaControls/index.ts
+++ b/packages/core/useMediaControls/index.ts
@@ -479,6 +479,10 @@ export function useMediaControls(target: MaybeRef<HTMLMediaElement | null | unde
   useEventListener(target, 'play', () => ignorePlayingUpdates(() => playing.value = true))
   useEventListener(target, 'enterpictureinpicture', () => isPictureInPicture.value = true)
   useEventListener(target, 'leavepictureinpicture', () => isPictureInPicture.value = false)
+  useEventListener(target, 'volumechange', () => {
+    options.muted.value = (unref(target))!.muted
+    volume.value = (unref(target))!.volume
+  })
 
   /**
    * The following listeners need to listen to a nested

--- a/packages/core/useMediaControls/index.ts
+++ b/packages/core/useMediaControls/index.ts
@@ -317,49 +317,49 @@ export function useMediaControls(target: MaybeRef<HTMLMediaElement | null | unde
 
     const loop = unref(options.loop)
     if (loop !== undefined) {
-      console.warn('loop option is deprecated. Use `<video loop>` attribute instead')
+      console.warn('[Deprecation] loop option is deprecated. Please use `<video loop>` attribute instead')
       el.loop = loop
     }
 
     const controls = unref(options.controls)
     if (controls !== undefined) {
-      console.warn('controls option is deprecated. Use `<video controls>` attribute instead')
+      console.warn('[Deprecation] controls option is deprecated. Please use `<video controls>` attribute instead')
       el.controls = controls
     }
 
     const muted = unref(options.muted)
     if (muted !== undefined) {
-      console.warn('Muted option is deprecated. Use `const { muted } = useMediaControls();` instead')
+      console.warn('[Deprecation] Muted option is deprecated. Please use `const { muted } = useMediaControls();` instead')
       el.muted = muted
     }
 
     const preload = unref(options.preload)
     if (preload !== undefined) {
-      console.warn('preload option is deprecated. Use `<video preload>` attribute instead')
+      console.warn('[Deprecation] preload option is deprecated. Please use `<video preload>` attribute instead')
       el.preload = preload
     }
 
     const autoplay = unref(options.autoplay)
     if (autoplay !== undefined) {
-      console.warn('autoplay option is deprecated. Use `<video autoplay>` attribute instead')
+      console.warn('[Deprecation] autoplay option is deprecated. Please use `<video autoplay>` attribute instead')
       el.autoplay = autoplay
     }
 
     const poster = unref(options.poster)
     if (poster !== undefined) {
-      console.warn('poster option is deprecated. Use `<video poster>` attribute instead')
+      console.warn('[Deprecation] poster option is deprecated. Please use `<video poster>` attribute instead')
       ;(el as HTMLVideoElement).poster = poster
     }
 
     const playsInline = unref(options.playsinline)
     if (playsInline !== undefined) {
-      console.warn('playsInline option is deprecated. Use `<video playsinline>` attribute instead')
+      console.warn('[Deprecation] playsInline option is deprecated. Please use `<video playsinline>` attribute instead')
       ;(el as HTMLVideoElement).playsInline = playsInline
     }
 
     const autoPictureInPicture = unref(options.autoPictureInPicture)
     if (autoPictureInPicture !== undefined) {
-      console.warn('autoPictureInPicture option is deprecated. Use `<video autopictureinpicture>` attribute instead')
+      console.warn('[Deprecation] autoPictureInPicture option is deprecated. Please use `<video autopictureinpicture>` attribute instead')
       // @ts-expect-error HTMLVideoElement.autoPictureInPicture not implemented in TS
       ;(el as HTMLVideoElement).autoPictureInPicture = autoPictureInPicture
     }

--- a/packages/core/useMediaControls/index.ts
+++ b/packages/core/useMediaControls/index.ts
@@ -316,53 +316,29 @@ export function useMediaControls(target: MaybeRef<HTMLMediaElement | null | unde
       return
 
     const loop = unref(options.loop)
-    if (loop !== undefined) {
-      console.warn('[Deprecation] loop option is deprecated. Please use `<video loop>` attribute instead')
-      el.loop = loop
-    }
+    if (loop !== undefined) el.loop = loop
 
     const controls = unref(options.controls)
-    if (controls !== undefined) {
-      console.warn('[Deprecation] controls option is deprecated. Please use `<video controls>` attribute instead')
-      el.controls = controls
-    }
+    if (controls !== undefined) el.controls = controls
 
     const muted = unref(options.muted)
-    if (muted !== undefined) {
-      console.warn('[Deprecation] Muted option is deprecated. Please use `const { muted } = useMediaControls();` instead')
-      el.muted = muted
-    }
+    if (muted !== undefined) el.muted = muted
 
     const preload = unref(options.preload)
-    if (preload !== undefined) {
-      console.warn('[Deprecation] preload option is deprecated. Please use `<video preload>` attribute instead')
-      el.preload = preload
-    }
+    if (preload !== undefined) el.preload = preload
 
     const autoplay = unref(options.autoplay)
-    if (autoplay !== undefined) {
-      console.warn('[Deprecation] autoplay option is deprecated. Please use `<video autoplay>` attribute instead')
-      el.autoplay = autoplay
-    }
+    if (autoplay !== undefined) el.autoplay = autoplay
 
     const poster = unref(options.poster)
-    if (poster !== undefined) {
-      console.warn('[Deprecation] poster option is deprecated. Please use `<video poster>` attribute instead')
-      ;(el as HTMLVideoElement).poster = poster
-    }
+    if (poster !== undefined) (el as HTMLVideoElement).poster = poster
 
     const playsInline = unref(options.playsinline)
-    if (playsInline !== undefined) {
-      console.warn('[Deprecation] playsInline option is deprecated. Please use `<video playsinline>` attribute instead')
-      ;(el as HTMLVideoElement).playsInline = playsInline
-    }
+    if (playsInline !== undefined) (el as HTMLVideoElement).playsInline = playsInline
 
     const autoPictureInPicture = unref(options.autoPictureInPicture)
-    if (autoPictureInPicture !== undefined) {
-      console.warn('[Deprecation] autoPictureInPicture option is deprecated. Please use `<video autopictureinpicture>` attribute instead')
-      // @ts-expect-error HTMLVideoElement.autoPictureInPicture not implemented in TS
-      ;(el as HTMLVideoElement).autoPictureInPicture = autoPictureInPicture
-    }
+    // @ts-expect-error HTMLVideoElement.autoPictureInPicture not implemented in TS
+    if (autoPictureInPicture !== undefined) (el as HTMLVideoElement).autoPictureInPicture = autoPictureInPicture
   })
 
   /**

--- a/packages/core/useMediaControls/index.ts
+++ b/packages/core/useMediaControls/index.ts
@@ -62,6 +62,8 @@ interface UseMediaControlsOptions extends ConfigurableDocument {
    * A URL for an image to be shown while the media is downloading. If this attribute
    * isn't specified, nothing is displayed until the first frame is available,
    * then the first frame is shown as the poster frame.
+   *
+   * @deprecated Use `<video poster>` attribute instead
    */
   poster?: MaybeRef<string>
 
@@ -70,6 +72,7 @@ interface UseMediaControlsOptions extends ConfigurableDocument {
    * can do so without stopping to finish loading the data.
    *
    * @default false
+   * @deprecated Use `<video autoplay>` attribute instead
    */
   autoplay?: MaybeRef<boolean>
 
@@ -79,6 +82,7 @@ interface UseMediaControlsOptions extends ConfigurableDocument {
    * not imply that the media will always be played in fullscreen.
    *
    * @default auto
+   * @deprecated Use `<video preload>` attribute instead
    */
   preload?: MaybeRef<'auto' | 'metadata' | 'none' >
 
@@ -87,6 +91,7 @@ interface UseMediaControlsOptions extends ConfigurableDocument {
    * upon reaching the end of the media.
    *
    * @default false
+   * @deprecated Use `<video loop>` attribute instead
    */
   loop?: MaybeRef<boolean>
 
@@ -95,6 +100,7 @@ interface UseMediaControlsOptions extends ConfigurableDocument {
    * media playback, including volume, seeking, and pause/resume playback.
    *
    * @default false
+   * @deprecated Use `<video controls>` attribute instead
    */
   controls?: MaybeRef<boolean>
 
@@ -103,8 +109,7 @@ interface UseMediaControlsOptions extends ConfigurableDocument {
    * meaning that the audio will be played when the media is played.
    *
    * @default false
-   * @deprecated This option is deprecated.
-   * Use `const { muted } = useMediaControls();` instead
+   * @deprecated Use `const { muted } = useMediaControls();` instead
    */
   muted?: MaybeRef<boolean>
 
@@ -114,6 +119,7 @@ interface UseMediaControlsOptions extends ConfigurableDocument {
    * that the video will always be played in fullscreen.
    *
    * @default false
+   * @deprecated Use `<video playsinline>` attribute instead
    */
   playsinline?: MaybeRef<boolean>
 
@@ -123,6 +129,7 @@ interface UseMediaControlsOptions extends ConfigurableDocument {
    * this document and another document or application.
    *
    * @default false
+   * @deprecated Use `<video autopictureinpicture>` attribute instead
    */
   autoPictureInPicture?: MaybeRef<boolean>
 
@@ -309,10 +316,16 @@ export function useMediaControls(target: MaybeRef<HTMLMediaElement | null | unde
       return
 
     const loop = unref(options.loop)
-    if (loop !== undefined) el.loop = loop
+    if (loop !== undefined) {
+      console.warn('loop option is deprecated. Use `<video loop>` attribute instead')
+      el.loop = loop
+    }
 
     const controls = unref(options.controls)
-    if (controls !== undefined) el.controls = controls
+    if (controls !== undefined) {
+      console.warn('controls option is deprecated. Use `<video controls>` attribute instead')
+      el.controls = controls
+    }
 
     const muted = unref(options.muted)
     if (muted !== undefined) {
@@ -321,22 +334,35 @@ export function useMediaControls(target: MaybeRef<HTMLMediaElement | null | unde
     }
 
     const preload = unref(options.preload)
-    if (preload !== undefined) el.preload = preload
+    if (preload !== undefined) {
+      console.warn('preload option is deprecated. Use `<video preload>` attribute instead')
+      el.preload = preload
+    }
 
     const autoplay = unref(options.autoplay)
-    if (autoplay !== undefined) el.autoplay = autoplay
+    if (autoplay !== undefined) {
+      console.warn('autoplay option is deprecated. Use `<video autoplay>` attribute instead')
+      el.autoplay = autoplay
+    }
 
     const poster = unref(options.poster)
-    if (poster !== undefined) (el as HTMLVideoElement).poster = poster
+    if (poster !== undefined) {
+      console.warn('poster option is deprecated. Use `<video poster>` attribute instead')
+      ;(el as HTMLVideoElement).poster = poster
+    }
 
     const playsInline = unref(options.playsinline)
-    if (playsInline !== undefined) (el as HTMLVideoElement).playsInline = playsInline
+    if (playsInline !== undefined) {
+      console.warn('playsInline option is deprecated. Use `<video playsinline>` attribute instead')
+      ;(el as HTMLVideoElement).playsInline = playsInline
+    }
 
     const autoPictureInPicture = unref(options.autoPictureInPicture)
-    // @ts-expect-error HTMLVideoElement.autoPictureInPicture not implemented in TS
-    if (autoPictureInPicture !== undefined) (el as HTMLVideoElement).autoPictureInPicture = autoPictureInPicture
-
-    // el.volume = unref(volume)!
+    if (autoPictureInPicture !== undefined) {
+      console.warn('autoPictureInPicture option is deprecated. Use `<video autopictureinpicture>` attribute instead')
+      // @ts-expect-error HTMLVideoElement.autoPictureInPicture not implemented in TS
+      ;(el as HTMLVideoElement).autoPictureInPicture = autoPictureInPicture
+    }
   })
 
   /**


### PR DESCRIPTION
If you change the volume or muted values by native controls (or in devtools) it does not effect reactive variables. [Here is a demonstration](https://sfc.vuejs.org/#eyJBcHAudnVlIjoiPHNjcmlwdCBzZXR1cD5cbmltcG9ydCB7IHJlZiB9IGZyb20gJ3Z1ZSdcbmltcG9ydCB7IHVzZU1lZGlhQ29udHJvbHMgfSBmcm9tICdAdnVldXNlL2NvcmUnXG4gIFxuY29uc3Qgb3JpZ2luU291cmNlID0gJ2h0dHBzOi8vaW50ZXJhY3RpdmUtZXhhbXBsZXMubWRuLm1vemlsbGEubmV0L21lZGlhL2NjMC12aWRlb3MvZmxvd2VyLndlYm0nXG5jb25zdCBzcmMgPSByZWYob3JpZ2luU291cmNlKVxuXG5jb25zdCBtdXRlZCA9IHJlZihmYWxzZSlcbmNvbnN0IHZpZGVvRWxlbWVudCA9IHJlZigpXG5jb25zdCB7cGxheWluZywgdm9sdW1lfSA9IHVzZU1lZGlhQ29udHJvbHModmlkZW9FbGVtZW50LCB7XG4gIGF1dG9wbGF5OiBmYWxzZSwgLy8gPC0tXG4gIGNvbnRyb2xzOiB0cnVlLCBcbiAgcHJlbG9hZDogJ21ldGFkYXRhJyxcbiAgc3JjLFxuICBtdXRlZFxufSlcblxuPC9zY3JpcHQ+XG5cbjx0ZW1wbGF0ZT5cbiAgPGRpdiBzdHlsZT1cImRpc3BsYXk6IGdyaWQ7IHBsYWNlLWNvbnRlbnQ6IGNlbnRlcjsgcGxhY2UtaXRlbXM6IGNlbnRlcjsgaGVpZ2h0OiAxMDAlOyBnYXA6IDFyZW07IHVzZXItc2VsZWN0OiBub25lO1wiPlxuICAgIDx2aWRlbyAgcmVmPVwidmlkZW9FbGVtZW50XCI+PC92aWRlbz5cbiAgICBcbiAgICB2b2x1bWU6IHt7dm9sdW1lfX1cbiAgICBtdXRlZDoge3ttdXRlZH19XG4gIDwvZGl2PlxuPC90ZW1wbGF0ZT5cbiIsImltcG9ydC1tYXAuanNvbiI6IntcbiAgXCJpbXBvcnRzXCI6IHtcblx0XHRcIkB2dWV1c2UvY29yZVwiOiBcImh0dHBzOi8vdW5wa2cuY29tL0B2dWV1c2UvY29yZS9kaXN0L2luZGV4LmVzbS5qc1wiLFxuICAgIFwiQHZ1ZXVzZS9zaGFyZWRcIjogXCJodHRwczovL3VucGtnLmNvbS9AdnVldXNlL3NoYXJlZC9kaXN0L2luZGV4LmVzbS5qc1wiLFxuICAgIFwidnVlLWRlbWlcIjogXCJodHRwczovL3VucGtnLmNvbS92dWUtZGVtaS9saWIvaW5kZXguZXNtLmpzXCJcbiAgfVxufSJ9).