### PR TITLE
feat(useVModel): add option to define defaultValue

### DIFF
--- a/packages/core/useVModel/index.test.ts
+++ b/packages/core/useVModel/index.test.ts
@@ -93,4 +93,13 @@ describe('useVModel', () => {
     expect(emitMock).toBeCalledTimes(1)
     expect(emitMock).toHaveBeenCalledWith('update:data', { hobbies: ['coding', 'basketball'] })
   })
+
+  it('should work with user define defaultValue', () => {
+    const props = {
+      ...defaultProps(),
+    }
+    const emitMock = vitest.fn()
+    const data = useVModel(props, 'data', emitMock, { defaultValue: 'default-data' })
+    expect(data.value).toBe('default-data')
+  })
 })

--- a/packages/core/useVModel/index.test.ts
+++ b/packages/core/useVModel/index.test.ts
@@ -102,4 +102,13 @@ describe('useVModel', () => {
     const data = useVModel(props, 'data', emitMock, { defaultValue: 'default-data' })
     expect(data.value).toBe('default-data')
   })
+
+  it('should work with user define defaultValue with passive', () => {
+    const props = {
+      ...defaultProps(),
+    }
+    const emitMock = vitest.fn()
+    const data = useVModel(props, 'data', emitMock, { passive: true, defaultValue: 'default-data' })
+    expect(data.value).toBe('default-data')
+  })
 })

--- a/packages/core/useVModel/index.ts
+++ b/packages/core/useVModel/index.ts
@@ -22,7 +22,7 @@ export interface VModelOptions<T> {
    */
   deep?: boolean
   /**
-   * Let user define their default what for return ref
+   * Defining default value for return ref when no value is passed.
    *
    * @default undefined
    */

--- a/packages/core/useVModel/index.ts
+++ b/packages/core/useVModel/index.ts
@@ -1,7 +1,7 @@
 import type { UnwrapRef } from 'vue-demi'
 import { computed, getCurrentInstance, isVue2, ref, watch } from 'vue-demi'
 
-export interface VModelOptions<T = undefined> {
+export interface VModelOptions<T> {
   /**
    * When passive is set to `true`, it will use `watch` to sync with props and ref.
    * Instead of relying on the `v-model` or `.sync` to work.

--- a/packages/core/useVModel/index.ts
+++ b/packages/core/useVModel/index.ts
@@ -1,7 +1,7 @@
 import type { UnwrapRef } from 'vue-demi'
 import { computed, getCurrentInstance, isVue2, ref, watch } from 'vue-demi'
 
-export interface VModelOptions<T> {
+export interface VModelOptions<T = undefined> {
   /**
    * When passive is set to `true`, it will use `watch` to sync with props and ref.
    * Instead of relying on the `v-model` or `.sync` to work.

--- a/packages/core/useVModel/index.ts
+++ b/packages/core/useVModel/index.ts
@@ -1,7 +1,7 @@
 import type { UnwrapRef } from 'vue-demi'
 import { computed, getCurrentInstance, isVue2, ref, watch } from 'vue-demi'
 
-export interface VModelOptions {
+export interface VModelOptions<T> {
   /**
    * When passive is set to `true`, it will use `watch` to sync with props and ref.
    * Instead of relying on the `v-model` or `.sync` to work.
@@ -21,6 +21,12 @@ export interface VModelOptions {
    * @default false
    */
   deep?: boolean
+  /**
+   * Let user define their default what for return ref
+   *
+   * @default undefined
+   */
+  defaultValue?: T
 }
 
 /**
@@ -35,12 +41,13 @@ export function useVModel<P extends object, K extends keyof P, Name extends stri
   props: P,
   key?: K,
   emit?: (name: Name, ...args: any[]) => void,
-  options: VModelOptions = {},
+  options: VModelOptions<P[K]> = {},
 ) {
   const {
     passive = false,
     eventName,
     deep = false,
+    defaultValue,
   } = options
 
   const vm = getCurrentInstance()
@@ -63,7 +70,7 @@ export function useVModel<P extends object, K extends keyof P, Name extends stri
   event = eventName || event || `update:${key}`
 
   if (passive) {
-    const proxy = ref<P[K]>(props[key!])
+    const proxy = ref<P[K]>(props[key!] || defaultValue!)
 
     watch(() => props[key!], v => proxy.value = v as UnwrapRef<P[K]>)
 
@@ -79,7 +86,7 @@ export function useVModel<P extends object, K extends keyof P, Name extends stri
   else {
     return computed<P[K]>({
       get() {
-        return props[key!]
+        return props[key!] || defaultValue!
       },
       set(value) {
         _emit(event, value)

--- a/packages/core/useVModels/index.ts
+++ b/packages/core/useVModels/index.ts
@@ -12,7 +12,7 @@ import { useVModel } from '../useVModel'
 export function useVModels<P extends object, Name extends string>(
   props: P,
   emit?: (name: Name, ...args: any[]) => void,
-  options: VModelOptions = {},
+  options: VModelOptions<any> = {},
 ): ToRefs<P> {
   const ret: any = {}
   // eslint-disable-next-line no-restricted-syntax


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Add new option `defaultValue` to use when props value is not passed or undefined. 
It can be useful in some situations:

My case: I'm using the same component(Modal) for CREATE and UPDATE a data model. I need to check if props passed or not to make sync of existing data (from API), this is for UPDATE. And for CREATE: I need some default data to let my form work property with v-model
```ts
const type = useVModel(props, 'type', emit)
const _type = ref('')
if (type.value)
  syncRef(type, _type) // old syncRef
```
simply 
```ts
const type = useVModel(props, 'type', emit, { defaultValue: 'none' )
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context
This is similar to Uncontrolled | Controlled component from
 [https://ahooks.js.org/hooks/use-controllable-value](url)

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
