### PR TITLE
docs(useInfiniteScroll): add usage note

### DIFF
--- a/packages/core/useInfiniteScroll/index.md
+++ b/packages/core/useInfiniteScroll/index.md
@@ -6,6 +6,8 @@ category: Sensors
 
 Infinite scrolling of the element. 
 
+> **Note**: You should ensure that the container element's height < content's height.
+
 ## Usage
 
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

It took me some time to realize that I needed to care about the content's height, as this is not how popular libraries like [vue-infinite-loading](https://www.npmjs.com/package/vue-infinite-loading) work.

Also, I'm not the first person to have this issue. See https://github.com/vueuse/vueuse/issues/1685#issuecomment-1153501021.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
