### PR TITLE
feat(useScroll): pass original scroll event to callbacks

### DIFF
--- a/packages/core/useScroll/index.ts
+++ b/packages/core/useScroll/index.ts
@@ -33,13 +33,13 @@ export interface UseScrollOptions {
    * Trigger it when scrolling.
    *
    */
-  onScroll?: () => void
+  onScroll?: (e: Event) => void
 
   /**
    * Trigger it when scrolling ends.
    *
    */
-  onStop?: () => void
+  onStop?: (e: Event) => void
 
   /**
    * Listener options for scroll event.
@@ -95,13 +95,13 @@ export function useScroll(
   })
 
   if (element) {
-    const onScrollEnd = useDebounceFn(() => {
+    const onScrollEnd = useDebounceFn((e: Event) => {
       isScrolling.value = false
       directions.left = false
       directions.right = false
       directions.top = false
       directions.bottom = false
-      onStop()
+      onStop(e)
     }, throttle + idle)
 
     const onScrollHandler = (e: Event) => {
@@ -126,8 +126,8 @@ export function useScroll(
       y.value = scrollTop
 
       isScrolling.value = true
-      onScrollEnd()
-      onScroll()
+      onScrollEnd(e)
+      onScroll(e)
     }
 
     useEventListener(


### PR DESCRIPTION
Allow `onScroll` and `onStop`callbacks to access the original scroll event