### PR TITLE
fix(useIntersectionObserver): 🐞

### DIFF
--- a/packages/core/useIntersectionObserver/index.ts
+++ b/packages/core/useIntersectionObserver/index.ts
@@ -75,7 +75,9 @@ export function useIntersectionObserver(
       },
       { immediate: true, flush: 'post' },
     )
-    : noop
+    : () => {
+        throw new Error('Please install Resize-Observer to implement polyfill')
+      }
 
   const stop = () => {
     cleanup()


### PR DESCRIPTION
useIntersectionObserver不适配ios12.1以下版本

<!-- Thank you for contributing! -->

### useIntersectionOnerver has no effect in the following iOS12.1

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### UseIntersectionObServer code does not exist in the browser in Window's browsers that will execute Noop in the browser in Window, hoping to throw an error on the user on the console. It is recommended that users install Resize-Observer to achieve Polyfill.So that the program is running normally.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ X ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
