### PR TITLE
docs(useFuse): add "fuzzy search" language to useFuse

### DIFF
--- a/packages/integrations/useFuse/index.md
+++ b/packages/integrations/useFuse/index.md
@@ -4,9 +4,15 @@ category: '@Integrations'
 
 # useFuse
 
-Reactive wrapper for [Fuse.js](https://github.com/krisk/fuse).
+Easily implement fuzzy search using a composable on top of the zero-dependency library [Fuse.js](https://github.com/krisk/fuse).
 
-## Install
+From the Fuse.js website:
+
+> What is fuzzy searching?
+> 
+> Generally speaking, fuzzy searching (more formally known as approximate string matching) is the technique of finding strings that are approximately equal to a given pattern (rather than exactly).
+
+## Install fuse.js as a peer dependency
 
 ### NPM
 

--- a/packages/integrations/useFuse/index.md
+++ b/packages/integrations/useFuse/index.md
@@ -12,7 +12,7 @@ From the Fuse.js website:
 > 
 > Generally speaking, fuzzy searching (more formally known as approximate string matching) is the technique of finding strings that are approximately equal to a given pattern (rather than exactly).
 
-## Install fuse.js as a peer dependency
+## Install Fuse.js as a peer dependency
 
 ### NPM
 


### PR DESCRIPTION
I added some additional wording to the `useFuse` documentation because when I searched the docs for "fuzzy", "search", or "searching" nothing came up.

I'd never heard of fuse.js and nearly implemented my own composable on top of https://github.com/bevacqua/fuzzysearch! 😅