### PR TITLE
fix(templateRef): add Component type

### DIFF
--- a/packages/core/templateRef/index.ts
+++ b/packages/core/templateRef/index.ts
@@ -1,4 +1,4 @@
-import type { Ref } from 'vue-demi'
+import type { Component, Ref } from 'vue-demi'
 import { customRef, getCurrentInstance, onUpdated } from 'vue-demi'
 import { tryOnMounted } from '@vueuse/shared'
 
@@ -9,7 +9,7 @@ import { tryOnMounted } from '@vueuse/shared'
  * @param key
  * @param initialValue
  */
-export function templateRef<T extends HTMLElement | SVGElement | null>(
+export function templateRef<T extends HTMLElement | SVGElement | Component | null>(
   key: string,
   initialValue: T | null = null,
 ): Readonly<Ref<T>> {


### PR DESCRIPTION
fix #1757

<!-- Thank you for contributing! -->

### Description

`templateRef` not supported vue componet type

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
