### PR TITLE
docs: replaces /recent-updated broken link

### DIFF
--- a/packages/.vitepress/config.ts
+++ b/packages/.vitepress/config.ts
@@ -30,7 +30,7 @@ const Links = [
   { text: 'Add-ons', link: '/add-ons' },
   { text: 'Ecosystem', link: '/ecosystem' },
   { text: 'Export Size', link: '/export-size' },
-  { text: 'Recent Updated', link: '/recent-updated' },
+  { text: 'Recent Updated', link: '/functions.html#sort=updated' },
 ]
 
 const DefaultSideBar = [
@@ -141,8 +141,6 @@ export default defineConfig({
       '/ecosystem': DefaultSideBar,
       '/guidelines': DefaultSideBar,
       '/export-size': DefaultSideBar,
-      '/recent-updated': DefaultSideBar,
-
       '/functions': FunctionsSideBar,
       '/core/': FunctionsSideBar,
       '/shared/': FunctionsSideBar,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The last link of the [sidebar](https://vueuse.org/guide/) with the title `Currently Updated` is broken.
Replaced with a link to the function page and the updated sorting enabled. [[link](https://vueuse.org/functions.html#sort=updated)]

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
