### PR TITLE
fix(useUrlSearchParams): should return initialValue

### DIFF
--- a/packages/core/useUrlSearchParams/index.test.ts
+++ b/packages/core/useUrlSearchParams/index.test.ts
@@ -46,6 +46,16 @@ describe('useUrlSearchParams', () => {
         expect(params.foo).toBe('bar')
       })
 
+      test('return initialValue', async () => {
+        const params = useUrlSearchParams(mode, {
+          initialValue: {
+            foo: 'bar',
+          },
+        })
+
+        expect(params.foo).toBe('bar')
+      })
+
       test('update params on poststate event', async () => {
         const params = useUrlSearchParams(mode)
         expect(params.foo).toBeUndefined()

--- a/packages/core/useUrlSearchParams/index.ts
+++ b/packages/core/useUrlSearchParams/index.ts
@@ -44,7 +44,7 @@ export function useUrlSearchParams<T extends Record<string, any> = UrlParams>(
   if (!window)
     return reactive(initialValue) as T
 
-  const state: Record<string, any> = reactive(initialValue)
+  const state: Record<string, any> = reactive({})
 
   function getRawParams() {
     if (mode === 'history') {
@@ -129,7 +129,11 @@ export function useUrlSearchParams<T extends Record<string, any> = UrlParams>(
   if (mode !== 'history')
     useEventListener(window, 'hashchange', onChanged, false)
 
-  updateState(read())
+  const initial = read()
+  if (initial.keys().next().value)
+    updateState(initial)
+  else
+    Object.assign(state, initialValue)
 
   return state as T
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Now the empty url will overwrite the initial value, making the initial value ineffective.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
