### PR TITLE
feat(useCounter): add options

### DIFF
--- a/packages/shared/useCounter/index.md
+++ b/packages/shared/useCounter/index.md
@@ -19,5 +19,5 @@ const { count, inc, dec, set, reset } = useCounter()
 ```js
 import { useCounter } from '@vueuse/core'
 
-const { count, inc, dec, set, reset } = useCounter(1, { minValue: 0, maxValue: 16 })
+const { count, inc, dec, set, reset } = useCounter(1, { min: 0, max: 16 })
 ```

--- a/packages/shared/useCounter/index.test.ts
+++ b/packages/shared/useCounter/index.test.ts
@@ -41,7 +41,7 @@ describe('useCounter', () => {
 
   it('should be update limited counter', () => {
     useSetup(() => {
-      const { count, inc, dec, get } = useCounter(1, { minValue: -2, maxValue: 15})
+      const { count, inc, dec, get } = useCounter(1, { min: -2, max: 15 })
 
       expect(count.value).toBe(1)
       expect(get()).toBe(1)

--- a/packages/shared/useCounter/index.ts
+++ b/packages/shared/useCounter/index.ts
@@ -1,16 +1,38 @@
 import { ref } from 'vue-demi'
 
+interface useCounterOptions {
+  minValue?: number
+  maxValue?: number
+}
+
 /**
  * Basic counter with utility functions.
  *
  * @see https://vueuse.org/useCounter
  * @param [initialValue=0]
+ * @param {Object} options
  */
-export function useCounter(initialValue = 0) {
+export function useCounter(initialValue = 0, options: useCounterOptions = { minValue: undefined, maxValue: undefined }) {
   const count = ref(initialValue)
 
-  const inc = (delta = 1) => (count.value += delta)
-  const dec = (delta = 1) => (count.value -= delta)
+  const inc = (delta = 1) => {
+    if (!options.maxValue) {
+      count.value += delta
+      return
+    }
+    if ((options.maxValue && count.value < options.maxValue)) {
+      count.value = count.value + delta > options.maxValue ? options.maxValue : count.value + delta
+    }
+  }
+  const dec = (delta = 1) => {
+    if (!options.maxValue) {
+      count.value -= delta
+      return
+    }
+    if ((options.minValue && count.value > options.minValue)) {
+      count.value = count.value - delta < options.minValue ? options.minValue : count.value - delta
+    }
+  }
   const get = () => count.value
   const set = (val: number) => (count.value = val)
   const reset = (val = initialValue) => {

--- a/packages/shared/useCounter/index.ts
+++ b/packages/shared/useCounter/index.ts
@@ -1,6 +1,6 @@
 import { ref } from 'vue-demi'
 
-interface useCounterOptions {
+export interface UseCounterOptions {
   min?: number
   max?: number
 }
@@ -12,25 +12,16 @@ interface useCounterOptions {
  * @param [initialValue=0]
  * @param {Object} options
  */
-export function useCounter(initialValue = 0, options: useCounterOptions = { min: undefined, max: undefined }) {
+export function useCounter(initialValue = 0, options: UseCounterOptions = {}) {
   const count = ref(initialValue)
 
-  const inc = (delta = 1) => {
-    if (!options.max) {
-      count.value += delta
-      return
-    }
-    if (options.max && count.value < options.max)
-      count.value = count.value + delta > options.max ? options.max : count.value + delta
-  }
-  const dec = (delta = 1) => {
-    if (!options.min) {
-      count.value -= delta
-      return
-    }
-    if (options.min && count.value > options.min)
-      count.value = count.value - delta < options.min ? options.min : count.value - delta
-  }
+  const {
+    max = Infinity,
+    min = -Infinity,
+  } = options
+
+  const inc = (delta = 1) => count.value = Math.min(max, count.value + delta)
+  const dec = (delta = 1) => count.value = Math.max(min, count.value - delta)
   const get = () => count.value
   const set = (val: number) => (count.value = val)
   const reset = (val = initialValue) => {

--- a/packages/shared/useCounter/index.ts
+++ b/packages/shared/useCounter/index.ts
@@ -1,8 +1,8 @@
 import { ref } from 'vue-demi'
 
 interface useCounterOptions {
-  minValue?: number
-  maxValue?: number
+  min?: number
+  max?: number
 }
 
 /**
@@ -12,26 +12,24 @@ interface useCounterOptions {
  * @param [initialValue=0]
  * @param {Object} options
  */
-export function useCounter(initialValue = 0, options: useCounterOptions = { minValue: undefined, maxValue: undefined }) {
+export function useCounter(initialValue = 0, options: useCounterOptions = { min: undefined, max: undefined }) {
   const count = ref(initialValue)
 
   const inc = (delta = 1) => {
-    if (!options.maxValue) {
+    if (!options.max) {
       count.value += delta
       return
     }
-    if ((options.maxValue && count.value < options.maxValue)) {
-      count.value = count.value + delta > options.maxValue ? options.maxValue : count.value + delta
-    }
+    if (options.max && count.value < options.max)
+      count.value = count.value + delta > options.max ? options.max : count.value + delta
   }
   const dec = (delta = 1) => {
-    if (!options.maxValue) {
+    if (!options.min) {
       count.value -= delta
       return
     }
-    if ((options.minValue && count.value > options.minValue)) {
-      count.value = count.value - delta < options.minValue ? options.minValue : count.value - delta
-    }
+    if (options.min && count.value > options.min)
+      count.value = count.value - delta < options.min ? options.min : count.value - delta
   }
   const get = () => count.value
   const set = (val: number) => (count.value = val)


### PR DESCRIPTION
Add as second parameter an options object with `minValue` and `maxValue` in order to create a limited counter.
can be useful for example to create a zoom 

```
const { count: zoom, inc, dec, reset } = useCounter(5, { minValue: 1, maxValue: 16 })
```