### PR TITLE
docs(useTextSelection): fix layout issues in the demo

### DIFF
--- a/packages/core/useTextSelection/demo.vue
+++ b/packages/core/useTextSelection/demo.vue
@@ -21,7 +21,7 @@ const selectedStyle = computed(() => text.value ? 'text-primary' : 'text-gray-40
     </p>
     <p>
       <strong class="w-140px inline-block">Selected rects:</strong>
-      {{ JSON.stringify(rects) }}
+      <pre lang="json">{{ rects }}</pre>
     </p>
   </div>
 </template>

--- a/packages/core/useTextSelection/demo.vue
+++ b/packages/core/useTextSelection/demo.vue
@@ -13,15 +13,15 @@ const selectedStyle = computed(() => text.value ? 'text-primary' : 'text-gray-40
       You can select any text on the page.
     </p>
     <p>
-      <strong class="w-140px inline-block">Selected Text:</strong>
+      <strong>Selected Text:</strong>
       <em
         :class="selectedStyle"
-        class="whitespace-pre h-72 overflow-y-auto inline-block"
+        class="whitespace-pre h-44 overflow-y-auto block"
       >{{ text || 'No selected' }}</em>
     </p>
     <p>
-      <strong class="w-140px inline-block">Selected rects:</strong>
-      <pre lang="json">{{ rects }}</pre>
+      <strong>Selected rects:</strong>
+      <pre class="h-72" lang="json">{{ rects }}</pre>
     </p>
   </div>
 </template>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

This PR aims to improve the [usetextselection's demo](https://vueuse.org/core/usetextselection/#demo) by addressing its layout issues.

This PR aims to 

### Additional context

Currently when the user selects something on the page, the "Selected rects" section of the demo overflows:

![image](https://user-images.githubusercontent.com/31937175/178325060-8892171a-eb5e-46ce-b505-06a9a372280a.png)

also, the "Selected text" label is far away from the text that it describes:

![image](https://user-images.githubusercontent.com/31937175/178325713-74606401-e277-4b20-9468-9f5b17ec9377.png)

After this PR:

![image](https://user-images.githubusercontent.com/31937175/178326073-6b617104-3ca8-4594-b6a5-90844cd605dc.png)

Let me know what you think about these changes

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
