### PR TITLE
fix(docs): code blocks did not show selected text when in dark mode

### DIFF
--- a/packages/.vitepress/theme/styles/code.css
+++ b/packages/.vitepress/theme/styles/code.css
@@ -65,9 +65,11 @@ a > code {
 
 html.dark .shiki-light {
   opacity: 0;
+  z-index: -1;
 }
 html:not(.dark) .shiki-dark {
   opacity: 0;
+  z-index: -1;
 }
 
 .shiki {


### PR DESCRIPTION
Seems like selecting text in code blocks would always select the light theme block. Guess this was caused by the light theme having a higher z-index. Now whichever block is inactive with have a negative z-index. 