### PR TITLE
fix(nuxt): add `useStorage` to disabled composables

### DIFF
--- a/packages/nuxt/index.ts
+++ b/packages/nuxt/index.ts
@@ -12,6 +12,7 @@ const disabledFunctions = [
   'useCookie',
   'useHead',
   'useTitle',
+  'useStorage',
 ]
 
 const packages = [


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Disable `useStorage` auto import in Nuxt plugin to prevent conflict with nitro's `useStorage` auto import.

FYI: https://nitro.unjs.io/guide/storage.html

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
