### PR TITLE
fix(useFetch): reject for `execute` on error

### DIFF
--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -308,7 +308,7 @@ export function useFetch<T>(url: MaybeRef<string>, ...args: any[]): UseFetchRetu
       return Promise.resolve()
     }
 
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       fetch(
         context.url,
         {
@@ -341,7 +341,7 @@ export function useFetch<T>(url: MaybeRef<string>, ...args: any[]): UseFetchRetu
         .catch((fetchError) => {
           error.value = fetchError.message || fetchError.name
           errorEvent.trigger(fetchError)
-          resolve(fetchError)
+          reject(fetchError)
         })
         .finally(() => {
           loading(false)

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -341,6 +341,7 @@ export function useFetch<T>(url: MaybeRef<string>, ...args: any[]): UseFetchRetu
         .catch((fetchError) => {
           error.value = fetchError.message || fetchError.name
           errorEvent.trigger(fetchError)
+          resolve(fetchError)
         })
         .finally(() => {
           loading(false)


### PR DESCRIPTION
fixes #611 

Since `useFetch` is a reactive function it should resolve always. The error is saved in the reactive variables.