### PR TITLE
fix(useScroll): types for ref include null and undefined

### DIFF
--- a/packages/core/useScroll/index.ts
+++ b/packages/core/useScroll/index.ts
@@ -47,7 +47,7 @@ export interface UseScrollOptions {
  */
 
 export function useScroll(
-  element: MaybeRef<HTMLElement | SVGElement | Window | Document>,
+  element: MaybeRef<HTMLElement | SVGElement | Window | Document | null | undefined>,
   options: UseScrollOptions = {},
 ) {
   const {


### PR DESCRIPTION
## The problem:

With Vue composition API the ref is null or undefined intially. There is a type error as these are not accepted

### Example
```
const someEl = ref<HTMLElement | null>(null)
const { y } = useScroll(someEl)
```

Error:
_Argument of type 'Ref<HTMLElement | null>' is not assignable to parameter of type 'MaybeRef<Window | HTMLElement | Document | SVGElement>'._

### Fix:

Add null and undefined as accepted types, **just like with useScroll()** and other vueuse functions

