### PR TITLE
fix(useArrayMap): allow return type matches the mapper function

### DIFF
--- a/packages/shared/useArrayMap/index.test.ts
+++ b/packages/shared/useArrayMap/index.test.ts
@@ -26,4 +26,16 @@ describe('useArrayMap', () => {
     list.value.pop()
     expect(result.value).toStrictEqual([0, 2, 4, 6])
   })
+
+  it('should match the return type of mapper function', () => {
+    const list = ref([0, 1, 2, 3])
+    const result1 = useArrayMap(list, i => i.toString())
+    result1.value.forEach(i => expect(i).toBeTypeOf('string'))
+
+    const result2 = useArrayMap(list, i => ({ value: i }))
+    result2.value.forEach((item, idx) => {
+      expect(item).toBeTypeOf('object')
+      expect(item).toHaveProperty('value', idx)
+    })
+  })
 })

--- a/packages/shared/useArrayMap/index.ts
+++ b/packages/shared/useArrayMap/index.ts
@@ -12,7 +12,7 @@ import { resolveUnref } from '../resolveUnref'
  *
  * @returns {Array} a new array with each element being the result of the callback function.
  */
-export function useArrayMap<T, U>(
+export function useArrayMap<T, U = T>(
   list: MaybeComputedRef<MaybeComputedRef<T>[]>,
   fn: (element: T, index: number, array: T[]) => U,
 ): ComputedRef<U[]> {

--- a/packages/shared/useArrayMap/index.ts
+++ b/packages/shared/useArrayMap/index.ts
@@ -12,9 +12,9 @@ import { resolveUnref } from '../resolveUnref'
  *
  * @returns {Array} a new array with each element being the result of the callback function.
  */
-export function useArrayMap<T>(
+export function useArrayMap<T, U>(
   list: MaybeComputedRef<MaybeComputedRef<T>[]>,
-  fn: (element: T, index: number, array: T[]) => T,
-): ComputedRef<T[]> {
+  fn: (element: T, index: number, array: T[]) => U,
+): ComputedRef<U[]> {
   return computed(() => resolveUnref(list).map(i => resolveUnref(i)).map(fn))
 }


### PR DESCRIPTION
fix [#2159](https://github.com/vueuse/vueuse/issues/2159)

<!-- Thank you for contributing! -->

### Description

fix [#2159](https://github.com/vueuse/vueuse/issues/2159)
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

let the `useArrayMap()` function to take the second generics argument, which should be used in the return type

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
