### PR TITLE
feat(useScroll): directions

### DIFF
--- a/packages/core/useScroll/demo.vue
+++ b/packages/core/useScroll/demo.vue
@@ -3,8 +3,9 @@ import { ref, toRefs } from 'vue-demi'
 import { useScroll } from '.'
 
 const el = ref<HTMLElement | null>(null)
-const { x, y, isScrolling, arrivedState } = useScroll(el)
+const { x, y, isScrolling, arrivedState, directions } = useScroll(el)
 const { left, right, top, bottom } = toRefs(arrivedState)
+const { left: toLeft, right: toRight, top: toTop, bottom: toBottom } = toRefs(directions)
 </script>
 
 <template>
@@ -28,29 +29,47 @@ const { left, right, top, bottom } = toRefs(arrivedState)
         </div>
       </div>
     </div>
-    <div class="m-auto w-280px px-6 py-4 mb-20 rounded grid grid-cols-[120px,auto] gap-2 bg-gray-500/5">
-      <span text="right" opacity="75">Position</span>
-      <div class="text-primary">
-        {{ x }}, {{ y }}
+    <div class="m-auto w-280px pl-4">
+      <div class="px-6 py-4 rounded grid grid-cols-[120px,auto] gap-2 bg-gray-500/5">
+        <span text="right" opacity="75">Position</span>
+        <div class="text-primary">
+          {{ x }}, {{ y }}
+        </div>
+        <span text="right" opacity="75">isScrolling</span>
+        <BooleanDisplay :value="isScrolling" />
+        <div text="right" opacity="75">
+          Top Arrived
+        </div>
+        <BooleanDisplay :value="top" />
+        <div text="right" opacity="75">
+          Right Arrived
+        </div>
+        <BooleanDisplay :value="right" />
+        <div text="right" opacity="75">
+          Bottom Arrived
+        </div>
+        <BooleanDisplay :value="bottom" />
+        <div text="right" opacity="75">
+          Left Arrived
+        </div>
+        <BooleanDisplay :value="left" />
+        <div text="right" opacity="75">
+          Scrolling Up
+        </div>
+        <BooleanDisplay :value="toTop" />
+        <div text="right" opacity="75">
+          Scrolling Right
+        </div>
+        <BooleanDisplay :value="toRight" />
+        <div text="right" opacity="75">
+          Scrolling Down
+        </div>
+        <BooleanDisplay :value="toBottom" />
+        <div text="right" opacity="75">
+          Scrolling Left
+        </div>
+        <BooleanDisplay :value="toLeft" />
       </div>
-      <span text="right" opacity="75">isScrolling</span>
-      <BooleanDisplay :value="isScrolling" />
-      <div text="right" opacity="75">
-        Top Arrived
-      </div>
-      <BooleanDisplay :value="top" />
-      <div text="right" opacity="75">
-        Right Arrived
-      </div>
-      <BooleanDisplay :value="right" />
-      <div text="right" opacity="75">
-        Bottom Arrived
-      </div>
-      <BooleanDisplay :value="bottom" />
-      <div text="right" opacity="75">
-        Left Arrived
-      </div>
-      <BooleanDisplay :value="left" />
     </div>
   </div>
 </template>

--- a/packages/core/useScroll/index.md
+++ b/packages/core/useScroll/index.md
@@ -13,7 +13,7 @@ Reactive scroll position and state
 import { useScroll } from '@vueuse/core'
 
 const el = ref<HTMLElement | null>(null)
-const { x, y, isScrolling, arrivedState } = useScroll(el)
+const { x, y, isScrolling, arrivedState, directions } = useScroll(el)
 </script>
 
 <template>
@@ -23,7 +23,7 @@ const { x, y, isScrolling, arrivedState } = useScroll(el)
 
 ```js
 // With offsets
-const { x, y, isScrolling, arrivedState } = useScroll(el, {
+const { x, y, isScrolling, arrivedState, directions } = useScroll(el, {
   offset: { top: 30, bottom: 30, right: 30, left: 30 },
 })
 ```

--- a/packages/core/useScroll/index.ts
+++ b/packages/core/useScroll/index.ts
@@ -4,7 +4,7 @@ import { useEventListener } from '../useEventListener'
 
 export interface UseScrollOptions {
   /**
-   * Throttle time for scroll event,it’s disabled by default.
+   * Throttle time for scroll event, it’s disabled by default.
    *
    * @default 0
    */
@@ -47,6 +47,13 @@ export interface UseScrollOptions {
    * @default {capture: false, passive: true}
    */
   eventListenerOptions?: boolean | AddEventListenerOptions
+
+  /**
+   * Scroll direction tolerance in pixels.
+   *
+   * @default 100
+  */
+  directionTolerance?: number
 }
 
 /**
@@ -87,10 +94,20 @@ export function useScroll(
     top: true,
     bottom: false,
   })
+  const directions = reactive({
+    left: false,
+    right: false,
+    top: false,
+    bottom: false,
+  })
 
   if (element) {
     const onScrollEnd = useDebounceFn(() => {
       isScrolling.value = false
+      directions.left = false
+      directions.right = false
+      directions.top = false
+      directions.bottom = false
       onStop()
     }, throttle + idle)
 
@@ -100,12 +117,16 @@ export function useScroll(
       ) as HTMLElement
 
       const scrollLeft = eventTarget.scrollLeft
+      directions.left = scrollLeft < x.value
+      directions.right = scrollLeft > x.value
       arrivedState.left = scrollLeft <= 0 + (offset.left || 0)
       arrivedState.right
           = scrollLeft + eventTarget.clientWidth >= eventTarget.scrollWidth - (offset.right || 0)
       x.value = scrollLeft
 
       const scrollTop = eventTarget.scrollTop
+      directions.top = scrollTop < y.value
+      directions.bottom = scrollTop > y.value
       arrivedState.top = scrollTop <= 0 + (offset.top || 0)
       arrivedState.bottom
           = scrollTop + eventTarget.clientHeight >= eventTarget.scrollHeight - (offset.bottom || 0)
@@ -129,6 +150,7 @@ export function useScroll(
     y,
     isScrolling,
     arrivedState,
+    directions,
   }
 }
 

--- a/packages/core/useScroll/index.ts
+++ b/packages/core/useScroll/index.ts
@@ -47,13 +47,6 @@ export interface UseScrollOptions {
    * @default {capture: false, passive: true}
    */
   eventListenerOptions?: boolean | AddEventListenerOptions
-
-  /**
-   * Scroll direction tolerance in pixels.
-   *
-   * @default 100
-  */
-  directionTolerance?: number
 }
 
 /**

--- a/packages/core/useVirtualList/component.ts
+++ b/packages/core/useVirtualList/component.ts
@@ -1,4 +1,4 @@
-import { defineComponent, h } from 'vue-demi'
+import { defineComponent, h, toRefs } from 'vue-demi'
 import { useVirtualList, UseVirtualListOptions } from '@vueuse/core'
 
 export interface UseVirtualListProps {
@@ -30,10 +30,9 @@ export const UseVirtualList = defineComponent<UseVirtualListProps>({
     'height',
   ] as unknown as undefined,
   setup(props, { slots }) {
-    const { list, containerProps, wrapperProps } = useVirtualList(
-      props.list,
-      props.options,
-    )
+    const { list: listRef } = toRefs(props)
+
+    const { list, containerProps, wrapperProps } = useVirtualList(listRef, props.options)
 
     containerProps.style.height = props.height || '300px'
     return () => h('div',


### PR DESCRIPTION
**Introduce detecting of scroll directions.**

...I also had some doubts as to whether I should reset directions to `false` when scrolling ended. This is in line with utility nature of the project, but as end user if I scroll up and, for example, nav bar appears, I expect it to be shown even if I stop scrolling - until I scroll in opposite direction.

Decided to reset it anyway and leave ui-firendly things on vueuser, but maybe it's room to add some callback options like `onChangeDirectionX`/`onChangeDirectionY` 🤔 🤔 🤔 

---

Related to #976 