### PR TITLE
Set the watch parameter of useTitle to flush: 'post'

### DIFF
--- a/packages/core/useTitle/index.ts
+++ b/packages/core/useTitle/index.ts
@@ -35,7 +35,10 @@ export function useTitle(
       if (isString(t) && t !== o && document)
         document.title = t
     },
-    { immediate: true },
+    { 
+      immediate: true ,
+      flush: 'post'
+    },
   )
 
   if (observe && document) {


### PR DESCRIPTION
in some cases useTitle doesn't work .
it has to  work in nextick 

https://codepen.io/yjl626/pen/rNyKVZW
https://github.com/vuejs/vue-next/issues/2730

set watch option as flush: 'post' can fixed it
I think it's a reliable option in this function