### PR TITLE
feat(fromEvent): support HTMLElement

### DIFF
--- a/packages/rxjs/from/index.ts
+++ b/packages/rxjs/from/index.ts
@@ -19,9 +19,12 @@ export function from<T>(value: ObservableInput<T> | Ref<T>, watchOptions?: Watch
   }
 }
 
-export function fromEvent<T extends HTMLElement>(value: Ref<T>, event: string): Observable<Event> {
-  return from(value, { immediate: true }).pipe(
-    filter(value => value instanceof HTMLElement),
-    mergeMap(value => fromEventRx(value, event)),
-  )
+export function fromEvent<T extends HTMLElement>(value: Ref<T> | T, event: string): Observable<Event> {
+  if (isRef<T>(value)) {
+    return from(value, { immediate: true }).pipe(
+      filter(value => value instanceof HTMLElement),
+      mergeMap(value => fromEventRx(value, event)),
+    )
+  }
+  return fromEventRx(value, event);
 }

--- a/packages/rxjs/from/index.ts
+++ b/packages/rxjs/from/index.ts
@@ -2,6 +2,7 @@ import { Observable, fromEvent as fromEventRx, from as fromRxjs } from 'rxjs'
 import type { ObservableInput } from 'rxjs'
 import { filter, mergeMap } from 'rxjs/operators'
 import type { Ref, WatchOptions } from 'vue-demi'
+import type { MaybeRef } from '@vueuse/shared'
 import { isRef, watch } from 'vue-demi'
 
 export function from<T>(value: ObservableInput<T> | Ref<T>, watchOptions?: WatchOptions): Observable<T> {
@@ -19,7 +20,7 @@ export function from<T>(value: ObservableInput<T> | Ref<T>, watchOptions?: Watch
   }
 }
 
-export function fromEvent<T extends HTMLElement>(value: Ref<T> | T, event: string): Observable<Event> {
+export function fromEvent<T extends HTMLElement>(value: MaybeRef<T>, event: string): Observable<Event> {
   if (isRef<T>(value)) {
     return from(value, { immediate: true }).pipe(
       filter(value => value instanceof HTMLElement),

--- a/packages/rxjs/from/index.ts
+++ b/packages/rxjs/from/index.ts
@@ -26,5 +26,5 @@ export function fromEvent<T extends HTMLElement>(value: Ref<T> | T, event: strin
       mergeMap(value => fromEventRx(value, event)),
     )
   }
-  return fromEventRx(value, event);
+  return fromEventRx(value, event)
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Hi, thanks to `@vueuse` and `@vueuse/rxjs`，I can use rxjs in vue easily.
The `fromEvent` function support `Ref<HTMLElement>`, and code:
```
import { fromEvent } from '@vueuse/rxjs'
import { fromEvent as fromEventRx } from "rxjs";
const mousedown$ = fromEvent(resizeAnchorRef!, 'mousedown');
const mouseup$ = fromEventRx(document.body, 'mouseup');
const mousemove$ = fromEventRx(document.body, 'mousemove');
```
Expect `fromEvent` can also support `HTMLElement`, so I can use like this:

```
import { fromEvent } from '@vueuse/rxjs'
const mousedown$ = fromEvent(resizeAnchorRef!, 'mousedown');
const mouseup$ = fromEvent(document.body, 'mouseup');
const mousemove$ = fromEvent(document.body, 'mousemove');

```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
