### PR TITLE
feat(isElectronEnv): new function

### DIFF
--- a/packages/electron/index.ts
+++ b/packages/electron/index.ts
@@ -1,3 +1,4 @@
+export * from './isElectronEnv'
 export * from './useIpcRenderer'
 export * from './useIpcRendererInvoke'
 export * from './useIpcRendererOn'

--- a/packages/electron/isElectronEnv/index.md
+++ b/packages/electron/isElectronEnv/index.md
@@ -1,0 +1,21 @@
+---
+category: '@Electron'
+---
+
+# isElectronEnv
+
+Detect whether it is currently in an Electronic environment. 
+
+Avoid `window.require is not a function` when using `window.require('electron')`.
+
+
+## Usage
+
+```ts
+import { isElectronEnv, useIpcRenderer } from '@vueuse/electron'
+
+if (isElectronEnv()) {
+  const ipcRenderer = useIpcRenderer()
+  const result = ipcRenderer.invoke<string>('custom-channel', 'some data')
+}
+```

--- a/packages/electron/isElectronEnv/index.ts
+++ b/packages/electron/isElectronEnv/index.ts
@@ -1,0 +1,15 @@
+export function isElectronEnv() {
+  // Renderer process
+  if (typeof window !== 'undefined' && typeof window.process === 'object' && window.process.type === 'renderer')
+    return true
+
+  // Main process
+  if (typeof process !== 'undefined' && typeof process.versions === 'object' && !!process.versions.electron)
+    return true
+
+  // Detect the user agent when the `nodeIntegration` option is set to true
+  if (typeof navigator === 'object' && typeof navigator.userAgent === 'string' && navigator.userAgent.includes('Electron'))
+    return true
+
+  return false
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Detect whether it is currently in an Electronic environment. 

Avoid `window.require is not a function` when using `window.require('electron')`.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
