### PR TITLE
docs(useFocusWithin): fix typos

### DIFF
--- a/packages/core/useFocusWithin/index.md
+++ b/packages/core/useFocusWithin/index.md
@@ -4,7 +4,7 @@ category: Sensors
 
 # useFocusWithin
 
-Reactive utility to track if an element or one of its decendants has focus. It is meant to match the behvaior of the `:focus-within` CSS psuedo-class. A common use case would be on a form element to see if any of its inputs currently have focus.
+Reactive utility to track if an element or one of its decendants has focus. It is meant to match the behavior of the `:focus-within` CSS pseudo-class. A common use case would be on a form element to see if any of its inputs currently have focus.
 
 ## Basic Usage
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix a couple of typos in useFocusWithin docs.

### Additional context

None.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
