### PR TITLE
fix(useMagicKeys): reset refs on target blur

### DIFF
--- a/packages/core/useMagicKeys/index.ts
+++ b/packages/core/useMagicKeys/index.ts
@@ -135,6 +135,10 @@ export function useMagicKeys(options: UseMagicKeysOptions<boolean> = {}): any {
       updateRefs(e, false)
       return onEventFired(e)
     }, { passive })
+    useEventListener(target, 'blur', (e: KeyboardEvent) => {
+      updateRefs(e, false)
+      return onEventFired(e)
+    }, { passive })
   }
 
   const proxy = new Proxy(

--- a/packages/core/useMagicKeys/index.ts
+++ b/packages/core/useMagicKeys/index.ts
@@ -94,6 +94,15 @@ export function useMagicKeys(options: UseMagicKeysOptions<boolean> = {}): any {
     }
   }
 
+  function reset() {
+    for (const key of Object.keys(refs)) {
+      if (useReactive)
+        refs[key] = false
+      else
+        refs[key].value = false
+    }
+  }
+
   function updateRefs(e: KeyboardEvent, value: boolean) {
     const key = e.key?.toLowerCase()
     const code = e.code?.toLowerCase()
@@ -135,14 +144,10 @@ export function useMagicKeys(options: UseMagicKeysOptions<boolean> = {}): any {
       updateRefs(e, false)
       return onEventFired(e)
     }, { passive })
-    useEventListener('blur', (e: FocusEvent) => {
-      updateRefs(e, false)
-      return onEventFired(e)
-    }, { passive })
-    useEventListener('focus', (e: FocusEvent) => {
-      updateRefs(e, false)
-      return onEventFired(e)
-    }, { passive })
+
+    // #1350
+    useEventListener('blur', reset, { passive: true })
+    useEventListener('focus', reset, { passive: true })
   }
 
   const proxy = new Proxy(

--- a/packages/core/useMagicKeys/index.ts
+++ b/packages/core/useMagicKeys/index.ts
@@ -135,7 +135,11 @@ export function useMagicKeys(options: UseMagicKeysOptions<boolean> = {}): any {
       updateRefs(e, false)
       return onEventFired(e)
     }, { passive })
-    useEventListener(target, 'blur', (e: KeyboardEvent) => {
+    useEventListener('blur', (e: FocusEvent) => {
+      updateRefs(e, false)
+      return onEventFired(e)
+    }, { passive })
+    useEventListener('focus', (e: FocusEvent) => {
       updateRefs(e, false)
       return onEventFired(e)
     }, { passive })


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
On macos when some keys are pressed in combo(cmd+p for example) open a dialog and the keyup is not triggered and the refs keep a wrong state.
I add a blur event listener so when the target lost the focus, the key refs are resetted to false.

fixes #1350 

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
