### PR TITLE
feat(loadify): new function

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Collection of essential Vue Composition Utilities
 <a href="https://www.npmjs.com/package/@vueuse/core" target="__blank"><img src="https://img.shields.io/npm/v/@vueuse/core?color=a1b858&label=" alt="NPM version"></a>
 <a href="https://www.npmjs.com/package/@vueuse/core" target="__blank"><img alt="NPM Downloads" src="https://img.shields.io/npm/dm/@vueuse/core?color=50a36f&label="></a>
 <a href="https://vueuse.org" target="__blank"><img src="https://img.shields.io/static/v1?label=&message=docs%20%26%20demos&color=1e8a7a" alt="Docs & Demos"></a>
-<img alt="Function Count" src="https://img.shields.io/badge/-148%20functions-13708a">
+<img alt="Function Count" src="https://img.shields.io/badge/-149%20functions-13708a">
 <br>
 <a href="https://github.com/vueuse/vueuse" target="__blank"><img alt="GitHub stars" src="https://img.shields.io/github/stars/vueuse/vueuse?style=social"></a>
 </p>

--- a/indexes.json
+++ b/indexes.json
@@ -454,6 +454,13 @@
       "description": "combine computed and inject"
     },
     {
+      "name": "loadify",
+      "package": "core",
+      "docs": "https://vueuse.org/core/loadify/",
+      "category": "Utilities",
+      "description": "convert a `Promise` or an async `Function` by binding it's to a ref"
+    },
+    {
       "name": "onClickOutside",
       "package": "core",
       "component": true,

--- a/indexes.json
+++ b/indexes.json
@@ -454,13 +454,6 @@
       "description": "combine computed and inject"
     },
     {
-      "name": "loadify",
-      "package": "core",
-      "docs": "https://vueuse.org/core/loadify/",
-      "category": "Utilities",
-      "description": "convert a `Promise` or an async `Function` by binding it's to a ref"
-    },
-    {
       "name": "onClickOutside",
       "package": "core",
       "component": true,

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1,6 +1,7 @@
 export * from './asyncComputed'
 export * from './autoResetRef'
 export * from './computedInject'
+export * from './loadify'
 export * from './onClickOutside'
 export * from './onKeyStroke'
 export * from './onStartTyping'

--- a/packages/core/loadify/demo.vue
+++ b/packages/core/loadify/demo.vue
@@ -2,7 +2,7 @@
 import { ref } from 'vue-demi'
 import axios from 'axios'
 import YAML from 'js-yaml'
-import { loadify } from './loadify.'
+import { loadify } from '.'
 
 const isLoading = ref(false)
 const state = ref({})

--- a/packages/core/loadify/demo.vue
+++ b/packages/core/loadify/demo.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { ref } from 'vue-demi'
+import axios from 'axios'
+import YAML from 'js-yaml'
+import { loadify } from './loadify.'
+
+const isLoading = ref(false)
+const state = ref({})
+const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+const rawFetch = async(id: number) => {
+  await delay(500)
+  return await axios
+    .get(`https://jsonplaceholder.typicode.com/todos/${id}`)
+    .then(t => state.value = t.data)
+}
+
+const fetch = loadify(isLoading, rawFetch)
+const clear = () => state.value = {}
+</script>
+
+<template>
+  <div>
+    <note>IsLoading: {{ isLoading.toString() }}</note>
+    <pre lang="json" class="ml-2">{{ YAML.dump(state) }}</pre>
+    <button :disabled="isLoading" @click="fetch(1)">
+      Fetch Todo #1
+    </button>
+    <button :disabled="isLoading" @click="fetch(2)">
+      Fetch Todo #2
+    </button>
+    <button :disabled="isLoading" @click="fetch(3)">
+      Fetch Todo #3
+    </button>
+    <button :disabled="isLoading" @click="clear()">
+      Clear
+    </button>
+    <button :disabled="isLoading" @click="rawFetch(4)">
+      Raw Fetch
+    </button>
+  </div>
+</template>

--- a/packages/core/loadify/index.md
+++ b/packages/core/loadify/index.md
@@ -28,7 +28,7 @@ const put =     loadify(isLoading, id => api.put(`/anything/${id}`, state.value)
 const remove =  loadify(isLoading, id => api.delete(`/anything/${id}`))
 
 const state = ref({})
-state.value = fetch(42)
+state.value = await fetch(42)
 ```
 
 ## Related Functions

--- a/packages/core/loadify/index.md
+++ b/packages/core/loadify/index.md
@@ -1,0 +1,36 @@
+---
+category: Utilities
+---
+
+# loadify
+
+Convert a `Promise` or an async `Function` by binding it's to a ref.
+Useful when you want to bind the loading state of multiple promises to a ref.
+
+::: tip
+Make sure you're using the right tool for the job. Using [`useAyncState`](/core/useAsyncState/)
+might be more pertinent in some cases where you only want to bind the loading state of a single function 
+or when you want to bind the loading states of multiple async functions individually.
+:::
+
+## Usage
+
+```ts
+import axios from 'axios'
+import { loadify } from '@vueuse/core'
+import { ref } from 'vue-demi'
+
+const api = axios.create({baseUrl: 'https://httpbin.org'})
+const isLoading = ref(false)
+
+const fetch =   loadify(isLoading, id => api.get(`/anything/${id}`).then(res => res.data))
+const put =     loadify(isLoading, id => api.put(`/anything/${id}`, state.value))
+const remove =  loadify(isLoading, id => api.delete(`/anything/${id}`))
+
+const state = ref({})
+state.value = fetch(42)
+```
+
+## Related Functions
+
+- `useAsyncState`

--- a/packages/core/loadify/index.md
+++ b/packages/core/loadify/index.md
@@ -4,7 +4,7 @@ category: Utilities
 
 # loadify
 
-Convert a `Promise` or an async `Function` by binding it's to a ref.
+Convert a `Promise` or an async `Function` by binding it's ready state to a ref.
 Useful when you want to bind the loading state of multiple promises to a ref.
 
 ::: tip

--- a/packages/core/loadify/index.test.ts
+++ b/packages/core/loadify/index.test.ts
@@ -1,0 +1,54 @@
+import { ref } from 'vue-demi'
+import { useSetup } from '../../.test'
+import { loadify } from '.'
+
+describe('loadify', () => {
+  it('should be defined', () => {
+    expect(loadify).toBeDefined()
+  })
+
+  it('should return a function that returns the same value', () => {
+    useSetup(async() => {
+      const isLoading = ref(false)
+      const value = 42
+      const fn = async(value: any) => value
+      const res = await fn(value)
+      const resWrapped = await loadify(isLoading, fn)(value)
+      expect(res).toBe(resWrapped)
+    })
+  })
+
+  it('should return a promise that resolves to the same value', () => {
+    useSetup(async() => {
+      const isLoading = ref(false)
+      const value = 42
+      const fn = async(value: any) => value
+      const promise = fn(value)
+      const res = await promise
+      const resWrapped = await loadify(isLoading, promise)
+      expect(res).toBe(resWrapped)
+    })
+  })
+
+  it('should set `isLoading` to `true` when the promise is not resolved yet', () => {
+    useSetup(() => {
+      const isLoading = ref(false)
+      const value = 42
+      const delay = (ms: number, value: any) => new Promise(resolve => setTimeout(() => resolve(value), ms))
+      const delayLoadified = loadify(isLoading, delay)
+      delayLoadified(value, 1)
+      expect(isLoading.value).toBe(true)
+    })
+  })
+
+  it('should set `isLoading` to `false` when the promise is resolved', () => {
+    useSetup(async() => {
+      const isLoading = ref(false)
+      const value = 42
+      const delay = (ms: number, value: any) => new Promise(resolve => setTimeout(() => resolve(value), ms))
+      const delayLoadified = loadify(isLoading, delay)
+      await delayLoadified(value, 1)
+      expect(isLoading.value).toBe(false)
+    })
+  })
+})

--- a/packages/core/loadify/index.ts
+++ b/packages/core/loadify/index.ts
@@ -1,0 +1,32 @@
+/* this implementation is original ported from https://github.com/shorwood/pompaute by Stanley Horwood */
+
+import { Ref } from 'vue-demi'
+
+/**
+ * Convert a `Promise` or an async `Function` by binding it's to a ref.
+ * Useful when you want to bind the loading state of multiple promises to a ref.
+ * @param isLoading Reactive `Ref` used to store the state.
+ * @param asyncFuncOrPromise Function or Promise to wrap.
+ */
+export function loadify<R>(isLoading: Ref<boolean>, promise: Promise<R>): Promise<R>
+export function loadify<R, TS extends any[]>(isLoading: Ref<boolean>, asyncFunction: (...args: TS) => Promise<R>): (...args: TS) => Promise<R>
+export function loadify<R, TS extends any[]>(isLoading: Ref<boolean>, asyncFuncOrPromise: ((...args: TS) => Promise<R>) | Promise<R>): ((...args: TS) => Promise<R>) | Promise<R> {
+  // Wrap the function.
+  async function wrapped(...args: TS): Promise<R> {
+    // Start the loading.
+    isLoading.value = true
+
+    // Get promise.
+    const promise = asyncFuncOrPromise instanceof Function
+      ? asyncFuncOrPromise(...args)
+      : asyncFuncOrPromise
+
+    // Await promise and end loading.
+    return await promise.finally(() => isLoading.value = false)
+  }
+
+  return (asyncFuncOrPromise instanceof Function)
+    ? wrapped
+    // @ts-ignore
+    : wrapped()
+}

--- a/packages/core/loadify/index.ts
+++ b/packages/core/loadify/index.ts
@@ -3,8 +3,8 @@
 import { Ref } from 'vue-demi'
 
 /**
- * Convert a `Promise` or an async `Function` by binding it's to a ref.
- * Useful when you want to bind the loading state of multiple promises to a ref.
+ * Convert a `Promise` or an async `Function` by binding it's ready state to a ref.
+ * Useful when you want to bind the ready state of multiple promises to a ref.
  * @param isLoading Reactive `Ref` used to store the state.
  * @param asyncFuncOrPromise Function or Promise to wrap.
  */

--- a/packages/functions.md
+++ b/packages/functions.md
@@ -117,6 +117,7 @@
   - [`eagerComputed`](https://vueuse.org/shared/eagerComputed/) — eager computed without lazy evaluation
   - [`extendRef`](https://vueuse.org/shared/extendRef/) — add extra attributes to Ref
   - [`get`](https://vueuse.org/shared/get/) — shorthand for accessing `ref.value`
+  - [`loadify`](https://vueuse.org/core/loadify/) — convert a `Promise` or an async `Function` by binding it's to a ref
   - [`makeDestructurable`](https://vueuse.org/shared/makeDestructurable/) — make isomorphic destructurable for object and array at the same time
   - [`not`](https://vueuse.org/shared/not/) — `NOT` condition for ref
   - [`or`](https://vueuse.org/shared/or/) — `OR` conditions for refs

--- a/packages/functions.md
+++ b/packages/functions.md
@@ -117,7 +117,7 @@
   - [`eagerComputed`](https://vueuse.org/shared/eagerComputed/) — eager computed without lazy evaluation
   - [`extendRef`](https://vueuse.org/shared/extendRef/) — add extra attributes to Ref
   - [`get`](https://vueuse.org/shared/get/) — shorthand for accessing `ref.value`
-  - [`loadify`](https://vueuse.org/core/loadify/) — convert a `Promise` or an async `Function` by binding it's to a ref
+  - [`loadify`](https://vueuse.org/core/loadify/) — convert a `Promise` or an async `Function` by binding it's ready state to a ref
   - [`makeDestructurable`](https://vueuse.org/shared/makeDestructurable/) — make isomorphic destructurable for object and array at the same time
   - [`not`](https://vueuse.org/shared/not/) — `NOT` condition for ref
   - [`or`](https://vueuse.org/shared/or/) — `OR` conditions for refs


### PR DESCRIPTION
Hello everyone,

While making some services, i had a need for a function wrapper that bind a `Ref` to a `Promise`'s pending state. I first turned to `useAsyncState` but it ended up very verbosy :

```ts
const { isReady: isReadyFetchAll, execute: fetchAll, state } = useAsyncState(() => api.get(`/anything`).then(res => res.data))
const { isReady: isReadyFetch, execute: fetch, state } = useAsyncState(id => api.get(`/anything/${id}`).then(res => res.data))
const { isReady: isReadyPut, execute: put } = useAsyncState(id => api.put(`/anything/${id}`, state.value))
const { isReady: isReadyRemove, execute: remove } = useAsyncState(id => api.delete(`/anything/${id}`))
const isLoading = or(isReadyFetch, isReadyFetchAll, isReadyPut, isReadyRemove)
```

So, inspired by `useAsyncState`, I came up with `loadify`
This below is *almost* the same as above but using `loadify` instead of `useAsyncState`

```ts
const isLoading = ref(false)
const fetchAll =  loadify(isLoading, () => api.get(`/anything`).then(res => res.data))
const fetch =     loadify(isLoading, id => api.get(`/anything/${id}`).then(res => res.data))
const put =       loadify(isLoading, id => api.put(`/anything/${id}`, state.value))
const remove =    loadify(isLoading, id => api.delete(`/anything/${id}`))
```

Bear in mind `useAsyncState` and `loadify` are very similar but have key differences :
- `loadify` wrapper keeps the original function's return.
- `loadify` allows chaining of wrappers. Eg - `partial(loadify(isLoading, axios.post), "https://httpbin.org")`.
- `useAsyncState` initialises the `isReady` ref so you don't have to.
- `loadify` expects you have to provide the `isLoading` ref.
- `useAsyncState` store the result of the function in the `state` ref.
- **loadified** function returns the original result directly.
- calling multiple **loadified** functions bound to the same `isLoading` ref at the same time will result in undefined behaviors.

Issue: #792 

# Documentation

Convert a `Promise` or an async `Function` by binding it's to a ref.
Useful when you want to bind the loading state of multiple promises to a ref.

::: tip
Make sure you're using the right tool for the job. Using [`useAyncState`](/core/useAsyncState/)
might be more pertinent in some cases where you only want to bind the loading state of a single function 
or when you want to bind the loading states of multiple async functions individually.
:::

## Usage

```ts
import axios from 'axios'
import { loadify } from '@vueuse/core'
import { ref } from 'vue-demi'

const api = axios.create({baseUrl: 'https://httpbin.org'})
const isLoading = ref(false)

const fetch =   loadify(isLoading, id => api.get(`/anything/${id}`).then(res => res.data))
const put =     loadify(isLoading, id => api.put(`/anything/${id}`, state.value))
const remove =  loadify(isLoading, id => api.delete(`/anything/${id}`))

const state = ref({})
state.value = fetch(42)
```

## Related Functions

- `useAsyncState`