### PR TITLE
fix(useDraggable): onEnd() runs even if target wasn't dragged directly in exact mode

### DIFF
--- a/packages/core/useDraggable/index.ts
+++ b/packages/core/useDraggable/index.ts
@@ -109,6 +109,8 @@ export function useDraggable(target: MaybeRef<HTMLElement | SVGElement | null>, 
   const end = (e: PointerEvent) => {
     if (!filterEvent(e))
       return
+    if (!pressedDelta.value)
+      return
     pressedDelta.value = undefined
     options.onEnd?.(position.value, e)
     preventDefault(e)


### PR DESCRIPTION
When using `exact: true`, `onEnd()` still gets called even if something else was dragged than the `target` directly.

Add the same check as in `onMove()` to detect if something was dragged. 