### PR TITLE
fix(useFocus): `focused` should be `false` when `element` is undefined

### DIFF
--- a/packages/core/useFocus/index.ts
+++ b/packages/core/useFocus/index.ts
@@ -1,5 +1,6 @@
 import type { Ref } from 'vue-demi'
 import { computed, watch } from 'vue-demi'
+import { isDef } from '@vueuse/shared'
 import type { MaybeElementRef } from '../unrefElement'
 import { unrefElement } from '../unrefElement'
 import { useActiveElement } from '../useActiveElement'
@@ -36,9 +37,7 @@ export function useFocus(target: MaybeElementRef, options: UseFocusOptions = {})
   const targetElement = computed(() => unrefElement(target))
   const focused = computed({
     get() {
-      if (activeElement.value === undefined && targetElement.value === undefined)
-        return false
-      return activeElement.value === targetElement.value
+      return isDef(activeElement.value) && isDef(targetElement.value) && activeElement.value === targetElement.value
     },
     set(value: boolean) {
       if (!value && focused.value)

--- a/packages/core/useFocus/index.ts
+++ b/packages/core/useFocus/index.ts
@@ -36,6 +36,8 @@ export function useFocus(target: MaybeElementRef, options: UseFocusOptions = {})
   const targetElement = computed(() => unrefElement(target))
   const focused = computed({
     get() {
+      if (activeElement.value === undefined && targetElement.value === undefined)
+        return false
       return activeElement.value === targetElement.value
     },
     set(value: boolean) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Closes #1560 

Caused by : both of the element to be `undefined` when the `Vitepress` generate HTML page.

<img width="371" alt="image" src="https://user-images.githubusercontent.com/22515951/167298612-2c0bc02d-6a00-472b-8aa2-5782f6365e53.png">

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
