### PR TITLE
fix(useAsyncState): optional argument of `execute`

### DIFF
--- a/packages/core/useAsyncState/index.ts
+++ b/packages/core/useAsyncState/index.ts
@@ -5,7 +5,7 @@ export interface UseAsyncStateReturn<T> {
   state: Ref<T>
   isReady: Ref<boolean>
   error: Ref<unknown>
-  execute: (delay: number, ...args: any[]) => Promise<T>
+  execute: (delay?: number, ...args: any[]) => Promise<T>
 }
 
 export interface AsyncStateOptions {


### PR DESCRIPTION
The first parameter `delay` of execute function should be optional(which has a default value of 0).