### PR TITLE
fix(useAxios): rename `aborted` to `isAborted`

### DIFF
--- a/packages/integrations/useAxios/index.ts
+++ b/packages/integrations/useAxios/index.ts
@@ -25,11 +25,11 @@ export interface UseAxiosReturn<T> {
    * Indicates if the request is currently loading
    */
   isLoading: Ref<boolean>
-
+  
   /**
    * Indicates if the request was canceled
    */
-  aborted: Ref<boolean>
+  isAborted: Ref<boolean>
 
   /**
    * Any errors that may have occurred
@@ -47,9 +47,14 @@ export interface UseAxiosReturn<T> {
   finished: Ref<boolean>
 
   /**
-   * loading alias
+   * isLoading alias
    */
   loading: Ref<boolean>
+  
+  /**
+   * isAborted alias
+   */
+  aborted: Ref<boolean>
 
   /**
    * abort alias
@@ -126,7 +131,7 @@ export function useAxios<T = any>(...args: any[]): OverallUseAxiosReturn<T> & Pr
   const data = shallowRef<T>()
   const isFinished = ref(false)
   const isLoading = ref(false)
-  const aborted = ref(false)
+  const isAborted = ref(false)
   const error = shallowRef<AxiosError<T>>()
 
   const cancelToken: CancelTokenSource = axios.CancelToken.source()
@@ -135,7 +140,7 @@ export function useAxios<T = any>(...args: any[]): OverallUseAxiosReturn<T> & Pr
       return
 
     cancelToken.cancel(message)
-    aborted.value = true
+    isAborted.value = true
     isLoading.value = false
     isFinished.value = false
   }
@@ -178,8 +183,9 @@ export function useAxios<T = any>(...args: any[]): OverallUseAxiosReturn<T> & Pr
     isFinished,
     isLoading,
     cancel: abort,
-    canceled: aborted,
-    aborted,
+    isAborted,
+    canceled: isAborted,
+    aborted: isAborted,
     abort,
     execute,
   } as OverallUseAxiosReturn<T>


### PR DESCRIPTION
### Description

Minor changes:
- Update useAxios package with better syntax: use isAborted like isLoading and isFinished in stead of just aborted (now just an alias).
-  Fix loading documentation comment.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
