### PR TITLE
fix(useCssVar): remove spaces at both ends

### DIFF
--- a/packages/core/useCssVar/index.ts
+++ b/packages/core/useCssVar/index.ts
@@ -30,7 +30,7 @@ export function useCssVar(
     [elRef, () => unref(prop)],
     ([el, prop]) => {
       if (el && window) {
-        const value = window.getComputedStyle(el).getPropertyValue(prop)
+        const value = window.getComputedStyle(el).getPropertyValue(prop)?.trim()
         variable.value = value || initialValue
       }
     },


### PR DESCRIPTION
fix #1738

<!-- Thank you for contributing! -->

### Description

When I define a css variable, `useCssVar` contains spaces in variable value. 
e.g.
In body: 
```css
body {
 --my-aaa:bold ;
 --my-bbb: bold;
}
```
```ts
const aaa = useCssVar('--my-aaa', document.body);
console.log(aaa.value) // `bold ` note: `bold` has a space after.

const bbb = useCssVar('--my-bbb', document.body);
console.log(bbb.value) // ` bold` note: `bold` has a space before.
```
So we maybe need remove spaces at both ends for ensure the correct value .

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
