### PR TITLE
fix(useScriptTag): enable setting arbitrary attrs

### DIFF
--- a/packages/core/useScriptTag/index.test.ts
+++ b/packages/core/useScriptTag/index.test.ts
@@ -54,6 +54,32 @@ describe('useScriptTag', () => {
     expect(scriptTagElement()).toBeInstanceOf(HTMLScriptElement)
   })
 
+  it('should support custom attributes', async() => {
+    const appendChildListener = vitest.spyOn(document.head, 'appendChild')
+
+    expect(appendChildListener).not.toBeCalled()
+
+    expect(scriptTagElement()).toBeNull()
+
+    useSetup(() => {
+      const { scriptTag } = useScriptTag(src, () => {}, {
+        attrs: { 'id': 'id-value', 'data-test': 'data-test-value' },
+        immediate: true,
+      })
+
+      return {
+        scriptTag,
+      }
+    })
+
+    expect(appendChildListener).toBeCalled()
+
+    const element = scriptTagElement()
+    expect(element).toBeInstanceOf(HTMLScriptElement)
+    expect(element?.getAttribute('id')).toBe('id-value')
+    expect(element?.getAttribute('data-test')).toBe('data-test-value')
+  })
+
   it('should remove script tag on unmount', async() => {
     const removeChildListener = vitest.spyOn(document.head, 'removeChild')
 

--- a/packages/core/useScriptTag/index.ts
+++ b/packages/core/useScriptTag/index.ts
@@ -117,8 +117,7 @@ export function useScriptTag(
       if (referrerPolicy)
         el.referrerPolicy = referrerPolicy
 
-      for (const attr in attrs)
-        (el as any)[attr] = attrs[attr]
+      Object.entries(attrs).forEach(([name, value]) => el?.setAttribute(name, value))
 
       // Enables shouldAppend
       shouldAppend = true


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Custom attributes feature (#1157) that has recently been added to `useScriptTag` didn't support arbitrary attribute names. Attributes were being set as fields directly on the element object and so only some of them worked (e.g. `id`). But any non-standard attributes (like `data-*` ones) didn't work.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
