### PR TITLE
docs(useMouse): update example

### DIFF
--- a/packages/core/useMouse/index.md
+++ b/packages/core/useMouse/index.md
@@ -11,7 +11,7 @@ Reactive mouse position
 ```js
 import { useMouse } from '@vueuse/core'
 
-const { x, y, source } = useMouse()
+const { x, y, sourceType } = useMouse()
 ```
 
 Touch is enabled by default. To only detect mouse changes, set `touch` to `false`.


### PR DESCRIPTION
The `useMouse` utility returns `sourceType`, not `source`.
https://github.com/vueuse/vueuse/blob/6b3bdaa6bdbe7454efda5f9044b5f5b81892c183/packages/core/useMouse/index.ts#L99