### PR TITLE
fix(fromEvent): set immediate for `from` (issue #1099)

### DIFF
--- a/packages/rxjs/from/index.ts
+++ b/packages/rxjs/from/index.ts
@@ -20,7 +20,7 @@ export function from<T>(value: ObservableInput<T> | Ref<T>, watchOptions?: Watch
 }
 
 export function fromEvent<T extends HTMLElement>(value: Ref<T>, event: string): Observable<Event> {
-  return from(value).pipe(
+  return from(value, {immediate: true}).pipe(
     filter(value => value instanceof HTMLElement),
     mergeMap(value => fromEventRx(value, event)),
   )


### PR DESCRIPTION
Makes this piece of code emit events, as it should:

```js
interval(1e3).pipe(
    switchMap(() => fromEvent(someDivRef, 'scroll')),
).subscribe(x => console.log(x));
```