### PR TITLE
feat(whenever): callback arguments

### DIFF
--- a/packages/guide/config.md
+++ b/packages/guide/config.md
@@ -38,7 +38,7 @@ motionControl.resume()
 
 VueUse's functions follow Vue's reactivity system defaults for [flush timing](https://v3.vuejs.org/guide/reactivity-computed-watchers.html#effect-flush-timing) where possible.
 
-For `watch`-like composables (e.g. `pausableWatch`, `when`, `useStorage`, `useRefHistory`) the default is `{ flush: 'pre' }`. Which means they will buffer invalidated effects and flush them asynchronously. This avoids unnecessary duplicate invocation when there are multiple state mutations happening in the same "tick".
+For `watch`-like composables (e.g. `pausableWatch`, `whenever`, `useStorage`, `useRefHistory`) the default is `{ flush: 'pre' }`. Which means they will buffer invalidated effects and flush them asynchronously. This avoids unnecessary duplicate invocation when there are multiple state mutations happening in the same "tick".
 
 In the same way as with `watch`, VueUse allows you to configure the timing by passing the `flush` option:
 

--- a/packages/shared/whenever/index.md
+++ b/packages/shared/whenever/index.md
@@ -31,6 +31,18 @@ watch(ready, (isReady) => {
 })
 ```
 
+### Callback Function
+
+Same as `watch`, the callback will be called with `cb(value, oldValue, onInvalidate)`.
+
+```ts
+whenever(height, (current, lastHeight) => {
+  if (current > lastHeight) {
+    console.log(`Increasing height by ${current - lastHeight}`)
+  }
+})
+```
+
 ### Computed
 
 Same as `watch`, you can pass a getter function to calculate on each change.

--- a/packages/shared/whenever/index.test.ts
+++ b/packages/shared/whenever/index.test.ts
@@ -1,4 +1,4 @@
-import { nextTick, ref, unref } from 'vue-demi'
+import { nextTick, Ref, ref, unref } from 'vue-demi'
 import { whenever } from '.'
 import { useSetup } from '../../.test'
 
@@ -9,8 +9,10 @@ describe('whenever', () => {
       const number = ref(1)
       const changeNumber = (v: number) => number.value = v
       const watchCount = ref(0)
-      const callback = () => {
+      const watchValue: Ref<number|undefined> = ref()
+      const callback = (v: number) => {
         watchCount.value += 1
+        watchValue.value = v
       }
 
       whenever(number, callback)
@@ -18,6 +20,7 @@ describe('whenever', () => {
       return {
         number,
         watchCount,
+        watchValue,
         changeNumber,
       }
     })
@@ -27,14 +30,17 @@ describe('whenever', () => {
     wrapper.changeNumber(2)
     await nextTick()
     expect(unref(wrapper.watchCount)).toEqual(1)
+    expect(unref(wrapper.watchValue)).toEqual(2)
 
     wrapper.changeNumber(0)
     await nextTick()
     expect(unref(wrapper.watchCount)).toEqual(1)
+    expect(unref(wrapper.watchValue)).toEqual(2)
 
     wrapper.changeNumber(3)
     await nextTick()
     expect(unref(wrapper.watchCount)).toEqual(2)
+    expect(unref(wrapper.watchValue)).toEqual(3)
 
     wrapper.unmount()
   })

--- a/packages/shared/whenever/index.test.ts
+++ b/packages/shared/whenever/index.test.ts
@@ -1,0 +1,41 @@
+import { nextTick, ref, unref } from 'vue-demi'
+import { whenever } from '.'
+import { useSetup } from '../../.test'
+
+describe('whenever', () => {
+  it('ignore falsy state change', async() => {
+    // use a component to simulate normal use case
+    const wrapper = useSetup(() => {
+      const number = ref(1)
+      const changeNumber = (v: number) => number.value = v
+      const watchCount = ref(0)
+      const callback = () => {
+        watchCount.value += 1
+      }
+
+      whenever(number, callback)
+
+      return {
+        number,
+        watchCount,
+        changeNumber,
+      }
+    })
+
+    expect(unref(wrapper.watchCount)).toEqual(0)
+
+    wrapper.changeNumber(2)
+    await nextTick()
+    expect(unref(wrapper.watchCount)).toEqual(1)
+
+    wrapper.changeNumber(0)
+    await nextTick()
+    expect(unref(wrapper.watchCount)).toEqual(1)
+
+    wrapper.changeNumber(3)
+    await nextTick()
+    expect(unref(wrapper.watchCount)).toEqual(2)
+
+    wrapper.unmount()
+  })
+})

--- a/packages/shared/whenever/index.ts
+++ b/packages/shared/whenever/index.ts
@@ -1,15 +1,14 @@
-import { WatchOptions, watch, WatchSource } from 'vue-demi'
-import { Fn } from '../utils'
+import { WatchOptions, watch, WatchSource, WatchCallback } from 'vue-demi'
 
 /**
  * Shorthand for watching value to be truthy
  *
  * @see https://vueuse.js.org/whenever
  */
-export function whenever<T = boolean>(source: WatchSource<T>, cb: Fn, options?: WatchOptions) {
+export function whenever<T>(source: WatchSource<T>, cb: WatchCallback, options?: WatchOptions) {
   return watch(
     source,
-    (v) => { if (v) cb() },
+    (v, ov, onInvalidate) => { if (v) cb(v, ov, onInvalidate) },
     options,
   )
 }


### PR DESCRIPTION
Change
---
- resolve #660 
- Use `WatchCallback` type instead of  void `Fn` type
- Remove constraints `<T = Boolean>` in type parameter
- Adjust document

Discussion
---
- Have notice this composable function is only meant to used by simple Boolean ref. However I found this function extremely useful to deal with possible undefined watch update, which doesn't need to be Boolean at all. Am I using it wrong?
- Not sure whether to add type parameter on `WatchCallback`
- Not sure if the test is meaningless in current test case
- Have tried to add a demo about ignoring falsy value, but it seems to be misleading people the purpose of this function

**Demo.vue**
```vue
<script setup lang="ts">
import { whenever } from '.'
import { ref } from 'vue-demi'

const number = ref(0)
const watchRes = ref('')

const changeNumber = () => {
  number.value = (number.value + 1) % 5
}

whenever(number, (v: Number, ov: Number) => {
  watchRes.value = `current: ${v}, last: ${ov}`
})
</script>

<template>
  <div>Number: {{ number }}</div>
  <button @click="changeNumber">
    Change Number
  </button>
  <div>{{ watchRes }}</div>
</template>

```
