### PR TITLE
feat(useWindowSize): support `includeScrollbar`

### DIFF
--- a/packages/core/useWindowSize/index.test.ts
+++ b/packages/core/useWindowSize/index.test.ts
@@ -23,6 +23,13 @@ describe('useWindowSize', () => {
     expect(height.value).toBe(window.innerHeight)
   })
 
+  it('should exclude scrollbar', () => {
+    const { width, height } = useWindowSize({ initialWidth: 100, initialHeight: 200, includeScrollbar: false })
+
+    expect(width.value).toBe(window.document.documentElement.clientWidth)
+    expect(height.value).toBe(window.document.documentElement.clientHeight)
+  })
+
   it('sets handler for window "resize" event', async () => {
     useWindowSize({ initialWidth: 100, initialHeight: 200, listenOrientation: false })
 

--- a/packages/core/useWindowSize/index.ts
+++ b/packages/core/useWindowSize/index.ts
@@ -13,6 +13,12 @@ export interface UseWindowSizeOptions extends ConfigurableWindow {
    * @default true
    */
   listenOrientation?: boolean
+
+  /**
+   * Whether the scrollbar should be included in the width and height
+   * @default true
+   */
+  includeScrollbar?: boolean
 }
 
 /**
@@ -27,6 +33,7 @@ export function useWindowSize(options: UseWindowSizeOptions = {}) {
     initialWidth = Infinity,
     initialHeight = Infinity,
     listenOrientation = true,
+    includeScrollbar = true,
   } = options
 
   const width = ref(initialWidth)
@@ -34,8 +41,14 @@ export function useWindowSize(options: UseWindowSizeOptions = {}) {
 
   const update = () => {
     if (window) {
-      width.value = window.innerWidth
-      height.value = window.innerHeight
+      if (includeScrollbar) {
+        width.value = window.innerWidth
+        height.value = window.innerHeight
+      }
+      else {
+        width.value = window.document.documentElement.clientWidth
+        height.value = window.document.documentElement.clientHeight
+      }
     }
   }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->
scrollbar size is included in `window.innerWidth / window.innerHeight`, we don't want it in some cases. \
For example,  to calculate the `top/left/right/bottom` offset for a `position: fixed` element.
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
