### PR TITLE
docs(onKeyStroke): allow typing into search on demo page

### DIFF
--- a/packages/core/onKeyStroke/demo.vue
+++ b/packages/core/onKeyStroke/demo.vue
@@ -7,22 +7,18 @@ const translateY = ref(0)
 
 onKeyStroke(['w', 'W', 'ArrowUp'], (e: KeyboardEvent) => {
   translateY.value -= 10
-  e.preventDefault()
 })
 
 onKeyStroke(['s', 'S', 'ArrowDown'], (e: KeyboardEvent) => {
   translateY.value += 10
-  e.preventDefault()
 })
 
 onKeyStroke(['a', 'A', 'ArrowLeft'], (e: KeyboardEvent) => {
   translateX.value -= 10
-  e.preventDefault()
 })
 
 onKeyStroke(['d', 'D', 'ArrowRight'], (e: KeyboardEvent) => {
   translateX.value += 10
-  e.preventDefault()
 })
 </script>
 


### PR DESCRIPTION
### Description

Previously, on the onKeyStroke demo page, the user could not type into
the search box because of a `preventDefault()` that was present in the
demo.

After this fix, the search box can be typed into on the onKeyStroke
demo page.

fix #1951

https://user-images.githubusercontent.com/3038600/183084586-d5a3cfa5-4129-447d-a037-65fa1a06eba0.mov



---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
