### PR TITLE
fix: `useScrollLock` lock the entire page

### DIFF
--- a/packages/core/useScrollLock/index.ts
+++ b/packages/core/useScrollLock/index.ts
@@ -49,7 +49,7 @@ export function useScrollLock(
       return
     if (isIOS) {
       touchMoveListener = useEventListener(
-        document,
+        ele,
         'touchmove',
         preventDefault,
         { passive: false },


### PR DESCRIPTION
### Description
Fixes https://github.com/vueuse/vueuse/issues/1558
useScrollLock In IOS will lock the entire page, In other cases only the specified element will be locked.

<!-- ### Additional context -->


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
