### PR TITLE
feat(useAbs): new function

### DIFF
--- a/packages/math/useAbs/index.md
+++ b/packages/math/useAbs/index.md
@@ -1,0 +1,17 @@
+---
+category: '@Math'
+alias: abs
+---
+
+# useAbs
+
+Reactively [Math.abs(value)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/abs).
+
+## Usage
+
+```ts
+import { useAbs } from '@vueuse/math'
+
+const value = ref(-23)
+const absValue = useAbs(value)
+```

--- a/packages/math/useAbs/index.md
+++ b/packages/math/useAbs/index.md
@@ -4,7 +4,7 @@ category: '@Math'
 
 # useAbs
 
-Reactively [Math.abs(value)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/abs).
+Reactive `Math.abs`.
 
 ## Usage
 
@@ -12,5 +12,5 @@ Reactively [Math.abs(value)](https://developer.mozilla.org/en-US/docs/Web/JavaSc
 import { useAbs } from '@vueuse/math'
 
 const value = ref(-23)
-const absValue = useAbs(value)
+const absValue = useAbs(value) // Ref<23>
 ```

--- a/packages/math/useAbs/index.md
+++ b/packages/math/useAbs/index.md
@@ -1,6 +1,5 @@
 ---
 category: '@Math'
-alias: abs
 ---
 
 # useAbs

--- a/packages/math/useAbs/index.test.ts
+++ b/packages/math/useAbs/index.test.ts
@@ -1,0 +1,7 @@
+import { useAbs } from '.'
+
+describe('useAbs', () => {
+  it('should be defined', () => {
+    expect(useAbs).toBeDefined()
+  })
+})

--- a/packages/math/useAbs/index.test.ts
+++ b/packages/math/useAbs/index.test.ts
@@ -1,7 +1,24 @@
+import { ref } from 'vue-demi'
 import { useAbs } from '.'
 
 describe('useAbs', () => {
-  it('should be defined', () => {
+  test('should be defined', () => {
     expect(useAbs).toBeDefined()
+  })
+
+  test('this should work', () => {
+    const original = ref(-1)
+    const abs = useAbs(original)
+
+    expect(abs.value).toBe(1)
+
+    original.value = -23
+    expect(abs.value).toBe(23)
+
+    original.value = 10
+    expect(abs.value).toBe(10)
+
+    original.value = 0
+    expect(abs.value).toBe(0)
   })
 })

--- a/packages/math/useAbs/index.test.ts
+++ b/packages/math/useAbs/index.test.ts
@@ -21,4 +21,20 @@ describe('useAbs', () => {
     original.value = 0
     expect(abs.value).toBe(0)
   })
+
+  test('getter', () => {
+    const original = ref(-1)
+    const abs = useAbs(() => original.value)
+
+    expect(abs.value).toBe(1)
+
+    original.value = -23
+    expect(abs.value).toBe(23)
+
+    original.value = 10
+    expect(abs.value).toBe(10)
+
+    original.value = 0
+    expect(abs.value).toBe(0)
+  })
 })

--- a/packages/math/useAbs/index.ts
+++ b/packages/math/useAbs/index.ts
@@ -1,0 +1,3 @@
+export function useAbs() {
+
+}

--- a/packages/math/useAbs/index.ts
+++ b/packages/math/useAbs/index.ts
@@ -1,3 +1,13 @@
-export function useAbs() {
+import type { MaybeRef } from '@vueuse/shared'
+import { resolveUnref } from '@vueuse/shared'
+import type { ComputedRef } from 'vue-demi'
+import { computed } from 'vue-demi'
 
+/**
+ * Reactively Math.abs(value).
+ *
+ * @see https://vueuse.org/useAbs
+ */
+export function useAbs(value: MaybeRef<number>): ComputedRef<number> {
+  return computed(() => Math.abs(resolveUnref(value)))
 }

--- a/packages/math/useAbs/index.ts
+++ b/packages/math/useAbs/index.ts
@@ -4,7 +4,7 @@ import type { ComputedRef } from 'vue-demi'
 import { computed } from 'vue-demi'
 
 /**
- * Reactively Math.abs(value).
+ * Reactive `Math.abs`.
  *
  * @see https://vueuse.org/useAbs
  */

--- a/packages/math/useAbs/index.ts
+++ b/packages/math/useAbs/index.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/shared'
+import type { MaybeComputedRef } from '@vueuse/shared'
 import { resolveUnref } from '@vueuse/shared'
 import type { ComputedRef } from 'vue-demi'
 import { computed } from 'vue-demi'
@@ -8,6 +8,6 @@ import { computed } from 'vue-demi'
  *
  * @see https://vueuse.org/useAbs
  */
-export function useAbs(value: MaybeRef<number>): ComputedRef<number> {
+export function useAbs(value: MaybeComputedRef<number>): ComputedRef<number> {
   return computed(() => Math.abs(resolveUnref(value)))
 }


### PR DESCRIPTION
## From #1812 

### Description

Reactively [Math.abs(value)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/abs).


### Usage

```ts
import { useAbs } from '@vueuse/math'

const value = ref(-23)
const absValue = useAbs(value)

// absValue.value: 23
```

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
