### PR TITLE
fix(useNProgress): allow partial options

### DIFF
--- a/packages/integrations/useNProgress/index.ts
+++ b/packages/integrations/useNProgress/index.ts
@@ -13,7 +13,7 @@ import { computed, isRef, ref, watchEffect } from 'vue-demi'
  */
 export function useNProgress(
   currentProgress: MaybeRef<number | null | undefined> = null,
-  options?: NProgressOptions | undefined,
+  options?: Partial<NProgressOptions> | undefined,
 ) {
   const progress = isRef(currentProgress)
     ? currentProgress

--- a/packages/integrations/useNProgress/index.ts
+++ b/packages/integrations/useNProgress/index.ts
@@ -13,7 +13,7 @@ import { computed, isRef, ref, watchEffect } from 'vue-demi'
  */
 export function useNProgress(
   currentProgress: MaybeRef<number | null | undefined> = null,
-  options?: Partial<NProgressOptions> | undefined,
+  options?: Partial<NProgressOptions>,
 ) {
   const progress = isRef(currentProgress)
     ? currentProgress


### PR DESCRIPTION
### Description

This commit changes the type definition for the `options` argument of `useNProgress()` from `NProgressOptions | undefined` to `Partial<NProgressOptions> | undefined`.

This matches NProgress' own type definitions and will prevent errors when using only a subset of NProgress options.

### Additional context

This error came up via `vue-tsc`:

```
resources/panel/components/AppProgress.vue:10:73 - error TS2345: Argument of type '{ minimum: number; showSpinner: false; }' is not assignable to parameter of type 'NProgressOptions'.
  Type '{ minimum: number; showSpinner: false; }' is missing the following properties from type 'NProgressOptions': template, easing, speed, trickle, and 5 more.

10 const { start, done, remove, progress, isLoading } = useNProgress(null, {
                                                                           ~
11   minimum: props.minimum || 0.1,
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
12   showSpinner: false,
   ~~~~~~~~~~~~~~~~~~~~~
13 });
   ~


Found 1 error in resources/panel/components/AppProgress.vue:10
```

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
