### PR TITLE
docs: remove unnecessary dayjs usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "bumpp": "^7.1.1",
     "consola": "^2.15.3",
     "cross-env": "^7.0.3",
-    "dayjs": "^1.11.1",
     "esbuild-register": "^3.3.2",
     "eslint": "^8.14.0",
     "esno": "^0.14.1",

--- a/packages/.vitepress/theme/components/FunctionInfo.vue
+++ b/packages/.vitepress/theme/components/FunctionInfo.vue
@@ -1,15 +1,13 @@
 <script setup lang="ts">
-import dayjs from 'dayjs'
-import relativeTime from 'dayjs/plugin/relativeTime'
+import { useTimeAgo } from '@vueuse/core'
 import { computed } from 'vue'
 import { functions } from '../../../../packages/metadata/metadata'
 
 const props = defineProps<{ fn: string }>()
 
-dayjs.extend(relativeTime)
-
 const info = computed(() => functions.find(i => i.name === props.fn))
-const format = (ts: number) => dayjs(ts).fromNow()
+const format = (ts: number) => ago(-1, 'day')
+const lastUpdated = useTimeAgo(new Date(info.value?.lastUpdated || 0))
 const link = computed(() => `/functions\#category=${encodeURIComponent(info.value.category)}`)
 
 const getFunctionLink = (fn: string) => {
@@ -34,7 +32,7 @@ const getFunctionLink = (fn: string) => {
       <div opacity="50">
         Last Changed
       </div>
-      <div>{{ format(info.lastUpdated) }}</div>
+      <div>{{ lastUpdated }}</div>
     </template>
     <template v-if="info.alias?.length">
       <div opacity="50">

--- a/packages/contributors.json
+++ b/packages/contributors.json
@@ -120,6 +120,7 @@
   "Ericteen",
   "Akryum",
   "guillenotfound",
+  "harlan-zw",
   "Hebilicious",
   "hognevevle",
   "HomyeeKing",
@@ -185,6 +186,7 @@
   "Atinux",
   "thalesagapito",
   "thierrymichel",
+  "tmkx",
   "livthomas",
   "scvnc",
   "viniciuskneves",
@@ -222,6 +224,5 @@
   "songlairui",
   "jiangmaniu",
   "Hongbusi",
-  "egoist",
-  "harlan-zw"
+  "egoist"
 ]

--- a/packages/core/useDebouncedRefHistory/demo.vue
+++ b/packages/core/useDebouncedRefHistory/demo.vue
@@ -1,11 +1,11 @@
 <script lang="ts" setup>
-import { ref } from '@vue/reactivity'
+import { ref } from 'vue'
 import { useCounter } from '@vueuse/shared'
-import dayjs from 'dayjs'
-import type { Ref } from 'vue'
-import { useDebouncedRefHistory } from '@vueuse/core'
+import { formatDate, useDebouncedRefHistory } from '@vueuse/core'
 
-const format = (ts: number) => dayjs(ts).format()
+import type { Ref } from 'vue'
+
+const format = (ts: number) => formatDate(new Date(ts), 'YYYY-MM-DD HH:mm:ss')
 const delay: Ref<number> = ref(1000)
 
 const { count, inc, dec } = useCounter()

--- a/packages/core/useManualRefHistory/demo.vue
+++ b/packages/core/useManualRefHistory/demo.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
-import dayjs from 'dayjs'
 import { useCounter } from '@vueuse/shared'
-import { useManualRefHistory } from '@vueuse/core'
+import { formatDate, useManualRefHistory } from '@vueuse/core'
 
-const format = (ts: number) => dayjs(ts).format()
+const format = (ts: number) => formatDate(new Date(ts), 'YYYY-MM-DD HH:mm:ss')
 
 const { inc, dec, count } = useCounter()
 const { canUndo, canRedo, history, commit, undo, redo } = useManualRefHistory(count, { capacity: 10 })

--- a/packages/core/useRefHistory/demo.vue
+++ b/packages/core/useRefHistory/demo.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
 import { useCounter } from '@vueuse/shared'
-import dayjs from 'dayjs'
-import { useRefHistory } from '@vueuse/core'
+import { formatDate, useRefHistory } from '@vueuse/core'
 
-const format = (ts: number) => dayjs(ts).format()
+const format = (ts: number) => formatDate(new Date(ts), 'YYYY-MM-DD HH:mm:ss')
 
 const { count, inc, dec } = useCounter()
 const { history, undo, redo, canUndo, canRedo } = useRefHistory(count, { capacity: 10 })

--- a/packages/core/useThrottledRefHistory/demo.vue
+++ b/packages/core/useThrottledRefHistory/demo.vue
@@ -1,11 +1,10 @@
 <script setup lang="ts">
-import { ref } from '@vue/reactivity'
+import { ref } from 'vue'
 import { useCounter } from '@vueuse/shared'
-import dayjs from 'dayjs'
+import { formatDate, useThrottledRefHistory } from '@vueuse/core'
 import type { Ref } from 'vue'
-import { useThrottledRefHistory } from '@vueuse/core'
 
-const format = (ts: number) => dayjs(ts).format()
+const format = (ts: number) => formatDate(new Date(ts), 'YYYY-MM-DD HH:mm:ss')
 const delay: Ref<number> = ref(1000)
 
 const { count, inc, dec } = useCounter()

--- a/packages/core/useWebWorkerFn/demo.vue
+++ b/packages/core/useWebWorkerFn/demo.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
-import dayjs from 'dayjs'
 import { computed, nextTick, ref } from 'vue'
-import { useTimestamp, useWebWorkerFn } from '@vueuse/core'
+import { useDateFormat, useTimestamp, useWebWorkerFn } from '@vueuse/core'
 
 const heavyTask = () => {
   const randomNumber = () => Math.trunc(Math.random() * 5_000_00)
@@ -12,7 +11,7 @@ const heavyTask = () => {
 
 const { workerFn, workerStatus, workerTerminate } = useWebWorkerFn(heavyTask)
 const time = useTimestamp()
-const computedTime = computed(() => dayjs(time.value).format('YYYY-MM-DD HH:mm:ss SSS'))
+const computedTime = useDateFormat(time, 'YYYY-MM-DD HH:mm:ss SSS')
 const running = computed(() => workerStatus.value === 'RUNNING')
 
 const data = ref<number[] | null>(null)

--- a/packages/vite.config.ts
+++ b/packages/vite.config.ts
@@ -99,7 +99,6 @@ export default defineConfig(async () => {
       ],
       include: [
         'axios',
-        'dayjs',
         'js-yaml',
         'nprogress',
         'qrcode',
@@ -107,7 +106,6 @@ export default defineConfig(async () => {
         'tslib',
         'fuse.js',
         'universal-cookie',
-        'dayjs/plugin/relativeTime',
       ],
     },
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,6 @@ importers:
       bumpp: ^7.1.1
       consola: ^2.15.3
       cross-env: ^7.0.3
-      dayjs: ^1.11.1
       esbuild-register: ^3.3.2
       eslint: ^8.14.0
       esno: ^0.14.1
@@ -96,7 +95,6 @@ importers:
       bumpp: 7.1.1
       consola: 2.15.3
       cross-env: 7.0.3
-      dayjs: 1.11.1
       esbuild-register: 3.3.2
       eslint: 8.14.0
       esno: 0.14.1
@@ -169,7 +167,7 @@ importers:
       '@vueuse/shared': link:../shared
       vue-demi: 0.12.5
     devDependencies:
-      electron: 13.4.0
+      electron: 13.6.9
 
   packages/firebase:
     specifiers:
@@ -205,7 +203,7 @@ importers:
       axios: 0.27.2
       change-case: 4.1.2
       drauu: 0.3.0
-      focus-trap: 6.9.0
+      focus-trap: 6.9.1
       fuse.js: 6.6.0
       jwt-decode: 3.1.2
       nprogress: 0.2.0
@@ -241,7 +239,7 @@ importers:
       '@vueuse/shared': link:../shared
       vue-demi: 0.12.5
     devDependencies:
-      vue-router: 4.0.14
+      vue-router: 4.0.15
 
   packages/rxjs:
     specifiers:
@@ -1623,8 +1621,8 @@ packages:
       regenerator-runtime: 0.13.9
     dev: true
 
-  /@babel/standalone/7.17.7:
-    resolution: {integrity: sha512-461jrYyk7g4bRQoOROABqErtygmZrx1cZXWONIPCQzVTynT5VL83btu1PJIaXNgl4JtHXjzaYT7j3IOlVhnC1Q==}
+  /@babel/standalone/7.17.11:
+    resolution: {integrity: sha512-47wVYBeTktYHwtzlFuK7qqV/H5X6mU4MUNqpQ9iiJOqnP8rWL0eX0GWLKRsv8D8suYzhuS1K/dtwgGr+26U7Gg==}
     engines: {node: '>=6.9.0'}
     dev: false
 
@@ -1732,11 +1730,11 @@ packages:
       perfect-freehand: 1.0.16
     dev: true
 
-  /@electron/get/1.13.0:
-    resolution: {integrity: sha512-+SjZhRuRo+STTO1Fdhzqnv9D2ZhjxXP6egsJ9kiO8dtP68cDx7dFCwWi64dlMQV7sWcfW1OYCW4wviEBzmRsfQ==}
+  /@electron/get/1.14.1:
+    resolution: {integrity: sha512-BrZYyL/6m0ZXz/lDxy/nlVhQz+WF+iPS6qXolEU8atw7h6v1aYkjwJZ63m+bJMBTxDE66X+r2tPS4a/8C82sZw==}
     engines: {node: '>=8.6'}
     dependencies:
-      debug: 4.3.2
+      debug: 4.3.4
       env-paths: 2.2.1
       fs-extra: 8.1.0
       got: 9.6.0
@@ -1744,7 +1742,7 @@ packages:
       semver: 6.3.0
       sumchecker: 3.0.1
     optionalDependencies:
-      global-agent: 2.2.0
+      global-agent: 3.0.0
       global-tunnel-ng: 2.7.1
     transitivePeerDependencies:
       - supports-color
@@ -2492,12 +2490,8 @@ packages:
       '@types/unist': 2.0.6
     dev: true
 
-  /@types/node/14.17.18:
-    resolution: {integrity: sha512-haYyibw4pbteEhkSg0xdDLAI3679L75EJ799ymVrPxOA922bPx3ML59SoDsQ//rHlvqpu+e36kcbR3XRQtFblA==}
-    dev: true
-
-  /@types/node/16.11.12:
-    resolution: {integrity: sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw==}
+  /@types/node/14.18.16:
+    resolution: {integrity: sha512-X3bUMdK/VmvrWdoTkz+VCn6nwKwrKCFTHtqwBIaQJNx4RUIBBUFXM00bqPz/DsDd+Icjmzm6/tyYZzeGVqb6/Q==}
     dev: true
 
   /@types/node/17.0.31:
@@ -2519,7 +2513,7 @@ packages:
   /@types/qrcode/1.4.2:
     resolution: {integrity: sha512-7uNT9L4WQTNJejHTSTdaJhfBSCN73xtXaHFyBJ8TSwiLhe4PRuTue7Iph0s2nG9R/ifUaSnGhLUOZavlBEqDWQ==}
     dependencies:
-      '@types/node': 16.11.12
+      '@types/node': 17.0.31
     dev: true
 
   /@types/resolve/1.17.1:
@@ -2862,8 +2856,8 @@ packages:
       vue: 3.2.33
     dev: true
 
-  /@vue/devtools-api/6.0.12:
-    resolution: {integrity: sha512-iO/4FIezHKXhiDBdKySCvJVh8/mZPxHpiQrTy+PXVqJZgpTPTdHy4q8GXulaY+UKEagdkBb0onxNQZ0LNiqVhw==}
+  /@vue/devtools-api/6.1.4:
+    resolution: {integrity: sha512-IiA0SvDrJEgXvVxjNkHPFfDx6SXw0b/TUkqMcDZWNg9fnCAHbTpoo59YfJ9QLFkwa3raau5vSlRVzMSLDnfdtQ==}
     dev: true
 
   /@vue/reactivity-transform/3.2.33:
@@ -3276,8 +3270,8 @@ packages:
     resolution: {integrity: sha1-aN/1++YMUes3cl6p4+0xDcwed24=}
     dev: true
 
-  /boolean/3.1.4:
-    resolution: {integrity: sha512-3hx0kwU3uzG6ReQ3pnaFQPSktpBw6RHN3/ivDKEuU8g1XSfafowyvDnadjv1xp8IZqhtSukxlwv9bF6FhX8m0w==}
+  /boolean/3.2.0:
+    resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     dev: true
     optional: true
 
@@ -3746,11 +3740,6 @@ packages:
     dependencies:
       safe-buffer: 5.1.2
 
-  /cookie/0.4.1:
-    resolution: {integrity: sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==}
-    engines: {node: '>= 0.6'}
-    dev: true
-
   /cookie/0.4.2:
     resolution: {integrity: sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==}
     engines: {node: '>= 0.6'}
@@ -3768,12 +3757,6 @@ packages:
       browserslist: 4.19.1
       semver: 7.0.0
     dev: true
-
-  /core-js/3.18.0:
-    resolution: {integrity: sha512-WJeQqq6jOYgVgg4NrXKL0KLQhi0CT4ZOCvFL+3CQ5o7I6J8HkT5wd53EadMfqTDp1so/MT1J+w2ujhWcCJtN7w==}
-    requiresBuild: true
-    dev: true
-    optional: true
 
   /core-js/3.6.5:
     resolution: {integrity: sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==}
@@ -3859,10 +3842,6 @@ packages:
       whatwg-url: 10.0.0
     dev: true
 
-  /dayjs/1.11.1:
-    resolution: {integrity: sha512-ER7EjqVAMkRRsxNCC5YqJ9d9VQYuWdGt7aiH2qA5R5wt8ZmWaP2dLUSIK6y/kVzLMlmh1Tvu5xUf4M/wdGJ5KA==}
-    dev: true
-
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     dependencies:
@@ -3873,18 +3852,6 @@ packages:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     dependencies:
       ms: 2.1.3
-    dev: true
-
-  /debug/4.3.2:
-    resolution: {integrity: sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.1.2
     dev: true
 
   /debug/4.3.4:
@@ -4099,13 +4066,13 @@ packages:
   /electron-to-chromium/1.4.28:
     resolution: {integrity: sha512-Gzbf0wUtKfyPaqf0Plz+Ctinf9eQIzxEqBHwSvbGfeOm9GMNdLxyu1dNiCUfM+x6r4BE0xUJNh3Nmg9gfAtTmg==}
 
-  /electron/13.4.0:
-    resolution: {integrity: sha512-KJGWS2qa0xZXIMPMDUNkRVO8/JxRd4+M0ejYYOzu2LIQ5ijecPzNuNR9nvDkml9XyyRBzu975FkhJcwD17ietQ==}
+  /electron/13.6.9:
+    resolution: {integrity: sha512-Es/sBy85NIuqsO9MW41PUCpwIkeinlTQ7g0ainfnmRAM2rmog3GBxVCaoV5dzEjwTF7TKG1Yr/E7Z3qHmlfWAg==}
     engines: {node: '>= 8.6'}
     hasBin: true
     dependencies:
-      '@electron/get': 1.13.0
-      '@types/node': 14.17.18
+      '@electron/get': 1.14.1
+      '@types/node': 14.18.16
       extract-zip: 1.7.0
     transitivePeerDependencies:
       - supports-color
@@ -5399,10 +5366,10 @@ packages:
     resolution: {integrity: sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==}
     dev: true
 
-  /focus-trap/6.9.0:
-    resolution: {integrity: sha512-Yv3ieSeAPbfjzjU6xIuF1yAGw0kIKO5EkEJL9o/8MYfBcr99cV7dE6rJM4slk1itDHHeEhoNorQVzvEIT1rNsw==}
+  /focus-trap/6.9.1:
+    resolution: {integrity: sha512-TcIk4k52Mk5IWTJWdaq5AEoxDUp7znnws+5A1RBe/1X03t1Zw4ylNMajJ3aXG/J9S3TkuSUzRPB+l0RCO0nYVg==}
     dependencies:
-      tabbable: 5.3.1
+      tabbable: 5.3.2
     dev: true
 
   /follow-redirects/1.14.9:
@@ -5602,17 +5569,16 @@ packages:
       path-is-absolute: 1.0.1
     dev: true
 
-  /global-agent/2.2.0:
-    resolution: {integrity: sha512-+20KpaW6DDLqhG7JDiJpD1JvNvb8ts+TNl7BPOYcURqCrXqnN1Vf+XVOrkKJAFPqfX+oEhsdzOj1hLWkBTdNJg==}
+  /global-agent/3.0.0:
+    resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
     engines: {node: '>=10.0'}
     requiresBuild: true
     dependencies:
-      boolean: 3.1.4
-      core-js: 3.18.0
+      boolean: 3.2.0
       es6-error: 4.1.1
       matcher: 3.0.0
       roarr: 2.15.4
-      semver: 7.3.5
+      semver: 7.3.7
       serialize-error: 7.0.1
     dev: true
     optional: true
@@ -6273,7 +6239,7 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
     dependencies:
-      minimist: 1.2.5
+      minimist: 1.2.6
 
   /jsonc-eslint-parser/2.1.0:
     resolution: {integrity: sha512-qCRJWlbP2v6HbmKW7R3lFbeiVWHo+oMJ0j+MizwvauqnCV/EvtAeEeuCgoc/ErtsuoKgYB8U4Ih8AxJbXoE6/g==}
@@ -6669,10 +6635,10 @@ packages:
 
   /minimist/1.2.5:
     resolution: {integrity: sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==}
+    dev: true
 
   /minimist/1.2.6:
     resolution: {integrity: sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==}
-    dev: true
 
   /minipass/2.9.0:
     resolution: {integrity: sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==}
@@ -6693,7 +6659,7 @@ packages:
     resolution: {integrity: sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==}
     hasBin: true
     dependencies:
-      minimist: 1.2.5
+      minimist: 1.2.6
 
   /mlly/0.3.19:
     resolution: {integrity: sha512-zMq5n3cOf4fOzA4WoeulxagbAgMChdev3MgP6K51k7M0u2whTXxupfIY4VVzws4vxkiWhwH1rVQcsw7zDGfRhA==}
@@ -6897,7 +6863,6 @@ packages:
 
   /nprogress/0.2.0:
     resolution: {integrity: sha1-y480xTIT2JVyP8urkH6UIq28r7E=}
-    requiresBuild: true
     dev: true
 
   /nth-check/2.0.1:
@@ -7439,7 +7404,6 @@ packages:
     resolution: {integrity: sha512-9MgRpgVc+/+47dFvQeD6U2s0Z92EsKzcHogtum4QB+UNd025WOJSHvn/hjk9xmzj7Stj95CyUAs31mrjxliEsQ==}
     engines: {node: '>=10.13.0'}
     hasBin: true
-    requiresBuild: true
     dependencies:
       dijkstrajs: 1.0.2
       encode-utf8: 1.0.3
@@ -7663,7 +7627,7 @@ packages:
     resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
     engines: {node: '>=8.0'}
     dependencies:
-      boolean: 3.1.4
+      boolean: 3.2.0
       detect-node: 2.1.0
       globalthis: 1.0.2
       json-stringify-safe: 5.0.1
@@ -8217,7 +8181,7 @@ packages:
     resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
     engines: {node: '>= 8.0'}
     dependencies:
-      debug: 4.3.2
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8249,8 +8213,8 @@ packages:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
     dev: true
 
-  /tabbable/5.3.1:
-    resolution: {integrity: sha512-NtO7I7eoAHR+JwwcNsi/PipamtAEebYDnur/k9wM6n238HHy/+1O4+7Zx7e/JaDAbKJPlIFYsfsV/6tPqTOQvg==}
+  /tabbable/5.3.2:
+    resolution: {integrity: sha512-6G/8EWRFx8CiSe2++/xHhXkmCRq2rHtDtZbQFHx34cvDfZzIBfvwG9zGUNTWMXWLCYvDj3aQqOzdl3oCxKuBkQ==}
     dev: true
 
   /tapable/1.1.3:
@@ -8599,10 +8563,9 @@ packages:
 
   /universal-cookie/4.0.4:
     resolution: {integrity: sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==}
-    requiresBuild: true
     dependencies:
       '@types/cookie': 0.3.3
-      cookie: 0.4.1
+      cookie: 0.4.2
     dev: true
 
   /universalify/0.1.2:
@@ -8751,7 +8714,7 @@ packages:
     resolution: {integrity: sha512-sY6u8RedwfLfBis0copfU/fzROieyAndqPs8Kn2PfyzTjtA88vCk81J1b5z+8/VJc+cwfGy23/AqOCpvAbkNVw==}
     dependencies:
       '@babel/core': 7.17.7
-      '@babel/standalone': 7.17.7
+      '@babel/standalone': 7.17.11
       '@babel/types': 7.17.0
       scule: 0.2.1
     transitivePeerDependencies:
@@ -8980,12 +8943,12 @@ packages:
       - supports-color
     dev: true
 
-  /vue-router/4.0.14:
-    resolution: {integrity: sha512-wAO6zF9zxA3u+7AkMPqw9LjoUCjSxfFvINQj3E/DceTt6uEz1XZLraDhdg2EYmvVwTBSGlLYsUw8bDmx0754Mw==}
+  /vue-router/4.0.15:
+    resolution: {integrity: sha512-xa+pIN9ZqORdIW1MkN2+d9Ui2pCM1b/UMgwYUCZOiFYHAvz/slKKBDha8DLrh5aCG/RibtrpyhKjKOZ85tYyWg==}
     peerDependencies:
       vue: ^3.2.0
     dependencies:
-      '@vue/devtools-api': 6.0.12
+      '@vue/devtools-api': 6.1.4
     dev: true
 
   /vue/2.6.14:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Seems that dayjs doesn't ship esm which makes the demos that use it not work in the playground. Replaced it with the vueuse `formatDate` function instead for relevant demos. Also replaced its usage in the docs for the "last changed" property on components with VueUse's `useTimeAgo` function.

Since there were no more instances of it I removed it from the dependencies as well 

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
