### PR TITLE
docs: edit links to main branch

### DIFF
--- a/packages/.vitepress/theme/composables/editLink.ts
+++ b/packages/.vitepress/theme/composables/editLink.ts
@@ -11,7 +11,7 @@ export function useEditLink() {
     const {
       repo,
       docsDir = '',
-      docsBranch = 'master',
+      docsBranch = 'main',
       docsRepo = repo,
       editLinks,
     } = theme.value


### PR DESCRIPTION
fix: after rename of default branch from `master` to `main`, edit links didn't work anymore. This change will **likely** fix that.

fixes #558