### PR TITLE
feat(useFetch): allow useFetch to be awaited

### DIFF
--- a/packages/core/useFetch/index.test.ts
+++ b/packages/core/useFetch/index.test.ts
@@ -324,4 +324,20 @@ describe('useFetch', () => {
 
     expect(data.value).toStrictEqual(JSON.stringify({ message: 'Hello World' }))
   })
+
+  test('should await request', async() => {
+    fetchMock.mockResponse(JSON.stringify({ message: 'Hello World' }), { status: 200 })
+    const { data } = await useFetch('https://example.com')
+
+    expect(data.value).toStrictEqual(JSON.stringify({ message: 'Hello World' }))
+    expect(fetchMock).toBeCalledTimes(1)
+  })
+
+  test('should await json response', async() => {
+    fetchMock.mockResponse(JSON.stringify({ message: 'Hello World' }), { status: 200 })
+    const { data } = await useFetch('https://example.com').json()
+
+    expect(data.value).toStrictEqual({ message: 'Hello World' })
+    expect(fetchMock).toBeCalledTimes(1)
+  })
 })


### PR DESCRIPTION
Allows `useFetch` to be awaited. For example

```html
<script setup lang="ts">
import { useFetch } from '@vueuse/core'

const { data }  = await useFetch(url)

console.log(data.value) // outputs resolved data
</script>
```