### PR TITLE
fix(useMagicKeys)!: store `key` instead of `keyCode` in `current`

### DIFF
--- a/packages/core/useMagicKeys/index.ts
+++ b/packages/core/useMagicKeys/index.ts
@@ -51,7 +51,7 @@ export interface MagicKeysInternal {
    * A Set of currently pressed keys,
    * Stores raw keyCodes.
    *
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key
    */
   current: Set<string>
 }
@@ -100,11 +100,11 @@ export function useMagicKeys(options: UseMagicKeysOptions<boolean> = {}): any {
     const values = [code, key].filter(Boolean)
 
     // current set
-    if (code) {
+    if (key) {
       if (value)
-        current.add(e.code)
+        current.add(key)
       else
-        current.delete(e.code)
+        current.delete(key)
     }
 
     for (const key of values)
@@ -112,7 +112,7 @@ export function useMagicKeys(options: UseMagicKeysOptions<boolean> = {}): any {
 
     // #1312
     // In macOS, keys won't trigger "keyup" event when Meta key is released
-    // We track it's combination and relese manually
+    // We track it's combination and release manually
     if (key === 'meta' && !value) {
       // Meta key released
       metaDeps.forEach((key) => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

`current` now contains keys instead of key codes. It's now compatible with the example from docs.

### Additional context

fixes #1503 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
