### PR TITLE
fix(useColorMode): resolve auto to preferred mode internally

### DIFF
--- a/packages/core/useColorMode/index.ts
+++ b/packages/core/useColorMode/index.ts
@@ -140,7 +140,8 @@ export function useColorMode<T extends string = BasicColorSchema>(options: UseCo
     })
 
   function defaultOnChanged(mode: T | BasicColorSchema) {
-    updateHTMLAttrs(selector, attribute, modes[mode] ?? mode)
+    const resolvedMode = mode === 'auto' ? preferredMode.value : mode
+    updateHTMLAttrs(selector, attribute, modes[resolvedMode] ?? resolvedMode)
   }
 
   function onChanged(mode: T | BasicColorSchema) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I recently added the `emitAuto` option to `useColorMode` (#1627).
Now I discovered a bug with that. The HTML class attribute is now being updated with `auto` class, which is wrong. Even if the `emitAuto` option is enabled and the value `auto` is emitted to the user of the composable, we still need to resolve that in either `light` or `dark` internally.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

How to reproduce the bug:

1. Set your system into light mode
2. Visit https://vueuse.org/core/usecolormode/
3. The page should render in light mode
4. Set your system into dark mode
5.  The page should render in dark mode
6. Press the green button until it displays `Auto` again
7. The page renders in light mode, which is wrong

With this fix, the page correctly renders in dark for step 7).
Note: Fix only works with this other fix for `useMediaQuery` #1765

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
