### PR TITLE
refactor(useSwipe): switch to PointerEvents

### DIFF
--- a/indexes.json
+++ b/indexes.json
@@ -772,7 +772,7 @@
       "package": "core",
       "docs": "https://vueuse.org/core/useSwipe/",
       "category": "Sensors",
-      "description": "reactive swipe detection based on [`TouchEvents`](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent)"
+      "description": "reactive swipe detection based on [`PointerEvents`](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events)"
     },
     {
       "name": "useTimeAgo",

--- a/packages/core/useSwipe/demo.vue
+++ b/packages/core/useSwipe/demo.vue
@@ -17,7 +17,7 @@ const reset = () => {
 const { direction, isSwiping, lengthX, lengthY } = useSwipe(
   target, {
     passive: false,
-    onSwipe(e: TouchEvent) {
+    onSwipe(e: PointerEvent) {
       if (containerWidth.value) {
         if (lengthX.value < 0) {
           const length = Math.abs(lengthX.value)
@@ -30,7 +30,7 @@ const { direction, isSwiping, lengthX, lengthY } = useSwipe(
         }
       }
     },
-    onSwipeEnd(e: TouchEvent, direction: SwipeDirection) {
+    onSwipeEnd(e: PointerEvent, direction: SwipeDirection) {
       if (lengthX.value < 0 && containerWidth.value && (Math.abs(lengthX.value) / containerWidth.value) >= 0.5) {
         left.value = '100%'
         opacity.value = 0

--- a/packages/core/useSwipe/index.md
+++ b/packages/core/useSwipe/index.md
@@ -4,7 +4,7 @@ category: Sensors
 
 # useSwipe
 
-Reactive swipe detection based on [`TouchEvents`](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent).
+Reactive swipe detection based on [`PointerEvents`](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events).
 
 ## Usage
 
@@ -50,15 +50,15 @@ export interface SwipeOptions extends ConfigurableWindow {
   /**
    * Callback on swipe start
    */
-  onSwipeStart?: (e: TouchEvent) => void
+  onSwipeStart?: (e: PointerEvent) => void
   /**
    * Callback on swipe moves
    */
-  onSwipe?: (e: TouchEvent) => void
+  onSwipe?: (e: PointerEvent) => void
   /**
    * Callback on swipe ends
    */
-  onSwipeEnd?: (e: TouchEvent, direction: SwipeDirection) => void
+  onSwipeEnd?: (e: PointerEvent, direction: SwipeDirection) => void
 }
 export interface SwipeReturn {
   isPassiveEventSupported: boolean
@@ -84,7 +84,7 @@ export interface SwipeReturn {
  * @param options
  */
 export declare function useSwipe(
-  target: MaybeRef<EventTarget | null | undefined>,
+  target: MaybeRef<Element | null | undefined>,
   options?: SwipeOptions
 ): {
   isPassiveEventSupported: boolean

--- a/packages/core/useSwipe/index.test.ts
+++ b/packages/core/useSwipe/index.test.ts
@@ -3,43 +3,43 @@ import { useSetup } from '../../.test'
 
 import each from 'jest-each'
 
+// polyfill for jsdom (https://github.com/jsdom/jsdom/pull/2666)
+if (!global.PointerEvent) {
+  class PointerEvent extends MouseEvent {
+    public pointerId?: number
+
+    constructor(type: string, params: PointerEventInit = {}) {
+      super(type, params)
+      this.pointerId = params.pointerId
+    }
+  }
+  global.PointerEvent = PointerEvent as any
+}
+
 describe('useSwipe', () => {
   const target = document.createElement('div')
+  // set to noop, else test will fail
+  target.setPointerCapture = (pointerId: number) => {}
   target.id = 'target'
   document.body.appendChild(target)
 
-  const mockTouchEventInit = (x: number, y: number): TouchEventInit => ({
-    touches: [{
-      clientX: x,
-      clientY: y,
-      altitudeAngle: 0,
-      azimuthAngle: 0,
-      force: 0,
-      identifier: 0,
-      pageX: 0,
-      pageY: 0,
-      radiusX: 0,
-      radiusY: 0,
-      rotationAngle: 0,
-      screenX: 0,
-      screenY: 0,
-      target,
-      touchType: 'direct',
-    }],
+  const mockPointerEventInit = (x: number, y: number): PointerEventInit => ({
+    clientX: x,
+    clientY: y,
   })
 
-  const mockTouchStart = (x: number, y: number) => new TouchEvent('touchstart', mockTouchEventInit(x, y))
-  const mockTouchMove = (x: number, y: number) => new TouchEvent('touchmove', mockTouchEventInit(x, y))
-  const mockTouchEnd = (x: number, y: number) => new TouchEvent('touchend', mockTouchEventInit(x, y))
+  const mockPointerDown = (x: number, y: number) => new PointerEvent('pointerdown', mockPointerEventInit(x, y))
+  const mockPointerMove = (x: number, y: number) => new PointerEvent('pointermove', mockPointerEventInit(x, y))
+  const mockPointerUp = (x: number, y: number) => new PointerEvent('pointerup', mockPointerEventInit(x, y))
 
-  const mockTouchEvents = (target: EventTarget, coords: Array<number[]>) => {
+  const mockPointerEvents = (target: Element, coords: Array<number[]>) => {
     coords.forEach(([x, y], i) => {
       if (i === 0)
-        target.dispatchEvent(mockTouchStart(x, y))
+        target.dispatchEvent(mockPointerDown(x, y))
       else if (i === coords.length - 1)
-        target.dispatchEvent(mockTouchEnd(x, y))
+        target.dispatchEvent(mockPointerUp(x, y))
       else
-        target.dispatchEvent(mockTouchMove(x, y))
+        target.dispatchEvent(mockPointerMove(x, y))
     })
   }
 
@@ -48,15 +48,15 @@ describe('useSwipe', () => {
   const threshold = 30
 
   beforeEach(() => {
-    onSwipe = jest.fn((e: TouchEvent) => {})
-    onSwipeEnd = jest.fn((e: TouchEvent, direction: SwipeDirection) => {})
+    onSwipe = jest.fn((e: PointerEvent) => {})
+    onSwipeEnd = jest.fn((e: PointerEvent, direction: SwipeDirection) => {})
   })
 
   it('threshold not exceeded', () => {
     useSetup(() => {
       useSwipe(target, { threshold, onSwipe, onSwipeEnd })
 
-      mockTouchEvents(target, [[0, 0], [threshold - 1, 0], [threshold - 1, 0]])
+      mockPointerEvents(target, [[0, 0], [threshold - 1, 0], [threshold - 1, 0]])
 
       expect(onSwipe.mock.calls.length).toBe(0)
       expect(onSwipeEnd.mock.calls.length).toBe(0)
@@ -67,7 +67,7 @@ describe('useSwipe', () => {
     useSetup(() => {
       useSwipe(target, { threshold, onSwipe, onSwipeEnd })
 
-      mockTouchEvents(target, [[0, 0], [threshold / 2, 0], [threshold, 0], [threshold, 0]])
+      mockPointerEvents(target, [[0, 0], [threshold / 2, 0], [threshold, 0], [threshold, 0]])
 
       expect(onSwipe.mock.calls.length).toBe(1)
       expect(onSwipeEnd.mock.calls.length).toBe(1)
@@ -78,7 +78,7 @@ describe('useSwipe', () => {
     useSetup(() => {
       useSwipe(target, { threshold, onSwipe, onSwipeEnd })
 
-      mockTouchEvents(target, [[0, 0], [threshold / 2, 0], [threshold, 0], [threshold - 1, 0], [threshold - 1, 0]])
+      mockPointerEvents(target, [[0, 0], [threshold / 2, 0], [threshold, 0], [threshold - 1, 0], [threshold - 1, 0]])
 
       expect(onSwipe.mock.calls.length).toBe(2)
       expect(onSwipeEnd.mock.calls.length).toBe(1)
@@ -90,19 +90,19 @@ describe('useSwipe', () => {
     useSetup(() => {
       const { isSwiping, direction, lengthX, lengthY } = useSwipe(target, { threshold, onSwipe, onSwipeEnd })
 
-      target.dispatchEvent(mockTouchStart(0, 0))
+      target.dispatchEvent(mockPointerDown(0, 0))
       expect(isSwiping.value).toBeFalsy()
       expect(direction.value).toBe(SwipeDirection.NONE)
       expect(lengthX.value).toBe(0)
       expect(lengthY.value).toBe(0)
 
-      target.dispatchEvent(mockTouchMove(threshold, 5))
+      target.dispatchEvent(mockPointerMove(threshold, 5))
       expect(isSwiping.value).toBeTruthy()
       expect(direction.value).toBe(SwipeDirection.RIGHT)
       expect(lengthX.value).toBe(-threshold)
       expect(lengthY.value).toBe(-5)
 
-      target.dispatchEvent(mockTouchEnd(threshold, 5))
+      target.dispatchEvent(mockPointerUp(threshold, 5))
     })
   })
 
@@ -115,7 +115,7 @@ describe('useSwipe', () => {
     useSetup(() => {
       const { direction } = useSwipe(target, { threshold, onSwipe, onSwipeEnd })
 
-      mockTouchEvents(target, coords)
+      mockPointerEvents(target, coords)
 
       expect(direction.value).toBe(expected)
       expect(onSwipeEnd.mock.calls[0][1]).toBe(expected)

--- a/packages/functions.md
+++ b/packages/functions.md
@@ -83,7 +83,7 @@
   - [`useParallax`](https://vueuse.org/core/useParallax/) — create parallax effect easily
   - [`useResizeObserver`](https://vueuse.org/core/useResizeObserver/) — reports changes to the dimensions of an Element's content or the border-box
   - [`useSpeechRecognition`](https://vueuse.org/core/useSpeechRecognition/) — reactive [SpeechRecognition](https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition)
-  - [`useSwipe`](https://vueuse.org/core/useSwipe/) — reactive swipe detection based on [`TouchEvents`](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent)
+  - [`useSwipe`](https://vueuse.org/core/useSwipe/) — reactive swipe detection based on [`PointerEvents`](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events)
   - [`useUserMedia`](https://vueuse.org/core/useUserMedia/) — reactive [`mediaDevices.getUserMedia`](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia) streaming
   - [`useWindowScroll`](https://vueuse.org/core/useWindowScroll/) — reactive window scroll
   - [`useWindowSize`](https://vueuse.org/core/useWindowSize/) — reactive window size


### PR DESCRIPTION
Hi there,

it was not that easy as I thought but I managed to switch `useSwipe` to [PointerEvents](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events). Unfortunately there are some breaking changes... and I needed to add a css workaround via [touch-action](https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action) to keep the `Touch` functionality (else the events are canceled by the browser which wants to keep scrolling enabled). This means we could drop the `passive` option, since it's no longer possible to have it passive.

Closes #511 