### PR TITLE
fix(computedAsync): keep evaluating true for concurrent changes

### DIFF
--- a/packages/core/computedAsync/index.ts
+++ b/packages/core/computedAsync/index.ts
@@ -97,7 +97,7 @@ export function computedAsync<T>(
       onError(e)
     }
     finally {
-      if (evaluating)
+      if (evaluating && counterAtBeginning === counter)
         evaluating.value = false
 
       hasFinished = true


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

When the async computation in `computedAsync` finish out-of-order, all but the result for the final value are discarded.
This works fine, but was previously untested afaics.
The status ref `evaluating` which tracks, whether a computation is currently running, was however already set to `false` when any computation finished, even though others were still in progress.

I have added a test which checks both and fixed the problem with `evaluating`, so it is now only `false` after the computation for the latest dependency value(s) has finished.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
