### PR TITLE
docs(useRTDB): replace collection ref with db ref

### DIFF
--- a/packages/firebase/useRTDB/index.md
+++ b/packages/firebase/useRTDB/index.md
@@ -24,7 +24,7 @@ const todos = useRTDB(db.ref('todos'))
 You can reuse the db reference by passing `autoDispose: false`
 
 ```ts
-const todos = useRTDB(db.collection('todos'), { autoDispose: false })
+const todos = useRTDB(db.ref('todos'), { autoDispose: false })
 ```
 
 or use `createGlobalState` from the core package


### PR DESCRIPTION
Replace

```ts
const todos = useRTDB(db.collection('todos'), { autoDispose: false })
```

with

```ts
const todos = useRTDB(db.ref('todos'), { autoDispose: false })
```