### PR TITLE
fix(useAxios): args param need limit

### DIFF
--- a/packages/integrations/useAxios/index.test.ts
+++ b/packages/integrations/useAxios/index.test.ts
@@ -1,0 +1,133 @@
+import { watch } from 'vue-demi'
+import type { AxiosRequestConfig } from 'axios'
+import axios from 'axios'
+import { useAxios } from '.'
+
+describe('useAxios', () => {
+  const url = 'https://jsonplaceholder.typicode.com/todos/1'
+  const config: AxiosRequestConfig = {
+    method: 'GET',
+  }
+  const instance = axios.create({
+    baseURL: 'https://jsonplaceholder.typicode.com',
+  })
+  const options = { immediate: false }
+  const path = '/todos/1'
+  test('params: url', (done) => {
+    const { isFinished, data } = useAxios(url)
+    expect(isFinished.value).toBeFalsy()
+    watch(
+      () => data.value,
+      (result) => {
+        expect(Object.keys(result).length > 0).toBeTruthy()
+        // macrotask
+        setTimeout(() => {
+          expect(isFinished.value).toBeTruthy()
+          done()
+        })
+      },
+    )
+  })
+
+  test('params: url config', (done) => {
+    const { isFinished, data } = useAxios(url, config)
+    expect(isFinished.value).toBeFalsy()
+    watch(
+      () => data.value,
+      (result) => {
+        expect(Object.keys(result).length > 0).toBeTruthy()
+        // macrotask
+        setTimeout(() => {
+          expect(isFinished.value).toBeTruthy()
+          done()
+        })
+      },
+    )
+  })
+
+  test('params: url config options', (done) => {
+    const { isLoading, data, execute } = useAxios(url, config, options)
+    expect(isLoading.value).toBeFalsy()
+    execute()
+    expect(isLoading.value).toBeTruthy()
+    watch(
+      () => data.value,
+      (result) => {
+        expect(Object.keys(result).length > 0).toBeTruthy()
+        // macrotask
+        setTimeout(() => {
+          expect(isLoading.value).toBeFalsy()
+          done()
+        })
+      },
+    )
+  })
+
+  test('params: url instance', (done) => {
+    const { isFinished, data } = useAxios(path, instance)
+    expect(isFinished.value).toBeFalsy()
+    watch(
+      () => data.value,
+      (result) => {
+        expect(Object.keys(result).length > 0).toBeTruthy()
+        // macrotask
+        setTimeout(() => {
+          expect(isFinished.value).toBeTruthy()
+          done()
+        })
+      },
+    )
+  })
+
+  test('params: url instance options', (done) => {
+    const { isLoading, data, execute } = useAxios(path, instance, options)
+    expect(isLoading.value).toBeFalsy()
+    execute()
+    expect(isLoading.value).toBeTruthy()
+    watch(
+      () => data.value,
+      (result) => {
+        expect(Object.keys(result).length > 0).toBeTruthy()
+        // macrotask
+        setTimeout(() => {
+          expect(isLoading.value).toBeFalsy()
+          done()
+        })
+      },
+    )
+  })
+
+  test('params: url config instance', (done) => {
+    const { isFinished, data } = useAxios(path, config, instance)
+    expect(isFinished.value).toBeFalsy()
+    watch(
+      () => data.value,
+      (result) => {
+        expect(Object.keys(result).length > 0).toBeTruthy()
+        // macrotask
+        setTimeout(() => {
+          expect(isFinished.value).toBeTruthy()
+          done()
+        })
+      },
+    )
+  })
+
+  test('params: url config instance options', (done) => {
+    const { isLoading, data, execute } = useAxios(path, config, instance, options)
+    expect(isLoading.value).toBeFalsy()
+    execute()
+    expect(isLoading.value).toBeTruthy()
+    watch(
+      () => data.value,
+      (result) => {
+        expect(Object.keys(result).length > 0).toBeTruthy()
+        // macrotask
+        setTimeout(() => {
+          expect(isLoading.value).toBeFalsy()
+          done()
+        })
+      },
+    )
+  })
+})

--- a/packages/integrations/useAxios/index.ts
+++ b/packages/integrations/useAxios/index.ts
@@ -85,12 +85,11 @@ export function useAxios<T = any>(url: string, ...args: any[]) {
     if ('request' in args[1])
       instance = args[1]
   }
-  if (args.length >= 2) {
-    const instanceInArgs1 = "request" in args[1]
-    if (!instanceInArgs1 && args.length !== 2) {
-      options = args[args.length - 1];
-    }
-  }
+  if (
+    (args.length === 2 && !('request' in args[1]))
+    || args.length === 3
+  )
+    options = args[args.length - 1]
 
   const response = shallowRef<AxiosResponse<T>>()
   const data = shallowRef<T>()

--- a/packages/integrations/useAxios/index.ts
+++ b/packages/integrations/useAxios/index.ts
@@ -85,8 +85,12 @@ export function useAxios<T = any>(url: string, ...args: any[]) {
     if ('request' in args[1])
       instance = args[1]
   }
-  if (args.length >= 2)
-    options = args[args.length - 1]
+  if (args.length >= 2) {
+    const instanceInArgs1 = "request" in args[1]
+    if (!instanceInArgs1 && args.length !== 2) {
+      options = args[args.length - 1];
+    }
+  }
 
   const response = shallowRef<AxiosResponse<T>>()
   const data = shallowRef<T>()


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
when use the following demo, can't run, options's value is intance, not { immediate: true }
```ts
import axios from 'axios'
import { useAxios } from '@vueuse/integrations/useAxios'

const instance = axios.create({
  baseURL: '/api'
})

const { data, isFinished } = useAxios('/posts', { method: 'POST' }, instance)
```
the reason is
```js
if (args.length >= 2) {
      options = args[args.length - 1];
 }
```
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
