### PR TITLE
docs(useMediaControls): Add example for changing initial media state

### DIFF
--- a/packages/core/useMediaControls/index.md
+++ b/packages/core/useMediaControls/index.md
@@ -11,12 +11,18 @@ Reactive media controls for both `audio` and `video` elements
 ### Basic Usage
 ```html
 <script setup lang="ts">
-import { ref } from 'vue'
+import { onMounted, ref } from 'vue'
 import { useMediaControls } from '@vueuse/core'
 
 const video = ref()
-const { playing, currentTime, duration } = useMediaControls(video, { 
+const { playing, currentTime, duration, volume } = useMediaControls(video, { 
   src: 'video.mp4',
+})
+
+// Change initial media properties
+onMounted(() => {
+  volume.value = 0.5
+  currentTime.value = 60
 })
 </script>
 


### PR DESCRIPTION
I added little example for `useMediaControls` docs:
```js
const { playing, currentTime, duration, volume } = useMediaControls(video, { 
  src: 'video.mp4',
})

// Change initial media properties
onMounted(() => {
  volume.value = 0.5
  currentTime.value = 60
})
```

At first glance, it may seem that to change the initial state, it is enough to simply change the value without wrapping in the mount hook:
```js
const { playing, currentTime, duration, volume } = useMediaControls(video, { 
  src: 'video.mp4',
})

// Change initial media properties
volume.value = 0.5
currentTime.value = 60
```
But in reality it will not lead to the desired result because at the `setup` time target media element may not yet exist
https://github.com/vueuse/vueuse/blob/52c7a04cdacc5ac2601e51f1fe500a215d7cea15/packages/core/useMediaControls/index.ts#L298-L300