### PR TITLE
docs(useTimeoutFn): clarify the meaning of immediate

### DIFF
--- a/packages/shared/useTimeoutFn/index.md
+++ b/packages/shared/useTimeoutFn/index.md
@@ -21,7 +21,7 @@ const { isPending, start, stop } = useTimeoutFn(() => {
 ```typescript
 export interface TimeoutFnOptions {
   /**
-   * Execute the callback immediate after calling this function
+   * Start the timer immediate after calling this function
    *
    * @default true
    */

--- a/packages/shared/useTimeoutFn/index.ts
+++ b/packages/shared/useTimeoutFn/index.ts
@@ -4,7 +4,7 @@ import { isClient, MaybeRef, Stopable } from '../utils'
 
 export interface TimeoutFnOptions {
   /**
-   * Execute the callback immediate after calling this function
+   * Start the timer immediate after calling this function
    *
    * @default true
    */


### PR DESCRIPTION
The immediate option makes the timer starts immediately after calling
the function, but the current document is worded like the callback
function is called immediately without timeout. Fix the document.