### PR TITLE
docs(useTitle): fix link

### DIFF
--- a/packages/core/useTitle/index.md
+++ b/packages/core/useTitle/index.md
@@ -40,7 +40,7 @@ const title = computed(() => {
 useTitle(title) // document title will match with the ref "title"
 ```
 
-Pass an optional template tag (Vue Meta Title Template)[https://vue-meta.nuxtjs.org/guide/metainfo.html] 
+Pass an optional template tag [Vue Meta Title Template](https://vue-meta.nuxtjs.org/guide/metainfo.html) 
 to update the title to be injected into this template:
 
 ```js


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix markdown syntax of link in `useTitle` documentation page.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other