### PR TITLE
fix(useBroadcastChannel): fix isError to error

### DIFF
--- a/packages/core/useBroadcastChannel/demo.vue
+++ b/packages/core/useBroadcastChannel/demo.vue
@@ -38,7 +38,7 @@ watch(data, () => {
       received: {{ data }}
     </p>
 
-    <p v-if="isError">
+    <p v-if="error">
       error: {{ error }}
     </p>
   </div>


### PR DESCRIPTION
Fix isError to error so that error can be displayed normally when an error occurs when using useBroadcastChannel to deliver a message.