### PR TITLE
fix(useStorage): sync too strict

### DIFF
--- a/packages/core/useStorage/index.ts
+++ b/packages/core/useStorage/index.ts
@@ -145,7 +145,7 @@ export function useStorage<T extends(string|number|boolean|object|null)> (
    * Prevent writing while reading #808
    */
   let synced = false
-  let syncReset: ReturnType<typeof setTimeout>;
+  let syncReset: ReturnType<typeof setTimeout>
 
   function read(event?: StorageEvent) {
     if (!storage || (event && event.key !== key))
@@ -177,7 +177,7 @@ export function useStorage<T extends(string|number|boolean|object|null)> (
       setTimeout(() => {
         if (synced) {
           synced = false
-          clearTimeout(syncReset);
+          clearTimeout(syncReset)
           return
         }
         read(e)

--- a/packages/core/useStorage/index.ts
+++ b/packages/core/useStorage/index.ts
@@ -145,6 +145,7 @@ export function useStorage<T extends(string|number|boolean|object|null)> (
    * Prevent writing while reading #808
    */
   let synced = false
+  let syncReset: ReturnType<typeof setTimeout>;
 
   function read(event?: StorageEvent) {
     if (!storage || (event && event.key !== key))
@@ -176,6 +177,7 @@ export function useStorage<T extends(string|number|boolean|object|null)> (
       setTimeout(() => {
         if (synced) {
           synced = false
+          clearTimeout(syncReset);
           return
         }
         read(e)
@@ -193,6 +195,7 @@ export function useStorage<T extends(string|number|boolean|object|null)> (
           else
             storage!.setItem(key, serializer.write(data.value))
           synced = true
+          syncReset = setTimeout(() => {synced = false}, 150)
         }
         catch (e) {
           onError(e)


### PR DESCRIPTION
fix(useStorage): sync too strict

- add timeout to reset sync after 150ms

<!-- Thank you for contributing! -->

### Description

After the latest changes to useStorage I had a problem, that the synchronisation between two browser tabs did not work as before. The first change was always ignored because the reset of the sync var was only triggered on the storage event which did not happen there. 
The fix adds a timeout that ensures that the sync var will always set back to false after some time independend of a storage event. 

### Additional context

It is discusable what is the best time in ms. Feel free to set it to a different value.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

