### PR TITLE
fix(useFetch): make helper methods return `PromiseLike<UseFetchReturn<T>>`

### DIFF
--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -72,20 +72,20 @@ export interface UseFetchReturn<T> {
   onFetchFinally: EventHookOn
 
   // methods
-  get(): UseFetchReturn<T>
-  post(payload?: MaybeRef<unknown>, type?: string): UseFetchReturn<T>
-  put(payload?: MaybeRef<unknown>, type?: string): UseFetchReturn<T>
-  delete(payload?: MaybeRef<unknown>, type?: string): UseFetchReturn<T>
-  patch(payload?: MaybeRef<unknown>, type?: string): UseFetchReturn<T>
-  head(payload?: MaybeRef<unknown>, type?: string): UseFetchReturn<T>
-  options(payload?: MaybeRef<unknown>, type?: string): UseFetchReturn<T>
+  get(): UseFetchReturn<T> & PromiseLike<UseFetchReturn<T>>
+  post(payload?: MaybeRef<unknown>, type?: string): UseFetchReturn<T> & PromiseLike<UseFetchReturn<T>>
+  put(payload?: MaybeRef<unknown>, type?: string): UseFetchReturn<T> & PromiseLike<UseFetchReturn<T>>
+  delete(payload?: MaybeRef<unknown>, type?: string): UseFetchReturn<T> & PromiseLike<UseFetchReturn<T>>
+  patch(payload?: MaybeRef<unknown>, type?: string): UseFetchReturn<T> & PromiseLike<UseFetchReturn<T>>
+  head(payload?: MaybeRef<unknown>, type?: string): UseFetchReturn<T> & PromiseLike<UseFetchReturn<T>>
+  options(payload?: MaybeRef<unknown>, type?: string): UseFetchReturn<T> & PromiseLike<UseFetchReturn<T>>
 
   // type
-  json<JSON = any>(): UseFetchReturn<JSON>
-  text(): UseFetchReturn<string>
-  blob(): UseFetchReturn<Blob>
-  arrayBuffer(): UseFetchReturn<ArrayBuffer>
-  formData(): UseFetchReturn<FormData>
+  json<JSON = any>(): UseFetchReturn<JSON> & PromiseLike<UseFetchReturn<JSON>>
+  text(): UseFetchReturn<string> & PromiseLike<UseFetchReturn<string>>
+  blob(): UseFetchReturn<Blob> & PromiseLike<UseFetchReturn<Blob>>
+  arrayBuffer(): UseFetchReturn<ArrayBuffer> & PromiseLike<UseFetchReturn<ArrayBuffer>>
+  formData(): UseFetchReturn<FormData> & PromiseLike<UseFetchReturn<FormData>>
 }
 
 type DataType = 'text' | 'json' | 'blob' | 'arrayBuffer' | 'formData'


### PR DESCRIPTION
### Description

This PR fixes #1321. I ran into this issue earlier, `useFetch` (as well as the returned function from `createFetch`) return `UseFetchReturn<T> & PromiseLike<UseFetchReturn<T>>`, however, as soon as you used `.get()`, `.post()`, `.json()`, or any of the other methods, the return type would be narrowed down to `UseFetchReturn<T>`, which does not let us use `await`.

### Additional context

--- I didn't make the `UseFetchReturn<T>` interface extend `PromiseLike<UseFetchReturn<T>>` because that seems to require more code changes, and I'm unsure if it'd be breaking.
--- There's also a test for this (`should await json response`, at the end of this function's test file), TypeScript does not complain because it's an ESLint rule (https://typescript-eslint.io/rules/await-thenable) what's causing the error, and is not enabled in this project. In order to properly test this, the ESLint rule would need to be enabled.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
