### PR TITLE
fix(createSharedComposable): use tryOnScopeDispose instead of onScopeDispose

### DIFF
--- a/packages/shared/createSharedComposable/index.ts
+++ b/packages/shared/createSharedComposable/index.ts
@@ -1,4 +1,4 @@
-import { effectScope, EffectScope, onScopeDispose } from 'vue-demi'
+import { effectScope, EffectScope } from 'vue-demi'
 import { tryOnScopeDispose } from '../tryOnScopeDispose'
 
 /**

--- a/packages/shared/createSharedComposable/index.ts
+++ b/packages/shared/createSharedComposable/index.ts
@@ -1,4 +1,5 @@
 import { effectScope, EffectScope, onScopeDispose } from 'vue-demi'
+import { tryOnScopeDispose } from '../tryOnScopeDispose'
 
 /**
  * Make a composable function usable with multiple Vue instances.
@@ -25,7 +26,7 @@ export function createSharedComposable<Fn extends((...args: any[]) => any)>(comp
       scope = effectScope(true)
       state = scope.run(() => composable(...args))
     }
-    onScopeDispose(dispose)
+    tryOnScopeDispose(dispose)
     return state
   })
 }


### PR DESCRIPTION
Prevent Vue warnings if it is called outside of a component lifecycle.