### PR TITLE
feat(useMousePressed): support drag and drop

### DIFF
--- a/packages/core/useMousePressed/demo.vue
+++ b/packages/core/useMousePressed/demo.vue
@@ -7,8 +7,7 @@ import { useMousePressed } from '.'
 const el = ref<Element | null>(null)
 const [withTarget, toggle] = useToggle()
 const target = computed<Element | null>(() => {
-  if (withTarget.value)
-    return el.value
+  if (withTarget.value) return el.value
   return window as any as Element
 })
 
@@ -24,6 +23,12 @@ const text = stringify(mouse)
       <button class="ml-2 button small" @click="toggle">
         {{ withTarget ? 'Demo section' : 'Entire page' }}
       </button>
+    </div>
+    <div
+      class="h-40 w-40 bg-green-200 p-3 flex flex-row items-center text-center"
+      @drop.prevent="() => {}"
+    >
+      Drop something here to try drag and drop.
     </div>
   </div>
 </template>

--- a/packages/core/useMousePressed/demo.vue
+++ b/packages/core/useMousePressed/demo.vue
@@ -7,7 +7,8 @@ import { useMousePressed } from '.'
 const el = ref<Element | null>(null)
 const [withTarget, toggle] = useToggle()
 const target = computed<Element | null>(() => {
-  if (withTarget.value) return el.value
+  if (withTarget.value)
+    return el.value
   return window as any as Element
 })
 

--- a/packages/core/useMousePressed/index.ts
+++ b/packages/core/useMousePressed/index.ts
@@ -48,6 +48,10 @@ export function useMousePressed(options: MousePressedOptions = {}) {
     }
   }
 
+  const onPressed = (srcType: MouseSourceType) => () => {
+    pressed.value = true
+    sourceType.value = srcType
+  }
   const onReleased = () => {
     pressed.value = false
     sourceType.value = null
@@ -55,26 +59,20 @@ export function useMousePressed(options: MousePressedOptions = {}) {
 
   const target = computed(() => unrefElement(options.target) || window)
 
+  useEventListener(target, 'mousedown', onPressed('mouse'), { passive: true })
+  useEventListener(target, 'dragover', onPressed('mouse'), { passive: true })
+  useEventListener(target, 'dragstart', onPressed('mouse'), { passive: true })
+
   useEventListener(window, 'mouseleave', onReleased, { passive: true })
   useEventListener(window, 'mouseup', onReleased, { passive: true })
-  useEventListener(target, 'mousedown',
-    () => {
-      pressed.value = true
-      sourceType.value = 'mouse'
-    },
-    { passive: true },
-  )
+  useEventListener(target, 'drop', onReleased, { passive: true })
+  useEventListener(target, 'dragleave', onReleased, { passive: true })
+  useEventListener(target, 'dragend', onReleased, { passive: true })
 
   if (touch) {
     useEventListener(window, 'touchend', onReleased, { passive: true })
     useEventListener(window, 'touchcancel', onReleased, { passive: true })
-    useEventListener(target, 'touchstart',
-      () => {
-        pressed.value = true
-        sourceType.value = 'touch'
-      },
-      { passive: true },
-    )
+    useEventListener(target, 'touchstart', onPressed('touch'), { passive: true })
   }
 
   return {

--- a/packages/core/useMousePressed/index.ts
+++ b/packages/core/useMousePressed/index.ts
@@ -13,6 +13,13 @@ export interface MousePressedOptions extends ConfigurableWindow {
   touch?: boolean
 
   /**
+   * Listen to `dragstart` `drop` and `dragend` events
+   *
+   * @default true
+   */
+  drag?: boolean
+
+  /**
    * Initial values
    *
    * @default false
@@ -34,6 +41,7 @@ export interface MousePressedOptions extends ConfigurableWindow {
 export function useMousePressed(options: MousePressedOptions = {}) {
   const {
     touch = true,
+    drag = true,
     initialValue = false,
     window = defaultWindow,
   } = options
@@ -60,19 +68,22 @@ export function useMousePressed(options: MousePressedOptions = {}) {
   const target = computed(() => unrefElement(options.target) || window)
 
   useEventListener(target, 'mousedown', onPressed('mouse'), { passive: true })
-  useEventListener(target, 'dragover', onPressed('mouse'), { passive: true })
-  useEventListener(target, 'dragstart', onPressed('mouse'), { passive: true })
 
   useEventListener(window, 'mouseleave', onReleased, { passive: true })
   useEventListener(window, 'mouseup', onReleased, { passive: true })
-  useEventListener(target, 'drop', onReleased, { passive: true })
-  useEventListener(target, 'dragleave', onReleased, { passive: true })
-  useEventListener(target, 'dragend', onReleased, { passive: true })
+
+  if (drag) {
+    useEventListener(target, 'dragstart', onPressed('mouse'), { passive: true })
+
+    useEventListener(window, 'drop', onReleased, { passive: true })
+    useEventListener(window, 'dragend', onReleased, { passive: true })
+  }
 
   if (touch) {
+    useEventListener(target, 'touchstart', onPressed('touch'), { passive: true })
+
     useEventListener(window, 'touchend', onReleased, { passive: true })
     useEventListener(window, 'touchcancel', onReleased, { passive: true })
-    useEventListener(target, 'touchstart', onPressed('touch'), { passive: true })
   }
 
   return {


### PR DESCRIPTION
This is an initial attempt at drag and drop support for isMousePressed.  I realized that I don't really need this since I can use the PR I made to `useMouse`.  I'm only making the PR to see if somebody thinks the feature is worth supporting and wants to do a few minutes of cleanup.  Here's the cleanup I think this might need:

- [ ] The main reason I abandoned this is that the `dragleave` event fires when dragging into a child element.  The `dragenter` event that fires immediately afterwards sets the state correct, but there's that tiny bit of boolean thrashing that occurs.  This might be able to be solved by using a 10ms timeout that gets canceled if another `dragenter` event occurs.
- [ ] The demo uses a div with some styles on it.  It might be able to be replaced by an existing component.

If nobody is interested in carrying on this work, please close as it's not my intention to waste anybody's time.  🙏