### PR TITLE
docs(useNetwork):Add Navigator.connection.type compatibility hint and format my pr

### DIFF
--- a/packages/core/useNetwork/index.md
+++ b/packages/core/useNetwork/index.md
@@ -4,7 +4,7 @@ category: Sensors
 
 # useNetwork
 
-Reactive [Network status](https://developer.mozilla.org/en-US/docs/Web/API/Network_Information_API). The Network Information API provides information about the system's connection in terms of general connection type (e.g., 'wifi', 'cellular', etc.). This can be used to select high definition content or low definition content based on the user's connection. The entire API consists of the addition of the NetworkInformation interface and a single property to the Navigator interface: Navigator.connection.Note that Navigator.connection.type is only supported in Chrome Os.
+Reactive [Network status](https://developer.mozilla.org/en-US/docs/Web/API/Network_Information_API). The Network Information API provides information about the system's connection in terms of general connection type (e.g., 'wifi', 'cellular', etc.). This can be used to select high definition content or low definition content based on the user's connection. The entire API consists of the addition of the NetworkInformation interface and a single property to the Navigator interface: Navigator.connection. Note that Navigator.connection.type is only supported in Chrome Os.
 
 ## Usage
 

--- a/packages/core/useNetwork/index.md
+++ b/packages/core/useNetwork/index.md
@@ -4,7 +4,7 @@ category: Sensors
 
 # useNetwork
 
-Reactive [Network status](https://developer.mozilla.org/en-US/docs/Web/API/Network_Information_API). The Network Information API provides information about the system's connection in terms of general connection type (e.g., 'wifi', 'cellular', etc.). This can be used to select high definition content or low definition content based on the user's connection. The entire API consists of the addition of the NetworkInformation interface and a single property to the Navigator interface: Navigator.connection.
+Reactive [Network status](https://developer.mozilla.org/en-US/docs/Web/API/Network_Information_API). The Network Information API provides information about the system's connection in terms of general connection type (e.g., 'wifi', 'cellular', etc.). This can be used to select high definition content or low definition content based on the user's connection. The entire API consists of the addition of the NetworkInformation interface and a single property to the Navigator interface: Navigator.connection.Note that Navigator.connection.type is only supported in Chrome Os.
 
 ## Usage
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Navigator.connection.type  is only supported in Chrome Os.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context
This is Compatibility Notes.
https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation/type

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.

