### PR TITLE
fix(ssr-handlers): fix `_global` is undefined

### DIFF
--- a/packages/core/ssr-handlers.ts
+++ b/packages/core/ssr-handlers.ts
@@ -21,7 +21,14 @@ export interface SSRHandlersMap {
   updateHTMLAttrs: (selector: string, attribute: string, value: string) => void
 }
 
-const _global = typeof globalThis === 'undefined' ? this : globalThis
+const _global
+  = typeof globalThis !== 'undefined'
+    ? globalThis
+    : typeof window !== 'undefined'
+      ? window
+      : typeof global !== 'undefined'
+        ? global
+        : typeof self !== 'undefined' ? self : {}
 const globalKey = '__vueuse_ssr_handlers__'
 // @ts-expect-error inject global
 _global[globalKey] = _global[globalKey] || {}


### PR DESCRIPTION
In https://github.com/vueuse/vueuse/commit/3c8cdded6e949ccfbbdc2539f6d0d26e6c954b61 the build output is
```typescript
const _global = typeof globalThis === "undefined" ? undefined : globalThis;
```
`this` will transform to undefined.
This will cause an exception to occur if there is no `globalThis`
`Uncaught TypeError: Cannot read property '__vueuse_ssr_handlers__' of undefined`