### PR TITLE
feat: change the time to change the status of copied

### DIFF
--- a/packages/core/useClipboard/index.ts
+++ b/packages/core/useClipboard/index.ts
@@ -69,12 +69,13 @@ export function useClipboard(options: ClipboardOptions<MaybeRef<string> | undefi
   }
 
   async function copy(value = unref(source)) {
+    copied.value = false
     if (isSupported && value != null) {
       // @ts-expect-error untyped API
       await navigator.clipboard.writeText(value)
       text.value = value
       copied.value = true
-      timeout.start()
+      // timeout.start()
     }
   }
 


### PR DESCRIPTION
I think we should chang the status of copied when the copy funciton is called, instead of change copied to false after some duration. 