### PR TITLE
feat: 增强useFetch函数afterFetch钩子

### DIFF
--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -4,6 +4,8 @@ import { containsProp, createEventHook, until, useTimeoutFn } from '@vueuse/shar
 import { computed, isRef, ref, shallowRef, unref, watch } from 'vue-demi'
 import { defaultWindow } from '../_configurable'
 
+export interface InternalConfig { method: HttpMethod; type: DataType; payload: unknown; payloadType?: string }
+
 export interface UseFetchReturn<T> {
   /**
    * Indicates if the fetch request has finished
@@ -118,6 +120,8 @@ export interface AfterFetchContext<T = any> {
   response: Response
 
   data: T | null
+
+  config: InternalConfig
 }
 
 export interface OnFetchErrorContext<T = any, E = any> {
@@ -263,7 +267,6 @@ export function useFetch<T>(url: MaybeRef<string>, ...args: any[]): UseFetchRetu
 
   let fetchOptions: RequestInit = {}
   let options: UseFetchOptions = { immediate: true, refetch: false, timeout: 0 }
-  interface InternalConfig { method: HttpMethod; type: DataType; payload: unknown; payloadType?: string }
   const config: InternalConfig = {
     method: 'GET',
     type: 'text' as DataType,
@@ -383,7 +386,7 @@ export function useFetch<T>(url: MaybeRef<string>, ...args: any[]): UseFetchRetu
           responseData = await fetchResponse[config.type]()
 
           if (options.afterFetch && statusCode.value >= 200 && statusCode.value < 300)
-            ({ data: responseData } = await options.afterFetch({ data: responseData, response: fetchResponse }))
+            ({ data: responseData } = await options.afterFetch({ data: responseData, response: fetchResponse, config }))
 
           data.value = responseData
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
有时候，我们需要在接口请求失败时，发起另外一个请求并把新请求的结果返回，典型的例子就是access-token和refresh-token：

access-token失效后需要先通过 refresh-token 获取新的access-token，再重新发起一个新的请求，把最后结果交给最开始的请求，这应该在afterFetch执行。

但是我获取最新的access_token后，想要再发起一个一模一样的请求时，我发现无法在afterFetch中得知它是否调用了post方法，或者json等方法。

在查阅源码后，我发现源码中有一个config变量用来盛放这些信息，我不清楚直接在afterFetch返回config是否合适？这可能需要考虑一下。

抛开 access-token 具体的例子不说，在afterFetch中清楚请求的方法、参数类型这些信息我觉得也很重要。

很明显，这是一个增量的代码，并不会对现有功能和api造成影响。


### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.