### PR TITLE
feat(onClickOutside): customizable phase

### DIFF
--- a/packages/core/onClickOutside/index.ts
+++ b/packages/core/onClickOutside/index.ts
@@ -10,6 +10,11 @@ export interface OnClickOutsideOptions extends ConfigurableWindow {
    * List of elements that should not trigger the event.
    */
   ignore?: MaybeElementRef[]
+  /**
+   * Use capturing phase for internal event listener.
+   * @default true
+   */
+  capture?: boolean
 }
 
 /**
@@ -25,7 +30,7 @@ export function onClickOutside(
   handler: (evt: PointerEvent) => void,
   options: OnClickOutsideOptions = {},
 ) {
-  const { window = defaultWindow, ignore } = options
+  const { window = defaultWindow, ignore, capture = true } = options
 
   if (!window)
     return
@@ -51,7 +56,7 @@ export function onClickOutside(
   }
 
   const cleanup = [
-    useEventListener(window, 'click', listener, { passive: true }),
+    useEventListener(window, 'click', listener, { passive: true, capture }),
     useEventListener(window, 'pointerdown', (e) => {
       const el = unrefElement(target)
       shouldListen.value = !!el && !e.composedPath().includes(el)

--- a/packages/core/onClickOutside/index.ts
+++ b/packages/core/onClickOutside/index.ts
@@ -51,7 +51,7 @@ export function onClickOutside(
   }
 
   const cleanup = [
-    useEventListener(window, 'click', listener, { passive: true, capture: true }),
+    useEventListener(window, 'click', listener, { passive: true }),
     useEventListener(window, 'pointerdown', (e) => {
       const el = unrefElement(target)
       shouldListen.value = !!el && !e.composedPath().includes(el)


### PR DESCRIPTION
Fix #1405

### Description

If we were using bubbling phase, issues like #1405 could have been fixed by appending `.stop` modifier. Switching to bubbling is breaking change and have different behaviour than capture phase in terms of execution order.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
