### PR TITLE
fix(useClipboard):support MouseEvent

### DIFF
--- a/packages/core/useClipboard/index.ts
+++ b/packages/core/useClipboard/index.ts
@@ -34,7 +34,7 @@ export interface ClipboardReturn<Optional> {
   isSupported: boolean
   text: ComputedRef<string>
   copied: ComputedRef<boolean>
-  copy: Optional extends true ? (text?: string) => Promise<void> : (text: string | MouseEvent) => Promise<void>
+  copy: Optional extends true ? (text?: string | MouseEvent) => Promise<void> : (text: string) => Promise<void>
 }
 
 /**

--- a/packages/core/useClipboard/index.ts
+++ b/packages/core/useClipboard/index.ts
@@ -34,7 +34,7 @@ export interface ClipboardReturn<Optional> {
   isSupported: boolean
   text: ComputedRef<string>
   copied: ComputedRef<boolean>
-  copy: Optional extends true ? (text?: string) => Promise<void> : (text: string) => Promise<void>
+  copy: Optional extends true ? (text?: string) => Promise<void> : (text: string | MouseEvent) => Promise<void>
 }
 
 /**
@@ -72,6 +72,7 @@ export function useClipboard(options: ClipboardOptions<MaybeRef<string> | undefi
   }
 
   async function copy(value = unref(source)) {
+    if (typeof value !== 'string') value = unref(source)
     if (isSupported && value != null) {
       await navigator!.clipboard.writeText(value)
       text.value = value


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
fix `useClipboard` `copy` method without passing parameters, the value is `Event`

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context
close #1427 
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
