### PR TITLE
fix(useClipboard)!: disable `read` by default

### DIFF
--- a/packages/core/useClipboard/index.ts
+++ b/packages/core/useClipboard/index.ts
@@ -9,7 +9,7 @@ export interface ClipboardOptions<Source> extends ConfigurableNavigator {
   /**
    * Enabled reading for clipboard
    *
-   * @default true
+   * @default false
    */
   read?: boolean
 
@@ -44,7 +44,7 @@ export function useClipboard(options: ClipboardOptions<MaybeRef<string>>): Clipb
 export function useClipboard(options: ClipboardOptions<MaybeRef<string> | undefined> = {}): ClipboardReturn<boolean> {
   const {
     navigator = defaultNavigator,
-    read = true,
+    read = false,
     source,
     copiedDuring = 1500,
   } = options


### PR DESCRIPTION
Since reading the clipboard could be a sensible move (#321) and requires permissions on Chrome and is NOT supported by Firefox (#937). Instead of opt-out, we should make it opt-out for this feature.