### PR TITLE
fix(useCycleList): nullish check

### DIFF
--- a/packages/core/useCycleList/index.ts
+++ b/packages/core/useCycleList/index.ts
@@ -26,7 +26,7 @@ export interface UseCycleListOptions<T> {
  * @see https://vueuse.org/useCycleList
  */
 export function useCycleList<T>(list: T[], options?: UseCycleListOptions<T>) {
-  const state = shallowRef(options?.initialValue || list[0]) as Ref<T>
+  const state = shallowRef(options?.initialValue ?? list[0]) as Ref<T>
 
   const index = computed<number>({
     get() {


### PR DESCRIPTION
more rigorous default value

Before 👇👇
```ts
import { useCycleList } from '@vueuse/core'

const { state } = useCycleList([1, 2, 3, 4], {
  initialValue: 0 
})

console.log(state.value) // 1
```

Now 👇👇
```ts
import { useCycleList } from '@vueuse/core'

const { state } = useCycleList([1, 2, 3, 4], {
  initialValue: 0 
})

console.log(state.value) // 0
```
