### PR TITLE
fix(useMagicKeys): `getModifierState` is not function error in Chrome

### DIFF
--- a/packages/core/useMagicKeys/index.ts
+++ b/packages/core/useMagicKeys/index.ts
@@ -121,7 +121,7 @@ export function useMagicKeys(options: UseMagicKeysOptions<boolean> = {}): any {
       })
       metaDeps.clear()
     }
-    else if (e.getModifierState('Meta') && value) {
+    else if (typeof e.getModifierState === 'function' && e.getModifierState('Meta') && value) {
       [...current, ...values].forEach(key => metaDeps.add(key))
     }
   }


### PR DESCRIPTION

### Description

Chrome send native autofill events that are a bit different than native KeyboardEvent: they do not have some properties (fixed by 03929c770b74691873a724b976d9443daa64d67d) and the `getModifierState` method is not present.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
