### PR TITLE
feat(useSubject): new function

### DIFF
--- a/packages/rxjs/useSubject/demo.vue
+++ b/packages/rxjs/useSubject/demo.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import { tryOnScopeDispose } from '@vueuse/shared'
+import { BehaviorSubject } from 'rxjs'
+import { watch } from 'vue-demi'
+import { useSubject } from '.'
+
+const countSubject = new BehaviorSubject(0)
+const count = useSubject(countSubject)
+
+// eslint-disable-next-line no-console
+watch(count, value => console.info('from watcher:', value))
+
+// eslint-disable-next-line no-console
+const subscription = countSubject.subscribe(value => console.info('from subscriber: ', value))
+tryOnScopeDispose(() => { subscription.unsubscribe() })
+</script>
+
+<template>
+  <button @click="count++">
+    count is: {{ count }}
+  </button>
+</template>

--- a/packages/rxjs/useSubject/index.md
+++ b/packages/rxjs/useSubject/index.md
@@ -1,0 +1,37 @@
+---
+category: '@RxJS'
+---
+
+# useSubject
+
+Bind Subject to ref and propagate value changes both ways.
+
+## Usage
+
+```ts
+import { useSubject } from '@vueuse/rxjs'
+import { Subject } from 'rxjs'
+
+const subject = new Subject()
+
+// setup()
+const subjectRef = useSubject(subject)
+```
+
+If you want to add custom error handling to a Subject that might error, you can supply an optional `onError` configuration. Without this, RxJS will treat any error in the supplied observable as an "unhandled error" and it will be thrown in a new call stack and reported to `window.onerror` (or `process.on('error')` if you happen to be in node).
+
+```ts
+import { useSubject } from '@vueuse/rxjs'
+import { Subject } from 'rxjs'
+
+const subject = new Subject()
+
+// setup()
+const subjectRef = useSubject(subject,
+  {
+    onError: err => {
+      console.log(err.message) // "oops"
+    }
+  }
+)
+```

--- a/packages/rxjs/useSubject/index.test.ts
+++ b/packages/rxjs/useSubject/index.test.ts
@@ -1,0 +1,49 @@
+import { BehaviorSubject, Subject } from 'rxjs'
+import { first, skip } from 'rxjs/operators'
+import { useInjectedSetup } from '../../.test'
+import { useSubject } from '.'
+
+describe('useSubject', () => {
+  it('should be defined', () => {
+    expect(useSubject).toBeDefined()
+  })
+
+  it('should be ref', () => {
+    const subject = new Subject<boolean>()
+
+    useInjectedSetup(() => {
+      const subjectRef = useSubject(subject)
+
+      expect(subjectRef.value).toBe(undefined)
+      subject.next(true)
+      expect(subjectRef.value).toBe(true)
+    })
+  })
+
+  it('should get value immediately from BehaviorSubject', () => {
+    const subject = new BehaviorSubject(false)
+
+    useInjectedSetup(() => {
+      const subjectRef = useSubject(subject)
+
+      expect(subjectRef.value).toBe(false)
+      subject.next(true)
+      expect(subjectRef.value).toBe(true)
+    })
+  })
+
+  it('should propagate value change to Subject', async() => {
+    const subject = new BehaviorSubject(false)
+
+    const value = await new Promise((resolve) => {
+      subject.pipe(skip(1), first()).subscribe(resolve)
+
+      const subjectRef = useSubject(subject)
+
+      subjectRef.value = true
+    })
+
+    expect(value).toBe(true)
+    expect(subject.value).toBe(true)
+  })
+})

--- a/packages/rxjs/useSubject/index.ts
+++ b/packages/rxjs/useSubject/index.ts
@@ -1,0 +1,30 @@
+import { Subject, BehaviorSubject } from 'rxjs'
+import { Ref, ref, watch } from 'vue-demi'
+import { tryOnScopeDispose } from '@vueuse/shared'
+import type { UseObservableOptions } from '../useObservable'
+
+export interface UseSubjectOptions extends UseObservableOptions {
+}
+
+export function useSubject<H>(subject: BehaviorSubject<H>, options?: UseSubjectOptions): Ref<H>
+export function useSubject<H>(subject: Subject<H>, options?: UseSubjectOptions): Ref<H | undefined>
+export function useSubject<H>(subject: Subject<H>, options?: UseSubjectOptions) {
+  const value = ref(
+    subject instanceof BehaviorSubject
+      ? subject.value
+      : undefined,
+  ) as typeof subject extends BehaviorSubject<H> ? Ref<H> : Ref<H | undefined>
+
+  const subscription = subject.subscribe({
+    next(val) { value.value = val },
+    error: options?.onError,
+  })
+
+  watch(value, (nextValue) => { subject.next(nextValue) })
+
+  tryOnScopeDispose(() => {
+    subscription.unsubscribe()
+  })
+
+  return value
+}


### PR DESCRIPTION
Add simple way for two-way binding between Vue.js refs and RxJS subjects

- Connecting BehaviorSubject will immediately use it's current value
- Connecting other Subject types will set Ref's value to undefined
- Update Ref value will propagate to the subject

Closes #1028