### PR TITLE
fix(useAxios): reuse url when only AxiosRequestConfig is passed to execute

### DIFF
--- a/packages/contributors.json
+++ b/packages/contributors.json
@@ -103,6 +103,7 @@
   "Maiquu",
   "Danmer",
   "emilsgulbis",
+  "iendeavor",
   "web2033",
   "sp1ker",
   "Flamenco",

--- a/packages/integrations/useAxios/index.test.ts
+++ b/packages/integrations/useAxios/index.test.ts
@@ -1,6 +1,5 @@
 import type { AxiosRequestConfig } from 'axios'
 import axios from 'axios'
-import { until } from '@vueuse/shared'
 import { useAxios } from '.'
 
 describe('useAxios', () => {

--- a/packages/integrations/useAxios/index.test.ts
+++ b/packages/integrations/useAxios/index.test.ts
@@ -1,5 +1,6 @@
 import type { AxiosRequestConfig } from 'axios'
 import axios from 'axios'
+import { until } from '@vueuse/shared'
 import { useAxios } from '.'
 
 describe('useAxios', () => {
@@ -108,6 +109,28 @@ describe('useAxios', () => {
       expect(isLoading.value).toBeFalsy()
       expect(onRejected).toBeCalledTimes(0)
       done()
+    }, onRejected)
+  })
+
+  test('params: url; reuse url in execute', (done) => {
+    const { isFinished, data, then, execute, error } = useAxios(url)
+    expect(isFinished.value).toBeFalsy()
+    const onRejected = vitest.fn()
+
+    then((result) => {
+      expect(data.value.id).toBe(1)
+      expect(result.data).toBe(data)
+      expect(isFinished.value).toBeTruthy()
+      expect(onRejected).toBeCalledTimes(0)
+
+      execute({})
+      expect(isFinished.value).toBeFalsy()
+      until(isFinished).toBe(true)
+        .then(() => {
+          expect(data.value.id).toBe(1)
+          expect(error.value).toBeUndefined()
+          done()
+        })
     }, onRejected)
   })
 

--- a/packages/integrations/useAxios/index.test.ts
+++ b/packages/integrations/useAxios/index.test.ts
@@ -112,25 +112,18 @@ describe('useAxios', () => {
     }, onRejected)
   })
 
-  test('params: url; reuse url in execute', (done) => {
-    const { isFinished, data, then, execute, error } = useAxios(url)
-    expect(isFinished.value).toBeFalsy()
+  test('params: url config instance options, execute: config', (done) => {
+    const { isLoading, then, execute } = useAxios(path, config, instance, options)
+    expect(isLoading.value).toBeFalsy()
+    execute(config)
+    expect(isLoading.value).toBeTruthy()
     const onRejected = vitest.fn()
 
     then((result) => {
-      expect(data.value.id).toBe(1)
-      expect(result.data).toBe(data)
-      expect(isFinished.value).toBeTruthy()
+      expect(result.data.value.id).toBe(1)
+      expect(isLoading.value).toBeFalsy()
       expect(onRejected).toBeCalledTimes(0)
-
-      execute({})
-      expect(isFinished.value).toBeFalsy()
-      until(isFinished).toBe(true)
-        .then(() => {
-          expect(data.value.id).toBe(1)
-          expect(error.value).toBeUndefined()
-          done()
-        })
+      done()
     }, onRejected)
   })
 

--- a/packages/integrations/useAxios/index.ts
+++ b/packages/integrations/useAxios/index.ts
@@ -143,7 +143,7 @@ export function useAxios<T = any>(...args: any[]): OverallUseAxiosReturn<T> & Pr
     isFinished.value = !loading
   }
   const execute: OverallUseAxiosReturn<T>['execute'] = (executeUrl: string | AxiosRequestConfig | undefined = url, config: AxiosRequestConfig = {}) => {
-    let _url = ''
+    let _url = url ?? ''
     let _config
     if (typeof executeUrl === 'string') {
       _url = executeUrl


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
fixes #1437

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
