### PR TITLE
fix(useWebSocket): close WebSocket gently

### DIFF
--- a/packages/core/useWebSocket/index.ts
+++ b/packages/core/useWebSocket/index.ts
@@ -249,7 +249,7 @@ export function useWebSocket<Data = any>(
   }
 
   const open = () => {
-    close()
+    close(1012) // Status code 1012 -> Service Restart https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent/code
     retried = 0
     _init()
   }


### PR DESCRIPTION
Uncaught InvalidAccessError: Failed to execute 'close' on 'WebSocket': The code must be either 1000, or between 3000 and 4999. 0 is neither.