### PR TITLE
fix(useWebWorkerFn): fix multiple dependencies handling

### DIFF
--- a/packages/core/useWebWorkerFn/lib/depsParser.ts
+++ b/packages/core/useWebWorkerFn/lib/depsParser.ts
@@ -8,13 +8,13 @@
  * elements "deps" and "importScripts".
  *
  * @example
- * depsParser(['demo1', 'demo2']) // return importScripts('demo1, demo2')
+ * depsParser(['demo1', 'demo2']) // return importScripts('demo1', 'demo2')
  */
 const depsParser = (deps: string[]) => {
   if (deps.length === 0) return ''
 
-  const depsString = deps.map(dep => `${dep}`).toString()
-  return `importScripts('${depsString}')`
+  const depsString = deps.map(dep => `'${dep}'`).toString()
+  return `importScripts(${depsString})`
 }
 
 export default depsParser


### PR DESCRIPTION
PR fix #430.

Multiple dependencies not working in useWebWorkerFn, because the syntax for multiple dependencies is `self.importScripts('foo.js', 'bar.js', ...);`, not `self.importScripts('foo.js, bar.js, ...');`.