### PR TITLE
feat(useStorage): support serializing Date

### DIFF
--- a/packages/core/useStorage/guess.ts
+++ b/packages/core/useStorage/guess.ts
@@ -5,15 +5,17 @@ export function guessSerializerType<T extends(string | number | boolean | object
       ? 'set'
       : rawInit instanceof Map
         ? 'map'
-        : typeof rawInit === 'boolean'
-          ? 'boolean'
-          : typeof rawInit === 'string'
-            ? 'string'
-            : typeof rawInit === 'object'
-              ? 'object'
-              : Array.isArray(rawInit)
+        : rawInit instanceof Date
+          ? 'date'
+          : typeof rawInit === 'boolean'
+            ? 'boolean'
+            : typeof rawInit === 'string'
+              ? 'string'
+              : typeof rawInit === 'object'
                 ? 'object'
-                : !Number.isNaN(rawInit)
-                  ? 'number'
-                  : 'any'
+                : Array.isArray(rawInit)
+                  ? 'object'
+                  : !Number.isNaN(rawInit)
+                    ? 'number'
+                    : 'any'
 }

--- a/packages/core/useStorage/index.test.ts
+++ b/packages/core/useStorage/index.test.ts
@@ -126,19 +126,15 @@ describe('useStorage', () => {
   })
 
   it('date', async() => {
-    const initialValue = new Date('2000-01-01')
-    const initialValueString = 'Sat Jan 01 2000 01:00:00 GMT+0100 (Central European Standard Time)'
-    storageState.set(KEY, initialValueString)
+    storageState.set(KEY, '2000-01-01T00:00:00.000Z')
 
-    const store = useStorage(KEY, new Date('2000-01-02'), storage)
-    expect(store.value).toEqual(initialValue)
+    const store = useStorage(KEY, new Date('2000-01-02T00:00:00.000Z'), storage)
+    expect(store.value).toEqual(new Date('2000-01-01T00:00:00.000Z'))
 
-    const secondValue = new Date('2000-01-03')
-    const secondValueString = 'Mon Jan 03 2000 01:00:00 GMT+0100 (Central European Standard Time)'
-    store.value = secondValue
+    store.value = new Date('2000-01-03T00:00:00.000Z')
     await nextTwoTick()
 
-    expect(storage.setItem).toBeCalledWith(KEY, secondValueString)
+    expect(storage.setItem).toBeCalledWith(KEY, '2000-01-03T00:00:00.000Z')
   })
 
   it('object', async() => {

--- a/packages/core/useStorage/index.test.ts
+++ b/packages/core/useStorage/index.test.ts
@@ -125,6 +125,22 @@ describe('useStorage', () => {
     expect(storage.setItem).toBeCalledWith(KEY, '2')
   })
 
+  it('date', async() => {
+    const initialValue = new Date('2000-01-01')
+    const initialValueString = 'Sat Jan 01 2000 01:00:00 GMT+0100 (Central European Standard Time)'
+    storageState.set(KEY, initialValueString)
+
+    const store = useStorage(KEY, new Date('2000-01-02'), storage)
+    expect(store.value).toEqual(initialValue)
+
+    const secondValue = new Date('2000-01-03')
+    const secondValueString = 'Mon Jan 03 2000 01:00:00 GMT+0100 (Central European Standard Time)'
+    store.value = secondValue
+    await nextTwoTick()
+
+    expect(storage.setItem).toBeCalledWith(KEY, secondValueString)
+  })
+
   it('object', async() => {
     expect(storage.getItem(KEY)).toEqual(undefined)
 

--- a/packages/core/useStorage/index.ts
+++ b/packages/core/useStorage/index.ts
@@ -49,7 +49,7 @@ export const StorageSerializers: Record<'boolean' | 'object' | 'number' | 'any' 
   },
   date: {
     read: (v: any) => new Date(v),
-    write: (v: any) => String(v),
+    write: (v: any) => v.toISOString(),
   },
 }
 

--- a/packages/core/useStorage/index.ts
+++ b/packages/core/useStorage/index.ts
@@ -18,7 +18,7 @@ export interface SerializerAsync<T> {
   write(value: T): Awaitable<string>
 }
 
-export const StorageSerializers: Record<'boolean' | 'object' | 'number' | 'any' | 'string' | 'map' | 'set', Serializer<any>> = {
+export const StorageSerializers: Record<'boolean' | 'object' | 'number' | 'any' | 'string' | 'map' | 'set' | 'date', Serializer<any>> = {
   boolean: {
     read: (v: any) => v === 'true',
     write: (v: any) => String(v),
@@ -46,6 +46,10 @@ export const StorageSerializers: Record<'boolean' | 'object' | 'number' | 'any' 
   set: {
     read: (v: any) => new Set(JSON.parse(v)),
     write: (v: any) => JSON.stringify(Array.from((v as Set<any>).entries())),
+  },
+  date: {
+    read: (v: any) => new Date(v),
+    write: (v: any) => String(v),
   },
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Support [`Date`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) in the [`useStorage`](https://vueuse.org/core/usestorage/) composition. It also affects the `useLocalStorage` and `useSessionStorage` compositions.

### Additional context

To parse the date into a string, I decided to use the `toISOString`, because it's short and human-readable. Additionally, I found [this peace of spec](https://262.ecma-international.org/11.0/#sec-date.parse) that confirms that, given a Date `x` this code `new Date(x.toISOString())` generates the same date.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
