### PR TITLE
feat(useTimestamp): expose immediate option

### DIFF
--- a/packages/core/useTimestamp/component.ts
+++ b/packages/core/useTimestamp/component.ts
@@ -3,7 +3,7 @@ import { useTimestamp, TimestampOptions } from '@vueuse/core'
 
 export const UseTimestamp = defineComponent<Omit<TimestampOptions<true>, 'controls'>>({
   name: 'UseTimestamp',
-  props: ['interval', 'offset'] as unknown as undefined,
+  props: ['immediate', 'interval', 'offset'] as unknown as undefined,
   setup(props, { slots }) {
     const data = reactive(useTimestamp({ ...props, controls: true }))
 

--- a/packages/core/useTimestamp/index.test.ts
+++ b/packages/core/useTimestamp/index.test.ts
@@ -1,0 +1,33 @@
+import { promiseTimeout } from '@vueuse/shared'
+import { useTimestamp } from '.'
+
+describe('useTimestamp', () => {
+  it('starts immediately by default', async() => {
+    const timestamp = useTimestamp()
+
+    const initial = timestamp.value
+
+    await promiseTimeout(50)
+
+    expect(timestamp.value).toBeGreaterThan(initial)
+  })
+
+  it('allows for a delayed start', async() => {
+    const { resume, timestamp } = useTimestamp({
+      controls: true,
+      immediate: false,
+    })
+
+    const initial = timestamp.value
+
+    await promiseTimeout(50)
+
+    expect(timestamp.value).toBe(initial)
+
+    resume()
+
+    await promiseTimeout(50)
+
+    expect(timestamp.value).toBeGreaterThan(initial)
+  })
+})

--- a/packages/core/useTimestamp/index.ts
+++ b/packages/core/useTimestamp/index.ts
@@ -18,6 +18,13 @@ export interface TimestampOptions<Controls extends boolean> {
   offset?: number
 
   /**
+   * Update the timestamp immediately
+   *
+   * @default true
+   */
+  immediate?: boolean
+
+  /**
    * Update interval, or use requestAnimationFrame
    *
    * @default requestAnimationFrame
@@ -37,6 +44,7 @@ export function useTimestamp(options: TimestampOptions<boolean> = {}) {
   const {
     controls: exposeControls = false,
     offset = 0,
+    immediate = true,
     interval = 'requestAnimationFrame',
   } = options
 
@@ -45,8 +53,8 @@ export function useTimestamp(options: TimestampOptions<boolean> = {}) {
   const update = () => ts.value = timestamp() + offset
 
   const controls: Pausable = interval === 'requestAnimationFrame'
-    ? useRafFn(update, { immediate: true })
-    : useIntervalFn(update, interval, { immediate: true })
+    ? useRafFn(update, { immediate })
+    : useIntervalFn(update, interval, { immediate })
 
   if (exposeControls) {
     return {


### PR DESCRIPTION
Sometimes it is useful to create timestamps that don't start immediately. Currently, this can be achieved by calling `pause()` as soon as the timestamp is created, but I think exposing the underlying `immediate` option would be a slightly cleaner solution.

```vue
<template>
  <button @click="resume">{{ timestamp }}</button>
</template>

<script setup>
import { useTimestamp } from '@vueuse/core'

const { timestamp, resume } = useTimestamp({
  controls: true,
  immediate: false,
})
</script>
```

The default behavior remains unchanged, and I've added a test to verify this. Let me know if there is anything else is needed for this PR. And if we'd rather not expand the `useTimestamp` options, no worries, feel free to just close my PR.