### PR TITLE
docs: add focus outline to checkboxes for accessibility

### DIFF
--- a/packages/.vitepress/theme/components/FunctionsList.vue
+++ b/packages/.vitepress/theme/components/FunctionsList.vue
@@ -177,12 +177,13 @@ input {
 }
 
 .checkbox {
-  @apply inline-flex items-center my-auto cursor-pointer select-none;
+  @apply inline-flex items-center my-auto cursor-pointer select-none rounded px-2;
 }
 
 .checkbox input {
   appearance: none;
   padding: 0;
+  margin: 0;
   -webkit-print-color-adjust: exact;
   color-adjust: exact;
   display: inline-block;

--- a/packages/.vitepress/theme/styles/main.css
+++ b/packages/.vitepress/theme/styles/main.css
@@ -14,3 +14,9 @@ html.dark {
 .VPSidebarGroup .link {
   padding: 3px 0 !important;
 }
+
+#app a:focus-visible,
+#app button:focus-visible,
+#app input[type="checkbox"]:focus-visible {
+  @apply outline-1 outline-primary ring-2 ring-primary;
+}


### PR DESCRIPTION
### Description

Previously, when tabbing through elements on the page, the checkboxes would not change in appearance on focus. [Common web accessibility guidance](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-focus-visible.html) typically says that elements like checkboxes should have some keyboard focus indicator.

This also changes the focus indicator to match the primary color.

These changes only affect when navigating through the VueUse docs with a keyboard. These particular changes probably don't make sense to contribute upstream to the Vitepress project because this PR is focused on primarily styling the checkboxes that are implemented only in the VueUse docs.

### Before (checkboxes do not have focus outline)

https://user-images.githubusercontent.com/3038600/180933187-8427c285-3e51-450f-900c-cd01762665ce.mov

### After (checkboxes have focus outline, outline color matches theme)

https://user-images.githubusercontent.com/3038600/180933209-dd95b9d1-85af-41cd-8371-3e0f9e5d8e5c.mov

### After (light mode)

<img width="650" alt="Screen Shot 2022-07-26 at 12 55 18 AM" src="https://user-images.githubusercontent.com/3038600/180934106-3653e484-e6de-438b-8a57-8e73a0dde529.png">




---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
