### PR TITLE
feat(useNetwork): new `onlineAt` attribute

### DIFF
--- a/packages/core/useNetwork/index.ts
+++ b/packages/core/useNetwork/index.ts
@@ -21,6 +21,10 @@ export interface NetworkState {
    */
   offlineAt: Ref<number | undefined>
   /**
+   * At this time, if the user is offline and reconnects
+   */
+  onlineAt: Ref<number | undefined>
+  /**
    * The download speed in Mbps.
    */
   downlink: Ref<number | undefined>
@@ -60,6 +64,7 @@ export function useNetwork(options: ConfigurableWindow = {}): Readonly<NetworkSt
   const isOnline = ref(true)
   const saveData = ref(false)
   const offlineAt: Ref<number | undefined> = ref(undefined)
+  const onlineAt: Ref<number | undefined> = ref(undefined)
   const downlink: Ref<number | undefined> = ref(undefined)
   const downlinkMax: Ref<number | undefined> = ref(undefined)
   const rtt: Ref<number | undefined> = ref(undefined)
@@ -74,6 +79,7 @@ export function useNetwork(options: ConfigurableWindow = {}): Readonly<NetworkSt
 
     isOnline.value = navigator.onLine
     offlineAt.value = isOnline.value ? undefined : Date.now()
+    onlineAt.value = isOnline.value ? Date.now() : undefined
 
     if (connection) {
       downlink.value = connection.downlink
@@ -93,6 +99,7 @@ export function useNetwork(options: ConfigurableWindow = {}): Readonly<NetworkSt
 
     useEventListener(window, 'online', () => {
       isOnline.value = true
+      onlineAt.value = Date.now()
     })
   }
 
@@ -106,6 +113,7 @@ export function useNetwork(options: ConfigurableWindow = {}): Readonly<NetworkSt
     isOnline,
     saveData,
     offlineAt,
+    onlineAt,
     downlink,
     downlinkMax,
     effectiveType,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
add new attribute（ onlineAt time ）
This attribute records the network reconnection time
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
