### PR TITLE
fix(useRafFn): call `cancelAnimationFrame` on pause

### DIFF
--- a/packages/core/useRafFn/demo.vue
+++ b/packages/core/useRafFn/demo.vue
@@ -8,4 +8,10 @@ const { pause, resume } = useRafFn(() => count.value += 1)
 
 <template>
   <div>Count: {{ count }}</div>
+  <button @click="pause">
+    pause
+  </button>
+  <button @click="resume">
+    resume
+  </button>
 </template>

--- a/packages/core/useRafFn/index.ts
+++ b/packages/core/useRafFn/index.ts
@@ -46,7 +46,7 @@ export function useRafFn(fn: Fn, options: RafFnOptions = {}): Pausable {
 
   function pause() {
     isActive.value = false
-    if(rafId.value && window){
+    if(rafId.value && window) {
       window.cancelAnimationFrame(rafId.value)
       rafId.value = null
     }

--- a/packages/core/useRafFn/index.ts
+++ b/packages/core/useRafFn/index.ts
@@ -27,13 +27,14 @@ export function useRafFn(fn: Fn, options: RafFnOptions = {}): Pausable {
   } = options
 
   const isActive = ref(false)
+  const rafId = ref(null)
 
   function loop() {
     if (!isActive.value || !window)
       return
 
     fn()
-    window.requestAnimationFrame(loop)
+    rafId.value = window.requestAnimationFrame(loop)
   }
 
   function resume() {
@@ -45,6 +46,10 @@ export function useRafFn(fn: Fn, options: RafFnOptions = {}): Pausable {
 
   function pause() {
     isActive.value = false
+    if(rafId.value && window){
+      window.cancelAnimationFrame(rafId.value)
+      rafId.value = null
+    }
   }
 
   if (immediate)

--- a/packages/core/useRafFn/index.ts
+++ b/packages/core/useRafFn/index.ts
@@ -1,4 +1,3 @@
-import type { Ref } from 'vue-demi'
 import { ref } from 'vue-demi'
 import type { Fn, Pausable } from '@vueuse/shared'
 import { tryOnScopeDispose } from '@vueuse/shared'
@@ -28,14 +27,14 @@ export function useRafFn(fn: Fn, options: RafFnOptions = {}): Pausable {
   } = options
 
   const isActive = ref(false)
-  const rafId = ref(null) as Ref<null | number>
+  let rafId: null | number = null
 
   function loop() {
     if (!isActive.value || !window)
       return
 
     fn()
-    rafId.value = window.requestAnimationFrame(loop)
+    rafId = window.requestAnimationFrame(loop)
   }
 
   function resume() {
@@ -47,9 +46,9 @@ export function useRafFn(fn: Fn, options: RafFnOptions = {}): Pausable {
 
   function pause() {
     isActive.value = false
-    if (rafId.value && window) {
-      window.cancelAnimationFrame(rafId.value)
-      rafId.value = null
+    if (typeof rafId === 'number' && window) {
+      window.cancelAnimationFrame(rafId)
+      rafId = null
     }
   }
 

--- a/packages/core/useRafFn/index.ts
+++ b/packages/core/useRafFn/index.ts
@@ -1,3 +1,4 @@
+import type { Ref } from 'vue-demi'
 import { ref } from 'vue-demi'
 import type { Fn, Pausable } from '@vueuse/shared'
 import { tryOnScopeDispose } from '@vueuse/shared'
@@ -27,7 +28,7 @@ export function useRafFn(fn: Fn, options: RafFnOptions = {}): Pausable {
   } = options
 
   const isActive = ref(false)
-  const rafId = ref(null)
+  const rafId = ref(null) as Ref<null | number>
 
   function loop() {
     if (!isActive.value || !window)
@@ -46,7 +47,7 @@ export function useRafFn(fn: Fn, options: RafFnOptions = {}): Pausable {
 
   function pause() {
     isActive.value = false
-    if(rafId.value && window) {
+    if (rafId.value && window) {
       window.cancelAnimationFrame(rafId.value)
       rafId.value = null
     }

--- a/packages/core/useRafFn/index.ts
+++ b/packages/core/useRafFn/index.ts
@@ -46,7 +46,7 @@ export function useRafFn(fn: Fn, options: RafFnOptions = {}): Pausable {
 
   function pause() {
     isActive.value = false
-    if (typeof rafId === 'number' && window) {
+    if (rafId != null && window) {
       window.cancelAnimationFrame(rafId)
       rafId = null
     }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This commit is out of my notice about the green button `Transition` in [useTransition demo](https://vueuse.org/core/usetransition/) 

If you use the performance panel of chrome dev tool to record , and then click button `Transition` quickily for several times.

And then you will find there are many `Animation Frame Fired` in just one frame.

This commit try to add `cancelAnimationFrame` to avoid the unnecessary invoke of the repeated raf callbacks


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
