### PR TITLE
chore(useIntervalFn): improve internal types

### DIFF
--- a/packages/shared/useIntervalFn/index.ts
+++ b/packages/shared/useIntervalFn/index.ts
@@ -33,7 +33,7 @@ export function useIntervalFn(cb: Fn, interval: MaybeComputedRef<number> = 1000,
     immediateCallback = false,
   } = options
 
-  let timer: any = null
+  let timer: NodeJS.Timer | null = null
   const isActive = ref(false)
 
   function clean() {

--- a/packages/shared/useIntervalFn/index.ts
+++ b/packages/shared/useIntervalFn/index.ts
@@ -33,7 +33,7 @@ export function useIntervalFn(cb: Fn, interval: MaybeComputedRef<number> = 1000,
     immediateCallback = false,
   } = options
 
-  let timer: NodeJS.Timer | null = null
+  let timer: ReturnType<typeof setInterval> | null = null
   const isActive = ref(false)
 
   function clean() {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

rename timer type `any `to `ReturnType<typeof setInterval> | null`

### Additional context

What Is the Correct TypeScript Return Type for JavaScript's setInterval() Function?
[link](https://www.designcise.com/web/tutorial/what-is-the-correct-typescript-return-type-for-javascripts-setinterval-function)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
