### PR TITLE
docs(useRefHistory): Suggest structuredClone as deep clone implementation

### DIFF
--- a/packages/core/useManualRefHistory/index.md
+++ b/packages/core/useManualRefHistory/index.md
@@ -52,7 +52,15 @@ commit()
 
 To use a full featured or custom clone function, you can set up via the `dump` options.
 
-For example, using [lodash's `cloneDeep`](https://lodash.com/docs/4.17.15#cloneDeep):
+For example, using [structuredClone](https://developer.mozilla.org/en-US/docs/Web/API/structuredClone):
+
+```ts
+import { cloneDeep } from 'lodash-es'
+
+const refHistory = useManualRefHistory(target, { clone: structuredClone })
+```
+
+Or by using [lodash's `cloneDeep`](https://lodash.com/docs/4.17.15#cloneDeep):
 
 ```ts
 import { cloneDeep } from 'lodash-es'

--- a/packages/core/useRefHistory/index.md
+++ b/packages/core/useRefHistory/index.md
@@ -65,7 +65,15 @@ console.log(history.value)
 
 `useRefHistory` only embeds the minimal clone function `x => JSON.parse(JSON.stringify(x))`. To use a full featured or custom clone function, you can set up via the `dump` options.
 
-For example, using [lodash's `cloneDeep`](https://lodash.com/docs/4.17.15#cloneDeep):
+For example, using [structuredClone](https://developer.mozilla.org/en-US/docs/Web/API/structuredClone):
+
+```ts
+import { useRefHistory } from '@vueuse/core'
+
+const refHistory = useRefHistory(target, { dump: structuredClone })
+```
+
+Or by using [lodash's `cloneDeep`](https://lodash.com/docs/4.17.15#cloneDeep):
 
 ```ts
 import { cloneDeep } from 'lodash-es'


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Add [strucutedClone](https://developer.mozilla.org/en-US/docs/Web/API/structuredClone) as a deep clone implementation in appropriate documentations.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

- [ ] 🤔 [useManualRefHistory](https://github.com/Holi0317/vueuse/blob/docs-deep-clone/packages/core/useManualRefHistory/index.md#custom-clone-function) mentioned `dump` in the documentation but used `clone` in code. I think that's a typo?

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
