### PR TITLE
docs(useElementByPoint): fix example

### DIFF
--- a/packages/core/useElementByPoint/index.md
+++ b/packages/core/useElementByPoint/index.md
@@ -9,8 +9,8 @@ Reactive element by point.
 ## Usage
 
 ```ts
-import { useElementByPoint, useMouse } from "@vueuse/core";
+import { useElementByPoint, useMouse } from '@vueuse/core'
 
-const { x, y } = useMouse({ type: "client" });
-const { element } = useElementByPoint({ x, y });
+const { x, y } = useMouse({ type: 'client' })
+const { element } = useElementByPoint({ x, y })
 ```

--- a/packages/core/useElementByPoint/index.md
+++ b/packages/core/useElementByPoint/index.md
@@ -9,7 +9,8 @@ Reactive element by point.
 ## Usage
 
 ```ts
-import { useElementByPoint } from '@vueuse/core'
+import { useElementByPoint, useMouse } from "@vueuse/core";
 
-const { element } = useElementByPoint(x, y)
+const { x, y } = useMouse({ type: "client" });
+const { element } = useElementByPoint({ x, y });
 ```


### PR DESCRIPTION
docs(useElementByPoint): fix doc error "packages/core/useElementByPoint/index.md"

## Type Declarations

```typescript
export interface UseElementByPointOptions {
  x: MaybeRef<number>
  y: MaybeRef<number>
}
/**
 * Reactive element by point.
 *
 * @see https://vueuse.org/useElementByPoint
 * @param options - UseElementByPointOptions
 */
export declare function useElementByPoint(options: UseElementByPointOptions): {
  isActive: Ref<boolean>
  pause: Fn
  resume: Fn
  element: Ref<HTMLElement | null>
}
export declare type UseElementByPointReturn = ReturnType<
  typeof useElementByPoint
>
```
Hi guys ! 

Maybe it's a mistake

She need a `UseElementByPointOptions` parameter .

Not `x` & `y`
