### PR TITLE
feat(useDevicesList): add option

### DIFF
--- a/packages/core/useDevicesList/component.ts
+++ b/packages/core/useDevicesList/component.ts
@@ -3,7 +3,7 @@ import { useDevicesList, UseDevicesListOptions } from '@vueuse/core'
 
 export const UseDevicesList = defineComponent<UseDevicesListOptions>({
   name: 'UseDevicesList',
-  props: ['onUpdated', 'requestPermissions'] as unknown as undefined,
+  props: ['onUpdated', 'requestPermissions', 'constraints'] as unknown as undefined,
   setup(props, { slots }) {
     const data = reactive(useDevicesList(props))
 

--- a/packages/core/useDevicesList/index.ts
+++ b/packages/core/useDevicesList/index.ts
@@ -14,6 +14,12 @@ export interface UseDevicesListOptions extends ConfigurableNavigator {
    * @default false
    */
   requestPermissions?: boolean
+  /**
+   * Request for types of media permissions
+   *
+   * @default { audio: true, video: true }
+   */
+  constraints?: MediaStreamConstraints
 }
 
 export interface UseDevicesListReturn {
@@ -39,6 +45,7 @@ export function useDevicesList(options: UseDevicesListOptions = {}): UseDevicesL
   const {
     navigator = defaultNavigator,
     requestPermissions = false,
+    constraints = { audio: true, video: true },
     onUpdated,
   } = options
 
@@ -67,7 +74,7 @@ export function useDevicesList(options: UseDevicesListOptions = {}): UseDevicesL
     const { state, query } = usePermission('camera', { controls: true })
     await query()
     if (state.value !== 'granted') {
-      const stream = await navigator!.mediaDevices.getUserMedia({ audio: true, video: true })
+      const stream = await navigator!.mediaDevices.getUserMedia(constraints)
       stream.getTracks().forEach(t => t.stop())
       update()
       permissionGranted.value = true


### PR DESCRIPTION
New option for [useDevicesList](https://vueuse.org/core/useDevicesList/) to describe media types for [permission request](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia#parameters) instead of the current hardcoded `{ audio: true, video: true }`. It can be useful when only the audio or video stream is used, leaving the rest of the devices untouched.

---

This is my first PR here, please let me (over)explain myself even if it’s a slight change.

- The parameter is not _ref_ nor _reactive_. I don’t really see its advantage in general here but it would take an extra watcher, reset `permissionGranted`, too much complexity doesn’t sound good.
- The demo page is untouched. This new parameter is very straightforward and introducing checkboxes for this could be confusing.
- _I’m happy to update it by request or simply cancel it if there is no need._