### PR TITLE
feat: useMouse supports drag and drop

### DIFF
--- a/packages/core/useMouse/index.md
+++ b/packages/core/useMouse/index.md
@@ -14,7 +14,8 @@ import { useMouse } from '@vueuse/core'
 const { x, y, source } = useMouse()
 ```
 
-Touching is enabled by default. To make it only detects mouse changes, set `touch` to `false`
+Touch is enabled by default. To only detect mouse changes, set `touch` to `false`.
+The `dragover` event is used to track mouse position while dragging.
 
 ```js
 const { x, y } = useMouse({ touch: false })

--- a/packages/core/useMouse/index.ts
+++ b/packages/core/useMouse/index.ts
@@ -62,6 +62,7 @@ export function useMouse(options: MouseOptions = {}) {
 
   if (window) {
     useEventListener(window, 'mousemove', mouseHandler, { passive: true })
+    useEventListener(window, 'dragover', mouseHandler, { passive: true })
     if (touch) {
       useEventListener(window, 'touchstart', touchHandler, { passive: true })
       useEventListener(window, 'touchmove', touchHandler, { passive: true })


### PR DESCRIPTION
This PR makes it easy to create fluid drag and drop user experiences with `useMouse`.

- Uses the `dragover` event to continue to track mouse position while dragging.

I've enabled support for `dragover` by default.  I thought about putting it behind a `drag` option but chose not to.  I can't think of a use case where this would break somebody's app all because mouse position is now tracked during drag and drop.