### PR TITLE
feat(useFetch): add defaultData option

### DIFF
--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -138,6 +138,12 @@ export interface UseFetchOptions {
   refetch?: MaybeRef<boolean>
 
   /**
+   * Will set to the data before the request done
+   * @default null
+   */
+  defaultData?: any
+
+  /**
    * Will run immediately before the fetch request is dispatched
    */
   beforeFetch?: (ctx: BeforeFetchContext) => Promise<Partial<BeforeFetchContext> | void> | Partial<BeforeFetchContext> | void
@@ -173,7 +179,7 @@ export interface CreateFetchOptions {
  * to include the new options
  */
 function isFetchOptions(obj: object): obj is UseFetchOptions {
-  return containsProp(obj, 'immediate', 'refetch', 'beforeFetch', 'afterFetch')
+  return containsProp(obj, 'immediate', 'refetch', 'defaultData', 'beforeFetch', 'afterFetch')
 }
 
 function headersToObject(headers: HeadersInit | undefined) {
@@ -252,6 +258,7 @@ export function useFetch<T>(url: MaybeRef<string>, ...args: any[]): UseFetchRetu
 
   const {
     fetch = defaultWindow?.fetch,
+    defaultData,
   } = options
 
   // Event Hooks
@@ -265,7 +272,7 @@ export function useFetch<T>(url: MaybeRef<string>, ...args: any[]): UseFetchRetu
   const statusCode = ref<number | null>(null)
   const response = shallowRef<Response | null>(null)
   const error = ref<any>(null)
-  const data = shallowRef<T | null>(null)
+  const data = shallowRef<T | null>(defaultData)
 
   const canAbort = computed(() => supportsAbort && isFetching.value)
 
@@ -341,9 +348,7 @@ export function useFetch<T>(url: MaybeRef<string>, ...args: any[]): UseFetchRetu
 
           if (options.afterFetch)
             ({ data: responseData } = await options.afterFetch({ data: responseData, response: fetchResponse }))
-
           data.value = responseData as any
-
           // see: https://www.tjvantoll.com/2015/09/13/fetch-and-errors/
           if (!fetchResponse.ok)
             throw new Error(fetchResponse.statusText)

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -138,10 +138,11 @@ export interface UseFetchOptions {
   refetch?: MaybeRef<boolean>
 
   /**
-   * Will set to the data before the request done
+   * Initial data before the request finished
+   *
    * @default null
    */
-  defaultData?: any
+  initialData?: any
 
   /**
    * Will run immediately before the fetch request is dispatched
@@ -179,7 +180,7 @@ export interface CreateFetchOptions {
  * to include the new options
  */
 function isFetchOptions(obj: object): obj is UseFetchOptions {
-  return containsProp(obj, 'immediate', 'refetch', 'defaultData', 'beforeFetch', 'afterFetch')
+  return containsProp(obj, 'immediate', 'refetch', 'initialData', 'beforeFetch', 'afterFetch')
 }
 
 function headersToObject(headers: HeadersInit | undefined) {
@@ -258,7 +259,7 @@ export function useFetch<T>(url: MaybeRef<string>, ...args: any[]): UseFetchRetu
 
   const {
     fetch = defaultWindow?.fetch,
-    defaultData,
+    initialData,
   } = options
 
   // Event Hooks
@@ -272,7 +273,7 @@ export function useFetch<T>(url: MaybeRef<string>, ...args: any[]): UseFetchRetu
   const statusCode = ref<number | null>(null)
   const response = shallowRef<Response | null>(null)
   const error = ref<any>(null)
-  const data = shallowRef<T | null>(defaultData)
+  const data = shallowRef<T | null>(initialData)
 
   const canAbort = computed(() => supportsAbort && isFetching.value)
 


### PR DESCRIPTION
Sometimes we need a default value to avoid waiting for async results

like this:
```js
 <div>
      <p>{{ res.value }}</p>
    </div>
const {
  data: res,
} = useFetch(url, { refetch, defaultData: { id: 2, value: 'test' } })