### PR TITLE
fix(onClickOutside): avoid calling safari workaround on right click

### DIFF
--- a/packages/core/onClickOutside/index.ts
+++ b/packages/core/onClickOutside/index.ts
@@ -66,7 +66,11 @@ export function onClickOutside(
       shouldListen.value = !!el && !e.composedPath().includes(el)
     }, { passive: true }),
     useEventListener(window, 'pointerup', (e) => {
-      fallback = window.setTimeout(() => listener(e), 50)
+      if (e.button === 0) {
+        const path = e.composedPath()
+        e.composedPath = () => path
+        fallback = window.setTimeout(() => listener(e), 50)
+      }
     }, { passive: true }),
   ]
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #1672

This PR fixes 2 issues:

1- Safari iOS workaround was being called on right clicks. This is changing the behaviour of the function. By wrapping workaround in `if (e.button === 0) {` we ensure it's left click.

2- `composedPath` returns an empty array after in `setTimeout` call. This is breaking the functionality of the `ignore` option. Fixed it by reassigning its result to itself.

### Additional context

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
