### PR TITLE
feat(useBreakpoints): return readonly reactive object

### DIFF
--- a/packages/core/useBreakpoints/index.ts
+++ b/packages/core/useBreakpoints/index.ts
@@ -1,4 +1,5 @@
 import type { Ref } from 'vue-demi'
+import { reactive, readonly } from 'vue-demi'
 import { increaseWithUnit } from '@vueuse/shared'
 import { useMediaQuery } from '../useMediaQuery'
 import type { ConfigurableWindow } from '../_configurable'
@@ -48,7 +49,7 @@ export function useBreakpoints<K extends string>(breakpoints: Breakpoints<K>, op
       return shortcuts
     }, {} as Record<K, Ref<boolean>>)
 
-  return {
+  return readonly(reactive({
     greater,
     smaller(k: K) {
       return useMediaQuery(`(max-width: ${getValue(k, -0.1)})`, options)
@@ -66,7 +67,7 @@ export function useBreakpoints<K extends string>(breakpoints: Breakpoints<K>, op
       return match(`(min-width: ${getValue(a)}) and (max-width: ${getValue(b, -0.1)})`)
     },
     ...shortcutMethods,
-  }
+  }))
 }
 
 export type UseBreakpointsReturn = ReturnType<typeof useBreakpoints>


### PR DESCRIPTION
I'm not sure if this is a good practice to return a reactive object. 
But I wanna directly use `breakpoints.md` in template.

```vue
<script setup lang="ts">
import { breakpointsTailwind, useBreakpoints } from '.'

const breakpoints = useBreakpoints(breakpointsTailwind)
</script>

<template>
  <div class="font-mono">
    <div> sm: <BooleanDisplay :value="breakpoints.sm" /></div>
    <div> md: <BooleanDisplay :value="breakpoints.md" /></div>
    <div> lg: <BooleanDisplay :value="breakpoints.lg" /></div>
    <div> xl: <BooleanDisplay :value="breakpoints.xl" /></div>
  </div>
</template>
```