### PR TITLE
docs(useMediaControls): fix heading typo

### DIFF
--- a/packages/core/useMediaControls/index.md
+++ b/packages/core/useMediaControls/index.md
@@ -33,7 +33,7 @@ onMounted(() => {
 </template>
 ```
 
-### Proving Captions, Subtitles, etc...
+### Providing Captions, Subtitles, etc...
 You can provide captions, subtitles, etc in the `tracks` options of the
 `useMediaControls` function. The function will return an array of tracks
 along with two functions for controlling them, `enableTrack`, `disableTrack`, and `selectedTrack`.


### PR DESCRIPTION
### Description

This PR fixes a typing error in the documentation of `useMediaControls`

### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other
