### PR TITLE
feat(useFirestore): support dependent queries

### DIFF
--- a/packages/firebase/useFirestore/index.md
+++ b/packages/firebase/useFirestore/index.md
@@ -8,7 +8,7 @@ Reactive [Firestore](https://firebase.google.com/docs/firestore) binding. Making
 
 ## Usage
 
-```js {9,12,17}
+```js {9,12,17,22}
 import { computed, ref } from 'vue'
 import { initializeApp } from 'firebase/app'
 import { collection, doc, getFirestore, limit, orderBy, query } from 'firebase/firestore'
@@ -26,6 +26,11 @@ const user = useFirestore(doc(db, 'users', 'my-user-id'))
 const postLimit = ref(10)
 const postsQuery = computed(() => query(collection(db, 'posts'), orderBy('createdAt', 'desc'), limit(postLimit.value)))
 const posts = useFirestore(postsQuery)
+
+// you can use the boolean value to tell a query when it is ready to run
+// when it gets falsy value, return the initial value
+const userId = ref('')
+const userData = useFirestore(() => !!userId.value && doc(db, 'users', userId.value), [])
 ```
 
 ## Share across instances

--- a/packages/firebase/useFirestore/index.md
+++ b/packages/firebase/useFirestore/index.md
@@ -23,14 +23,14 @@ const todos = useFirestore(collection(db, 'todos'))
 const user = useFirestore(doc(db, 'users', 'my-user-id'))
 
 // you can also use ref value for reactive query
-const postLimit = ref(10)
-const postsQuery = computed(() => query(collection(db, 'posts'), orderBy('createdAt', 'desc'), limit(postLimit.value)))
+const postsLimit = ref(10)
+const postsQuery = computed(() => query(collection(db, 'posts'), orderBy('createdAt', 'desc'), limit(postsLimit.value)))
 const posts = useFirestore(postsQuery)
 
 // you can use the boolean value to tell a query when it is ready to run
 // when it gets falsy value, return the initial value
 const userId = ref('')
-const userData = useFirestore(() => !!userId.value && doc(db, 'users', userId.value), [])
+const userData = useFirestore(() => !!userId.value && doc(db, 'users', userId.value), null)
 ```
 
 ## Share across instances

--- a/packages/firebase/useFirestore/index.md
+++ b/packages/firebase/useFirestore/index.md
@@ -30,7 +30,8 @@ const posts = useFirestore(postsQuery)
 // you can use the boolean value to tell a query when it is ready to run
 // when it gets falsy value, return the initial value
 const userId = ref('')
-const userData = useFirestore(() => !!userId.value && doc(db, 'users', userId.value), null)
+const userQuery = computed(() => !!userId.value && doc(db, 'users', userId.value))
+const userData = useFirestore(userQuery, null)
 ```
 
 ## Share across instances

--- a/packages/firebase/useFirestore/index.test.ts
+++ b/packages/firebase/useFirestore/index.test.ts
@@ -1,27 +1,89 @@
-import { ref } from 'vue-demi'
-import { onSnapshot } from 'firebase/firestore'
-import type { Mock } from 'vitest'
+import { computed, nextTick, ref } from 'vue-demi'
 import { useFirestore } from './index'
 
-vi.mock('firebase/firestore', () => ({
-  onSnapshot: vi.fn(),
-}))
+const getMockSnapFromRef = (docRef: any) => ({
+  id: `${docRef.path}-id`,
+  data: () => (docRef),
+})
+
+const getData = (docRef: any) => ({
+  ...docRef.data(),
+  id: docRef.id,
+})
+
+const unsubscribe = vi.fn()
+
+vi.mock('firebase/firestore', () => {
+  const onSnapshot = vi.fn((docRef: any, callbackFn: (payload: any) => {}) => {
+    if (docRef.path.includes('//'))
+      throw new Error('Invalid segment')
+
+    callbackFn({
+      ...getMockSnapFromRef(docRef),
+      docs: [getMockSnapFromRef(docRef)],
+    })
+    return unsubscribe
+  })
+  return { onSnapshot }
+})
 
 describe('useFirestore', () => {
   beforeEach(() => {
-    (onSnapshot as Mock).mockClear()
+    unsubscribe.mockClear()
   })
 
-  it('should call onSnapshot with document reference', () => {
-    const docRef = { path: 'users' } as any
-    useFirestore(docRef)
-    expect((onSnapshot as Mock).mock.calls[0][0]).toStrictEqual(docRef)
+  it('should get `users` collection data', () => {
+    const collectionRef = { path: 'users' } as any
+    const data = useFirestore(collectionRef)
+    expect(data.value).toMatchObject([getData(getMockSnapFromRef(collectionRef))])
   })
 
-  it('should call onSnapshot with ref value of document reference', () => {
-    const docRef = { path: 'posts' } as any
-    const refOfDocRef = ref(docRef)
-    useFirestore(refOfDocRef)
-    expect((onSnapshot as Mock).mock.calls[0][0]).toStrictEqual(docRef)
+  it('should get `users/userId` document data', () => {
+    const docRef = { path: 'users/userId' } as any
+    const data = useFirestore(docRef)
+    expect(data.value).toMatchObject(getData(getMockSnapFromRef(docRef)))
+  })
+
+  it('should get `posts` computed query data', () => {
+    const queryRef = { path: 'posts', orderBy: 'desc' } as any
+    const data = useFirestore(computed(() => queryRef))
+    expect(data.value).toMatchObject([getData(getMockSnapFromRef(queryRef))])
+  })
+
+  it('should get `todos` function query data', () => {
+    const collectionRef = { path: 'todos' } as any
+    const data = useFirestore(() => collectionRef)
+    expect(data.value).toMatchObject([getData(getMockSnapFromRef(collectionRef))])
+  })
+
+  it('should get initial value when pass falsy value', () => {
+    const collectionRef = { path: 'todos' } as any
+    const falsy = computed(() => false)
+    const data = useFirestore(() => falsy.value && collectionRef, [{ id: 'default' }])
+    expect(data.value).toMatchObject([{ id: 'default' }])
+  })
+
+  it('should get reactive query data & unsubscribe previous query when re-querying', async () => {
+    const queryRef = { path: 'posts', orderBy: 'desc' } as any
+    const reactiveQueryRef = ref(queryRef)
+    const data = useFirestore(reactiveQueryRef)
+    expect(data.value).toMatchObject([getData(getMockSnapFromRef(reactiveQueryRef.value))])
+    reactiveQueryRef.value = { ...queryRef, orderBy: 'asc' }
+    await nextTick()
+    expect(unsubscribe).toHaveBeenCalled()
+    expect(data.value).toMatchObject([getData(getMockSnapFromRef(reactiveQueryRef.value))])
+  })
+
+  it('should get user data only when user id exists', async () => {
+    const userId = ref('')
+    const data = useFirestore(() => !!userId.value && { path: `users/${userId.value}/posts` } as any, [{ id: 'default' }])
+    expect(data.value).toMatchObject([{ id: 'default' }])
+    userId.value = 'userId'
+    await nextTick()
+    expect(data.value).toMatchObject([getData(getMockSnapFromRef({ path: `users/${userId.value}/posts` }))])
+    userId.value = ''
+    await nextTick()
+    expect(unsubscribe).toHaveBeenCalled()
+    expect(data.value).toMatchObject([{ id: 'default' }])
   })
 })

--- a/packages/firebase/useFirestore/index.test.ts
+++ b/packages/firebase/useFirestore/index.test.ts
@@ -1,30 +1,47 @@
+import { collection, doc } from 'firebase/firestore'
+import type { Firestore } from 'firebase/firestore'
 import { computed, nextTick, ref } from 'vue-demi'
 import { useFirestore } from './index'
+
+const dummyFirestore = {} as Firestore
 
 const getMockSnapFromRef = (docRef: any) => ({
   id: `${docRef.path}-id`,
   data: () => (docRef),
 })
 
-const getData = (docRef: any) => ({
-  ...docRef.data(),
-  id: docRef.id,
-})
+const getData = (docRef: any) => {
+  const data = docRef.data()
+  Object.defineProperty(data, 'id', {
+    value: docRef.id.toString(),
+    writable: false,
+  })
+  return data
+}
 
 const unsubscribe = vi.fn()
 
 vi.mock('firebase/firestore', () => {
-  const onSnapshot = vi.fn((docRef: any, callbackFn: (payload: any) => {}) => {
-    if (docRef.path.includes('//'))
+  const doc = vi.fn((_: Firestore, path: string) => {
+    if (path.includes('//'))
       throw new Error('Invalid segment')
+    return { path }
+  })
 
+  const collection = vi.fn((_: Firestore, path: string) => {
+    if (path.includes('//'))
+      throw new Error('Invalid segment')
+    return { path }
+  })
+
+  const onSnapshot = vi.fn((docRef: any, callbackFn: (payload: any) => {}) => {
     callbackFn({
       ...getMockSnapFromRef(docRef),
       docs: [getMockSnapFromRef(docRef)],
     })
     return unsubscribe
   })
-  return { onSnapshot }
+  return { onSnapshot, collection, doc }
 })
 
 describe('useFirestore', () => {
@@ -33,57 +50,52 @@ describe('useFirestore', () => {
   })
 
   it('should get `users` collection data', () => {
-    const collectionRef = { path: 'users' } as any
+    const collectionRef = collection(dummyFirestore, 'users')
     const data = useFirestore(collectionRef)
-    expect(data.value).toMatchObject([getData(getMockSnapFromRef(collectionRef))])
+    expect(data.value).toEqual([getData(getMockSnapFromRef(collectionRef))])
   })
 
   it('should get `users/userId` document data', () => {
-    const docRef = { path: 'users/userId' } as any
+    const docRef = doc(dummyFirestore, 'users/userId')
     const data = useFirestore(docRef)
-    expect(data.value).toMatchObject(getData(getMockSnapFromRef(docRef)))
+    expect(data.value).toEqual(getData(getMockSnapFromRef(docRef)))
   })
 
   it('should get `posts` computed query data', () => {
-    const queryRef = { path: 'posts', orderBy: 'desc' } as any
+    const queryRef = collection(dummyFirestore, 'posts')
     const data = useFirestore(computed(() => queryRef))
-    expect(data.value).toMatchObject([getData(getMockSnapFromRef(queryRef))])
-  })
-
-  it('should get `todos` function query data', () => {
-    const collectionRef = { path: 'todos' } as any
-    const data = useFirestore(() => collectionRef)
-    expect(data.value).toMatchObject([getData(getMockSnapFromRef(collectionRef))])
+    expect(data.value).toEqual([getData(getMockSnapFromRef(queryRef))])
   })
 
   it('should get initial value when pass falsy value', () => {
-    const collectionRef = { path: 'todos' } as any
-    const falsy = computed(() => false)
-    const data = useFirestore(() => falsy.value && collectionRef, [{ id: 'default' }])
-    expect(data.value).toMatchObject([{ id: 'default' }])
+    const collectionRef = collection(dummyFirestore, 'todos')
+    const falsy = computed(() => false as boolean && collectionRef)
+    const data = useFirestore(falsy, [{ id: 'default' }])
+    expect(data.value).toEqual([{ id: 'default' }])
   })
 
   it('should get reactive query data & unsubscribe previous query when re-querying', async () => {
-    const queryRef = { path: 'posts', orderBy: 'desc' } as any
+    const queryRef = collection(dummyFirestore, 'posts')
     const reactiveQueryRef = ref(queryRef)
     const data = useFirestore(reactiveQueryRef)
-    expect(data.value).toMatchObject([getData(getMockSnapFromRef(reactiveQueryRef.value))])
-    reactiveQueryRef.value = { ...queryRef, orderBy: 'asc' }
+    expect(data.value).toEqual([getData(getMockSnapFromRef(reactiveQueryRef.value))])
+    reactiveQueryRef.value = collection(dummyFirestore, 'todos')
     await nextTick()
     expect(unsubscribe).toHaveBeenCalled()
-    expect(data.value).toMatchObject([getData(getMockSnapFromRef(reactiveQueryRef.value))])
+    expect(data.value).toEqual([getData(getMockSnapFromRef(reactiveQueryRef.value))])
   })
 
   it('should get user data only when user id exists', async () => {
     const userId = ref('')
-    const data = useFirestore(() => !!userId.value && { path: `users/${userId.value}/posts` } as any, [{ id: 'default' }])
-    expect(data.value).toMatchObject([{ id: 'default' }])
+    const queryRef = computed(() => !!userId.value && collection(dummyFirestore, `users/${userId.value}/posts`))
+    const data = useFirestore(queryRef, [{ id: 'default' }])
+    expect(data.value).toEqual([{ id: 'default' }])
     userId.value = 'userId'
     await nextTick()
-    expect(data.value).toMatchObject([getData(getMockSnapFromRef({ path: `users/${userId.value}/posts` }))])
+    expect(data.value).toEqual([getData(getMockSnapFromRef(collection(dummyFirestore, `users/${userId.value}/posts`)))])
     userId.value = ''
     await nextTick()
     expect(unsubscribe).toHaveBeenCalled()
-    expect(data.value).toMatchObject([{ id: 'default' }])
+    expect(data.value).toEqual([{ id: 'default' }])
   })
 })

--- a/packages/firebase/useFirestore/index.ts
+++ b/packages/firebase/useFirestore/index.ts
@@ -34,24 +34,24 @@ function isDocumentReference<T>(docRef: any): docRef is DocumentReference<T> {
 }
 
 export function useFirestore<T extends DocumentData>(
-  maybeDocRefOrFunc: (() => DocumentReference<T>) | MaybeRef<DocumentReference<T>>,
+  maybeDocRef: MaybeRef<DocumentReference<T> | false>,
   initialValue: T,
   options?: UseFirestoreOptions
 ): Ref<T | null>
 export function useFirestore<T extends DocumentData>(
-  maybeDocRefOrFunc: (() => Query<T>) | MaybeRef<Query<T>>,
+  maybeDocRef: MaybeRef<Query<T> | false>,
   initialValue: T[],
   options?: UseFirestoreOptions
 ): Ref<T[]>
 
 // nullable initial values
 export function useFirestore<T extends DocumentData>(
-  maybeDocRefOrFunc: (() => DocumentReference<T>) | MaybeRef<DocumentReference<T>>,
+  maybeDocRef: MaybeRef<DocumentReference<T> | false>,
   initialValue?: T | undefined,
   options?: UseFirestoreOptions,
 ): Ref<T | undefined | null>
 export function useFirestore<T extends DocumentData>(
-  maybeDocRefOrFunc: (() => Query<T>) | MaybeRef<Query<T>>,
+  maybeDocRef: MaybeRef<Query<T> | false>,
   initialValue?: T[],
   options?: UseFirestoreOptions
 ): Ref<T[] | undefined>
@@ -63,7 +63,7 @@ export function useFirestore<T extends DocumentData>(
  * @see https://vueuse.org/useFirestore
  */
 export function useFirestore<T extends DocumentData>(
-  maybeDocRefOrFunc: (() => FirebaseDocRef<T>) | MaybeRef<FirebaseDocRef<T>>,
+  maybeDocRef: MaybeRef<FirebaseDocRef<T> | false>,
   initialValue: any = undefined,
   options: UseFirestoreOptions = {},
 ) {
@@ -72,11 +72,9 @@ export function useFirestore<T extends DocumentData>(
     autoDispose = true,
   } = options
 
-  const refOfDocRef = typeof maybeDocRefOrFunc === 'function'
-    ? computed(() => maybeDocRefOrFunc())
-    : isRef(maybeDocRefOrFunc)
-      ? maybeDocRefOrFunc
-      : computed(() => maybeDocRefOrFunc)
+  const refOfDocRef = isRef(maybeDocRef)
+    ? maybeDocRef
+    : computed(() => maybeDocRef)
 
   let close = () => { }
   const data = ref(initialValue) as Ref<T | T[] | null | undefined>

--- a/packages/firebase/useFirestore/index.ts
+++ b/packages/firebase/useFirestore/index.ts
@@ -34,24 +34,24 @@ function isDocumentReference<T>(docRef: any): docRef is DocumentReference<T> {
 }
 
 export function useFirestore<T extends DocumentData>(
-  maybeDocRef: MaybeRef<DocumentReference<T>>,
+  maybeDocRefOrFunc: (() => DocumentReference<T>) | MaybeRef<DocumentReference<T>>,
   initialValue: T,
   options?: UseFirestoreOptions
 ): Ref<T | null>
 export function useFirestore<T extends DocumentData>(
-  maybeDocRef: MaybeRef<Query<T>>,
+  maybeDocRefOrFunc: (() => Query<T>) | MaybeRef<Query<T>>,
   initialValue: T[],
   options?: UseFirestoreOptions
 ): Ref<T[]>
 
 // nullable initial values
 export function useFirestore<T extends DocumentData>(
-  maybeDocRef: MaybeRef<DocumentReference<T>>,
+  maybeDocRefOrFunc: (() => DocumentReference<T>) | MaybeRef<DocumentReference<T>>,
   initialValue?: T | undefined,
   options?: UseFirestoreOptions,
 ): Ref<T | undefined | null>
 export function useFirestore<T extends DocumentData>(
-  maybeDocRef: MaybeRef<Query<T>>,
+  maybeDocRefOrFunc: (() => Query<T>) | MaybeRef<Query<T>>,
   initialValue?: T[],
   options?: UseFirestoreOptions
 ): Ref<T[] | undefined>
@@ -63,7 +63,7 @@ export function useFirestore<T extends DocumentData>(
  * @see https://vueuse.org/useFirestore
  */
 export function useFirestore<T extends DocumentData>(
-  maybeDocRef: MaybeRef<FirebaseDocRef<T>>,
+  maybeDocRefOrFunc: (() => FirebaseDocRef<T>) | MaybeRef<FirebaseDocRef<T>>,
   initialValue: any = undefined,
   options: UseFirestoreOptions = {},
 ) {
@@ -72,41 +72,37 @@ export function useFirestore<T extends DocumentData>(
     autoDispose = true,
   } = options
 
-  const refOfDocRef = isRef(maybeDocRef) ? maybeDocRef : computed(() => maybeDocRef)
+  const refOfDocRef = typeof maybeDocRefOrFunc === 'function'
+    ? computed(() => maybeDocRefOrFunc())
+    : isRef(maybeDocRefOrFunc)
+      ? maybeDocRefOrFunc
+      : computed(() => maybeDocRefOrFunc)
 
-  if (isDocumentReference<T>(refOfDocRef.value)) {
-    const data = ref(initialValue) as Ref<T | null | undefined>
-    let close = () => { }
+  let close = () => { }
+  const data = ref(initialValue) as Ref<T | T[] | null | undefined>
 
-    watch(refOfDocRef, (docRef) => {
-      close()
+  watch(refOfDocRef, (docRef) => {
+    close()
+    if (!refOfDocRef.value) {
+      data.value = initialValue
+    }
+    else if (isDocumentReference<T>(refOfDocRef.value)) {
       close = onSnapshot(docRef as DocumentReference<T>, (snapshot) => {
         data.value = getData(snapshot) || null
       }, errorHandler)
-    }, { immediate: true })
-
-    tryOnScopeDispose(() => {
-      close()
-    })
-
-    return data
-  }
-  else {
-    const data = ref(initialValue) as Ref<T[] | undefined>
-    let close = () => { }
-
-    watch(refOfDocRef, (docRef) => {
-      close()
+    }
+    else {
       close = onSnapshot(docRef as Query<T>, (snapshot) => {
         data.value = snapshot.docs.map(getData).filter(isDef)
       }, errorHandler)
-    }, { immediate: true })
-
-    if (autoDispose) {
-      tryOnScopeDispose(() => {
-        close()
-      })
     }
-    return data
+  }, { immediate: true })
+
+  if (autoDispose && !isDocumentReference<T>(refOfDocRef.value)) {
+    tryOnScopeDispose(() => {
+      close()
+    })
   }
+
+  return data
 }


### PR DESCRIPTION
### Description

Enable to use the boolean value to tell a query when it is ready to run.

```typescript
const userId = ref('')
const docRef = computed(() => !!userId.value && doc(db, 'users', userId.value))
const userData = useFirestore(docRef, null)

userId.value = 'userId' // start querying
```

### Additional context

Fixes https://github.com/vueuse/vueuse/issues/2018 @smakinson

You can avoid invalid segment error of firestore path.

Similar interface of https://github.com/Kong/swrv#dependent-fetching

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] New Feature
- [x] Documentation update

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
