### PR TITLE
docs(reactifyObject): fix initialization

### DIFF
--- a/packages/shared/reactifyObject/index.md
+++ b/packages/shared/reactifyObject/index.md
@@ -11,9 +11,9 @@ Apply `reactify` to an object
 ```ts
 import { reactifyObject } from '@vueuse/core'
 
-const console = reactifyObject(console)
+const reactifiedConsole = reactifyObject(console)
 
 const a = ref('42')
 
-console.log(a) // no longer need `.value`
+reactifiedConsole.log(a) // no longer need `.value`
 ```


### PR DESCRIPTION
Cannot access 'console' before initialization

<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
