### PR TITLE
fix(nuxt): use `useHead` and import from `#app`

### DIFF
--- a/packages/nuxt/ssr-plugin.mjs
+++ b/packages/nuxt/ssr-plugin.mjs
@@ -1,6 +1,5 @@
 import { setSSRHandler } from '@vueuse/core'
-import { useMeta } from '#meta'
-import { useCookie } from '#app'
+import { useCookie, useHead } from '#app'
 
 setSSRHandler('getDefaultStorage', () => {
   const cookieMap = new Map()
@@ -19,14 +18,14 @@ setSSRHandler('getDefaultStorage', () => {
 if (process.server) {
   setSSRHandler('updateHTMLAttrs', (selector, attr, value) => {
     if (selector === 'html') {
-      useMeta({
+      useHead({
         htmlAttrs: {
           [attr]: value,
         },
       })
     }
     else if (selector === 'body') {
-      useMeta({
+      useHead({
         bodyAttrs: {
           [attr]: value,
         },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

We recently updated the name (`useMeta` -> `useHead`) within Nuxt itself, and renamed the virtual import from `#meta` to `#head`: https://github.com/nuxt/framework/pull/4066

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
