### PR TITLE
docs(useScroll): position retains one decimal

### DIFF
--- a/packages/core/useScroll/demo.vue
+++ b/packages/core/useScroll/demo.vue
@@ -33,7 +33,7 @@ const { left: toLeft, right: toRight, top: toTop, bottom: toBottom } = toRefs(di
       <div class="px-6 py-4 rounded grid grid-cols-[120px,auto] gap-2 bg-gray-500/5">
         <span text="right" opacity="75">Position</span>
         <div class="text-primary">
-          {{ x }}, {{ y }}
+          {{ x.toFixed(1) }}, {{ y.toFixed(1) }}
         </div>
         <span text="right" opacity="75">isScrolling</span>
         <BooleanDisplay :value="isScrolling" />


### PR DESCRIPTION
The position value overflow
![image](https://user-images.githubusercontent.com/24516654/145922838-5ee2a446-90d6-47d7-afc9-73ca6d6bbcea.png)
