### PR TITLE
fix(useElementBounding): call `update` on mounted (#626)

### DIFF
--- a/packages/core/useElementBounding/index.ts
+++ b/packages/core/useElementBounding/index.ts
@@ -1,4 +1,5 @@
 import { ref, watch } from 'vue-demi'
+import { tryOnMounted } from '@vueuse/shared'
 import { useEventListener } from '../useEventListener'
 import type { MaybeElementRef } from '../unrefElement'
 import { unrefElement } from '../unrefElement'
@@ -24,6 +25,13 @@ export interface UseElementBoundingOptions {
    * @default true
    */
   windowScroll?: boolean
+
+  /**
+   * Immediately call update on component mounted
+   *
+   * @default true
+   */
+  immediate?: boolean
 }
 
 /**
@@ -40,6 +48,7 @@ export function useElementBounding(
     reset = true,
     windowResize = true,
     windowScroll = true,
+    immediate = true,
   } = options
 
   const height = ref(0)
@@ -87,6 +96,11 @@ export function useElementBounding(
     useEventListener('scroll', update, { passive: true })
   if (windowResize)
     useEventListener('resize', update, { passive: true })
+
+  tryOnMounted(() => {
+    if (immediate)
+      update()
+  })
 
   return {
     height,


### PR DESCRIPTION
- Call update on compoment mounted
- Add a flag to disable that behaviour
- Default it to true to return the correct values immediately

<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Fixes #626

UseElementBounding doesn't return the correct value immediately, which is inconsistent with `element.getBoundingClientRect()`. This changes adds an optional flag defaulted to true to call the update function onMounted.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

N/A

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [ x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
