### PR TITLE
fix(refDebounced): allow debouncing objects

### DIFF
--- a/packages/shared/refDebounced/index.ts
+++ b/packages/shared/refDebounced/index.ts
@@ -12,13 +12,15 @@ export function refDebounced<T>(value: Ref<T>, ms = 200, options: DebounceFilter
   if (ms <= 0)
     return value
 
-  const debounced = ref(value.value as T) as Ref<T>
+  const debounced = ref(cloneDeep(value.value) as T) as Ref<T>
 
   const updater = useDebounceFn(() => {
-    debounced.value = value.value
+    debounced.value = cloneDeep(value.value)
   }, ms, options)
 
-  watch(value, () => updater())
+  watch(value, () => updater(), {
+    deep: true
+  })
 
   return debounced
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Currently refs holding an object are updated immediately. This PR deeply watches the original ref value and clones it to avoid copying by reference in case the ref value is an object.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context
TODO: choose, install and import the library for deep cloning the original ref value (here with an example of lodash)
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
