### PR TITLE
fix(useCycleList): operator precedence

### DIFF
--- a/packages/core/useCycleList/index.ts
+++ b/packages/core/useCycleList/index.ts
@@ -46,7 +46,7 @@ export function useCycleList<T>(list: T[], options?: UseCycleListOptions<T>) {
 
   function set(i: number) {
     const length = list.length
-    const index = i % length + length % length
+    const index = (i % length + length) % length
     const value = list[index]
     state.value = value
     return value


### PR DESCRIPTION
Currently go prev when index=0 would get `undefined`