### PR TITLE
refactor(useSpeechSynthesis)!: remove `voiceInfo`, allow `voice` as ref

### DIFF
--- a/packages/core/useSpeechSynthesis/demo.vue
+++ b/packages/core/useSpeechSynthesis/demo.vue
@@ -2,22 +2,22 @@
 import { ref } from 'vue'
 import { useSpeechSynthesis } from '@vueuse/core'
 
-const lang = ref('en-US')
+const voices = ref<SpeechSynthesisVoice[]>([])
+const voice = ref()
 const text = ref('Hello, everyone! Good morning!')
 
 const speech = useSpeechSynthesis(text, {
-  lang,
+  voice,
 })
 
 let synth: SpeechSynthesis
 
-const voices = ref<SpeechSynthesisVoice[]>([])
-
-if (speech.isSupported.value) {
+if (speech.isSupported) {
   // load at last
   setTimeout(() => {
     synth = window.speechSynthesis
     voices.value = synth.getVoices()
+    voice.value = voices.value[0]
   })
 }
 
@@ -57,7 +57,7 @@ const stop = () => {
       <label class="font-bold mr-2">Language</label>
       <div bg="$vt-c-bg" border="$vt-c-divider-light 1" inline-flex items-center relative rounded>
         <i i-carbon-language absolute left-2 opacity-80 pointer-events-none />
-        <select v-model="lang" px-8 border-0 bg-transparent h-9 rounded appearance-none>
+        <select v-model="voice" px-8 border-0 bg-transparent h-9 rounded appearance-none>
           <option bg="$vt-c-bg" disabled>
             Select Language
           </option>
@@ -65,7 +65,7 @@ const stop = () => {
             v-for="(voice, i) in voices"
             :key="i"
             bg="$vt-c-bg"
-            :value="voice.lang"
+            :value="voice"
           >
             {{ `${voice.name} (${voice.lang})` }}
           </option>

--- a/packages/core/useSpeechSynthesis/demo.vue
+++ b/packages/core/useSpeechSynthesis/demo.vue
@@ -12,7 +12,7 @@ const speech = useSpeechSynthesis(text, {
 
 let synth: SpeechSynthesis
 
-if (speech.isSupported) {
+if (speech.isSupported.value) {
   // load at last
   setTimeout(() => {
     synth = window.speechSynthesis

--- a/packages/core/useSpeechSynthesis/index.ts
+++ b/packages/core/useSpeechSynthesis/index.ts
@@ -1,4 +1,4 @@
-import type { MaybeComputedRef } from '@vueuse/shared'
+import type { MaybeComputedRef, MaybeRef } from '@vueuse/shared'
 import { resolveRef, tryOnScopeDispose } from '@vueuse/shared'
 import type { Ref } from 'vue-demi'
 import { computed, ref, shallowRef, unref, watch } from 'vue-demi'
@@ -7,8 +7,6 @@ import type { ConfigurableWindow } from '../_configurable'
 import { defaultWindow } from '../_configurable'
 
 export type Status = 'init' | 'play' | 'pause' | 'end'
-
-export type VoiceInfo = Pick<SpeechSynthesisVoice, 'lang' | 'name'>
 
 export interface SpeechSynthesisOptions extends ConfigurableWindow {
   /**
@@ -32,7 +30,7 @@ export interface SpeechSynthesisOptions extends ConfigurableWindow {
   /**
    * Gets and sets the voice that will be used to speak the utterance.
    */
-  voice?: SpeechSynthesisVoice
+  voice?: MaybeRef<SpeechSynthesisVoice>
   /**
    * Gets and sets the volume that the utterance will be spoken at.
    *
@@ -62,11 +60,6 @@ export function useSpeechSynthesis(text: MaybeComputedRef<string>, options: Spee
   const isPlaying = ref(false)
   const status = ref<Status>('init')
 
-  const voiceInfo = {
-    lang: options.voice?.lang || 'default',
-    name: options.voice?.name || '',
-  }
-
   const spokenText = resolveRef(text || '')
   const lang = resolveRef(options.lang || 'en-US')
   const error = shallowRef(undefined) as Ref<SpeechSynthesisErrorEvent | undefined>
@@ -77,8 +70,7 @@ export function useSpeechSynthesis(text: MaybeComputedRef<string>, options: Spee
 
   const bindEventsForUtterance = (utterance: SpeechSynthesisUtterance) => {
     utterance.lang = unref(lang)
-
-    options.voice && (utterance.voice = options.voice)
+    utterance.voice = unref(options.voice) || null
     utterance.pitch = pitch
     utterance.rate = rate
     utterance.volume = volume
@@ -150,7 +142,6 @@ export function useSpeechSynthesis(text: MaybeComputedRef<string>, options: Spee
     isSupported,
     isPlaying,
     status,
-    voiceInfo,
     utterance,
     error,
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

[useSpeechSynthesis ](https://vueuse.org/core/usespeechsynthesis/) demo is not playing the right voice when multiple voices are available for the same language, because we are passing language code instead of a `SpeechSynthesisVoice` object. It wouldn't work even if we pass it as `voice` option, because `voice` option is static. I changed it to `MaybeRef` and this required me to make `voiceInfo` a `ref`, and this was a breaking change. Then I thought it was pointless to return the same input that we received from users. So, I removed it.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [x] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
