### PR TITLE
fix(useMouseInElement) isOutside is true for detached elements (#1614)

### DIFF
--- a/packages/core/useMouseInElement/index.ts
+++ b/packages/core/useMouseInElement/index.ts
@@ -33,7 +33,7 @@ export function useMouseInElement(
   const elementPositionY = ref(0)
   const elementHeight = ref(0)
   const elementWidth = ref(0)
-  const isOutside = ref(false)
+  const isOutside = ref(true)
 
   let stop = () => {}
 
@@ -59,7 +59,9 @@ export function useMouseInElement(
 
         const elX = x.value - elementPositionX.value
         const elY = y.value - elementPositionY.value
-        isOutside.value = elX < 0 || elY < 0 || elX > elementWidth.value || elY > elementHeight.value
+        isOutside.value = width === 0 || height === 0
+          || elX < 0 || elY < 0
+          || elX > width || elY > height
 
         if (handleOutside || !isOutside.value) {
           elementX.value = elX


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Close #1614 
when element is not in viewport
isOutside property initial value is false (when pointer is outside of the screen)

reproduction contains fix
will provide PR immediately

Reproduction
https://stackblitz.com/edit/vitejs-vite-efwwbf?file=src/Comp.vue

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
