### PR TITLE
fix(useUrlSearchParams): preserve history state when updating query

### DIFF
--- a/packages/core/useUrlSearchParams/index.ts
+++ b/packages/core/useUrlSearchParams/index.ts
@@ -116,7 +116,11 @@ export function useUrlSearchParams<T extends Record<string, any> = UrlParams>(
     if (shouldUpdate)
       updateState(params)
 
-    window.history.replaceState({}, '', window.location.pathname + constructQuery(params))
+    window.history.replaceState(
+      window.history.state,
+      window.document.title,
+      window.location.pathname + constructQuery(params)
+    )
 
     resume()
   }


### PR DESCRIPTION
### Description

The `useUrlSearchParams` function uses `history.replaceState` when updating query parameters. 
Currently the function uses an empty object as "new state" which overrides existing state, this is an issues for router implementation.

This PR reuses the current state and title instead of overwriting it with pseudo content.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
