### PR TITLE
fix(useDropZone): improve argument type

### DIFF
--- a/packages/core/useDropZone/demo.vue
+++ b/packages/core/useDropZone/demo.vue
@@ -15,7 +15,7 @@ function onDrop(files: File[] | null) {
   }
 }
 
-const dropZoneRef = ref<HTMLElement | null>(null)
+const dropZoneRef = ref<HTMLElement>()
 
 const { isOverDropZone } = useDropZone(dropZoneRef, onDrop)
 </script>

--- a/packages/core/useDropZone/index.md
+++ b/packages/core/useDropZone/index.md
@@ -12,7 +12,7 @@ Create an zone where files can be dropped.
 <script setup lang="ts">
 import { useDropZone } from '@vueuse/core'
 
-const dropZoneRef = ref(null)
+const dropZoneRef = ref<HTMLDivElement>()
 
 function onDrop(files: File[] | null) {
   // called when files are dropped on zone

--- a/packages/core/useDropZone/index.ts
+++ b/packages/core/useDropZone/index.ts
@@ -8,7 +8,7 @@ export interface UseDropZoneReturn {
   isOverDropZone: Ref<boolean>
 }
 
-export function useDropZone(target: MaybeRef<HTMLElement | null>, onDrop: (files: File[] | null) => void): UseDropZoneReturn {
+export function useDropZone(target: MaybeRef<HTMLElement | null | undefined>, onDrop: (files: File[] | null) => void): UseDropZoneReturn {
   const isOverDropZone = ref(false)
   let counter = 0
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

```vue
<script setup lang="ts">
import { useDropZone } from '@vueuse/core'

const dropZoneRef = ref<HTMLElement>()

function onDrop(files: File[] | null) {
  // called when files are dropped on zone
}

const { isOverDropZone } = useDropZone(dropZoneRef, onDrop)
</script>

<template>
  <div ref="dropZoneRef">
    Drop files here
  </div>
</template>
```

This code is a type error.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
