### PR TITLE
fix(useDark): demo dark button style

### DIFF
--- a/packages/core/useDark/demo.vue
+++ b/packages/core/useDark/demo.vue
@@ -8,8 +8,8 @@ const toggleDark = useToggle(isDark)
 
 <template>
   <button @click="toggleDark()">
-    <carbon-moon v-show="isDark" class="align-middle" />
-    <carbon-sun v-show="!isDark" class="align-middle" />
+    <carbon-moon v-if="isDark" class="align-middle" />
+    <carbon-sun v-else class="align-middle" />
 
     <span class="ml-2">{{ isDark ? 'Dark': 'Light' }}</span>
   </button>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

`v-show` causes `display: none`(-> null) overwrite `display: inline-block`.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<img width="704" alt="image" src="https://user-images.githubusercontent.com/25154432/155460109-156e458d-d225-43db-8df6-0c3f7e7c9f69.png">


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
