### PR TITLE
build!: use `.mjs`/`.cjs` file extensions for node module context support

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -15,14 +15,14 @@
   "author": "Jacob Clevenger<https://github.com/wheatjs>",
   "exports": {
     ".": {
-      "import": "./index.esm.js",
-      "require": "./index.cjs.js"
+      "import": "./index.mjs",
+      "require": "./index.cjs"
     },
     "./*": "./*"
   },
-  "main": "./index.cjs.js",
+  "main": "./index.cjs",
   "types": "./index.d.ts",
-  "module": "./index.esm.js",
+  "module": "./index.mjs",
   "unpkg": "./index.iife.min.js",
   "jsdelivr": "./index.iife.min.js",
   "sideEffects": false,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,14 +16,14 @@
   "author": "Anthony Fu<https://github.com/antfu>",
   "exports": {
     ".": {
-      "import": "./index.esm.js",
-      "require": "./index.cjs.js"
+      "import": "./index.mjs",
+      "require": "./index.cjs"
     },
     "./*": "./*"
   },
-  "main": "./index.cjs.js",
+  "main": "./index.cjs",
   "types": "./index.d.ts",
-  "module": "./index.esm.js",
+  "module": "./index.mjs",
   "unpkg": "./index.iife.min.js",
   "jsdelivr": "./index.iife.min.js",
   "sideEffects": false,

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -18,14 +18,14 @@
   "author": "Archer Gu<https://github.com/ArcherGu>",
   "exports": {
     ".": {
-      "import": "./index.esm.js",
-      "require": "./index.cjs.js"
+      "import": "./index.mjs",
+      "require": "./index.cjs"
     },
     "./*": "./*"
   },
-  "main": "./index.cjs.js",
+  "main": "./index.cjs",
   "types": "./index.d.ts",
-  "module": "./index.esm.js",
+  "module": "./index.mjs",
   "sideEffects": false,
   "bugs": {
     "url": "https://github.com/vueuse/vueuse/issues"

--- a/packages/firebase/package.json
+++ b/packages/firebase/package.json
@@ -18,26 +18,26 @@
   "author": "Anthony Fu<https://github.com/antfu>",
   "exports": {
     ".": {
-      "import": "./index.esm.js",
-      "require": "./index.cjs.js"
+      "import": "./index.mjs",
+      "require": "./index.cjs"
     },
     "./*": "./*",
     "./useAuth": {
-      "import": "./useAuth.esm.js",
-      "require": "./useAuth.cjs.js"
+      "import": "./useAuth.mjs",
+      "require": "./useAuth.cjs"
     },
     "./useFirestore": {
-      "import": "./useFirestore.esm.js",
-      "require": "./useFirestore.cjs.js"
+      "import": "./useFirestore.mjs",
+      "require": "./useFirestore.cjs"
     },
     "./useRTDB": {
-      "import": "./useRTDB.esm.js",
-      "require": "./useRTDB.cjs.js"
+      "import": "./useRTDB.mjs",
+      "require": "./useRTDB.cjs"
     }
   },
-  "main": "./index.cjs.js",
+  "main": "./index.cjs",
   "types": "./index.d.ts",
-  "module": "./index.esm.js",
+  "module": "./index.mjs",
   "unpkg": "./index.iife.min.js",
   "jsdelivr": "./index.iife.min.js",
   "sideEffects": false,

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -16,38 +16,38 @@
   "author": "Anthony Fu<https://github.com/antfu>",
   "exports": {
     ".": {
-      "import": "./index.esm.js",
-      "require": "./index.cjs.js"
+      "import": "./index.mjs",
+      "require": "./index.cjs"
     },
     "./*": "./*",
     "./useAxios": {
-      "import": "./useAxios.esm.js",
-      "require": "./useAxios.cjs.js"
+      "import": "./useAxios.mjs",
+      "require": "./useAxios.cjs"
     },
     "./useCookies": {
-      "import": "./useCookies.esm.js",
-      "require": "./useCookies.cjs.js"
+      "import": "./useCookies.mjs",
+      "require": "./useCookies.cjs"
     },
     "./useFocusTrap": {
-      "import": "./useFocusTrap.esm.js",
-      "require": "./useFocusTrap.cjs.js"
+      "import": "./useFocusTrap.mjs",
+      "require": "./useFocusTrap.cjs"
     },
     "./useJwt": {
-      "import": "./useJwt.esm.js",
-      "require": "./useJwt.cjs.js"
+      "import": "./useJwt.mjs",
+      "require": "./useJwt.cjs"
     },
     "./useNProgress": {
-      "import": "./useNProgress.esm.js",
-      "require": "./useNProgress.cjs.js"
+      "import": "./useNProgress.mjs",
+      "require": "./useNProgress.cjs"
     },
     "./useQRCode": {
-      "import": "./useQRCode.esm.js",
-      "require": "./useQRCode.cjs.js"
+      "import": "./useQRCode.mjs",
+      "require": "./useQRCode.cjs"
     }
   },
-  "main": "./index.cjs.js",
+  "main": "./index.cjs",
   "types": "./index.d.ts",
-  "module": "./index.esm.js",
+  "module": "./index.mjs",
   "unpkg": "./index.iife.min.js",
   "jsdelivr": "./index.iife.min.js",
   "sideEffects": false,

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -17,14 +17,14 @@
   "author": "Anthony Fu<https://github.com/antfu>",
   "exports": {
     ".": {
-      "import": "./index.esm.js",
-      "require": "./index.cjs.js"
+      "import": "./index.mjs",
+      "require": "./index.cjs"
     },
     "./*": "./*"
   },
-  "main": "./index.cjs.js",
+  "main": "./index.cjs",
   "types": "./index.d.ts",
-  "module": "./index.esm.js",
+  "module": "./index.mjs",
   "unpkg": "./index.iife.min.js",
   "jsdelivr": "./index.iife.min.js",
   "sideEffects": false,

--- a/packages/rxjs/package.json
+++ b/packages/rxjs/package.json
@@ -18,14 +18,14 @@
   "author": "Anthony Fu<https://github.com/antfu>",
   "exports": {
     ".": {
-      "import": "./index.esm.js",
-      "require": "./index.cjs.js"
+      "import": "./index.mjs",
+      "require": "./index.cjs"
     },
     "./*": "./*"
   },
-  "main": "./index.cjs.js",
+  "main": "./index.cjs",
   "types": "./index.d.ts",
-  "module": "./index.esm.js",
+  "module": "./index.mjs",
   "unpkg": "./index.iife.min.js",
   "jsdelivr": "./index.iife.min.js",
   "sideEffects": false,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -15,14 +15,14 @@
   "author": "Anthony Fu<https://github.com/antfu>",
   "exports": {
     ".": {
-      "import": "./index.esm.js",
-      "require": "./index.cjs.js"
+      "import": "./index.mjs",
+      "require": "./index.cjs"
     },
     "./*": "./*"
   },
-  "main": "./index.cjs.js",
+  "main": "./index.cjs",
   "types": "./index.d.ts",
-  "module": "./index.esm.js",
+  "module": "./index.mjs",
   "unpkg": "./index.iife.min.js",
   "jsdelivr": "./index.iife.min.js",
   "sideEffects": false,

--- a/scripts/rollup.config.ts
+++ b/scripts/rollup.config.ts
@@ -36,11 +36,11 @@ for (const { globals, name, external, submodules, iife } of activePackages) {
 
     const output: OutputOptions[] = [
       {
-        file: `packages/${name}/dist/${fn}.cjs.js`,
+        file: `packages/${name}/dist/${fn}.cjs`,
         format: 'cjs',
       },
       {
-        file: `packages/${name}/dist/${fn}.esm.js`,
+        file: `packages/${name}/dist/${fn}.mjs`,
         format: 'es',
       },
     ]

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -348,17 +348,17 @@ export async function updatePackageJSON(indexes: PackageIndexes) {
     packageJSON.homepage = name === 'core'
       ? 'https://github.com/vueuse/vueuse#readme'
       : `https://github.com/vueuse/vueuse/tree/main/packages/${name}#readme`
-    packageJSON.main = './index.cjs.js'
+    packageJSON.main = './index.cjs'
     packageJSON.types = './index.d.ts'
-    packageJSON.module = './index.esm.js'
+    packageJSON.module = './index.mjs'
     if (iife !== false) {
       packageJSON.unpkg = './index.iife.min.js'
       packageJSON.jsdelivr = './index.iife.min.js'
     }
     packageJSON.exports = {
       '.': {
-        import: './index.esm.js',
-        require: './index.cjs.js',
+        import: './index.mjs',
+        require: './index.cjs',
       },
       './*': './*',
     }
@@ -368,8 +368,8 @@ export async function updatePackageJSON(indexes: PackageIndexes) {
         .filter(i => i.package === name)
         .forEach((i) => {
           packageJSON.exports[`./${i.name}`] = {
-            import: `./${i.name}.esm.js`,
-            require: `./${i.name}.cjs.js`,
+            import: `./${i.name}.mjs`,
+            require: `./${i.name}.cjs`,
           }
         })
     }


### PR DESCRIPTION
This PR uses `.cjs` and `.mjs` file extensions for proper support within a Node module context.

Without it the following errors are generated when importing within a Vite server build:
```
import { isClient, isString, noop, tryOnScopeDispose, promiseTimeout, increaseWithUnit, useTimeoutFn, watchWithFilter, tryOnMounted, createFilterWrapper, bypassFilter, createSingletonPromise, containsProp, createEventHook, throttleFilter, timestamp, isFunction, isObject, ignorableWatch, isNumber, useIntervalFn, pausableFilter, tryOnUnmounted, identity, clamp, pausableWatch } from '@vueuse/shared';
                             ^^^^
SyntaxError: Named export 'noop' not found. The requested module '@vueuse/shared' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from '@vueuse/shared';
const { isClient, isString, noop, tryOnScopeDispose, promiseTimeout, increaseWithUnit, useTimeoutFn, watchWithFilter, tryOnMounted, createFilterWrapper, bypassFilter, createSingletonPromise, containsProp, createEventHook, throttleFilter, timestamp, isFunction, isObject, ignorableWatch, isNumber, useIntervalFn, pausableFilter, tryOnUnmounted, identity, clamp, pausableWatch } = pkg;
```