### PR TITLE
feat(useInfiniteScroll): new options

### DIFF
--- a/packages/core/useInfiniteScroll/index.ts
+++ b/packages/core/useInfiniteScroll/index.ts
@@ -1,5 +1,5 @@
 import type { UnwrapNestedRefs } from 'vue-demi'
-import { reactive, watch } from 'vue-demi'
+import { reactive, watch, unref, nextTick } from 'vue-demi'
 import type { MaybeRef } from '@vueuse/shared'
 import type { UseScrollOptions } from '../useScroll'
 import { useScroll } from '../useScroll'
@@ -11,6 +11,20 @@ export interface UseInfiniteScrollOptions extends UseScrollOptions {
    * @default 0
    */
   distance?: number
+  
+  /**
+   * The direction in which to listen the scroll.
+   *
+   * @default 'bottom'
+   */
+  direction?: 'top' | 'bottom'
+
+  /**
+   * Whether to keep the current scroll position when loading more items.
+   *
+   * @default false
+   */
+  keepScrollPosition?: boolean
 }
 
 /**
@@ -20,25 +34,42 @@ export interface UseInfiniteScrollOptions extends UseScrollOptions {
  */
 export function useInfiniteScroll(
   element: MaybeRef<HTMLElement | SVGElement | Window | Document | null | undefined>,
-  onLoadMore: (state: UnwrapNestedRefs<ReturnType<typeof useScroll>>) => void,
+  onLoadMore: (state: UnwrapNestedRefs<ReturnType<typeof useScroll>>) => void | Promise<void>,
   options: UseInfiniteScrollOptions = {},
 ) {
+  const direction = options.direction ?? 'bottom'
   const state = reactive(useScroll(
     element,
     {
       ...options,
       offset: {
-        bottom: options.distance ?? 0,
+        [direction]: options.distance ?? 0,
         ...options.offset,
       },
     },
   ))
 
   watch(
-    () => state.arrivedState.bottom,
-    (v) => {
-      if (v)
-        onLoadMore(state)
+    () => state.arrivedState[direction],
+    async(v) => {
+      if (v) {
+        const elem = unref(element) as Element
+        const previous = {
+          height: elem?.scrollHeight ?? 0,
+          width: elem?.scrollWidth ?? 0,
+        }
+
+        await onLoadMore(state)
+
+        if (options.keepScrollPosition && elem) {
+          nextTick(() => {
+            elem.scrollTo({
+              top: elem.scrollHeight - previous.height,
+              left: elem.scrollWidth - previous.width,
+            })
+          })
+        }
+      }
     },
   )
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR adds two new options to `useInfiniteScroll`:
- `direction`, to chose in which direction to use the infinite scroll
- `keepScrollPosition`, to automatically compute the scroll position so it stays in place

The current behavior stays the same without explicitly defining these options.

### Use case

I was building a chat with infinite scroll, which I want to behave kind of like Discord when you scroll up. For this, I had to revert the direction to `top` instead of the default `bottom`, and I needed to keep the scroll position the same after updating the message list.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
