### PR TITLE
feat(useMagicKeys): Add keyboard sequences support

### DIFF
--- a/packages/core/useMagicKeys/index.md
+++ b/packages/core/useMagicKeys/index.md
@@ -55,6 +55,24 @@ watch(Ctrl_A_B, (v) => {
 })
 ```
 
+### Sequences
+
+You can magically use sequences of keys by connecting keys with `>`.
+
+```ts
+import { useMagicKeys } from '@vueuse/core'
+
+const keys = useMagicKeys()
+const sequence = keys['A>B>C']
+
+watch(sequence, (v) => {
+  if (v)
+    console.log('Sequence A then B then C has been pressed')
+})
+```
+
+### `whenever`
+
 You can also use `whenever` function to make it shorter
 
 ```ts
@@ -64,6 +82,14 @@ const keys = useMagicKeys()
 
 whenever(keys.shift_space, () => {
   console.log('Shift+Space have been pressed')
+})
+
+whenever(keys['Meta+S'], () => {
+  console.log('Meta+S have been pressed')
+})
+
+whenever(keys['Q>P'], () => {
+  console.log('Q then P sequence has been pressed')
 })
 ```
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Currently `useMagicKeys` supports only keyboard shortcuts (`A+S`, `Meta+S`...) - to trigger something keys need to be pressed at the same time. This PR changes add support for keyboard sequences (`A then S`...) by extending current functionality.

PR fixes #427

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
