### PR TITLE
feat(useScrollLock): adds new option `avoidShake`

### DIFF
--- a/packages/core/useScrollLock/demo.vue
+++ b/packages/core/useScrollLock/demo.vue
@@ -9,7 +9,7 @@ useScroll(el)
 const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)
 
 const isLocked = useScrollLock(el, false, {
-  avoidShake: !isMobile
+  placeholder: !isMobile
 })
 const toggleLock = useToggle(isLocked)
 </script>

--- a/packages/core/useScrollLock/demo.vue
+++ b/packages/core/useScrollLock/demo.vue
@@ -16,7 +16,7 @@ const toggleLock = useToggle(isLocked)
 
 <template>
   <div class="flex flex-wrap">
-    <div ref="el" class="w-300px h-300px m-auto overflow-scroll bg-gray-500/5 rounded">
+    <div ref="el" class="w-300px h-300px m-auto overflow-scroll bg-gray-500/5 rounded p-1" style="padding-right: 10px;padding-bottom:20px;">
       <div class="w-500px h-400px relative">
         <div position="absolute left-0 top-0" bg="gray-500/5" p="x-2 y-1">
           TopLeft

--- a/packages/core/useScrollLock/demo.vue
+++ b/packages/core/useScrollLock/demo.vue
@@ -16,7 +16,7 @@ const toggleLock = useToggle(isLocked)
 
 <template>
   <div class="flex flex-wrap">
-    <div ref="el" class="w-300px h-300px m-auto overflow-scroll bg-gray-500/5 rounded p-1" style="padding-right: 10px;padding-bottom:20px;">
+    <div ref="el" class="w-300px h-300px m-auto overflow-scroll bg-gray-500/5 rounded p-1" style="padding-right: 10px">
       <div class="w-500px h-400px relative">
         <div position="absolute left-0 top-0" bg="gray-500/5" p="x-2 y-1">
           TopLeft

--- a/packages/core/useScrollLock/demo.vue
+++ b/packages/core/useScrollLock/demo.vue
@@ -5,7 +5,12 @@ import { useScroll, useScrollLock } from '@vueuse/core'
 
 const el = ref<HTMLElement | null>(null)
 useScroll(el)
-const isLocked = useScrollLock(el)
+
+const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)
+
+const isLocked = useScrollLock(el, false, {
+  avoidShake: !isMobile
+})
 const toggleLock = useToggle(isLocked)
 </script>
 

--- a/packages/core/useScrollLock/index.md
+++ b/packages/core/useScrollLock/index.md
@@ -12,8 +12,12 @@ Lock scrolling of the element.
 <script setup lang="ts">
 import { useScrollLock } from '@vueuse/core'
 
+const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)
+
 const el = ref<HTMLElement | null>(null)
-const isLocked = useScrollLock(el)
+const isLocked = useScrollLock(el, false, {
+  avoidShake: !isMobile
+})
 
 isLocked.value = true // lock
 isLocked.value = false // unlock

--- a/packages/core/useScrollLock/index.md
+++ b/packages/core/useScrollLock/index.md
@@ -16,7 +16,7 @@ const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/
 
 const el = ref<HTMLElement | null>(null)
 const isLocked = useScrollLock(el, false, {
-  avoidShake: !isMobile
+  placeholder: !isMobile
 })
 
 isLocked.value = true // lock

--- a/packages/core/useScrollLock/index.ts
+++ b/packages/core/useScrollLock/index.ts
@@ -16,6 +16,11 @@ function preventDefault(rawEvent: TouchEvent): boolean {
   return false
 }
 
+let scrollbarSize: null | {
+  horizontal: string
+  vertical: string
+} = null
+
 /**
  * Lock scrolling of the element.
  *
@@ -25,10 +30,18 @@ function preventDefault(rawEvent: TouchEvent): boolean {
 export function useScrollLock(
   element: MaybeRef<HTMLElement | SVGElement | Window | Document | null | undefined>,
   initialState = false,
+  option: {
+    avoidShake?: boolean
+  } = {}
 ) {
   const isLocked = ref(initialState)
   let stopTouchMoveListener: Fn | null = null
   let initialOverflow: CSSStyleDeclaration['overflow']
+
+  if (option.avoidShake && !scrollbarSize) {
+    scrollbarSize = getScrollbarSize()
+  }
+
 
   watch(() => unref(element), (el) => {
     if (el) {
@@ -41,10 +54,41 @@ export function useScrollLock(
     immediate: true,
   })
 
+  const previousStatus = {
+    padding: {
+      bottom: '',
+      right: ''
+    },
+    isLocked: {
+      horizontal: false,
+      vertical: false,
+    }
+  }
+
   const lock = () => {
     const ele = (unref(element) as HTMLElement)
     if (!ele || isLocked.value)
       return
+
+    if (option.avoidShake) {
+      const isLockedHorizontal = ele.clientWidth !== ele.scrollWidth
+      const isLockedVertical = ele.clientHeight !== ele.scrollHeight
+
+      previousStatus.isLocked.horizontal = isLockedHorizontal
+      previousStatus.isLocked.vertical = isLockedVertical
+
+      if (isLockedHorizontal) {
+        previousStatus.padding.bottom = ele.style.paddingBottom
+
+        ele.style.paddingBottom = ele.style.paddingBottom ? `calc(${ele.style.paddingBottom} + ${scrollbarSize!.vertical})` : scrollbarSize!.vertical
+      }
+
+      if (isLockedVertical) {
+        previousStatus.padding.right = ele.style.paddingRight
+        ele.style.paddingRight = ele.style.paddingRight ? `calc(${ele.style.paddingRight} + ${scrollbarSize!.vertical})` : scrollbarSize!.vertical
+      }
+    }
+
     if (isIOS) {
       stopTouchMoveListener = useEventListener(
         ele,
@@ -63,6 +107,16 @@ export function useScrollLock(
       return
     isIOS && stopTouchMoveListener?.()
     ele.style.overflow = initialOverflow
+
+
+    if (previousStatus.isLocked.vertical) {
+      ele.style.paddingRight = previousStatus.padding.right
+    }
+
+    if (previousStatus.isLocked.horizontal) {
+      ele.style.paddingBottom = previousStatus.padding.bottom
+    }
+
     isLocked.value = false
   }
 
@@ -78,4 +132,31 @@ export function useScrollLock(
       else unlock()
     },
   })
+}
+
+/**
+ * based on https://stackoverflow.com/a/13382873
+ */
+ function getScrollbarSize() {
+  // Creating invisible container
+  const outer = document.createElement('div')
+  outer.style.visibility = 'hidden'
+  outer.style.overflow = 'scroll' // forcing scrollbar to appear
+  document.body.appendChild(outer)
+
+  // Creating inner element and placing it in the container
+  const inner = document.createElement('div')
+  outer.appendChild(inner)
+
+  // Calculating difference between container's full width and the child width
+  const scrollbarWidth = outer.offsetWidth - inner.offsetWidth
+  const scrollbarHeight = outer.offsetHeight - inner.offsetHeight
+
+  // Removing temporary elements from the DOM
+  outer.parentNode?.removeChild(outer)
+
+  return {
+    vertical: scrollbarWidth + 'px',
+    horizontal: scrollbarHeight + 'px'
+  }
 }

--- a/packages/core/useScrollLock/index.ts
+++ b/packages/core/useScrollLock/index.ts
@@ -31,14 +31,19 @@ export function useScrollLock(
   element: MaybeRef<HTMLElement | SVGElement | Window | Document | null | undefined>,
   initialState = false,
   option: {
-    avoidShake?: boolean
+    /**
+     * This option will try to add a placeholder for the scrollbar if true.
+     *
+     * @default false
+     */
+    placeholder?: boolean
   } = {}
 ) {
   const isLocked = ref(initialState)
   let stopTouchMoveListener: Fn | null = null
   let initialOverflow: CSSStyleDeclaration['overflow']
 
-  if (option.avoidShake && !scrollbarSize) {
+  if (option.placeholder && !scrollbarSize) {
     scrollbarSize = getScrollbarSize()
   }
 
@@ -70,7 +75,7 @@ export function useScrollLock(
     if (!ele || isLocked.value)
       return
 
-    if (option.avoidShake) {
+    if (option.placeholder) {
       const isLockedHorizontal = ele.clientWidth !== ele.scrollWidth
       const isLockedVertical = ele.clientHeight !== ele.scrollHeight
 

--- a/packages/core/useScrollLock/index.ts
+++ b/packages/core/useScrollLock/index.ts
@@ -80,12 +80,13 @@ export function useScrollLock(
       if (isLockedHorizontal) {
         previousStatus.padding.bottom = ele.style.paddingBottom
 
-        ele.style.paddingBottom = ele.style.paddingBottom ? `calc(${ele.style.paddingBottom} + ${scrollbarSize!.vertical})` : scrollbarSize!.vertical
+        ele.style.paddingBottom =  `calc(${getComputedStyle(ele).paddingBottom} + ${scrollbarSize!.vertical})`
       }
 
       if (isLockedVertical) {
         previousStatus.padding.right = ele.style.paddingRight
-        ele.style.paddingRight = ele.style.paddingRight ? `calc(${ele.style.paddingRight} + ${scrollbarSize!.vertical})` : scrollbarSize!.vertical
+
+        ele.style.paddingRight =  `calc(${getComputedStyle(ele).paddingRight} + ${scrollbarSize!.vertical})`
       }
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

When I use `useScrollLock`, there is a slight shake when switching between lock-on/lock-off.

Then, I think, maybe we can provide an option for users to avoid this shake.

And, here is an example of how it works:

https://user-images.githubusercontent.com/14226737/169635252-c06218cf-0a76-4da1-91c0-1f1b1210ac70.mp4


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
