### PR TITLE
docs: note onClickOutside usage on IE11

### DIFF
--- a/packages/core/onClickOutside/index.md
+++ b/packages/core/onClickOutside/index.md
@@ -34,6 +34,8 @@ export default {
 </script>
 ```
 
+> This function uses [Event.composedPath()](https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath) which is NOT supported by IE 11, Edge 18 and below. If you are targeting these browsers, we recommend you to include [this code snippet](https://gist.github.com/sibbng/13e83b1dd1b733317ce0130ef07d4efd) on your project.
+
 ## Component
 
 ```html


### PR DESCRIPTION
Closes #699 

I included both TS and JS versions on the [gist](https://gist.github.com/sibbng/13e83b1dd1b733317ce0130ef07d4efd).