### PR TITLE
feat(useObservable): now supports optional error handling via `onError`.

### DIFF
--- a/packages/rxjs/useObservable/index.md
+++ b/packages/rxjs/useObservable/index.md
@@ -39,12 +39,12 @@ const count = useObservable(
       if (n === 10) {
         throw new Error('oops')
       }
-      return n + n;
+      return n + n
     })
   ),
   {
     onError: err => {
-      console.log(err.message); // "oops"
+      console.log(err.message) // "oops"
     }
   }
 )
@@ -55,9 +55,8 @@ const count = useObservable(
 
 ```typescript
 export interface UseObservableOptions {
-  onError?: (error: any) => void;
+  onError?: (err: any) => void
 }
-
 export declare function useObservable<H>(
   observable: Observable<H>,
   options?: UseObservableOptions

--- a/packages/rxjs/useObservable/index.md
+++ b/packages/rxjs/useObservable/index.md
@@ -24,13 +24,43 @@ const count = useObservable(
 )
 ```
 
+If you want to add custom error handling to an observable that might error, you can supply an optional `onError` configuration. Without this, RxJS will treat any error in the supplied observable as an "unhandled error" and it will be thrown in a new call stack and reported to `window.onerror` (or `process.on('error')` if you happen to be in node).
+
+```ts
+import { ref } from 'vue'
+import { useObservable } from '@vueuse/rxjs'
+import { interval } from 'rxjs'
+import { map } from 'rxjs/operators'
+
+// setup()
+const count = useObservable(
+  interval(1000).pipe(
+    map(n => {
+      if (n === 10) {
+        throw new Error('oops')
+      }
+      return n + n;
+    })
+  ),
+  {
+    onError: err => {
+      console.log(err.message); // "oops"
+    }
+  }
+)
+```
 
 <!--FOOTER_STARTS-->
 ## Type Declarations
 
 ```typescript
+export interface UseObservableOptions {
+  onError?: (error: any) => void;
+}
+
 export declare function useObservable<H>(
-  observable: Observable<H>
+  observable: Observable<H>,
+  options?: UseObservableOptions
 ): Readonly<Ref<H>>
 ```
 

--- a/packages/rxjs/useObservable/index.ts
+++ b/packages/rxjs/useObservable/index.ts
@@ -2,9 +2,16 @@ import { Observable } from 'rxjs'
 import { Ref, ref } from 'vue-demi'
 import { tryOnUnmounted } from '@vueuse/shared'
 
-export function useObservable<H>(observable: Observable<H>): Readonly<Ref<H>> {
+export interface UseObservableOptions {
+  onError?: (err: any) => void;
+}
+
+export function useObservable<H>(observable: Observable<H>, options?: UseObservableOptions): Readonly<Ref<H>> {
   const value = ref<H | undefined>()
-  const subscription = observable.subscribe(val => (value.value = val))
+  const subscription = observable.subscribe({
+    next: val => (value.value = val),
+    error: options?.onError
+  })
   tryOnUnmounted(() => {
     subscription.unsubscribe()
   })

--- a/packages/rxjs/useObservable/index.ts
+++ b/packages/rxjs/useObservable/index.ts
@@ -3,14 +3,14 @@ import { Ref, ref } from 'vue-demi'
 import { tryOnUnmounted } from '@vueuse/shared'
 
 export interface UseObservableOptions {
-  onError?: (err: any) => void;
+  onError?: (err: any) => void
 }
 
 export function useObservable<H>(observable: Observable<H>, options?: UseObservableOptions): Readonly<Ref<H>> {
   const value = ref<H | undefined>()
   const subscription = observable.subscribe({
     next: val => (value.value = val),
-    error: options?.onError
+    error: options?.onError,
   })
   tryOnUnmounted(() => {
     subscription.unsubscribe()


### PR DESCRIPTION
Adds a few feature to allow users to configure error handling if they so choose. Without this feature, any error from the source observable would be treated as "unhandled" by RxJS, and thrown in a new call stack.

Resolves #566