### PR TITLE
fix(useStorage): fix `Set` serialize error

### DIFF
--- a/packages/core/useStorage/index.test.ts
+++ b/packages/core/useStorage/index.test.ts
@@ -168,6 +168,59 @@ describe('useStorage', () => {
     expect(storage.removeItem).toBeCalledWith(KEY)
   })
 
+  it('map', async() => {
+    expect(storage.getItem(KEY)).toEqual(undefined)
+
+    const store = useStorage(KEY, new Map<number, string | number>([
+      [1, 'a'],
+      [2, 2],
+    ]), storage)
+
+    expect(storage.setItem).toBeCalledWith(KEY, '[[1,"a"],[2,2]]')
+
+    expect(store.value).toEqual(new Map<number, string | number>([[1, 'a'], [2, 2]]))
+
+    store.value.set(1, 'c')
+    await nextTwoTick()
+
+    expect(storage.setItem).toBeCalledWith(KEY, '[[1,"c"],[2,2]]')
+
+    store.value.set(2, 3)
+    await nextTwoTick()
+
+    expect(storage.setItem).toBeCalledWith(KEY, '[[1,"c"],[2,3]]')
+
+    store.value = null
+    await nextTwoTick()
+
+    expect(storage.removeItem).toBeCalledWith(KEY)
+  })
+
+  it('set', async() => {
+    expect(storage.getItem(KEY)).toEqual(undefined)
+
+    const store = useStorage(KEY, new Set<string | number>([1, '2']), storage)
+
+    expect(storage.setItem).toBeCalledWith(KEY, '[1,"2"]')
+
+    expect(store.value).toEqual(new Set<string | number>([1, '2']))
+
+    store.value.add('1')
+    await nextTwoTick()
+
+    expect(storage.setItem).toBeCalledWith(KEY, '[1,"2","1"]')
+
+    store.value.delete(1)
+    await nextTwoTick()
+
+    expect(storage.setItem).toBeCalledWith(KEY, '["2","1"]')
+
+    store.value = null
+    await nextTwoTick()
+
+    expect(storage.removeItem).toBeCalledWith(KEY)
+  })
+
   it('pass ref as initialValue', async() => {
     expect(storage.getItem(KEY)).toEqual(undefined)
 

--- a/packages/core/useStorage/index.test.ts
+++ b/packages/core/useStorage/index.test.ts
@@ -1,5 +1,5 @@
 import { debounceFilter, promiseTimeout } from '@vueuse/shared'
-import { ref } from 'vue-demi'
+import { isVue3, ref } from 'vue-demi'
 import { nextTwoTick, useSetup } from '../../.test'
 import { useStorage } from '.'
 
@@ -180,20 +180,22 @@ describe('useStorage', () => {
 
     expect(store.value).toEqual(new Map<number, string | number>([[1, 'a'], [2, 2]]))
 
-    store.value.set(1, 'c')
-    await nextTwoTick()
+    if (isVue3) {
+      store.value.set(1, 'c')
+      await nextTwoTick()
 
-    expect(storage.setItem).toBeCalledWith(KEY, '[[1,"c"],[2,2]]')
+      expect(storage.setItem).toBeCalledWith(KEY, '[[1,"c"],[2,2]]')
 
-    store.value.set(2, 3)
-    await nextTwoTick()
+      store.value.set(2, 3)
+      await nextTwoTick()
 
-    expect(storage.setItem).toBeCalledWith(KEY, '[[1,"c"],[2,3]]')
+      expect(storage.setItem).toBeCalledWith(KEY, '[[1,"c"],[2,3]]')
 
-    store.value = null
-    await nextTwoTick()
+      store.value = null
+      await nextTwoTick()
 
-    expect(storage.removeItem).toBeCalledWith(KEY)
+      expect(storage.removeItem).toBeCalledWith(KEY)
+    }
   })
 
   it('set', async() => {
@@ -205,20 +207,22 @@ describe('useStorage', () => {
 
     expect(store.value).toEqual(new Set<string | number>([1, '2']))
 
-    store.value.add('1')
-    await nextTwoTick()
+    if (isVue3) {
+      store.value.add('1')
+      await nextTwoTick()
 
-    expect(storage.setItem).toBeCalledWith(KEY, '[1,"2","1"]')
+      expect(storage.setItem).toBeCalledWith(KEY, '[1,"2","1"]')
 
-    store.value.delete(1)
-    await nextTwoTick()
+      store.value.delete(1)
+      await nextTwoTick()
 
-    expect(storage.setItem).toBeCalledWith(KEY, '["2","1"]')
+      expect(storage.setItem).toBeCalledWith(KEY, '["2","1"]')
 
-    store.value = null
-    await nextTwoTick()
+      store.value = null
+      await nextTwoTick()
 
-    expect(storage.removeItem).toBeCalledWith(KEY)
+      expect(storage.removeItem).toBeCalledWith(KEY)
+    }
   })
 
   it('pass ref as initialValue', async() => {

--- a/packages/core/useStorage/index.ts
+++ b/packages/core/useStorage/index.ts
@@ -45,7 +45,7 @@ export const StorageSerializers: Record<'boolean' | 'object' | 'number' | 'any' 
   },
   set: {
     read: (v: any) => new Set(JSON.parse(v)),
-    write: (v: any) => JSON.stringify(Array.from((v as Set<any>).entries())),
+    write: (v: any) => JSON.stringify(Array.from(v as Set<any>)),
   },
   date: {
     read: (v: any) => new Date(v),


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix `Set` serialize error, and add tests for `Map` and `Set`.

### Additional context

The entries() method returns a new [Iterator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators) object that contains an array of [value, value] for each element in the Set object, in insertion order. For Set objects there is no key like in Map objects. However, to keep the API similar to the Map object, each entry has the same value for its key and value here, so that an array [value, value] is returned.

The [code](https://github.com/vueuse/vueuse/blob/c8dcfc7a5825420d65b777e47821ec56152bcbac/packages/core/useStorage/index.ts#L48) will lead to wrong result when reload data from storage.

Example:
```js
> new Set(JSON.parse(JSON.stringify(Array.from(new Set([0]).entries()))))
< Set(1) {Array(2)}
```

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
