### PR TITLE
docs(useVModels): Fix typo

### DIFF
--- a/packages/core/useVModels/index.md
+++ b/packages/core/useVModels/index.md
@@ -19,7 +19,7 @@ export default {
   setup(props, { emit }) {
     const { foo, bar } = useVModels(props, emit)
 
-    console.log(foo.value) // props.data
+    console.log(foo.value) // props.foo
     foo.value = 'foo' // emit('update:foo', 'foo')
   },
 }


### PR DESCRIPTION
Looks like a copy/paste error from `useVModel`. The prop used in the example was changed from `data` to `foo`, but the comment wasn't updated.