### PR TITLE
fix(useFetch): uppercase HTTP methods in useFetch

### DIFF
--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -265,7 +265,7 @@ export function useFetch<T>(url: MaybeRef<string>, ...args: any[]): UseFetchRetu
   let options: UseFetchOptions = { immediate: true, refetch: false, timeout: 0 }
   interface InternalConfig { method: HttpMethod; type: DataType; payload: unknown; payloadType?: string }
   const config: InternalConfig = {
-    method: 'get',
+    method: 'GET',
     type: 'text' as DataType,
     payload: undefined as unknown,
   }

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -89,7 +89,7 @@ export interface UseFetchReturn<T> {
 }
 
 type DataType = 'text' | 'json' | 'blob' | 'arrayBuffer' | 'formData'
-type HttpMethod = 'get' | 'post' | 'put' | 'delete' | 'patch' | 'head' | 'options'
+type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'HEAD' | 'OPTIONS'
 
 const payloadMapping: Record<string, string> = {
   json: 'application/json',
@@ -442,13 +442,13 @@ export function useFetch<T>(url: MaybeRef<string>, ...args: any[]): UseFetchRetu
     onFetchError: errorEvent.on,
     onFetchFinally: finallyEvent.on,
     // method
-    get: setMethod('get'),
-    put: setMethod('put'),
-    post: setMethod('post'),
-    delete: setMethod('delete'),
-    patch: setMethod('patch'),
-    head: setMethod('head'),
-    options: setMethod('options'),
+    get: setMethod('GET'),
+    put: setMethod('PUT'),
+    post: setMethod('POST'),
+    delete: setMethod('DELETE'),
+    patch: setMethod('PATCH'),
+    head: setMethod('HEAD'),
+    options: setMethod('OPTIONS'),
     // type
     json: setType('json'),
     text: setType('text'),

--- a/packages/core/useStyleTag/index.md
+++ b/packages/core/useStyleTag/index.md
@@ -47,7 +47,7 @@ useStyleTag('.foo { margin-top: 32px; }', { id: 'custom-id' })
 ```html
 <!-- injected to <head> -->
 <style type="text/css" id="custom-id">
-.foo { margin-top: 64px; }
+.foo { margin-top: 32px; }
 </style>
 ```
 
@@ -62,6 +62,6 @@ useStyleTag('.foo { margin-top: 32px; }', { media: 'print' })
 ```html
 <!-- injected to <head> -->
 <style type="text/css" id="vueuse_styletag_1" media="print">
-.foo { margin-top: 64px; }
+.foo { margin-top: 32px; }
 </style>
 ```


### PR DESCRIPTION
### Description
By https://www.rfc-editor.org/rfc/rfc7231#section-4.1:
> The method token is case-sensitive because it might be
   used as a gateway to object-based systems with case-sensitive method
   names.

By http://www.iana.org/assignments/http-methods/http-methods.xhtml all existing method are uppercase.

I currently have a REST API that doesn't support `patch` method but works with `PATCH`.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
