### PR TITLE
fix: add @vueuse/core and @vueuse/shared to Nuxt build.transpile

### DIFF
--- a/packages/nuxt/index.ts
+++ b/packages/nuxt/index.ts
@@ -55,7 +55,7 @@ function VueUseModule(this: any) {
   // add @vueuse/nuxt to transpile target for alias resolution
   nuxt.options.build = nuxt.options.build || {}
   nuxt.options.build.transpile = nuxt.options.build.transpile || []
-  nuxt.options.build.transpile.push('@vueuse/nuxt')
+  nuxt.options.build.transpile.push('@vueuse/nuxt', '@vueuse/core', '@vueuse/shared')
 
   let indexes: PackageIndexes | undefined
 


### PR DESCRIPTION
Fixes #1058 

This PR simply adds `@vueuse/core` and `@vueuse/shared` to the `build.transpile` option of Nuxt config to prevent SSR issues with `refs`. I must admit I haven't tried to reproduce a similar issue with functions from other @vueuse packages (e.g. firebase, electron, etc.) Should those be added too? 