### PR TITLE
fix(useGeolocation)!: latitude and longitude default to Infinity

### DIFF
--- a/packages/core/useGeolocation/index.ts
+++ b/packages/core/useGeolocation/index.ts
@@ -26,8 +26,8 @@ export function useGeolocation(options: GeolocationOptions = {}) {
   const error = ref<GeolocationPositionError | null>(null)
   const coords: Ref<GeolocationPosition['coords']> = ref({
     accuracy: 0,
-    latitude: 0,
-    longitude: 0,
+    latitude: Infinity,
+    longitude: Infinity,
     altitude: null,
     altitudeAccuracy: null,
     heading: null,


### PR DESCRIPTION
useGeolocation API should return a valid number outside of the -90, + 90 / -180, +180 for coords.latitude and coords.longitude when the user isn't at coords { 0, 0 } and they haven't given permission to share their geoLocation.

This ensures we can make a determination between the user actually being at { 0, 0 } and not allowing us to access their geoLocation. 

If the value is Infinity, then we know "something" has gone wrong (i.e., we can confirm that the longitude or latitude is not valid)