### PR TITLE
fix(computedWithControl): source type match `watch`

### DIFF
--- a/packages/shared/computedWithControl/index.ts
+++ b/packages/shared/computedWithControl/index.ts
@@ -8,7 +8,7 @@ import type { Fn } from '../utils'
  * @param source
  * @param fn
  */
-export function computedWithControl<T, S>(source: WatchSource<S>, fn: () => T) {
+export function computedWithControl<T, S>(source: WatchSource<S> | WatchSource<S>[], fn: () => T) {
   let v: T = undefined!
   let track: Fn
   let trigger: Fn


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

`source` parameter of `computedWithControl` should match the [vue `watch` api](https://vuejs.org/api/reactivity-core.html#watch). Currently it couldn't accept array of `WatchSource` as parameter in ts. 🤣

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
