### PR TITLE
feat(useAsyncState): Provide params to callback function

### DIFF
--- a/packages/core/useAsyncState/demo.vue
+++ b/packages/core/useAsyncState/demo.vue
@@ -4,7 +4,10 @@ import YAML from 'js-yaml'
 import { useAsyncState } from '.'
 
 const { state, isReady, execute } = useAsyncState(
-  () => axios.get('https://jsonplaceholder.typicode.com/todos/1').then(t => t.data),
+  (args) => {
+    let id = args?.id || 1
+    return axios.get(`https://jsonplaceholder.typicode.com/todos/${id}`).then(t => t.data )
+  },
   {},
   {
     delay: 2000,
@@ -17,7 +20,7 @@ const { state, isReady, execute } = useAsyncState(
   <div>
     <note>Ready: {{ isReady.toString() }}</note>
     <pre lang="json" class="ml-2">{{ YAML.dump(state) }}</pre>
-    <button @click="execute(2000)">
+    <button @click="execute(2000, {id: 2})">
       Execute
     </button>
   </div>

--- a/packages/core/useAsyncState/index.ts
+++ b/packages/core/useAsyncState/index.ts
@@ -46,7 +46,7 @@ export interface AsyncStateOptions {
  * @param options
  */
 export function useAsyncState<T>(
-  promise: Promise<T> | (() => Promise<T>),
+  promise: Promise<T> | ((...args: any[]) => Promise<T>),
   initialState: T,
   options: AsyncStateOptions = {},
 ) {
@@ -61,10 +61,10 @@ export function useAsyncState<T>(
   const isReady = ref(false)
   const error = ref<unknown | undefined>(undefined)
 
-  async function execute(delay = 0) {
+  async function execute(delay = 0, ...args: any[]) {
     if (resetOnExecute)
       state.value = initialState
-
+    
     error.value = undefined
     isReady.value = false
 
@@ -72,7 +72,7 @@ export function useAsyncState<T>(
       await promiseTimeout(delay)
 
     const _promise = typeof promise === 'function'
-      ? promise()
+      ? promise(...args)
       : promise
 
     try {

--- a/packages/core/useAsyncState/index.ts
+++ b/packages/core/useAsyncState/index.ts
@@ -64,7 +64,6 @@ export function useAsyncState<T>(
   async function execute(delay = 0, ...args: any[]) {
     if (resetOnExecute)
       state.value = initialState
-    
     error.value = undefined
     isReady.value = false
 


### PR DESCRIPTION
It would be cool to be able to pass params to promise from `execute` function 

```javascript
const { state, isReady, execute } = useAsyncState(
  (args) => {
    let id = args?.id || 1
    return axios.get(`https://jsonplaceholder.typicode.com/todos/${id}`).then(t => t.data )
  },
  {},
  {
    delay: 2000,
    resetOnExecute: false,
  },
)
</script>

<template>
  <div>
    <note>Ready: {{ isReady.toString() }}</note>
    <pre lang="json" class="ml-2">{{ YAML.dump(state) }}</pre>
    <button @click="execute(2000, {id: 2})">
      Execute
    </button>
  </div>
</template>
```