### PR TITLE
docs(useScreenSafeArea): improve the documentation

### DIFF
--- a/packages/core/useScreenSafeArea/index.md
+++ b/packages/core/useScreenSafeArea/index.md
@@ -10,6 +10,14 @@ Reactive `env(safe-area-inset-*)`
 
 ## Usage
 
+In order to make the page to be fully rendered in the screen, the additional attribute `viewport-fit=cover` within  `viewport` meta tag must be set firstly, the viewport meta tag may look like this:
+
+```html
+<meta name='viewport' content='initial-scale=1, viewport-fit=cover'>
+```
+
+Then we could use `useScreenSafeArea` in the component as shown below:
+
 ```ts
 import { useScreenSafeArea } from '@vueuse/core'
 
@@ -20,6 +28,8 @@ const {
   left,
 } = useScreenSafeArea()
 ```
+
+For further details, you may refer to this documentation: [Designing Websites for iPhone X](https://webkit.org/blog/7929/designing-websites-for-iphone-x/)
 
 ## Component Usage
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The documentation for `useScreenSafeArea` seems to be missing some descriptions of the functionalities, which makes it difficult for me to use it, so I tried to improve and make it more complete.

> In order to make the page to be fully rendered in the screen, the additional attribute `viewport-fit=cover` within  `viewport` meta tag must be set firstly


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- ### Additional context -->

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
