### PR TITLE
docs(useWebNotification): update example

### DIFF
--- a/packages/core/useWebNotification/index.md
+++ b/packages/core/useWebNotification/index.md
@@ -25,6 +25,7 @@ const {
   dir: 'auto',
   lang: 'en',
   renotify: true,
+  tag: 'test',
 })
 
 if (isSupported) {


### PR DESCRIPTION
TypeError: Failed to construct 'Notification': Notifications which set the renotify flag must specify a non-empty tag.