### PR TITLE
fix(useColorMode): when emitAuto is true, onChanged does not trigger when preferredMode changed

### DIFF
--- a/packages/core/useColorMode/index.ts
+++ b/packages/core/useColorMode/index.ts
@@ -160,6 +160,8 @@ export function useColorMode<T extends string = BasicColorSchema>(options: UseCo
   }
 
   watch(state, onChanged, { flush: 'post', immediate: true })
+  if (emitAuto)
+    watch(preferredMode, onChanged, { flush: 'post' })
 
   tryOnMounted(() => onChanged(state.value))
 

--- a/packages/core/useColorMode/index.ts
+++ b/packages/core/useColorMode/index.ts
@@ -160,8 +160,12 @@ export function useColorMode<T extends string = BasicColorSchema>(options: UseCo
   }
 
   watch(state, onChanged, { flush: 'post', immediate: true })
-  if (emitAuto)
-    watch(preferredMode, onChanged, { flush: 'post' })
+  if (emitAuto) {
+    watch(preferredMode, () => {
+      if (store.value === 'auto')
+        onChanged(state.value)
+    }, { flush: 'post' })
+  }
 
   tryOnMounted(() => onChanged(state.value))
 

--- a/packages/core/useColorMode/index.ts
+++ b/packages/core/useColorMode/index.ts
@@ -160,12 +160,8 @@ export function useColorMode<T extends string = BasicColorSchema>(options: UseCo
   }
 
   watch(state, onChanged, { flush: 'post', immediate: true })
-  if (emitAuto) {
-    watch(preferredMode, () => {
-      if (store.value === 'auto')
-        onChanged(state.value)
-    }, { flush: 'post' })
-  }
+  if (emitAuto)
+    watch(preferredMode, () => onChanged(state.value), { flush: 'post' })
 
   tryOnMounted(() => onChanged(state.value))
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When enabling the emitAuto option, the onChanged function does not trigger when the preferredMode changed, so I added a watch for preferredMode if emitAuto enabled.

Before:
![Before](https://user-images.githubusercontent.com/6625879/181222146-4a17d6e8-6f47-49be-8dfa-38d9e9e006e6.gif)

After:
![After](https://user-images.githubusercontent.com/6625879/181222275-8a9cb28f-b64d-4482-948e-cf11109cf20c.gif)


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
