### PR TITLE
fix(useDevicePixelRatio): more efficient mechanism

### DIFF
--- a/packages/core/useDevicePixelRatio/demo.vue
+++ b/packages/core/useDevicePixelRatio/demo.vue
@@ -10,4 +10,5 @@ const code = stringify(pixelRatio)
 <template>
   <div>Device Pixel Ratio:</div>
   <pre>{{ code }}</pre>
+  <span class="opacity-50">Zoom in and out (or move the window to a screen with a different scaling factor) to see the value changes</span>
 </template>

--- a/packages/core/useDevicePixelRatio/index.md
+++ b/packages/core/useDevicePixelRatio/index.md
@@ -6,7 +6,7 @@ category: Sensors
 
 Reactively track [`window.devicePixelRatio`](https://developer.mozilla.org/ru/docs/Web/API/Window/devicePixelRatio)
 >
-> NOTE: there is no event listener for `window.devicePixelRatio` change. So this function uses [`Testing media queries programmatically (window.matchMedia)`](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Testing_media_queries) as described in [this example](https://stackoverflow.com/questions/28905420/window-devicepixelratio-change-listener/29653772#29653772), but unlike the example this function subscribes to **several** pixelRatio scales (taken from [mydevice.io](https://www.mydevice.io/)) to detect any `window.devicePixelRatio` change.
+> NOTE: there is no event listener for `window.devicePixelRatio` change. So this function uses [`Testing media queries programmatically (window.matchMedia)`](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Testing_media_queries) applying the same mechanism as described in [this example](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio#monitoring_screen_resolution_or_zoom_level_changes).
 
 ## Usage
 

--- a/packages/core/useDevicePixelRatio/index.ts
+++ b/packages/core/useDevicePixelRatio/index.ts
@@ -19,7 +19,6 @@ export function useDevicePixelRatio({
 
   const pixelRatio = ref(1)
 
-  let mqResolution: MediaQueryList
   const cleanups: Fn[] = []
 
   const cleanup = () => {
@@ -30,10 +29,10 @@ export function useDevicePixelRatio({
   const observe = () => {
     pixelRatio.value = window.devicePixelRatio
     cleanup()
-    mqResolution = window.matchMedia(`(resolution: ${pixelRatio.value}dppx)`)
-    mqResolution.addEventListener('change', observe, { once: true })
+    const media = window.matchMedia(`(resolution: ${pixelRatio.value}dppx)`)
+    media.addEventListener('change', observe, { once: true })
     cleanups.push(() => {
-      mqResolution.removeEventListener('change', observe)
+      media.removeEventListener('change', observe)
     })
   }
 

--- a/packages/core/useDevicePixelRatio/index.ts
+++ b/packages/core/useDevicePixelRatio/index.ts
@@ -1,24 +1,7 @@
-import { ref, watch } from 'vue-demi'
-import { useEventListener } from '../useEventListener'
-import { useMediaQuery } from '../useMediaQuery'
-import type { ConfigurableWindow } from '../_configurable'
-import { defaultWindow } from '../_configurable'
+import { ref } from 'vue-demi'
+import { type Fn, tryOnScopeDispose } from '@vueuse/shared'
+import { type ConfigurableWindow, defaultWindow } from '../_configurable'
 
-// device pixel ratio statistics from https://www.mydevice.io/
-const DEVICE_PIXEL_RATIO_SCALES = [
-  1,
-  1.325,
-  1.4,
-  1.5,
-  1.8,
-  2,
-  2.4,
-  2.5,
-  2.75,
-  3,
-  3.5,
-  4,
-]
 /**
  * Reactively track `window.devicePixelRatio`.
  *
@@ -34,21 +17,17 @@ export function useDevicePixelRatio({
     }
   }
 
-  const pixelRatio = ref(window.devicePixelRatio)
+  const pixelRatio = ref(1)
 
-  const handleDevicePixelRatio = () => {
+  let mqResolution: MediaQueryList
+  tryOnScopeDispose((function MqResolutionObserve(): Fn {
     pixelRatio.value = window.devicePixelRatio
-  }
-
-  useEventListener(window, 'resize', handleDevicePixelRatio, { passive: true })
-
-  DEVICE_PIXEL_RATIO_SCALES.forEach((dppx) => {
-    // listen mql events in both sides
-    const mqlMin = useMediaQuery(`screen and (min-resolution: ${dppx}dppx)`)
-    const mqlMax = useMediaQuery(`screen and (max-resolution: ${dppx}dppx)`)
-
-    watch([mqlMin, mqlMax], handleDevicePixelRatio)
-  })
+    mqResolution = window.matchMedia(`(resolution: ${pixelRatio.value}dppx)`)
+    mqResolution.addEventListener('change', MqResolutionObserve, { once: true })
+    return () => {
+      mqResolution.removeEventListener('change', MqResolutionObserve)
+    }
+  })())
 
   return { pixelRatio }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I implemented a more efficient mechanism for the `useDevicePixelRatio` function that inspired by [this example](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio#monitoring_screen_resolution_or_zoom_level_changes)

### Additional context

Currently the `useDevicePixelRatio` function create 12*2 watchers/eventListeners (+1 window resize) to achieve the same goal, this mechanism use only 1 event listener to check if the current `resolution` changed (once) then update the value and recursively check the new value

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
