### PR TITLE
fix(onClickOutside): fallback to `pointerup` event if `click` event not propagate

### DIFF
--- a/packages/core/onClickOutside/index.ts
+++ b/packages/core/onClickOutside/index.ts
@@ -37,7 +37,11 @@ export function onClickOutside(
 
   const shouldListen = ref(true)
 
+  let fallback: number
+
   const listener = (event: PointerEvent) => {
+    window.clearTimeout(fallback)
+
     const el = unrefElement(target)
     const composedPath = event.composedPath()
 
@@ -60,6 +64,9 @@ export function onClickOutside(
     useEventListener(window, 'pointerdown', (e) => {
       const el = unrefElement(target)
       shouldListen.value = !!el && !e.composedPath().includes(el)
+    }, { passive: true }),
+    useEventListener(window, 'pointerup', (e) => {
+      fallback = window.setTimeout(() => listener(e), 50)
     }, { passive: true }),
   ]
 


### PR DESCRIPTION
Fix #1520

### Description

[This article](https://www.quirksmode.org/blog/archives/2014/02/mouse_event_bub.html) from 2014 clearly explains what is going on there. This PR simply workaround this issue by falling back to `pointerup` event. 

`click` event is fired after all release events (`mouseup`, `touchend`, `pointerup`). So, if click event is propagated normally within 50ms, timeout will be cleared. Initially, I was thinking to use `touchend` event. But the type of `touchend` event is not compatible with PointerEvent.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
