### PR TITLE
docs(tryOnScopeDispose): align code comment to document

### DIFF
--- a/packages/shared/tryOnScopeDispose/index.md
+++ b/packages/shared/tryOnScopeDispose/index.md
@@ -22,7 +22,7 @@ tryOnScopeDispose(() => {
 
 ```typescript
 /**
- * Call onScopeDispose() if it's inside a component lifecycle, if not, run just call the function
+ * Call onScopeDispose() if it's inside a effect scope lifecycle, if not, do nothing
  *
  * @param fn
  */

--- a/packages/shared/tryOnScopeDispose/index.ts
+++ b/packages/shared/tryOnScopeDispose/index.ts
@@ -2,7 +2,7 @@ import { getCurrentScope, onScopeDispose } from 'vue-demi'
 import { Fn } from '../utils'
 
 /**
- * Call onScopeDispose() if it's inside a component lifecycle, if not, run just call the function
+ * Call onScopeDispose() if it's inside a effect scope lifecycle, if not, do nothing
  *
  * @param fn
  */


### PR DESCRIPTION
The document correctly specified that this works in effect scope, and
does nothing if not. Change the comment in code to be the same as in the
document.