### PR TITLE
Remove a broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ This project is heavily inspired by the following awesome projects.
 
 - [streamich/react-use](https://github.com/streamich/react-use)
 - [u3u/vue-hooks](https://github.com/u3u/vue-hooks)
-- [shuidi-fed/vue-composition-toolkit](https://github.com/shuidi-fed/vue-composition-toolkit)
 - [logaretm/vue-use-web](https://github.com/logaretm/vue-use-web)
 - [kripod/react-hooks](https://github.com/kripod/react-hooks)
 


### PR DESCRIPTION
It seems `shuidi-fed/vue-composition-toolkit` [has been transferred to](https://web.archive.org/web/20210314143733/https://github.com/shuidi-fed/vue-composition-toolkit) `HcySunYang/vue-composition-toolkit` but then got deleted by its owner.