### PR TITLE
feat(useFirestore): support reactive query

### DIFF
--- a/packages/firebase/useFirestore/index.md
+++ b/packages/firebase/useFirestore/index.md
@@ -8,18 +8,24 @@ Reactive [Firestore](https://firebase.google.com/docs/firestore) binding. Making
 
 ## Usage
 
-```js {7,9}
+```js {9,12,17}
+import { computed, ref } from 'vue'
 import { initializeApp } from 'firebase/app'
-import { getFirestore } from 'firebase/firestore'
+import { collection, doc, getFirestore, limit, orderBy, query } from 'firebase/firestore'
 import { useFirestore } from '@vueuse/firebase/useFirestore'
 
 const app = initializeApp({ projectId: 'MY PROJECT ID' })
 const db = getFirestore(app)
 
-const todos = useFirestore(db.collection('todos'))
+const todos = useFirestore(collection(db, 'todos'))
 
 // or for doc reference
-const user = useFirestore(db.collection('users').doc('my-user-id'))
+const user = useFirestore(doc(db, 'users', 'my-user-id'))
+
+// you can also use ref value for reactive query
+const postLimit = ref(10)
+const postsQuery = computed(() => query(collection(db, 'posts'), orderBy('createdAt', 'desc'), limit(postLimit.value)))
+const posts = useFirestore(postsQuery)
 ```
 
 ## Share across instances
@@ -27,7 +33,7 @@ const user = useFirestore(db.collection('users').doc('my-user-id'))
 You can reuse the db reference by passing `autoDispose: false`
 
 ```ts
-const todos = useFirestore(db.collection('todos'), undefined, { autoDispose: false })
+const todos = useFirestore(collection(db, 'todos'), undefined, { autoDispose: false })
 ```
 
 or use `createGlobalState` from the core package
@@ -38,7 +44,7 @@ import { createGlobalState } from '@vueuse/core'
 import { useFirestore } from '@vueuse/firebase/useFirestore'
 
 export const useTodos = createGlobalState(
-  () => useFirestore(db.collection('todos')),
+  () => useFirestore(collection(db, 'todos')),
 )
 ```
 

--- a/packages/firebase/useFirestore/index.test.ts
+++ b/packages/firebase/useFirestore/index.test.ts
@@ -1,0 +1,27 @@
+import { ref } from 'vue-demi'
+import { onSnapshot } from 'firebase/firestore'
+import type { Mock } from 'vitest'
+import { useFirestore } from './index'
+
+vi.mock('firebase/firestore', () => ({
+  onSnapshot: vi.fn(),
+}))
+
+describe('useFirestore', () => {
+  beforeEach(() => {
+    (onSnapshot as Mock).mockClear()
+  })
+
+  it('should call onSnapshot with document reference', () => {
+    const docRef = { path: 'users' } as any
+    useFirestore(docRef)
+    expect((onSnapshot as Mock).mock.calls[0][0]).toStrictEqual(docRef)
+  })
+
+  it('should call onSnapshot with ref value of document reference', () => {
+    const docRef = { path: 'posts' } as any
+    const refOfDocRef = ref(docRef)
+    useFirestore(refOfDocRef)
+    expect((onSnapshot as Mock).mock.calls[0][0]).toStrictEqual(docRef)
+  })
+})


### PR DESCRIPTION
### Description

Support `ref` of document reference.
You can use not reactive value as before.

### Additional context

We will be able to bind firestore data also when query is dynamic (e.g. date picker / pagination / infinite scroll)

This GIF shows the same impl custom composable works in my project.
[![Image from Gyazo](https://i.gyazo.com/e2c2a795b26ec04e3fbadb10351b90a4.gif)](https://gyazo.com/e2c2a795b26ec04e3fbadb10351b90a4)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
