### PR TITLE
chore(useQRCode): add alt text for Docs

### DIFF
--- a/packages/integrations/useQRCode/index.md
+++ b/packages/integrations/useQRCode/index.md
@@ -33,7 +33,7 @@ const qrcode = useQRCode(text)
 
 ```html
 <input v-model="text" type="text">
-<img :src="qrcode" />
+<img :src="qrcode" alt="QR Code" />
 ```
 
 


### PR DESCRIPTION
https://vueuse.org/integrations/useQRCode/

Alt text was included in [the source code of demo](https://github.com/vueuse/vueuse/blob/cb303d462e67925e040c6a499be5193d58ac1adb/packages/integrations/useQRCode/demo.vue#L17), but not in [the documentation](https://github.com/vueuse/vueuse/blob/cb303d462e67925e040c6a499be5193d58ac1adb/packages/integrations/useQRCode/index.md), so I added it.

