### PR TITLE
fix(refAutoReset): clear timeout on scope dispose

### DIFF
--- a/packages/shared/refAutoReset/index.ts
+++ b/packages/shared/refAutoReset/index.ts
@@ -1,6 +1,7 @@
 import type { Ref } from 'vue-demi'
 import { customRef, unref } from 'vue-demi'
 import type { MaybeRef } from '@vueuse/shared'
+import { tryOnScopeDispose } from '../tryOnScopeDispose'
 
 /**
  * Create a ref which will be reset to the default value after some time.
@@ -19,6 +20,11 @@ export function refAutoReset<T>(defaultValue: T, afterMs: MaybeRef<number> = 100
         value = defaultValue
         trigger()
       }, unref(afterMs))
+
+    tryOnScopeDispose(() => {
+      if (timer)
+        clearTimeout(timer)
+    })
 
     return {
       get() {

--- a/packages/shared/refAutoReset/index.ts
+++ b/packages/shared/refAutoReset/index.ts
@@ -22,8 +22,7 @@ export function refAutoReset<T>(defaultValue: T, afterMs: MaybeRef<number> = 100
       }, unref(afterMs))
 
     tryOnScopeDispose(() => {
-      if (timer)
-        clearTimeout(timer)
+       clearTimeout(timer)
     })
 
     return {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The timeout is not cleared on scope dispose in refAutoReset. This PR fixes that.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
