### PR TITLE
feat(workflow): add comment on new issue

### DIFF
--- a/.github/workflows/handle-new-issue.yml
+++ b/.github/workflows/handle-new-issue.yml
@@ -1,0 +1,17 @@
+name: 'Handle new issue'
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  comment_on_new_issue:
+    runs-on: ubuntu-latest
+    name: Job for commenting on new issue
+    steps:
+      - name: Comment
+        uses: jd-0001/gh-action-comment-on-new-issue@v2.0.3
+        with:
+          message: |
+            ### Hi there <img src="https://raw.githubusercontent.com/MartinHeinz/MartinHeinz/master/wave.gif" width="30px">
+            Please provide [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) link for resolving the issue quickly if this is technical issue.
+            Maintainers' time is limited, and most of the time, unpaid. With minimal reproduction it will take our less time to resolve the issue and if you are lucky, helpful people will help you in resolving the issue as well.


### PR DESCRIPTION
Hi @antfu 

I am a fan of your work. I really like your contribution to Vue & Vue DX :heart:.

This new workflow adds the below comment when someone raises a new issue.

> ### Hi there <img src="https://raw.githubusercontent.com/MartinHeinz/MartinHeinz/master/wave.gif" width="30px">
> Please provide [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) link for resolving the issue quickly if this is technical issue.
> Maintainers' time is limited, and most of the time, unpaid. With minimal reproduction it will take our less time to resolve the issue and if you are lucky, helpful people will help you in resolving the issue as well.

I follow you on Twitter and I found some tweets about the maintenance of the repo:
https://twitter.com/antfu7/status/1443778578575810561
https://twitter.com/antfu7/status/1449072024635142147

We at [ThemeSelection](https://themeselection.com/) create Admin Templates and we also require minimal reproduction for resolving the issue. To resolve this I created small but useful [GitHub action](https://github.com/jd-0001/gh-action-comment-on-new-issue) which comments on a new issue.

This is my small contribution in helping you invest more time developing than managing various GitHub projects.

From my experience, as soon as I started asking for minimal reproduction in our repo, most people automatically closed their issues. I hope this will also benefit you.

Screenshot from our private repo:
![image](https://user-images.githubusercontent.com/47495003/138447397-baf77da7-6dec-4bb3-992a-c69cbd95dcfe.png)