### PR TITLE
docs(useAuth): fix typo on usage section

### DIFF
--- a/packages/firebase/useAuth/index.md
+++ b/packages/firebase/useAuth/index.md
@@ -14,7 +14,7 @@ can easily react to changes in the users' authentication status.
 import firebase from 'firebase'
 import { useAuth } from '@vueuse/firebase/useAuth'
 
-const { GoogleAuthProvider } = auth
+const { GoogleAuthProvider } = firebase.auth
 
 const { isAuthenticated, user } = useAuth(firebase.auth)
 


### PR DESCRIPTION
Just fixed a small typo in the doc for `@vueuse/firebase > useAuth`

Cheers !