### PR TITLE
docs: Update Nuxt 3 configuration

### DIFF
--- a/packages/guide/index.md
+++ b/packages/guide/index.md
@@ -39,8 +39,9 @@ From v7.2.0, we shipped a Nuxt module to enable auto importing for Nuxt 3 and Nu
 npm i -D @vueuse/nuxt @vueuse/core
 ```
 
+Nuxt 3
 ```ts
-// Nuxt 3 - nuxt.config.ts
+// nuxt.config.ts
 export default {
   modules: [
     '@vueuse/nuxt',
@@ -48,8 +49,9 @@ export default {
 }
 ```
 
+Nuxt 2
 ```ts
-// Nuxt 2 - nuxt.config.js
+// nuxt.config.js
 export default {
   buildModules: [
     '@vueuse/nuxt',

--- a/packages/guide/index.md
+++ b/packages/guide/index.md
@@ -40,7 +40,16 @@ npm i -D @vueuse/nuxt @vueuse/core
 ```
 
 ```ts
-// nuxt.config.js
+// Nuxt 3 - nuxt.config.ts
+export default {
+  modules: [
+    '@vueuse/nuxt',
+  ],
+}
+```
+
+```ts
+// Nuxt 2 - nuxt.config.js
 export default {
   buildModules: [
     '@vueuse/nuxt',


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Since `buildModules` is not a config option anymore in Nuxt 3 I updated the docs with the correct option and splitted the configurations for Nuxt 2 and 3.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
