### PR TITLE
fix(types): `reactiveOmit` and `reactivePick` support array as second arg

### DIFF
--- a/packages/shared/reactiveOmit/index.ts
+++ b/packages/shared/reactiveOmit/index.ts
@@ -1,6 +1,5 @@
 import { toRefs } from 'vue-demi'
 import { reactiveComputed } from '../reactiveComputed'
-import type { Many } from '../utils'
 
 /**
  * Reactively omit fields from a reactive object
@@ -9,7 +8,7 @@ import type { Many } from '../utils'
  */
 export function reactiveOmit<T extends object, K extends keyof T>(
   obj: T,
-  ...keys: Array<Many<K>>
+  ...keys: (K | K[])[]
 ): Omit<T, K> {
   return reactiveComputed<any>(() => Object.fromEntries(Object.entries(toRefs(obj)).filter(e => !keys.includes(e[0] as any))))
 }

--- a/packages/shared/reactiveOmit/index.ts
+++ b/packages/shared/reactiveOmit/index.ts
@@ -1,5 +1,6 @@
 import { toRefs } from 'vue-demi'
 import { reactiveComputed } from '../reactiveComputed'
+import type { Many } from '../utils'
 
 /**
  * Reactively omit fields from a reactive object
@@ -8,7 +9,7 @@ import { reactiveComputed } from '../reactiveComputed'
  */
 export function reactiveOmit<T extends object, K extends keyof T>(
   obj: T,
-  ...keys: K[]
+  ...keys: Array<Many<K>>
 ): Omit<T, K> {
   return reactiveComputed<any>(() => Object.fromEntries(Object.entries(toRefs(obj)).filter(e => !keys.includes(e[0] as any))))
 }

--- a/packages/shared/reactivePick/index.ts
+++ b/packages/shared/reactivePick/index.ts
@@ -1,5 +1,6 @@
 import type { UnwrapRef } from 'vue-demi'
 import { reactive, toRef } from 'vue-demi'
+import { Many } from '../utils'
 
 /**
  * Reactively pick fields from a reactive object
@@ -8,7 +9,7 @@ import { reactive, toRef } from 'vue-demi'
  */
 export function reactivePick<T extends object, K extends keyof T>(
   obj: T,
-  ...keys: K[]
+  ...keys: Array<Many<K>>
 ): { [S in K]: UnwrapRef<T[S]> } {
   return reactive(Object.fromEntries(keys.map(k => [k, toRef(obj, k)]))) as any
 }

--- a/packages/shared/reactivePick/index.ts
+++ b/packages/shared/reactivePick/index.ts
@@ -1,6 +1,5 @@
 import type { UnwrapRef } from 'vue-demi'
 import { reactive, toRef } from 'vue-demi'
-import { Many } from '../utils'
 
 /**
  * Reactively pick fields from a reactive object
@@ -9,7 +8,7 @@ import { Many } from '../utils'
  */
 export function reactivePick<T extends object, K extends keyof T>(
   obj: T,
-  ...keys: Array<Many<K>>
+  ...keys: (K | K[])[]
 ): { [S in K]: UnwrapRef<T[S]> } {
   return reactive(Object.fromEntries(keys.map(k => [k, toRef(obj, k)]))) as any
 }

--- a/packages/shared/utils/types.ts
+++ b/packages/shared/utils/types.ts
@@ -51,8 +51,6 @@ export type ShallowUnwrapRef<T> = T extends Ref<infer P> ? P : T
 
 export type Awaitable<T> = Promise<T> | T
 
-export type Many<T> =  ReadonlyArray<T> | T
-
 export interface Pausable {
   /**
    * A ref indicate whether a pusable instance is active

--- a/packages/shared/utils/types.ts
+++ b/packages/shared/utils/types.ts
@@ -51,6 +51,8 @@ export type ShallowUnwrapRef<T> = T extends Ref<infer P> ? P : T
 
 export type Awaitable<T> = Promise<T> | T
 
+export type Many<T> =  ReadonlyArray<T> | T
+
 export interface Pausable {
   /**
    * A ref indicate whether a pusable instance is active


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixed reactiveOmit and reactivePick parameter types not supporting passed arrays

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
