### PR TITLE
feat(whenever): add type for callback param

### DIFF
--- a/packages/shared/whenever/index.test.ts
+++ b/packages/shared/whenever/index.test.ts
@@ -4,19 +4,29 @@ import { useSetup } from '../../.test'
 import { whenever } from '.'
 
 describe('whenever', () => {
+  const expectType = <T>(value: T) => value
+
   it('ignore falsy state change', async() => {
     // use a component to simulate normal use case
     const wrapper = useSetup(() => {
-      const number = ref(1)
+      const number = ref<number | null | undefined>(1)
       const changeNumber = (v: number) => number.value = v
       const watchCount = ref(0)
       const watchValue: Ref<number|undefined> = ref()
-      const callback = (v: number) => {
-        watchCount.value += 1
-        watchValue.value = v
-      }
 
-      whenever(number, callback)
+      whenever(number, (value) => {
+        watchCount.value += 1
+        watchValue.value = value
+
+        expectType<number>(value)
+
+        // @ts-expect-error value should be of type number
+        expectType<undefined>(value)
+        // @ts-expect-error value should be of type number
+        expectType<null>(value)
+        // @ts-expect-error value should be of type number
+        expectType<string>(value)
+      })
 
       return {
         number,

--- a/packages/shared/whenever/index.ts
+++ b/packages/shared/whenever/index.ts
@@ -6,7 +6,7 @@ import { watch } from 'vue-demi'
  *
  * @see https://vueuse.js.org/whenever
  */
-export function whenever<T>(source: WatchSource<T>, cb: WatchCallback, options?: WatchOptions) {
+export function whenever<T>(source: WatchSource<T | false | null | undefined>, cb: WatchCallback<T>, options?: WatchOptions) {
   return watch(
     source,
     (v, ov, onInvalidate) => { if (v) cb(v, ov, onInvalidate) },


### PR DESCRIPTION
Add type for value callback param and avoid default `any` typing. Forwards type of `WatchSource` to `WatchCallback` and removes `false`, `null` and `undefined`

```typescript
const counter = ref<number | null | undefined>()

whenever(counter, value => {
  // value is type number now instead of any
})
```