### PR TITLE
fix(useAsyncState): `isLoading` not reset

### DIFF
--- a/packages/core/useAsyncState/index.ts
+++ b/packages/core/useAsyncState/index.ts
@@ -102,8 +102,10 @@ export function useAsyncState<Data, Shallow extends boolean = true>(
       error.value = e
       onError(e)
     }
+    finally {
+      isLoading.value = false
+    }
 
-    isLoading.value = false
     return state.value as Data
   }
 


### PR DESCRIPTION
If the provided `onError` handler throws an exception, the `isLoading` state will never be reset to false.

In this circumstance, the `error` ref will still be set, and the `isReady` ref will likewise be correctly left at `false`.

<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
