### PR TITLE
Mark change-case as an optional peer dependacy

### DIFF
--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -98,6 +98,9 @@
     "axios": {
       "optional": true
     },
+    "change-case": {
+      "optional": true
+    },
     "drauu": {
       "optional": true
     },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

With `@vueuse/intergrations`, `change-case` gets forcefully installed as a peer dependency, even if the dev has no need for it. There is a meme of the `node_modules` directory being the heaviest object on the universe for a reason, let's not lend it any additional gravity.

### Additional context

N/A

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
