### PR TITLE
docs(useStorage): update example

### DIFF
--- a/packages/core/useStorage/index.md
+++ b/packages/core/useStorage/index.md
@@ -39,6 +39,7 @@ import { useStorage } from '@vueuse/core'
 useStorage(
   'key',
   {},
+  localStorage,
   { 
     serializer: {
       read: (v: any) => v ? JSON.parse(v) : null,
@@ -53,6 +54,6 @@ Please note when you provide `null` as the default value, `useStorage` can't ass
 ```ts
 import { useStorage, StorageSerializers } from '@vueuse/core'
 
-const objectLike = useStorage('key', null, { serializer: StorageSerializers.object })
+const objectLike = useStorage('key', null, localStorage, { serializer: StorageSerializers.object })
 objectLike.value = { foo: 'bar' }
 ```

--- a/packages/core/useStorage/index.md
+++ b/packages/core/useStorage/index.md
@@ -39,7 +39,7 @@ import { useStorage } from '@vueuse/core'
 useStorage(
   'key',
   {},
-  localStorage,
+  undefined,
   { 
     serializer: {
       read: (v: any) => v ? JSON.parse(v) : null,
@@ -54,6 +54,6 @@ Please note when you provide `null` as the default value, `useStorage` can't ass
 ```ts
 import { useStorage, StorageSerializers } from '@vueuse/core'
 
-const objectLike = useStorage('key', null, localStorage, { serializer: StorageSerializers.object })
+const objectLike = useStorage('key', null, undefined, { serializer: StorageSerializers.object })
 objectLike.value = { foo: 'bar' }
 ```


### PR DESCRIPTION
The `useStorage` docs are missing the third parameter of `useStorage` when talking about custom seralization.

`useStorage` has the following types:

```ts
declare function useStorage(key: string, initialValue: MaybeRef<string>, storage?: StorageLike, options?: StorageOptions<string>): RemovableRef<string>;
declare function useStorage(key: string, initialValue: MaybeRef<boolean>, storage?: StorageLike, options?: StorageOptions<boolean>): RemovableRef<boolean>;
declare function useStorage(key: string, initialValue: MaybeRef<number>, storage?: StorageLike, options?: StorageOptions<number>): RemovableRef<number>;
declare function useStorage<T>(key: string, initialValue: MaybeRef<T>, storage?: StorageLike, options?: StorageOptions<T>): RemovableRef<T>;
declare function useStorage<T = unknown>(key: string, initialValue: MaybeRef<null>, storage?: StorageLike, options?: StorageOptions<T>): RemovableRef<T>;
```

All require a StorageLike as the third parameter, before giving the options as a fourth.

However, [the current docs](https://vueuse.org/core/usestorage/#custom-serialization) give the following code example (without a StorageLike):

```ts
const objectLike = useStorage('key', null, { serializer: StorageSerializers.object })
                                        // ^ missing StorageLike
```

If following the docs instructions, user will receive following error:

```
TS2769: No overload matches this call.   The last overload gave the following error.     Argument of type '{ serializer: Serializer<any>; }' is not assignable to parameter of type 'StorageLike'.       Object literal may only specify known properties, and 'serializer' does not exist in type 'StorageLike'. 
```

This PR fixes the docs for custom serialisation