### PR TITLE
fix(useFileDialog): type UseFileDialogReturn

### DIFF
--- a/packages/core/useFileDialog/index.ts
+++ b/packages/core/useFileDialog/index.ts
@@ -1,4 +1,4 @@
-import { readonly, ref } from 'vue-demi'
+import { type Ref, readonly, ref } from 'vue-demi'
 import type { ConfigurableDocument } from '../_configurable'
 import { defaultDocument } from '../_configurable'
 
@@ -23,13 +23,19 @@ const DEFAULT_OPTIONS: UseFileDialogOptions = {
   accept: '*',
 }
 
+export interface UseFileDialogReturn {
+  files: Ref<FileList | null>
+  open: (localOptions?: Partial<UseFileDialogOptions>) => void
+  reset: () => void
+}
+
 /**
  * Open file dialog with ease.
  *
  * @see https://vueuse.org/useFileDialog
  * @param options
  */
-export function useFileDialog(options: UseFileDialogOptions = {}) {
+export function useFileDialog(options: UseFileDialogOptions = {}): UseFileDialogReturn {
   const {
     document = defaultDocument,
   } = options
@@ -74,5 +80,3 @@ export function useFileDialog(options: UseFileDialogOptions = {}) {
     reset,
   }
 }
-
-export type UseFileDialogReturn = ReturnType<typeof useFileDialog>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

```ts
/// <reference types="node" />
export interface UseFileDialogOptions extends ConfigurableDocument {
  /**
   * @default true
   */
  multiple?: boolean
  /**
   * @default '*'
   */
  accept?: string
  /**
   * Select the input source for the capture file.
   * @see [HTMLInputElement Capture](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/capture)
   */
  capture?: string
}
/**
 * Open file dialog with ease.
 *
 * @see https://vueuse.org/useFileDialog
 * @param options
 */
export declare function useFileDialog(options?: UseFileDialogOptions): {
  files: Readonly<
    Ref<{
      readonly [x: number]: {
        readonly lastModified: number
        readonly name: string
        readonly webkitRelativePath: string
        readonly path: string
        readonly size: number
        readonly type: string
        readonly arrayBuffer: {
          (): Promise<ArrayBuffer>
          (): Promise<ArrayBuffer>
        }
        readonly slice: {
          (
            start?: number | undefined,
            end?: number | undefined,
            contentType?: string | undefined
          ): Blob
          (
            start?: number | undefined,
            end?: number | undefined,
            contentType?: string | undefined
          ): Blob
        }
        readonly stream: {
          (): ReadableStream<Uint8Array>
          (): NodeJS.ReadableStream
        }
        readonly text: {
          (): Promise<string>
          (): Promise<string>
        }
      }
      readonly length: number
      readonly item: (index: number) => File | null
      readonly [Symbol.iterator]: () => IterableIterator<File>
    } | null>
  >
  open: (localOptions?: Partial<UseFileDialogOptions>) => void
  reset: () => void
}
```

This type has type error in browser because `NodeJS.ReadableStream` is needed.

```ts
        readonly stream: {
          (): ReadableStream<Uint8Array>
          (): NodeJS.ReadableStream
        }
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
