### PR TITLE
feat(useColorMode): add option to return `auto` mode

### DIFF
--- a/packages/core/useColorMode/component.ts
+++ b/packages/core/useColorMode/component.ts
@@ -4,7 +4,7 @@ import { useColorMode } from '.'
 
 export const UseColorMode = defineComponent<UseColorModeOptions>({
   name: 'UseColorMode',
-  props: ['selector', 'attribute', 'modes', 'onChanged', 'storageKey', 'storage', 'omitAuto'] as unknown as undefined,
+  props: ['selector', 'attribute', 'modes', 'onChanged', 'storageKey', 'storage', 'emitAuto'] as unknown as undefined,
   setup(props, { slots }) {
     const mode = useColorMode(props)
     const data = reactive({

--- a/packages/core/useColorMode/component.ts
+++ b/packages/core/useColorMode/component.ts
@@ -4,7 +4,7 @@ import { useColorMode } from '.'
 
 export const UseColorMode = defineComponent<UseColorModeOptions>({
   name: 'UseColorMode',
-  props: ['selector', 'attribute', 'modes', 'onChanged', 'storageKey', 'storage'] as unknown as undefined,
+  props: ['selector', 'attribute', 'modes', 'onChanged', 'storageKey', 'storage', 'omitAuto'] as unknown as undefined,
   setup(props, { slots }) {
     const mode = useColorMode(props)
     const data = reactive({

--- a/packages/core/useColorMode/demo.vue
+++ b/packages/core/useColorMode/demo.vue
@@ -2,13 +2,14 @@
 import { useColorMode, useCycleList } from '@vueuse/core'
 
 const mode = useColorMode({
+  omitAuto: false,
   modes: {
     contrast: 'dark contrast',
     cafe: 'cafe',
   },
 })
 
-const { next } = useCycleList(['dark', 'light', 'cafe', 'contrast'], { initialValue: mode })
+const { next } = useCycleList(['dark', 'light', 'cafe', 'contrast', 'auto'], { initialValue: mode })
 </script>
 
 <template>
@@ -17,6 +18,7 @@ const { next } = useCycleList(['dark', 'light', 'cafe', 'contrast'], { initialVa
     <i v-if="mode === 'light'" i-carbon-sun inline-block align-middle class="align-middle" />
     <i v-if="mode === 'cafe'" i-carbon-cafe inline-block align-middle class="align-middle" />
     <i v-if="mode === 'contrast'" i-carbon-contrast inline-block align-middle class="align-middle" />
+    <i v-if="mode === 'auto'" i-carbon-laptop inline-block align-middle class="align-middle" />
 
     <span class="ml-2 capitalize">{{ mode }}</span>
   </button>

--- a/packages/core/useColorMode/demo.vue
+++ b/packages/core/useColorMode/demo.vue
@@ -2,7 +2,7 @@
 import { useColorMode, useCycleList } from '@vueuse/core'
 
 const mode = useColorMode({
-  omitAuto: false,
+  emitAuto: true,
   modes: {
     contrast: 'dark contrast',
     cafe: 'cafe',

--- a/packages/core/useColorMode/index.md
+++ b/packages/core/useColorMode/index.md
@@ -18,7 +18,7 @@ import { useColorMode } from '@vueuse/core'
 const mode = useColorMode() // Ref<'dark' | 'light'>
 ```
 
-By default, it will match with users' browser preference using `usePreferredDark` (a.k.a `auto` mode). When reading the ref, it will always return the current color mode (`dark`, `light` or your custom modes). When writing to the ref, it will trigger DOM updates and persist the color mode to local storage (or your custom storage). You can pass `auto` to set back to auto mode.
+By default, it will match with users' browser preference using `usePreferredDark` (a.k.a `auto` mode). When reading the ref, it will by default return the current color mode (`dark`, `light` or your custom modes). The `auto` mode can be included in the returned modes by disabling the `omitAuto` option. When writing to the ref, it will trigger DOM updates and persist the color mode to local storage (or your custom storage). You can pass `auto` to set back to auto mode.
 
 ```ts
 mode.value // 'dark' | 'light'

--- a/packages/core/useColorMode/index.md
+++ b/packages/core/useColorMode/index.md
@@ -18,7 +18,7 @@ import { useColorMode } from '@vueuse/core'
 const mode = useColorMode() // Ref<'dark' | 'light'>
 ```
 
-By default, it will match with users' browser preference using `usePreferredDark` (a.k.a `auto` mode). When reading the ref, it will by default return the current color mode (`dark`, `light` or your custom modes). The `auto` mode can be included in the returned modes by disabling the `omitAuto` option. When writing to the ref, it will trigger DOM updates and persist the color mode to local storage (or your custom storage). You can pass `auto` to set back to auto mode.
+By default, it will match with users' browser preference using `usePreferredDark` (a.k.a `auto` mode). When reading the ref, it will by default return the current color mode (`dark`, `light` or your custom modes). The `auto` mode can be included in the returned modes by enabling the `emitAuto` option. When writing to the ref, it will trigger DOM updates and persist the color mode to local storage (or your custom storage). You can pass `auto` to set back to auto mode.
 
 ```ts
 mode.value // 'dark' | 'light'

--- a/packages/core/useColorMode/index.test.ts
+++ b/packages/core/useColorMode/index.test.ts
@@ -2,14 +2,14 @@ import { expect } from 'vitest'
 import { useColorMode } from '.'
 
 describe('useColorMode', () => {
-  it('should omit auto mode', () => {
+  it('should translate auto mode', () => {
     const mode = useColorMode()
     mode.value = 'auto'
     expect(mode.value).toBe('light')
   })
 
   it('should include auto mode', () => {
-    const mode = useColorMode({ omitAuto: false })
+    const mode = useColorMode({ emitAuto: true })
     mode.value = 'auto'
     expect(mode.value).toBe('auto')
   })

--- a/packages/core/useColorMode/index.test.ts
+++ b/packages/core/useColorMode/index.test.ts
@@ -1,0 +1,16 @@
+import { expect } from 'vitest'
+import { useColorMode } from '.'
+
+describe('useColorMode', () => {
+  it('should omit auto mode', () => {
+    const mode = useColorMode()
+    mode.value = 'auto'
+    expect(mode.value).toBe('light')
+  })
+
+  it('should include auto mode', () => {
+    const mode = useColorMode({ omitAuto: false })
+    mode.value = 'auto'
+    expect(mode.value).toBe('auto')
+  })
+})

--- a/packages/core/useColorMode/index.ts
+++ b/packages/core/useColorMode/index.ts
@@ -62,13 +62,14 @@ export interface UseColorModeOptions<T extends string = BasicColorSchema> extend
   storage?: StorageLike
 
   /**
-   * Omit `auto` mode from state
+   * Emit `auto` mode from state
    *
-   * When set to `true`, preferred mode is translated into `light` or `dark`
+   * When set to `true`, preferred mode won't be translated into `light` or `dark`.
+   * This is useful when the fact that `auto` mode was selected needs to be known.
    *
-   * @default true
+   * @default false
    */
-  omitAuto?: boolean
+  emitAuto?: boolean
 }
 
 /**
@@ -86,7 +87,7 @@ export function useColorMode<T extends string = BasicColorSchema>(options: UseCo
     storageKey = 'vueuse-color-scheme',
     listenToStorageChanges = true,
     storageRef,
-    omitAuto = true,
+    emitAuto = false,
   } = options
 
   const modes = {
@@ -105,7 +106,7 @@ export function useColorMode<T extends string = BasicColorSchema>(options: UseCo
 
   const state = computed<T | BasicColorSchema>({
     get() {
-      return store.value === 'auto' && omitAuto
+      return store.value === 'auto' && !emitAuto
         ? preferredMode.value
         : store.value
     },

--- a/packages/core/useColorMode/index.ts
+++ b/packages/core/useColorMode/index.ts
@@ -60,6 +60,15 @@ export interface UseColorModeOptions<T extends string = BasicColorSchema> extend
    * @default localStorage
    */
   storage?: StorageLike
+
+  /**
+   * Omit `auto` mode from state
+   *
+   * When set to `true`, preferred mode is translated into `light` or `dark`
+   *
+   * @default true
+   */
+  omitAuto?: boolean
 }
 
 /**
@@ -77,6 +86,7 @@ export function useColorMode<T extends string = BasicColorSchema>(options: UseCo
     storageKey = 'vueuse-color-scheme',
     listenToStorageChanges = true,
     storageRef,
+    omitAuto = true,
   } = options
 
   const modes = {
@@ -95,7 +105,7 @@ export function useColorMode<T extends string = BasicColorSchema>(options: UseCo
 
   const state = computed<T | BasicColorSchema>({
     get() {
-      return store.value === 'auto'
+      return store.value === 'auto' && omitAuto
         ? preferredMode.value
         : store.value
     },

--- a/packages/core/useColorMode/index.ts
+++ b/packages/core/useColorMode/index.ts
@@ -67,7 +67,7 @@ export interface UseColorModeOptions<T extends string = BasicColorSchema> extend
    * When set to `true`, preferred mode won't be translated into `light` or `dark`.
    * This is useful when the fact that `auto` mode was selected needs to be known.
    *
-   * @default false
+   * @default undefined
    */
   emitAuto?: boolean
 }
@@ -87,7 +87,7 @@ export function useColorMode<T extends string = BasicColorSchema>(options: UseCo
     storageKey = 'vueuse-color-scheme',
     listenToStorageChanges = true,
     storageRef,
-    emitAuto = false,
+    emitAuto,
   } = options
 
   const modes = {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Some applications need to know if the preferred color mode was used, e.g. when showing a dropdown menu with the three options `light`, `dark` or `system`. With the current implementation, there is no way to figure out if the user selected `auto` mode. That means it's not possible to highlight the `system` option in the dropdown as active.

I added an option `emitAuto` which defaults to `false`. When enabled, it includes the `auto` mode in the returned state variable.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
