### PR TITLE
fix(useWindowFocus): revert example

### DIFF
--- a/packages/core/useWindowFocus/demo.vue
+++ b/packages/core/useWindowFocus/demo.vue
@@ -6,11 +6,11 @@ const startMessage = '💡 Click somewhere outside of the document to unfocus.'
 const message = ref(startMessage)
 const focused = useWindowFocus()
 
-watch(focused, (current) => {
-  if (current)
-    message.value = 'ℹ Tab is unfocused'
-  else
+watch(focused, (isFocused) => {
+  if (isFocused)
     message.value = startMessage
+  else
+    message.value = 'ℹ Tab is unfocused'
 })
 </script>
 


### PR DESCRIPTION
I couldn't test the demo code with the vitepress dev command and that caused me to include a bug which reverted the shown state.

Not sure how I could've tested that demo page properly, I _did_ run the `build` script alongside the `dev` script but that didn't work and I couldn't test it.

Maybe there should be additional steps in the contributing.md