### PR TITLE
feat(useObservable): now returns destructured values, including an `onError` hook

### DIFF
--- a/packages/rxjs/useObservable/index.md
+++ b/packages/rxjs/useObservable/index.md
@@ -4,7 +4,8 @@ category: '@RxJS'
 
 # useObservable
 
-Use an Observable, return a ref and automatically unsubscribe from it when the component is unmounted.
+Use an Observable, return a ref and automatically unsubscribe from it when the component is unmounted. It also returns an `onError` hook registration point that can be used to register 
+handlers for errors that are emitted by the observable.
 
 ## Usage
 
@@ -15,13 +16,18 @@ import { interval } from 'rxjs'
 import { mapTo, startWith, scan } from 'rxjs/operators'
 
 // setup()
-const count = useObservable(
+const { out: count, onError } = useObservable(
   interval(1000).pipe(
     mapTo(1),
     startWith(0),
     scan((total, next) => next + total),
   )
 )
+
+// Optional
+onError(err => {
+  console.log('An error occurred in the observable')
+})
 ```
 
 
@@ -31,7 +37,10 @@ const count = useObservable(
 ```typescript
 export declare function useObservable<H>(
   observable: Observable<H>
-): Readonly<Ref<H>>
+): {
+  out: Readonly<Ref<H>>;
+  onError: (cb: (error: any) => void) => void;
+}
 ```
 
 ## Source

--- a/packages/rxjs/useObservable/index.ts
+++ b/packages/rxjs/useObservable/index.ts
@@ -2,11 +2,38 @@ import { Observable } from 'rxjs'
 import { Ref, ref } from 'vue-demi'
 import { tryOnUnmounted } from '@vueuse/shared'
 
-export function useObservable<H>(observable: Observable<H>): Readonly<Ref<H>> {
-  const value = ref<H | undefined>()
-  const subscription = observable.subscribe(val => (value.value = val))
+export function useObservable<H>(observable: Observable<H>): { out: Readonly<Ref<H>>, onError: (cb: (err: any) => void) => void } {
+  const out = ref<H | undefined>()
+  const errorHandlers = new Set<(err: any) => void>()
+
+  const subscription = observable.subscribe({
+    next: val => (out.value = val),
+    error: err => {
+      if (errorHandlers.size) {
+        errorHandlers.forEach(cb => cb(err))
+      } else {
+        // Allow RxJS to treat the error as unhandled, as it normally would
+        // with no error handling provided.
+        throw err
+      }
+    }
+  })
+
+  subscription.add(() => {
+    // Ensure that our error handlers are cleaned up when our subscription is done.
+    errorHandlers.clear();
+  });
+
   tryOnUnmounted(() => {
     subscription.unsubscribe()
   })
-  return value as Readonly<Ref<H>>
+
+  const onError = (cb: (err: any) => void) => {
+    errorHandlers.add(cb);
+  }
+
+  return {
+    out: out as Readonly<Ref<H>>,
+    onError
+  }
 }


### PR DESCRIPTION
Per a [suggestion here](https://github.com/vueuse/vueuse/issues/566#issuecomment-857228255) this PR attempts to use an `onError` "hook" pattern. However it should be noted that this will be a breaking change.

Resolves #566

BREAKING CHANGE: The return value of `useObservable` now returns a destructured object containing the ref as `out`, and an `onError` hook registration point.


---

This is an alternative PR to #567 