### PR TITLE
fix(watchThrottled): duplicate callback invokation when leading and trailing edges coincide

### DIFF
--- a/packages/core/useThrottledRefHistory/index.test.ts
+++ b/packages/core/useThrottledRefHistory/index.test.ts
@@ -16,7 +16,7 @@ describe('useThrottledRefHistory - sync', () => {
 
     await promiseTimeout(ms * 3)
 
-    expect(history.value.length).toBe(3)
+    expect(history.value.length).toBe(2)
     expect(history.value[0].snapshot).toBe(100)
 
     v.value = 200
@@ -25,7 +25,7 @@ describe('useThrottledRefHistory - sync', () => {
 
     await promiseTimeout(ms * 3)
 
-    expect(history.value.length).toBe(5)
+    expect(history.value.length).toBe(3)
     expect(history.value[0].snapshot).toBe(400)
   })
 })

--- a/packages/shared/utils/filters.ts
+++ b/packages/shared/utils/filters.ts
@@ -103,7 +103,7 @@ export function debounceFilter(ms: MaybeRef<number>, options: DebounceFilterOpti
 export function throttleFilter(ms: MaybeRef<number>, trailing = true, leading = true) {
   let lastExec = 0
   let timer: ReturnType<typeof setTimeout> | undefined
-  let preventLeading = !leading
+  let isLeading = true
 
   const clear = () => {
     if (timer) {
@@ -123,24 +123,23 @@ export function throttleFilter(ms: MaybeRef<number>, trailing = true, leading = 
       return invoke()
     }
 
-    if (elapsed > duration) {
+    if (elapsed > duration && (leading || !isLeading)) {
       lastExec = Date.now()
-      if (preventLeading)
-        preventLeading = false
-      else invoke()
+      invoke()
     }
-    if (trailing) {
+    else if (trailing) {
       timer = setTimeout(() => {
         lastExec = Date.now()
-        if (!leading)
-          preventLeading = true
+        isLeading = true
         clear()
         invoke()
       }, duration)
     }
 
     if (!leading && !timer)
-      timer = setTimeout(() => preventLeading = true, duration)
+      timer = setTimeout(() => isLeading = true, duration)
+
+    isLeading = false
   }
 
   return filter

--- a/packages/shared/utils/index.test.ts
+++ b/packages/shared/utils/index.test.ts
@@ -88,4 +88,15 @@ describe('filters', () => {
 
     expect(debouncedFilterSpy).toHaveBeenCalledTimes(2)
   })
+
+  it('should not duplicate single event', () => {
+    const debouncedFilterSpy = vitest.fn()
+    const filter = createFilterWrapper(throttleFilter(1000), debouncedFilterSpy)
+
+    setTimeout(filter, 500)
+
+    vitest.runAllTimers()
+
+    expect(debouncedFilterSpy).toHaveBeenCalledTimes(1)
+  })
 })

--- a/packages/shared/utils/index.test.ts
+++ b/packages/shared/utils/index.test.ts
@@ -72,20 +72,6 @@ describe('filters', () => {
     expect(debouncedFilterSpy).toHaveBeenCalledTimes(2)
   })
 
-  it('should throttle', () => {
-    const debouncedFilterSpy = vitest.fn()
-    const filter = createFilterWrapper(throttleFilter(1000), debouncedFilterSpy)
-
-    setTimeout(filter, 500)
-    setTimeout(filter, 500)
-    setTimeout(filter, 500)
-    setTimeout(filter, 500)
-
-    vitest.runAllTimers()
-
-    expect(debouncedFilterSpy).toHaveBeenCalledTimes(2)
-  })
-
   it('should throttle with ref', () => {
     const debouncedFilterSpy = vitest.fn()
     const throttle = ref(0)


### PR DESCRIPTION
- chore: remove duplicate test
- fix(throttleFilter): only invoke once when leading is also trailing edge

<!-- Thank you for contributing! -->

### Description

When using `watchThrottled` and only exactly one change occurs in the source, the callback is still called two times: once immediately on the first change and once after the timeout.
This second call should not occur, because the leading and trailing edges actually coincide, when there is a single event only.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
