### PR TITLE
fix(useURLSearchParams): avoid referencing to global `location`

### DIFF
--- a/packages/core/useUrlSearchParams/index.ts
+++ b/packages/core/useUrlSearchParams/index.ts
@@ -64,9 +64,9 @@ export function useUrlSearchParams<T extends Record<string, any> = UrlParams>(
     const stringified = params.toString()
 
     if (mode === 'history')
-      return `${stringified ? `?${stringified}` : ''}${location.hash || ''}`
+      return `${stringified ? `?${stringified}` : ''}${window.location.hash || ''}`
     if (mode === 'hash-params')
-      return `${location.search || ''}${stringified ? `#${stringified}` : ''}`
+      return `${window.location.search || ''}${stringified ? `#${stringified}` : ''}`
     const hash = window.location.hash || '#'
     const index = hash.indexOf('?')
     if (index > 0)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Avoid using global `location` variable in case it is not available. Instead access it as property on the global `window` object.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

I might contribute an extended version of useURLSearchParams that provides reactive access to the complete URL path instead of just the search params. Soon™ 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
