### PR TITLE
feat(useTitleTemplate): new function

### DIFF
--- a/packages/core/useTitleTemplate/demo.vue
+++ b/packages/core/useTitleTemplate/demo.vue
@@ -6,5 +6,5 @@ const title = useTitleTemplate(null, '%s | My Awesome Website')
 
 <template>
   <note>Title</note>
-  <input v-model="title" type="text" />
+  <input v-model="title" type="text">
 </template>

--- a/packages/core/useTitleTemplate/demo.vue
+++ b/packages/core/useTitleTemplate/demo.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+import { useTitleTemplate } from '.'
+
+const title = useTitleTemplate(null, '%s | My Awesome Website')
+</script>
+
+<template>
+  <note>Title</note>
+  <input v-model="title" type="text" />
+</template>

--- a/packages/core/useTitleTemplate/index.md
+++ b/packages/core/useTitleTemplate/index.md
@@ -1,0 +1,42 @@
+---
+category: Browser
+---
+
+# useTemplateTitle
+
+Reactive document title with template reference.
+
+## Usage
+
+If the template string contains substring '%s', that value will be the target for the replacement:
+
+```js
+import { useTemplateTitle } from '@vueuse/core'
+
+const title = useTemplateTitle(null, '%s | My Awesome Website')
+
+title.value = 'Hello, World!' // Change current title
+
+console.log(title.value) // 'Hello, World! | My Awesome Website'
+
+```
+
+Set initial title immediately
+
+```js
+const title = useTemplateTitle('New Title', '%s | My Awesome Website')
+```
+
+Pass a `ref` and the title will be updated when the source ref changes
+
+```js
+import { useTemplateTitle } from '@vueuse/core'
+
+const messages = ref(0)
+
+const title = computed(() => {
+  return !messages.value ? 'No message' : `${messages.value} new messages`
+})
+
+useTemplateTitle(title, '%s | My Awesome Website') // document title will match with the ref "title"
+```

--- a/packages/core/useTitleTemplate/index.test.ts
+++ b/packages/core/useTitleTemplate/index.test.ts
@@ -1,0 +1,7 @@
+import { useTitleTemplate } from '.'
+
+describe('useTitleTemplate', () => {
+  it('should be defined', () => {
+    expect(useTitleTemplate).toBeDefined()
+  })
+})

--- a/packages/core/useTitleTemplate/index.ts
+++ b/packages/core/useTitleTemplate/index.ts
@@ -5,7 +5,7 @@ import { defaultDocument } from '../_configurable'
 import type { ConfigurableDocument } from '../_configurable'
 import { useMutationObserver } from '../useMutationObserver'
 
-export interface UseTitleOptions extends ConfigurableDocument {
+export interface UseTemplateTitleOptions extends ConfigurableDocument {
   /**
    * Observe `document.title` changes using MutationObserve
    *
@@ -34,7 +34,7 @@ export interface UseTitleOptions extends ConfigurableDocument {
  */
 export const useTitleTemplate = (
   newTitle: MaybeRef<string | null | undefined> = null,
-  options: UseTitleOptions = {},
+  options: UseTemplateTitleOptions = {},
 ) => {
   const {
     document = defaultDocument,

--- a/packages/core/useTitleTemplate/index.ts
+++ b/packages/core/useTitleTemplate/index.ts
@@ -1,6 +1,8 @@
 import { ref, watch } from 'vue-demi'
-import { isString, MaybeRef } from '@vueuse/shared'
-import { ConfigurableDocument, defaultDocument } from '../_configurable'
+import { isString } from '@vueuse/shared'
+import type { MaybeRef } from '@vueuse/shared'
+import { defaultDocument } from '../_configurable'
+import type { ConfigurableDocument } from '../_configurable'
 import { useMutationObserver } from '../useMutationObserver'
 
 export interface UseTitleOptions extends ConfigurableDocument {

--- a/packages/core/useTitleTemplate/index.ts
+++ b/packages/core/useTitleTemplate/index.ts
@@ -1,4 +1,4 @@
-import { MaybeRef } from '@vueuse/shared'
+import type { MaybeRef } from '@vueuse/shared'
 
 import { computed } from 'vue-demi'
 

--- a/packages/core/useTitleTemplate/index.ts
+++ b/packages/core/useTitleTemplate/index.ts
@@ -1,0 +1,36 @@
+import { MaybeRef } from '@vueuse/shared'
+
+import { computed } from 'vue-demi'
+
+import { useTitle } from '../useTitle'
+
+/**
+ * Reactive document title with templated title, which follows the
+ * Vue Meta / Nuxt convention of replacing a sub-string with title.
+ *
+ * @see https://vueuse.org/useTitleTemplate
+ * @see https://vueuse.org/useTitle
+ * @see https://vue-meta.nuxtjs.org/guide/metainfo.html
+ *
+ * @param newTitle of type MaybeRef string | null | undefined
+ * @param titleTemplate of type string (e.g., '%s | My Website')
+ * @returns
+ */
+export const useTitleTemplate = (
+  newTitle: MaybeRef<string | null | undefined> = null,
+  titleTemplate: string,
+) => {
+  const title = useTitle(newTitle)
+
+  // Replace the pre-defined string in the title template:
+  const templatedTitle = computed(() => {
+    return title.value ? (titleTemplate.includes('%s') ? titleTemplate.replace('%s', title.value) : title.value) : titleTemplate
+  })
+
+  return {
+    title,
+    templatedTitle,
+  }
+}
+
+export type UseTitleTemplateReturn = ReturnType<typeof useTitleTemplate>

--- a/packages/functions.md
+++ b/packages/functions.md
@@ -39,6 +39,7 @@
   - [`useScriptTag`](https://vueuse.org/core/useScriptTag/) — script tag injecting
   - [`useShare`](https://vueuse.org/core/useShare/) — reactive [Web Share API](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/share)
   - [`useTitle`](https://vueuse.org/core/useTitle/) — reactive document title
+  - [`useTitleTemplate`](https://vueuse.org/core/useTitleTemplate/) — reactive document title with template
   - [`useUrlSearchParams`](https://vueuse.org/core/useUrlSearchParams/) — reactive [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams)
   - [`useWakeLock`](https://vueuse.org/core/useWakeLock/) — reactive [Screen Wake Lock API](https://developer.mozilla.org/en-US/docs/Web/API/Screen_Wake_Lock_API) provides a way to prevent devices from dimming or locking the screen when an application needs to keep running
 


### PR DESCRIPTION
Added the useTitleTemplate() composable which wraps the useTitle() composable to follow the https://vue-meta.nuxtjs.org/guide/metainfo.html style of specifying the title.