### PR TITLE
fix(useStorage): change sync logic #1444

### DIFF
--- a/packages/core/useStorage/demo.vue
+++ b/packages/core/useStorage/demo.vue
@@ -9,7 +9,7 @@ const state = useStorage('vue-use-local-storage', {
   count: 0,
 })
 
-const text = stringify(state.value)
+const text = stringify(state)
 </script>
 
 <template>

--- a/packages/core/useStorage/index.ts
+++ b/packages/core/useStorage/index.ts
@@ -144,7 +144,7 @@ export function useStorage<T extends(string|number|boolean|object|null)> (
   /**
    * Prevent writing while reading #808
    */
-  let synced = false
+  let synced = true
 
   function read(event?: StorageEvent) {
     if (!storage || (event && event.key !== key))
@@ -176,9 +176,8 @@ export function useStorage<T extends(string|number|boolean|object|null)> (
       setTimeout(() => {
         if (synced) {
           synced = false
-          return
+          read(e)
         }
-        read(e)
       }, 0)
     })
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
fix issue #1444 
analyze:
- initial `synced` = false, and then when trigger `storage` event, will exec func `read`;
- after `read` exec, data changed and trigger `watchWithFilter` callback, so will set `synced` to `true`
- next time trgger `storage` event, will match pre condition and do not exec `read`, so problem happened.

To fix it:
-  just set initial `synced` to `true`;
- when trigger `storage` event, if `synced` is `true`. set it to `false`, and invoke `read`
- In addition, after set data to storage, set `synced` to `true` again


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
