### PR TITLE
fix(toRefs): keep class prototype, close #1530

### DIFF
--- a/packages/core/useVModel/index.test.ts
+++ b/packages/core/useVModel/index.test.ts
@@ -155,4 +155,26 @@ describe('useVModel', () => {
     expect(dataD.value).toBe(null)
     expect(dataE.value).toBe('default-data')
   })
+
+  it('Should work with classes', async () => {
+    const emitMock = vitest.fn()
+
+    class SomeClass {
+      num1 = 1
+
+      someMethod() {}
+    }
+
+    const props = { cl: new SomeClass() }
+
+    const ref = useVModel(props, 'cl', emitMock, { passive: true, deep: true })
+
+    ref.value.num1 = 10
+
+    await nextTick()
+
+    const emitValue = (emitMock as any).calls[0][1]
+
+    expect(emitValue instanceof SomeClass).toBeTruthy()
+  })
 })

--- a/packages/shared/toRefs/index.test.ts
+++ b/packages/shared/toRefs/index.test.ts
@@ -96,4 +96,22 @@ describe('toRefs', () => {
     refs[1].value = 1
     expect(spy).toHaveBeenLastCalledWith(['a', 1])
   })
+
+  it('should save instance of class', () => {
+    class SomeClass {
+      v = 1
+
+      fn() {
+
+      }
+    }
+
+    const obj = ref(new SomeClass())
+
+    const { v } = toRefs(obj)
+
+    v.value = 10
+
+    expect(obj.value instanceof SomeClass).toBeTruthy()
+  })
 })

--- a/packages/shared/toRefs/index.ts
+++ b/packages/shared/toRefs/index.ts
@@ -31,7 +31,11 @@ export function toRefs<T extends object>(
           objectRef.value = copy
         }
         else {
-          objectRef.value = { ...objectRef.value, [key]: v }
+          const newObject = { ...objectRef.value, [key]: v }
+
+          Object.setPrototypeOf(newObject, objectRef.value)
+
+          objectRef.value = newObject
         }
       },
     }))


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Match the prototype object of target object and new object in toRefs composition.

fixes [#1530](https://github.com/vueuse/vueuse/issues/1530)

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
