### PR TITLE
feat(useCssVar): support `initialValue`

### DIFF
--- a/packages/core/useCssVar/index.md
+++ b/packages/core/useCssVar/index.md
@@ -19,5 +19,5 @@ const key = ref('--color')
 const colorVal = useCssVar(key, elv)
 
 const someEl = ref(null)
-const color = useCssVar('--color', someEl, '#eee')
+const color = useCssVar('--color', someEl, { initialValue: '#eee' })
 ```

--- a/packages/core/useCssVar/index.md
+++ b/packages/core/useCssVar/index.md
@@ -17,4 +17,7 @@ const color = useCssVar('--color', el)
 const elv = ref(null)
 const key = ref('--color')
 const colorVal = useCssVar(key, elv)
+
+const someEl = ref(null)
+const color = useCssVar('--color', someEl, '#eee')
 ```

--- a/packages/core/useCssVar/index.ts
+++ b/packages/core/useCssVar/index.ts
@@ -17,19 +17,18 @@ import { unrefElement } from '../unrefElement'
 export function useCssVar(
   prop: MaybeRef<string>,
   target?: MaybeElementRef,
-  initialValue?: MaybeRef<string>,
+  initialValue?: string,
   { window = defaultWindow }: ConfigurableWindow = {},
 ) {
   const variable = ref('')
   const elRef = computed(() => unrefElement(target) || window?.document?.documentElement)
-  const _initialValue = unref(initialValue)
 
   watch(
     [elRef, () => unref(prop)],
     ([el, prop]) => {
       if (el && window) {
         const value = window.getComputedStyle(el).getPropertyValue(prop)
-        variable.value = value == '' ? _initialValue : value
+        variable.value = value || initialValue || ''
       }
     },
     { immediate: true },

--- a/packages/core/useCssVar/index.ts
+++ b/packages/core/useCssVar/index.ts
@@ -5,6 +5,10 @@ import { defaultWindow } from '../_configurable'
 import type { MaybeElementRef } from '../unrefElement'
 import { unrefElement } from '../unrefElement'
 
+export interface UseCssVarOptions extends ConfigurableWindow {
+  initialValue?: string
+}
+
 /**
  * Manipulate CSS variables.
  *
@@ -17,10 +21,9 @@ import { unrefElement } from '../unrefElement'
 export function useCssVar(
   prop: MaybeRef<string>,
   target?: MaybeElementRef,
-  initialValue?: string,
-  { window = defaultWindow }: ConfigurableWindow = {},
+  { window = defaultWindow, initialValue = '' }: UseCssVarOptions = {},
 ) {
-  const variable = ref('')
+  const variable = ref(initialValue)
   const elRef = computed(() => unrefElement(target) || window?.document?.documentElement)
 
   watch(

--- a/packages/core/useCssVar/index.ts
+++ b/packages/core/useCssVar/index.ts
@@ -10,22 +10,27 @@ import { unrefElement } from '../unrefElement'
  *
  * @see https://vueuse.org/useCssVar
  * @param prop
- * @param el
+ * @param target
+ * @param initialValue
  * @param options
  */
 export function useCssVar(
   prop: MaybeRef<string>,
   target?: MaybeElementRef,
+  initialValue?: MaybeRef<string>,
   { window = defaultWindow }: ConfigurableWindow = {},
 ) {
   const variable = ref('')
   const elRef = computed(() => unrefElement(target) || window?.document?.documentElement)
+  const _initialValue = unref(initialValue)
 
   watch(
     [elRef, () => unref(prop)],
     ([el, prop]) => {
-      if (el && window)
-        variable.value = window.getComputedStyle(el).getPropertyValue(prop)
+      if (el && window) {
+        const value = window.getComputedStyle(el).getPropertyValue(prop)
+        variable.value = value == '' ? _initialValue : value
+      }
     },
     { immediate: true },
   )

--- a/packages/core/useCssVar/index.ts
+++ b/packages/core/useCssVar/index.ts
@@ -31,7 +31,7 @@ export function useCssVar(
     ([el, prop]) => {
       if (el && window) {
         const value = window.getComputedStyle(el).getPropertyValue(prop)
-        variable.value = value || initialValue || ''
+        variable.value = value || initialValue
       }
     },
     { immediate: true },


### PR DESCRIPTION
### Description

We might want to set an initial value for CSS var based on some variable if not preset on it.

This will allow us writing safe CSS where value will be always present.

### Additional context

I haven't added this to watch because I think changing the initial value once it's initialized doesn't matter.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
