### PR TITLE
docs: eventName "keyUp" in onKeyStroke docs

### DIFF
--- a/packages/core/onKeyStroke/index.md
+++ b/packages/core/onKeyStroke/index.md
@@ -31,7 +31,7 @@ onKeyStroke('A', (e) => {
 ```js
 onKeyStroke('Shift', (e) => {
   console.log('Shift key up')
-}, { eventName: 'keyUp' })
+}, { eventName: 'keyup' })
 ```
 
 Or


### PR DESCRIPTION
In docs was "keyUp" and in types "export declare type KeyStrokeEventName = "keydown" | "keypress" | "keyup""