### PR TITLE
feat(onKeyStroke): Added functionality to listen to multiple keys

### DIFF
--- a/packages/core/onKeyStroke/demo.vue
+++ b/packages/core/onKeyStroke/demo.vue
@@ -5,22 +5,22 @@ import { onKeyStroke } from '.'
 const translateX = ref(0)
 const translateY = ref(0)
 
-onKeyStroke('ArrowUp', (e: KeyboardEvent) => {
+onKeyStroke(['w', 'W', 'ArrowUp'], (e: KeyboardEvent) => {
   translateY.value -= 10
   e.preventDefault()
 })
 
-onKeyStroke('ArrowDown', (e: KeyboardEvent) => {
+onKeyStroke(['s', 'S', 'ArrowDown'], (e: KeyboardEvent) => {
   translateY.value += 10
   e.preventDefault()
 })
 
-onKeyStroke('ArrowLeft', (e: KeyboardEvent) => {
+onKeyStroke(['a', 'A', 'ArrowLeft'], (e: KeyboardEvent) => {
   translateX.value -= 10
   e.preventDefault()
 })
 
-onKeyStroke('ArrowRight', (e: KeyboardEvent) => {
+onKeyStroke(['d', 'D', 'ArrowRight'], (e: KeyboardEvent) => {
   translateX.value += 10
   e.preventDefault()
 })
@@ -32,7 +32,7 @@ onKeyStroke('ArrowRight', (e: KeyboardEvent) => {
       <div class="ball" :style="{transform: `translate(${translateX}px, ${translateY}px)`}" />
     </div>
     <div class="text-center mt-4">
-      Use the arrow keys to control the movement of the ball.
+      Use the arrow keys or w a s d keys to control the movement of the ball.
     </div>
   </div>
 </template>

--- a/packages/core/onKeyStroke/index.md
+++ b/packages/core/onKeyStroke/index.md
@@ -18,6 +18,16 @@ onKeyStroke('ArrowDown', (e) => {
 
 See [this table](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values) for all key codes.
 
+### Listen To Multiple Keys
+
+```js
+import { onKeyStroke } from '@vueuse/core'
+
+onKeyStroke(['s', 'S', 'ArrowDown'], (e) => {
+  e.preventDefault()
+})
+```
+
 ### Custom Event Target
 
 ```js

--- a/packages/core/onKeyStroke/index.ts
+++ b/packages/core/onKeyStroke/index.ts
@@ -3,7 +3,7 @@ import { useEventListener } from '../useEventListener'
 import { defaultWindow } from '../_configurable'
 
 export type KeyPredicate = (event: KeyboardEvent) => boolean
-export type KeyFilter = null | undefined | string | KeyPredicate
+export type KeyFilter = null | undefined | string | string[] | KeyPredicate
 export type KeyStrokeEventName = 'keydown' | 'keypress' | 'keyup'
 export type KeyStrokeOptions = {
   eventName?: KeyStrokeEventName
@@ -11,14 +11,22 @@ export type KeyStrokeOptions = {
   passive?: boolean
 }
 
-const createKeyPredicate = (keyFilter: KeyFilter): KeyPredicate =>
-  typeof keyFilter === 'function'
-    ? keyFilter
-    : typeof keyFilter === 'string'
-      ? (event: KeyboardEvent) => event.key === keyFilter
-      : keyFilter
-        ? () => true
-        : () => false
+const createKeyPredicate = (keyFilter: KeyFilter): KeyPredicate => {
+  if (typeof keyFilter === 'function')
+    return keyFilter
+
+  else if (typeof keyFilter === 'string')
+    return (event: KeyboardEvent) => event.key === keyFilter
+
+  else if (Array.isArray(keyFilter))
+    return (event: KeyboardEvent) => keyFilter.includes(event.key)
+
+  else if (keyFilter)
+    return () => true
+
+  else
+    return () => false
+}
 
 /**
  * Listen for keyboard keys being stroked.


### PR DESCRIPTION
This PR adds the ability to listen to multiple key for onKeyStroke.
This simply adds a parameter type of `string[]` so the previous API is still valid and the PR is not a breaking change.

Example:
```js
import { onKeyStroke } from '@vueuse/core'

// Previous API
onKeyStroke('ArrowDown', (e) => {
  e.preventDefault()
})

// Now possible to pass an array of keys
onKeyStroke(['w', 'W', 'ArrowUp'], (e) => {
  e.preventDefault()
})
```


