### PR TITLE
feat(useElementSize): support `box` sizing

### DIFF
--- a/packages/core/useElementSize/demo.vue
+++ b/packages/core/useElementSize/demo.vue
@@ -4,7 +4,9 @@ import { stringify } from '@vueuse/docs-utils'
 import { useElementSize } from '@vueuse/core'
 
 const el = ref(null)
-const size = reactive(useElementSize(el))
+const size = reactive(useElementSize(el, { width: 0, height: 0 }, {
+  box: 'border-box',
+}))
 const text = stringify(size)
 </script>
 

--- a/packages/core/useElementSize/demo.vue
+++ b/packages/core/useElementSize/demo.vue
@@ -4,9 +4,13 @@ import { stringify } from '@vueuse/docs-utils'
 import { useElementSize } from '@vueuse/core'
 
 const el = ref(null)
-const size = reactive(useElementSize(el, { width: 0, height: 0 }, {
-  box: 'border-box',
-}))
+const size = reactive(
+  useElementSize(
+    el,
+    { width: 0, height: 0 },
+    { box: 'border-box' },
+  ),
+)
 const text = stringify(size)
 </script>
 

--- a/packages/core/useElementSize/index.ts
+++ b/packages/core/useElementSize/index.ts
@@ -4,17 +4,6 @@ import type { UseResizeObserverOptions } from '../useResizeObserver'
 import { useResizeObserver } from '../useResizeObserver'
 import { unrefElement } from '../unrefElement'
 
-export interface UseElementSizeOptions extends UseResizeObserverOptions {
-  /**
-   *
-   * Indicates how the total width and height of an element is calculated.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing
-   * @default 'borderBox'
-   */
-  boxSizing?: 'borderBox' | 'contentBox'
-}
-
 export interface ElementSize {
   width: number
   height: number
@@ -31,7 +20,7 @@ export interface ElementSize {
 export function useElementSize(
   target: MaybeComputedElementRef,
   initialSize: ElementSize = { width: 0, height: 0 },
-  options: UseElementSizeOptions = {},
+  options: UseResizeObserverOptions = {},
 ) {
   const { box = 'content-box' } = options
   const width = ref(initialSize.width)

--- a/packages/core/useElementSize/index.ts
+++ b/packages/core/useElementSize/index.ts
@@ -33,15 +33,17 @@ export function useElementSize(
   initialSize: ElementSize = { width: 0, height: 0 },
   options: UseElementSizeOptions = {},
 ) {
-  const { boxSizing = 'borderBox' } = options
-
+  const { box = 'content-box' } = options
   const width = ref(initialSize.width)
   const height = ref(initialSize.height)
 
   useResizeObserver(
     target,
     ([entry]) => {
-      const boxSize = boxSizing === 'borderBox' ? entry.borderBoxSize : entry.contentBoxSize
+      const boxSize = box === 'border-box'
+        ? entry.borderBoxSize
+        : (box === 'content-box' ? entry.contentBoxSize : entry.devicePixelContentBoxSize)
+
       if (boxSize) {
         width.value = boxSize.reduce((acc, { inlineSize }) => acc + inlineSize, 0)
         height.value = boxSize.reduce((acc, { blockSize }) => acc + blockSize, 0)

--- a/packages/core/useElementSize/index.ts
+++ b/packages/core/useElementSize/index.ts
@@ -31,7 +31,9 @@ export function useElementSize(
     ([entry]) => {
       const boxSize = box === 'border-box'
         ? entry.borderBoxSize
-        : (box === 'content-box' ? entry.contentBoxSize : entry.devicePixelContentBoxSize)
+        : box === 'content-box'
+          ? entry.contentBoxSize
+          : entry.devicePixelContentBoxSize
 
       if (boxSize) {
         width.value = boxSize.reduce((acc, { inlineSize }) => acc + inlineSize, 0)
@@ -45,10 +47,15 @@ export function useElementSize(
     },
     options,
   )
-  watch(() => unrefElement(target), (ele) => {
-    width.value = ele ? initialSize.width : 0
-    height.value = ele ? initialSize.height : 0
-  })
+
+  watch(
+    () => unrefElement(target),
+    (ele) => {
+      width.value = ele ? initialSize.width : 0
+      height.value = ele ? initialSize.height : 0
+    },
+  )
+
   return {
     width,
     height,

--- a/packages/core/useResizeObserver/index.ts
+++ b/packages/core/useResizeObserver/index.ts
@@ -24,11 +24,11 @@ export type ResizeObserverCallback = (entries: ReadonlyArray<ResizeObserverEntry
 export interface UseResizeObserverOptions extends ConfigurableWindow {
   /**
    * Sets which box model the observer will observe changes to. Possible values
-   * are `content-box` (the default), and `border-box`.
+   * are `content-box` (the default), `border-box` and `device-pixel-content-box`.
    *
    * @default 'content-box'
    */
-  box?: 'content-box' | 'border-box'
+  box?: ResizeObserverBoxOptions
 }
 
 declare class ResizeObserver {


### PR DESCRIPTION
### Description

closes #2158 

Currently, it only returns the `content-box` size, which the `padding` & `border` is not included. Even if the `box` option is configured as `border-box`.

### Additional context


#### Before
![image](https://user-images.githubusercontent.com/30516060/187373186-87fa27ad-e53c-40be-91d5-618e21a34526.png)

#### After
![image](https://user-images.githubusercontent.com/30516060/187373302-4c8467c9-9521-4be2-bce1-e701db293be5.png)

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
