### PR TITLE
feat(useWebSocket): Added support for optional protocols

### DIFF
--- a/packages/core/useWebSocket/index.md
+++ b/packages/core/useWebSocket/index.md
@@ -14,14 +14,6 @@ import { useWebSocket } from '@vueuse/core'
 const { status, data, send, open, close } = useWebSocket('ws://websocketurl')
 ```
 
-Optionally with a list of one or more subprotocols to use.
-
-```js
-import { useWebSocket } from '@vueuse/core'
-
-const { status, data, send, open, close } = useWebSocket('ws://websocketurl', ['soap', 'wamp'])
-```
-
 See the [Type Declarations](#type-declarations) for more options.
 
 ### Immediate
@@ -74,6 +66,18 @@ const { status, data, close } = useWebSocket('ws://websocketurl', {
     message: 'ping',
     interval: 1000,
   },
+})
+```
+
+### Sub-protocols
+
+List of one or more subprotocols to use, in this case soap and wamp.
+
+```js
+import { useWebSocket } from '@vueuse/core'
+
+const { status, data, send, open, close } = useWebSocket('ws://websocketurl', {
+  protocols: ['soap'], // ['soap', 'wamp']
 })
 ```
 
@@ -139,6 +143,12 @@ export interface WebSocketOptions {
    * @default true
    */
   immediate?: boolean
+  /**
+   * List of one or more sub-protocol strings
+   *
+   * @default []
+   */
+   protocols?: string[],
 }
 export interface WebSocketResult<T> {
   /**
@@ -177,18 +187,15 @@ export interface WebSocketResult<T> {
  *
  * @see https://vueuse.org/useWebSocket
  * @param url
- * @param protocols
  */
 export declare function useWebSocket<Data = any>(
   url: string,
   options?: WebSocketOptions,
-  protocols?: string[]
 ): WebSocketResult<Data>
 ```
 
 ## Source
 
 [Source](https://github.com/vueuse/vueuse/blob/main/packages/core/useWebSocket/index.ts) • [Docs](https://github.com/vueuse/vueuse/blob/main/packages/core/useWebSocket/index.md)
-
 
 <!--FOOTER_ENDS-->

--- a/packages/core/useWebSocket/index.md
+++ b/packages/core/useWebSocket/index.md
@@ -14,6 +14,14 @@ import { useWebSocket } from '@vueuse/core'
 const { status, data, send, open, close } = useWebSocket('ws://websocketurl')
 ```
 
+Optionally with a list of one or more subprotocols to use.
+
+```js
+import { useWebSocket } from '@vueuse/core'
+
+const { status, data, send, open, close } = useWebSocket('ws://websocketurl', ['soap', 'wamp'])
+```
+
 See the [Type Declarations](#type-declarations) for more options.
 
 ### Immediate
@@ -169,10 +177,12 @@ export interface WebSocketResult<T> {
  *
  * @see https://vueuse.org/useWebSocket
  * @param url
+ * @param protocols
  */
 export declare function useWebSocket<Data = any>(
   url: string,
-  options?: WebSocketOptions
+  options?: WebSocketOptions,
+  protocols?: string[]
 ): WebSocketResult<Data>
 ```
 

--- a/packages/core/useWebSocket/index.ts
+++ b/packages/core/useWebSocket/index.ts
@@ -62,6 +62,13 @@ export interface WebSocketOptions {
    * @default true
    */
   immediate?: boolean
+
+  /**
+   * List of one or more sub-protocol strings
+   *
+   * @default []
+   */
+  protocols?: string[]
 }
 
 export interface WebSocketResult<T> {
@@ -113,12 +120,10 @@ function resolveNestedOptions<T>(options: T | true): T {
  *
  * @see https://vueuse.org/useWebSocket
  * @param url
- * @param protocols
  */
 export function useWebSocket<Data = any>(
   url: string,
   options: WebSocketOptions = {},
-  protocols: string[] = [],
 ): WebSocketResult<Data> {
   const {
     onConnected,
@@ -126,6 +131,7 @@ export function useWebSocket<Data = any>(
     onError,
     onMessage,
     immediate = true,
+    protocols = [],
   } = options
 
   const data: Ref<Data | null> = ref(null)

--- a/packages/core/useWebSocket/index.ts
+++ b/packages/core/useWebSocket/index.ts
@@ -113,10 +113,12 @@ function resolveNestedOptions<T>(options: T | true): T {
  *
  * @see https://vueuse.org/useWebSocket
  * @param url
+ * @param protocols
  */
 export function useWebSocket<Data = any>(
   url: string,
   options: WebSocketOptions = {},
+  protocols: string[] = [],
 ): WebSocketResult<Data> {
   const {
     onConnected,
@@ -166,7 +168,7 @@ export function useWebSocket<Data = any>(
   }
 
   const _init = () => {
-    const ws = new WebSocket(url)
+    const ws = new WebSocket(url, protocols)
     wsRef.value = ws
     status.value = 'CONNECTING'
     explicitlyClosed = false


### PR DESCRIPTION
Added support for an optional array parameter called protocols. This second parameter to the WebSocket constructor contains one or more protocol strings to use e.g. subprotocols. If not provided, internally the parameter always defaults to an empty array (`[]`), so that was chosen as parameter initializer. More information can be found [here](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/WebSocket).