### PR TITLE
Fixed incorrect documentation reference

### DIFF
--- a/packages/core/useFileSystemAccess/index.ts
+++ b/packages/core/useFileSystemAccess/index.ts
@@ -89,7 +89,7 @@ export type UseFileSystemAccessOptions = ConfigurableWindow & UseFileSystemAcces
 
 /**
  * Create and read and write local files.
- * @see https://vueuse.org/useElementByPoint
+ * @see https://vueuse.org/useFileSystemAccess
  * @param options
  */
 export function useFileSystemAccess(options: UseFileSystemAccessOptions & { dataType: 'Text' }): UseFileSystemAccessReturn<string>


### PR DESCRIPTION
### Description

The useFileSystemAccess documentation comment was pointing to incorrect URL (useElementByPoint) instead of useFileSystemAccess

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

