### PR TITLE
docs(useDebounceFn): update imports to use @vueuse/shared

### DIFF
--- a/packages/shared/useDebounceFn/index.md
+++ b/packages/shared/useDebounceFn/index.md
@@ -11,7 +11,7 @@ Debounce execution of a function.
 ## Usage
 
 ```js
-import { useDebounceFn } from '@vueuse/core'
+import { useDebounceFn } from '@vueuse/shared'
 
 const debouncedFn = useDebounceFn(() => {
   // do something
@@ -23,7 +23,7 @@ document.addEventListener('resize', debouncedFn)
 You can also pass a 3rd parameter to this, with a maximum wait time, similar to [lodash debounce](https://lodash.com/docs/4.17.15#debounce)
 
 ```js
-import { useDebounceFn } from '@vueuse/core'
+import { useDebounceFn } from '@vueuse/shared'
 
 // If no invokation after 5000ms due to repeated input,
 // the function will be called anyway.

--- a/packages/shared/useToggle/index.md
+++ b/packages/shared/useToggle/index.md
@@ -9,7 +9,7 @@ A boolean switcher with utility functions.
 ## Usage
 
 ```js
-import { useToggle } from '@vueuse/core'
+import { useToggle } from '@vueuse/shared'
 
 const [value, toggle] = useToggle()
 ```
@@ -17,7 +17,8 @@ const [value, toggle] = useToggle()
 When you pass a ref, `useToggle` will return a simple toggle function instead:
 
 ```js
-import { useDark, useToggle } from '@vueuse/core'
+import { useToggle } from '@vueuse/shared'
+import { useDark } from '@vueuse/components'
 
 const isDark = useDark()
 const toggleDark = useToggle(isDark)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix package name in the docs - 
useDebounceFn is in '@vueuse/shared' not '/core'
https://github.com/vueuse/vueuse/issues/1688

### Additional context



---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
