### PR TITLE
fix(useStyleTag): fix hydration mismatch issue

### DIFF
--- a/packages/core/useStyleTag/index.ts
+++ b/packages/core/useStyleTag/index.ts
@@ -1,4 +1,4 @@
-import { readonly, ref, watch } from 'vue-demi'
+import { nextTick, readonly, ref, watch } from 'vue-demi'
 import type { Ref } from 'vue-demi'
 import { tryOnScopeDispose } from '@vueuse/shared'
 import type { MaybeRef } from '@vueuse/shared'
@@ -89,7 +89,7 @@ export function useStyleTag(
       { immediate: true },
     )
 
-    isLoaded.value = true
+    nextTick(() => isLoaded.value = true)
   }
 
   const unload = () => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The buttons in the [useStyleTag](https://vueuse.org/core/usestyletag/) demo are not working if this page is visited with full-reload.  There is a hydration mismatch error on console. I thought changing the value of `isLoaded` immediately on client side is might be the cause of the issue. I wrapped it with `nextTick`. The hydration mismatch error is still there but at least the buttons are working now.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
