### PR TITLE
fix: Could not resolve "@vueuse/shared"

### DIFF
--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -69,6 +69,7 @@
   "homepage": "https://github.com/vueuse/vueuse/tree/main/packages/integrations#readme",
   "dependencies": {
     "@vueuse/core": "workspace:*",
+    "@vueuse/shared": "workspace:*",
     "vue-demi": "*"
   },
   "optionalDependencies": {


### PR DESCRIPTION
```bash
error when starting dev server:
Error: Build failed with 1 error:
node_modules/@vueuse/integrations/index.mjs:3:54: error: Could not resolve "@vueuse/shared" (mark it as external to exclude it from the bundle)
```