### PR TITLE
fix(unrefElement): don't return the Vue instance when `$el` is `null`/`undefined`

### DIFF
--- a/packages/core/unrefElement/index.test.ts
+++ b/packages/core/unrefElement/index.test.ts
@@ -11,7 +11,7 @@ describe('unrefElement', () => {
   it('works with regular html elements', () => {
     const refKey = 'target'
 
-    const vm = mount(defineComponent({
+    mount(defineComponent({
       setup() {
         const targetEl = templateRef(refKey)
 
@@ -47,7 +47,7 @@ describe('unrefElement', () => {
 
     })
 
-    const vm = mount(defineComponent({
+    mount(defineComponent({
       setup() {
         const targetEl = ref<InstanceType<typeof helperComponent> | null>(null)
         const myText = ref('')

--- a/packages/core/unrefElement/index.test.ts
+++ b/packages/core/unrefElement/index.test.ts
@@ -1,0 +1,72 @@
+import { defineComponent, h, nextTick, onMounted, ref } from 'vue-demi'
+import { mount } from '../../.test'
+import { templateRef } from '../templateRef'
+import { unrefElement } from '.'
+
+describe('unrefElement', () => {
+  it('should be defined', () => {
+    expect(unrefElement).toBeDefined()
+  })
+
+  it('works with regular html elements', () => {
+    const refKey = 'target'
+
+    const vm = mount(defineComponent({
+      setup() {
+        const targetEl = templateRef(refKey)
+
+        expect(unrefElement(targetEl)).toBeNull()
+
+        onMounted(() => {
+          expect(unrefElement(targetEl)).toBeInstanceOf(HTMLElement)
+        })
+
+        return { targetEl }
+      },
+      render() {
+        return h('div', { ref: refKey })
+      },
+    }))
+  })
+
+  it('works with Vue components which expose a proxy $el', () => {
+    const helperComponent = defineComponent({
+      props: {
+        text: String,
+      },
+      setup(props, { expose }) {
+        const buttonRef = ref<HTMLButtonElement | null>(null)
+
+        expose({ $el: buttonRef })
+
+        return () => [
+          props.text && h('button', { ref: buttonRef }),
+          h('p', props.text),
+        ]
+      },
+
+    })
+
+    const vm = mount(defineComponent({
+      setup() {
+        const targetEl = ref<InstanceType<typeof helperComponent> | null>(null)
+        const myText = ref('')
+
+        expect(unrefElement(targetEl)).toBeNull()
+
+        onMounted(() => {
+          expect(targetEl.value?.$el).toBeNull()
+          expect(unrefElement(targetEl)).toEqual(targetEl.value?.$el)
+
+          myText.value = 'Hello'
+          nextTick(() => {
+            expect(targetEl.value?.$el).not.toBeNull()
+            expect(unrefElement(targetEl)).toEqual(targetEl.value?.$el)
+          })
+        })
+
+        return () => h(helperComponent, { ref: targetEl, text: myText.value })
+      },
+    }))
+  })
+})

--- a/packages/core/unrefElement/index.ts
+++ b/packages/core/unrefElement/index.ts
@@ -16,5 +16,5 @@ export type UnRefElementReturn<T extends MaybeElement = MaybeElement> = T extend
 export function unrefElement<T extends MaybeElement>(elRef: MaybeElementRef<T>): UnRefElementReturn<T> {
   const plain = unref(elRef)
 
-  return '$el' in (plain as VueInstance) ? (plain as VueInstance).$el : plain
+  return plain != null && '$el' in (plain as VueInstance) ? (plain as VueInstance).$el : plain
 }

--- a/packages/core/unrefElement/index.ts
+++ b/packages/core/unrefElement/index.ts
@@ -15,5 +15,6 @@ export type UnRefElementReturn<T extends MaybeElement = MaybeElement> = T extend
  */
 export function unrefElement<T extends MaybeElement>(elRef: MaybeElementRef<T>): UnRefElementReturn<T> {
   const plain = unref(elRef)
-  return (plain as VueInstance)?.$el ?? plain
+
+  return '$el' in (plain as VueInstance) ? (plain as VueInstance).$el : plain
 }


### PR DESCRIPTION
When using `unrefElement` on a template ref of a Vue component which exposes a custom `$el` ([HeadlessUI](https://github.com/tailwindlabs/headlessui)]) that points to a not rendered inner ref (`v-if="false"`), `unrefElement` returns the Vue instance object with `{ $el: null }`. It should return `null` as it should unref the Vue instance ref.

The cause of this bug is how `plain` is checked to be a `VueInstance`. Rather than using the value of `$el`, it should check if it has a property named `$el`.

<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

---

_Update 1: added tests_
