### PR TITLE
fix: bug in throttleFilter

### DIFF
--- a/packages/shared/utils/filters.ts
+++ b/packages/shared/utils/filters.ts
@@ -90,6 +90,7 @@ export function throttleFilter(ms: MaybeRef<number>, trailing = true) {
     }
     else if (trailing) {
       timer = setTimeout(() => {
+        lastExec = Date.now()
         clear()
         invoke()
       }, duration)


### PR DESCRIPTION
In throttledFilter, it does not modify lastExec variable.
So events can occur multiple times, ignoring duration.

Fixes #689 