### PR TITLE
fix(useElementHover): support set el ref type

### DIFF
--- a/packages/core/useElementHover/demo.vue
+++ b/packages/core/useElementHover/demo.vue
@@ -2,7 +2,7 @@
 import { ref } from 'vue'
 import { useElementHover } from '@vueuse/core'
 
-const el = ref()
+const el = ref<HTMLButtonElement>()
 const isHovered = useElementHover(el)
 </script>
 

--- a/packages/core/useElementHover/index.ts
+++ b/packages/core/useElementHover/index.ts
@@ -3,7 +3,7 @@ import { ref } from 'vue-demi'
 import type { MaybeComputedRef } from '@vueuse/shared'
 import { useEventListener } from '../useEventListener'
 
-export function useElementHover(el: MaybeComputedRef<EventTarget>): Ref<boolean> {
+export function useElementHover(el: MaybeComputedRef<EventTarget | null | undefined>): Ref<boolean> {
   const isHovered = ref(false)
 
   useEventListener(el, 'mouseenter', () => isHovered.value = true)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

```ts
const dropZoneRef = ref<HTMLElement>()     // <-- when i set ref as a HTMLElement
function onDrop(files: File[] | null) {
  if (!files)
    return
  const url = window.URL.createObjectURL(files[0])
  gifUrl.value = url
}
const { isOverDropZone } = useDropZone(dropZoneRef, onDrop)
const isHovered = useElementHover(dropZoneRef) // <- it got a type error as follow
```

```html
<div ref="dropZoneRef">
  xxx
</div>
```

> 类型“Ref<HTMLDivElement | undefined>”的参数不能赋给类型“MaybeComputedRef<EventTarget>”的参数。
  不能将类型“Ref<HTMLDivElement | undefined>”分配给类型“Ref<EventTarget>”。

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->



---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
