### PR TITLE
refactor(onClickOutside)!: listen click event, remove event option

### DIFF
--- a/packages/core/onClickOutside/demo.vue
+++ b/packages/core/onClickOutside/demo.vue
@@ -22,7 +22,6 @@ onClickOutside(
     console.log(event)
     dropdown.value = false
   },
-  { event: 'mousedown' },
 )
 </script>
 

--- a/packages/core/onClickOutside/directive.ts
+++ b/packages/core/onClickOutside/directive.ts
@@ -1,9 +1,9 @@
 import { FunctionDirective } from 'vue-demi'
-import { onClickOutside, OnClickOutsideEvents } from '.'
+import { onClickOutside } from '.'
 
 /**
  * TODO: Test that this actually works
  */
-export const VOnClickOutside: FunctionDirective<any, (evt: OnClickOutsideEvents['pointerdown']) => void> = (el, binding) => {
+export const VOnClickOutside: FunctionDirective<any, (evt: PointerEvent) => void> = (el, binding) => {
   onClickOutside(el, binding.value)
 }


### PR DESCRIPTION
BREAKING CHANGE

- `event` option removed
- listen `click` event by default
- feat: prevent calling handler on selections inside target

Close #641 
Close #770

@antfu On #770 I said using `click` by default would fix all issues including _prevent handler call while selecting text in target element_. That was wrong but I come up with simpler solution with single `pointerdown` listener.

I work around click propagation issue by enabling capture phase in click listener. 

As I said, those listeners can be registered when target becomes available in DOM, so we don't have to use capture phase and constantly listening those events. I avoided doing that to prevent adding extra complexity on source code since footprint of those listeners are next to nothing.