### PR TITLE
docs: remove unexpected parentheses

### DIFF
--- a/packages/core/useElementBounding/index.md
+++ b/packages/core/useElementBounding/index.md
@@ -27,7 +27,7 @@ export default {
       /* ... */
     }
   }
-})
+}
 </script>
 ```
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

In the usage part of the original file, the penultimate line of the code has an extra parenthesis, which has been deleted.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
