### PR TITLE
refactor(useConfirmDialog): A more appropriate `isRevealed`

### DIFF
--- a/packages/core/useConfirmDialog/index.md
+++ b/packages/core/useConfirmDialog/index.md
@@ -85,3 +85,80 @@ const openDialog = async () => {
   </teleport>
 </template>
 ```
+
+### Binding on `v-model`
+
+Since the return `isRevealed` is `readonly`, it can't be bound on `v-model` directly.
+
+```html
+<script setup>
+import { ref } from 'vue'
+import { useConfirmDialog, onClickOutside } from '@vueuse/core'
+
+const isRevealed = ref(false)
+
+const {
+  // isRevealed,
+  reveal,
+  confirm,
+  cancel,
+} = useConfirmDialog(isRevealed)
+
+const openDialog = async () => {
+  const { data, isCanceled } = await reveal()
+  if (!isCanceled) {
+    console.log(data)
+  }
+}
+</script>
+
+<template>
+  <button @click="openDialog">Show Modal</button>
+
+  <teleport to="body">
+    <ThreeRdComponent @v-model:visible="isRevealed" class="modal-layout">
+      <div class="modal">
+        <h2>Confirm?</h2>
+        <button @click="confirm(true)">Yes</button>
+        <button @click="confirm(false)">No</button>
+      </div>
+    </ThreeRdComponent>
+  </teleport>
+</template>
+```
+
+or
+
+```html
+<script setup>
+import { useConfirmDialog, onClickOutside } from '@vueuse/core'
+
+const {
+  isRevealed,
+  reveal,
+  confirm,
+  cancel,
+} = useConfirmDialog()
+
+const openDialog = async () => {
+  const { data, isCanceled } = await reveal()
+  if (!isCanceled) {
+    console.log(data)
+  }
+}
+</script>
+
+<template>
+  <button @click="openDialog">Show Modal</button>
+
+  <teleport to="body">
+    <ThreeRdComponent :visible="isRevealed" @update:visible="cancel" class="modal-layout">
+      <div class="modal">
+        <h2>Confirm?</h2>
+        <button @click="confirm(true)">Yes</button>
+        <button @click="confirm(false)">No</button>
+      </div>
+    </ThreeRdComponent>
+  </teleport>
+</template>
+```

--- a/packages/core/useConfirmDialog/index.ts
+++ b/packages/core/useConfirmDialog/index.ts
@@ -1,5 +1,5 @@
-import type { ComputedRef, Ref } from 'vue-demi'
-import { computed, ref } from 'vue-demi'
+import type { DeepReadonly, Ref } from 'vue-demi'
+import { readonly, ref } from 'vue-demi'
 import type { EventHook, EventHookOn } from '@vueuse/shared'
 import { createEventHook, noop } from '@vueuse/shared'
 
@@ -16,7 +16,7 @@ export interface UseConfirmDialogReturn<RevealData, ConfirmData, CancelData> {
   /**
    * Revealing state
    */
-  isRevealed: ComputedRef<boolean>
+  isRevealed: DeepReadonly<Ref<boolean>>
 
   /**
    * Opens the dialog.
@@ -96,7 +96,7 @@ export function useConfirmDialog<
   }
 
   return {
-    isRevealed: computed(() => revealed.value),
+    isRevealed: readonly(revealed),
     reveal,
     confirm,
     cancel,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

#### Since the return `isRevealed` is `readonly`, it can't be bound on `v-model` directly.

![image](https://user-images.githubusercontent.com/11309921/166924897-70a1d44b-6397-4752-aad8-3ae5a14a385a.png)

#### So I have got two ways on `v-model` binding. Please review [index.md](https://github.com/lvjiaxuan/vueuse/blob/ae859bc76de0cbdd3c2c54232c4854d86e77a846/packages/core/useConfirmDialog/index.md)

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
