### PR TITLE
fix(useFocus): resolve issues when used with v-if

### DIFF
--- a/packages/core/useFocus/index.ts
+++ b/packages/core/useFocus/index.ts
@@ -1,8 +1,9 @@
 import { computed, Ref, watch } from 'vue-demi'
 import { MaybeElementRef, unrefElement } from '../unrefElement'
 import { useActiveElement } from '../useActiveElement'
+import { ConfigurableWindow } from '../_configurable'
 
-export interface FocusOptions {
+export interface FocusOptions extends ConfigurableWindow {
   /**
    * Initial value. If set true, then focus will be set on the target
    *
@@ -35,7 +36,7 @@ export function useFocus(options: FocusOptions = {}): FocusReturn {
     initialValue = false,
   } = options
 
-  const activeElement = useActiveElement()
+  const activeElement = useActiveElement(options)
   const target = computed(() => unrefElement(options.target))
   const focused = computed({
     get() {

--- a/packages/core/useFocus/index.ts
+++ b/packages/core/useFocus/index.ts
@@ -1,9 +1,8 @@
-import { computed, Ref, ref, watch } from 'vue-demi'
+import { computed, Ref, watch } from 'vue-demi'
 import { MaybeElementRef, unrefElement } from '../unrefElement'
-import { useEventListener } from '../useEventListener'
-import { ConfigurableWindow, defaultWindow } from '../_configurable'
+import { useActiveElement } from '../useActiveElement'
 
-export interface FocusOptions extends ConfigurableWindow {
+export interface FocusOptions {
   /**
    * Initial value. If set true, then focus will be set on the target
    *
@@ -34,34 +33,23 @@ export interface FocusReturn {
 export function useFocus(options: FocusOptions = {}): FocusReturn {
   const {
     initialValue = false,
-    window = defaultWindow,
   } = options
 
-  const focused = ref(initialValue)
+  const activeElement = useActiveElement()
+  const target = computed(() => unrefElement(options.target))
+  const focused = computed({
+    get() {
+      return activeElement.value === target.value
+    },
+    set(value: boolean) {
+      if (!value && focused.value)
+        target.value?.blur()
+      if (value && !focused.value)
+        target.value?.focus()
+    },
+  })
 
-  if (!window) return { focused }
-
-  const onFocus = () => { focused.value = true }
-  const onBlur = () => { focused.value = false }
-
-  const target = computed(() => unrefElement(options.target) ?? window)
-
-  useEventListener(target, 'focus', onFocus, { passive: true })
-  useEventListener(target, 'blur', onBlur, { passive: true })
-
-  const setFocus = (focused: boolean, oldFocused: boolean | undefined) => {
-    if (focused) {
-      if (!oldFocused) target.value?.focus()
-    }
-    else {
-      if (oldFocused) target.value?.blur()
-    }
-  }
-
-  watch(focused, setFocus, { immediate: true, flush: 'post' })
-  watch(target, () => {
-    setFocus(focused.value, false)
-  }, { immediate: true, flush: 'post' })
+  watch(target, () => { focused.value = initialValue }, { immediate: true, flush: 'post' })
 
   return { focused }
 }


### PR DESCRIPTION
Resolves #926

I noticed some issues when using `useFocus` with an element that was conditionally rendered. I refactored it to have the focus state be a computed based off of the existing `useActiveElement` function instead of trying to keep a ref in sync with value changes and events.