### PR TITLE
feat(useWebSocket): enhence heartbeat

### DIFF
--- a/packages/core/useWebSocket/index.md
+++ b/packages/core/useWebSocket/index.md
@@ -71,6 +71,7 @@ const { status, data, close } = useWebSocket('ws://websocketurl', {
   heartbeat: {
     message: 'ping',
     interval: 1000,
+    pongTimeout: 1000,
   },
 })
 ```


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
issue: #2096

1. a new option `pongTimeout` -> after sending ping, could not recieve any response in pongTimeout, then close the socket
2. skip the pong message in ws.onmessage()

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
