### PR TITLE
fix(useScroll): account for rounding errors when calculating arrivedState

### DIFF
--- a/packages/core/useScroll/index.ts
+++ b/packages/core/useScroll/index.ts
@@ -51,6 +51,14 @@ export interface UseScrollOptions {
 }
 
 /**
+ * We have to check if the scroll amount is close enough to some threshold in order to
+ * more accurately calculate arrivedState. This is because scrollTop/scrollLeft are non-rounded
+ * numbers, while scrollHeight/scrollWidth and clientHeight/clientWidth are rounded.
+ * https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight#determine_if_an_element_has_been_totally_scrolled
+ */
+const ARRIVED_STATE_THRESHOLD_PIXELS = 1
+
+/**
  * Reactive scroll.
  *
  * @see https://vueuse.org/useScroll
@@ -114,7 +122,7 @@ export function useScroll(
     directions.right = scrollLeft > x.value
     arrivedState.left = scrollLeft <= 0 + (offset.left || 0)
     arrivedState.right
-          = scrollLeft + eventTarget.clientWidth >= eventTarget.scrollWidth - (offset.right || 0)
+      = scrollLeft + eventTarget.clientWidth >= eventTarget.scrollWidth - (offset.right || 0) - ARRIVED_STATE_THRESHOLD_PIXELS
     x.value = scrollLeft
 
     let scrollTop = eventTarget.scrollTop
@@ -127,7 +135,7 @@ export function useScroll(
     directions.bottom = scrollTop > y.value
     arrivedState.top = scrollTop <= 0 + (offset.top || 0)
     arrivedState.bottom
-          = scrollTop + eventTarget.clientHeight >= eventTarget.scrollHeight - (offset.bottom || 0)
+      = scrollTop + eventTarget.clientHeight >= eventTarget.scrollHeight - (offset.bottom || 0) - ARRIVED_STATE_THRESHOLD_PIXELS
     y.value = scrollTop
 
     isScrolling.value = true


### PR DESCRIPTION
### Description

Sometimes when zooming the page to sizes other than 100% and scrolling a
container all the way to the bottom right, the calculation for
`arrivedState.right` and `arrivedState.bottom` would incorrectly say
`false`. This is due to a [rounding error][] because `scrollTop` is a
non-rounded number, while `scrollHeight` and `clientHeight` are rounded.

Using the MDN documentation on `Element.scrollHeight` as guidance,
this commit factors in a 1px margin of error to more accurately
calculate `arrivedState.right` and `arrivedState.bottom`.

[rounding error]: https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight#determine_if_an_element_has_been_totally_scrolled

fix #2047

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
