### PR TITLE
fix(onClickOutside): should work normal w/ directive

### DIFF
--- a/packages/core/onClickOutside/directive.test.ts
+++ b/packages/core/onClickOutside/directive.test.ts
@@ -1,0 +1,40 @@
+import { defineComponent } from 'vue-demi'
+import type { VueWrapper } from '@vue/test-utils'
+import { mount } from '@vue/test-utils'
+
+import { vOnClickOutside } from './directive'
+
+const App = defineComponent({
+  props: {
+    handler: {
+      type: Function,
+      required: true,
+    },
+  },
+
+  template: `<template>
+  <div v-on-click-outside="handler">Hello world!</div>
+  </template>
+  `,
+})
+
+describe('vOnClickOutside', () => {
+  let wrapper: VueWrapper<any>
+
+  beforeEach(() => {
+    wrapper = mount(App, {
+      props: {
+        handler: () => {},
+      },
+      global: {
+        directives: {
+          onClickOutside: vOnClickOutside,
+        },
+      },
+    })
+  })
+
+  it('should be defined', () => {
+    expect(wrapper).toBeDefined()
+  })
+})

--- a/packages/core/onClickOutside/directive.ts
+++ b/packages/core/onClickOutside/directive.ts
@@ -1,9 +1,19 @@
 import type { FunctionDirective } from 'vue-demi'
 import { onClickOutside } from '.'
 
-/**
- * TODO: Test that this actually works
- */
-export const VOnClickOutside: FunctionDirective<any, (evt: PointerEvent) => void> = (el, binding) => {
-  onClickOutside(el, binding.value)
+const handler = (): FunctionDirective<any, (evt: PointerEvent) => void> => {
+  let stop = null as unknown as ReturnType<typeof onClickOutside>
+  return (el, binding) => {
+    if (stop) {
+      stop?.()
+      stop = onClickOutside(el, binding.value)
+      return
+    }
+    stop = onClickOutside(el, binding.value)
+  }
 }
+
+export const vOnClickOutside = handler()
+
+// alias
+export { vOnClickOutside as VOnClickOutside }

--- a/packages/core/onClickOutside/directive.ts
+++ b/packages/core/onClickOutside/directive.ts
@@ -5,7 +5,7 @@ const handler = (): FunctionDirective<any, (evt: PointerEvent) => void> => {
   let stop = null as unknown as ReturnType<typeof onClickOutside>
   return (el, binding) => {
     if (stop) {
-      stop?.()
+      stop()
       stop = onClickOutside(el, binding.value)
       return
     }

--- a/packages/core/onClickOutside/index.md
+++ b/packages/core/onClickOutside/index.md
@@ -45,3 +45,26 @@ export default {
   </div>
 </OnClickOutside>
 ```
+## Directive Usage
+
+```html
+<script setup lang="ts">
+import { ref } from 'vue'
+import { vOnClickOutside } from '@vueuse/components'
+
+const modal = ref(false)
+function closeModal() {
+  modal.value = false
+}
+
+</script>
+
+<template>
+  <button @click="modal = true">
+    Open Modal
+  </button>
+  <div v-if="modal" v-on-click-outside="closeModal">
+    Hello World
+  </div>
+</template>
+```


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

1. `directive` work unnormal with `v-if`
2. `directive` can't  automatic registered (`VOnClickOutside` => `vOnClickOutside`)

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
