### PR TITLE
fix(useMediaQuery): check if window.matchMedia is a function

### DIFF
--- a/packages/core/useMediaQuery/index.ts
+++ b/packages/core/useMediaQuery/index.ts
@@ -14,7 +14,7 @@ import { defaultWindow } from '../_configurable'
  */
 export function useMediaQuery(query: string, options: ConfigurableWindow = {}) {
   const { window = defaultWindow } = options
-  const isSupported = Boolean(window && 'matchMedia' in window && typeof 'matchMedia' === 'function')
+  const isSupported = Boolean(window && 'matchMedia' in window && typeof window!.matchMedia === 'function')
 
   let mediaQuery: MediaQueryList | undefined
   const matches = ref(false)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The `useMediaQuery` recently got updated to perform a more strict check for browser support. However, a small mistake slipped in where `typeof 'matchMedia' === 'function'` instead of `typeof window!.matchMedia === 'function'` was checked. The wrong implementation results always in `'string' === 'function'`, so it never supports media queries.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
