### PR TITLE
fix(useFileDialog): not assign capture to input if value is nullable

### DIFF
--- a/packages/core/useFileDialog/index.ts
+++ b/packages/core/useFileDialog/index.ts
@@ -63,7 +63,9 @@ export function useFileDialog(options: UseFileDialogOptions = {}): UseFileDialog
     }
     input.multiple = _options.multiple!
     input.accept = _options.accept!
-    input.capture = _options.capture!
+
+    if (_options?.capture)
+      input.capture = _options.capture
 
     input.click()
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
should not assign capture to input element if value if nullable, this is what happend

codes

```ts
<script setup lang="ts">
import { useFileDialog } from '.'

const { files, open, reset } = useFileDialog()
</script>

<template>
  <button type="button" @click="open()">
    Choose files
  </button>
  <button type="button" :disabled="!files" @click="reset()">
    Reset
  </button>
  <template v-if="files">
    <p>You have selected: <b>{{ files.length }} files</b></p>
    <li v-for="file of files" :key="file.name">
      {{ file.name }}
    </li>
  </template>
</template>

```


before: 

https://user-images.githubusercontent.com/14126445/186048472-c56d7eb2-7e46-4c4c-bc28-990d4779ddc1.mp4

after fixed: 

https://user-images.githubusercontent.com/14126445/186048537-993bfed5-8e4e-4858-890d-7bbb05e66b0f.mp4



<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
