### PR TITLE
fix(useUrlSearchParams): missing bracket on code example

### DIFF
--- a/packages/core/useUrlSearchParams/index.md
+++ b/packages/core/useUrlSearchParams/index.md
@@ -8,11 +8,11 @@ Reactive [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLS
 
 ## Usage
 
-```html {19}
+```html {14}
 <template>
   <ul>
-    <li v-for='key in Object.keys(params)' :key="key">
-      { key }}={{ params[key] }}
+    <li v-for="key in Object.keys(params)" :key="key">
+      {{ key }}={{ params[key] }}
     </li>
   </ul>
 </template>


### PR DESCRIPTION
I see some problem in the `useUrlSearchParams` documentation.
