### PR TITLE
fix: useDark demo

### DIFF
--- a/packages/core/useDark/demo.vue
+++ b/packages/core/useDark/demo.vue
@@ -7,7 +7,7 @@ const toggleDark = useToggle(isDark)
 </script>
 
 <template>
-  <button @click="toggleDark">
+  <button @click="toggleDark()">
     <carbon-moon v-if="isDark" />
     <carbon-sun v-else />
 


### PR DESCRIPTION
### Description 📖 

This pull request fixes the `useDark` demo.

### Background 📜 

This incorrect usage causes the `MouseEvent` to be passed over to `toggleDark`, which in the [current implementation](https://github.com/vueuse/vueuse/blob/main/packages/core/useDark/index.ts#L96) results in never being able to switch back from dark mode (when system is not dark).

```js
// v is a MouseEvent
store.value = v ? 'dark' : 'light'
```

The bug can be replicated in the current [VueUse website](https://vueuse.org/).


https://user-images.githubusercontent.com/1158253/124516414-f4c16200-ddb7-11eb-853b-c109586d8144.mp4

### Future Work 🔮 

It might be desirable to log a warning or throw an error if an `Event` is passed to the setter in `useDark`, as it's very likely a mistake, and can cause the bug in the video.