### PR TITLE
refactor(types): useFetch return type

### DIFF
--- a/packages/core/useFetch/index.test.ts
+++ b/packages/core/useFetch/index.test.ts
@@ -232,9 +232,22 @@ describe('useFetch', () => {
 
     const shell = useFetch('https://example.com', {
       immediate: false,
-    }).get()
-    shell.text()
+    }).get().text()
+    shell.json()
+    shell.execute()
     const { isFinished, data } = shell
+    await until(isFinished).toBe(true)
+
+    expect(data.value).toStrictEqual({ message: 'Hello World' })
+  })
+
+  test('not allowed setting response type while doing request', async() => {
+    fetchMock.mockResponse(JSON.stringify({ message: 'Hello World' }), { status: 200 })
+
+    const shell = useFetch('https://example.com').get().text()
+    const { isFetching, isFinished, data } = shell
+    await until(isFetching).toBe(true)
+    shell.json()
     await until(isFinished).toBe(true)
 
     expect(data.value).toStrictEqual(JSON.stringify({ message: 'Hello World' }))

--- a/packages/core/useFetch/index.test.ts
+++ b/packages/core/useFetch/index.test.ts
@@ -206,4 +206,37 @@ describe('useFetch', () => {
     expect(didErrorEventFire).toBe(true)
     expect(didFinallyEventFire).toBe(true)
   })
+
+  test('setting the request method w/ get and return type w/ json', async() => {
+    fetchMock.mockResponse(JSON.stringify({ message: 'Hello World' }), { status: 200 })
+
+    const { data, isFinished } = useFetch('https://example.com').get().json()
+
+    await until(isFinished).toBe(true)
+
+    expect(data.value).toStrictEqual({ message: 'Hello World' })
+  })
+
+  test('setting the request method w/ post and return type w/ text', async() => {
+    fetchMock.mockResponse(JSON.stringify({ message: 'Hello World' }), { status: 200 })
+
+    const { data, isFinished } = useFetch('https://example.com').post().text()
+
+    await until(isFinished).toBe(true)
+
+    expect(data.value).toStrictEqual(JSON.stringify({ message: 'Hello World' }))
+  })
+
+  test('allow setting response type before doing request', async() => {
+    fetchMock.mockResponse(JSON.stringify({ message: 'Hello World' }), { status: 200 })
+
+    const shell = useFetch('https://example.com', {
+      immediate: false,
+    }).get()
+    shell.text()
+    const { isFinished, data } = shell
+    await until(isFinished).toBe(true)
+
+    expect(data.value).toStrictEqual(JSON.stringify({ message: 'Hello World' }))
+  })
 })

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -80,20 +80,20 @@ const payloadMapping: Record<string, string> = {
 }
 
 interface UseFetchReturnTypeConfigured<T> extends UseFetchReturnBase<T> {
-  // methods
-  get(): UseFetchReturnBase<T>
-  post(payload?: unknown, type?: string): UseFetchReturnBase<T>
-  put(payload?: unknown, type?: string): UseFetchReturnBase<T>
-  delete(payload?: unknown, type?: string): UseFetchReturnBase<T>
+  // type
+  json<JSON = any>(): UseFetchReturnBase<JSON>
+  text(): UseFetchReturnBase<string>
+  blob(): UseFetchReturnBase<Blob>
+  arrayBuffer(): UseFetchReturnBase<ArrayBuffer>
+  formData(): UseFetchReturnBase<FormData>
 }
 
 export interface UseFetchReturn<T> extends UseFetchReturnTypeConfigured<T> {
-  // type
-  json<JSON = any>(): UseFetchReturnTypeConfigured<JSON>
-  text(): UseFetchReturnTypeConfigured<string>
-  blob(): UseFetchReturnTypeConfigured<Blob>
-  arrayBuffer(): UseFetchReturnTypeConfigured<ArrayBuffer>
-  formData(): UseFetchReturnTypeConfigured<FormData>
+  // methods
+  get(): UseFetchReturnTypeConfigured<T>
+  post(payload?: unknown, type?: string): UseFetchReturnTypeConfigured<T>
+  put(payload?: unknown, type?: string): UseFetchReturnTypeConfigured<T>
+  delete(payload?: unknown, type?: string): UseFetchReturnTypeConfigured<T>
 }
 
 export interface BeforeFetchContext {
@@ -396,21 +396,19 @@ export function useFetch<T>(url: MaybeRef<string>, ...args: any[]): UseFetchRetu
 
   const typeConfigured: UseFetchReturnTypeConfigured<T> = {
     ...base,
-
-    get: setMethod('get'),
-    put: setMethod('put'),
-    post: setMethod('post'),
-    delete: setMethod('delete'),
-  }
-
-  const shell: UseFetchReturn<T> = {
-    ...typeConfigured,
-
     json: setType('json'),
     text: setType('text'),
     blob: setType('blob'),
     arrayBuffer: setType('arrayBuffer'),
     formData: setType('formData'),
+  }
+
+  const shell: UseFetchReturn<T> = {
+    ...typeConfigured,
+    get: setMethod('get'),
+    put: setMethod('put'),
+    post: setMethod('post'),
+    delete: setMethod('delete'),
   }
 
   function setMethod(method: HttpMethod) {
@@ -424,7 +422,7 @@ export function useFetch<T>(url: MaybeRef<string>, ...args: any[]): UseFetchRetu
         if (!payloadType && payload && Object.getPrototypeOf(payload) === Object.prototype)
           config.payloadType = 'json'
 
-        return base as any
+        return typeConfigured as any
       }
       return undefined
     }
@@ -434,7 +432,7 @@ export function useFetch<T>(url: MaybeRef<string>, ...args: any[]): UseFetchRetu
     return () => {
       if (!isFetching.value) {
         config.type = type
-        return typeConfigured as any
+        return base as any
       }
       return undefined
     }


### PR DESCRIPTION
## Version 
5.2.0

## What's happened

when setting the request method  and return type, you need to focus on the invoking sequence and can't invoking it more than once, which I don't think its flexible or easy to use.

## Reproduction link
https://codesandbox.io/s/boring-nobel-tq0m5?file=/src/App.vue

