### PR TITLE
feat(useBrowserLocation): two-way binding

### DIFF
--- a/packages/core/useBrowserLocation/demo.vue
+++ b/packages/core/useBrowserLocation/demo.vue
@@ -7,5 +7,7 @@ const text = stringify(location)
 </script>
 
 <template>
+  Input and hash will be changed:
+  <input v-model="location.hash" type="text" placeholder="Hash">
   <pre lang="yaml">{{ text }}</pre>
 </template>

--- a/packages/shared/utils/index.ts
+++ b/packages/shared/utils/index.ts
@@ -101,3 +101,7 @@ export function objectPick<O, T extends keyof O>(obj: O, keys: T[], omitUndefine
     return n
   }, {} as Pick<O, T>)
 }
+
+export function objectEntries<T extends object>(obj: T) {
+  return Object.entries(obj) as Array<[keyof T, T[keyof T]]>
+}


### PR DESCRIPTION
closes #1125

<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Two-way binding of `window.location`. It's readonly before. After this PR, it can be changed by user.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

I think the returning value of `useBrowserLocation` should be a ref map. But ATM let it be a reactive (maybe it can be refactored in the next major version.)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
