### PR TITLE
feat(useCycleList): support non-unique list

### DIFF
--- a/packages/core/useCycleList/index.test.ts
+++ b/packages/core/useCycleList/index.test.ts
@@ -26,4 +26,19 @@ describe('useCycleList', () => {
       next()
     })
   })
+
+  it('should cycle list objects with `initialValue` and `getIndexOf` orderly', () => {
+    const listItems = [{ name: 'Dog' }, { name: 'Cat' }, { name: 'Lizard' }]
+    const expectedListItems = [{ name: 'Cat' }, { name: 'Lizard' }, { name: 'Dog' }]
+
+    const { state, next } = useCycleList(listItems, {
+      initialValue: { name: 'Cat' },
+      getIndexOf: (cur, list) => list.findIndex(item => item.name === cur.name),
+    })
+
+    expectedListItems.forEach((item) => {
+      expect(state.value).toMatchObject(item)
+      next()
+    })
+  })
 })

--- a/packages/core/useCycleList/index.test.ts
+++ b/packages/core/useCycleList/index.test.ts
@@ -1,0 +1,29 @@
+import { useCycleList } from '.'
+
+describe('useCycleList', () => {
+  it('should be defined', () => {
+    expect(useCycleList).toBeDefined()
+  })
+
+  it('should cycle [0, 1, 2, 0, 3, 4] orderly', () => {
+    const listItems = [0, 1, 2, 0, 3, 4]
+    const { state, next } = useCycleList(listItems)
+
+    listItems.forEach((item) => {
+      expect(state.value).toBe(item)
+      next()
+    })
+  })
+
+  it('should cycle [0, 1, 2, 0, 3, 4] with `initialValue` is 3 orderly', () => {
+    const listItems = [0, 1, 2, 0, 3, 4]
+    const expectedListItems = [3, 4, 0, 1, 2, 0]
+
+    const { state, next } = useCycleList(listItems, { initialValue: 3 })
+
+    expectedListItems.forEach((item) => {
+      expect(state.value).toBe(item)
+      next()
+    })
+  })
+})

--- a/packages/core/useCycleList/index.ts
+++ b/packages/core/useCycleList/index.ts
@@ -27,11 +27,13 @@ export interface UseCycleListOptions<T> {
 export function useCycleList<T>(list: T[], options?: UseCycleListOptions<T>): UseCycleListReturn<T> {
   const state = shallowRef(options?.initialValue ?? list[0]) as Ref<T>
 
+  const stateIndex = shallowRef(0)
+
   const index = computed<number>({
     get() {
       let index = options?.getIndexOf
         ? options.getIndexOf(state.value, list)
-        : list.indexOf(state.value)
+        : stateIndex.value
 
       if (index < 0)
         index = options?.fallbackIndex ?? 0
@@ -48,6 +50,7 @@ export function useCycleList<T>(list: T[], options?: UseCycleListOptions<T>): Us
     const index = (i % length + length) % length
     const value = list[index]
     state.value = value
+    stateIndex.value = index
     return value
   }
 

--- a/packages/core/useCycleList/index.ts
+++ b/packages/core/useCycleList/index.ts
@@ -27,7 +27,7 @@ export interface UseCycleListOptions<T> {
 export function useCycleList<T>(list: T[], options?: UseCycleListOptions<T>): UseCycleListReturn<T> {
   const state = shallowRef(options?.initialValue ?? list[0]) as Ref<T>
 
-  const stateIndex = ref(0)
+  const stateIndex = ref(list.indexOf(state.value))
 
   const index = computed<number>({
     get() {

--- a/packages/core/useCycleList/index.ts
+++ b/packages/core/useCycleList/index.ts
@@ -1,4 +1,5 @@
-import { type Ref, computed, ref, shallowRef } from 'vue-demi'
+import type { Ref } from 'vue-demi'
+import { computed, ref, shallowRef } from 'vue-demi'
 import { type MaybeRef } from '@vueuse/shared'
 
 export interface UseCycleListOptions<T> {

--- a/packages/core/useCycleList/index.ts
+++ b/packages/core/useCycleList/index.ts
@@ -1,4 +1,4 @@
-import { type Ref, computed, shallowRef } from 'vue-demi'
+import { type Ref, computed, ref, shallowRef } from 'vue-demi'
 import { type MaybeRef } from '@vueuse/shared'
 
 export interface UseCycleListOptions<T> {
@@ -27,7 +27,7 @@ export interface UseCycleListOptions<T> {
 export function useCycleList<T>(list: T[], options?: UseCycleListOptions<T>): UseCycleListReturn<T> {
   const state = shallowRef(options?.initialValue ?? list[0]) as Ref<T>
 
-  const stateIndex = shallowRef(0)
+  const stateIndex = ref(0)
 
   const index = computed<number>({
     get() {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR is related and solving #2137.

There has a mistake with `useCycleList` when some values are identical.
The index of these values will always be the same as the first one.

So, I implemented `stateIndex` as state variable to store own index, when `getIndexOf` is not defined`

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

* I use `shallowRef` for `stateIndex`. I'm not sure that should I use `ref` instead?
* This is my first PR for VueUse. If you have any feedback with my code or I missed some guidelines, please do not hesitate to comment on this PR.
* And thank you so much. 😁

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
