### PR TITLE
feat(useMediaQuery): allow query to be a `ref`

### DIFF
--- a/packages/core/useMediaQuery/index.ts
+++ b/packages/core/useMediaQuery/index.ts
@@ -1,6 +1,7 @@
 /* this implementation is original ported from https://github.com/logaretm/vue-use-web by Abdelrahman Awad */
 
-import { ref } from 'vue-demi'
+import { ref, unref, watchEffect } from 'vue-demi'
+import type { MaybeRef } from '@vueuse/shared'
 import { tryOnBeforeMount, tryOnScopeDispose } from '@vueuse/shared'
 import type { ConfigurableWindow } from '../_configurable'
 import { defaultWindow } from '../_configurable'
@@ -13,7 +14,7 @@ import { useSupported } from '../useSupported'
  * @param query
  * @param options
  */
-export function useMediaQuery(query: string, options: ConfigurableWindow = {}) {
+export function useMediaQuery(query: MaybeRef<string>, options: ConfigurableWindow = {}) {
   const { window = defaultWindow } = options
   const isSupported = useSupported(() => window && 'matchMedia' in window && typeof window!.matchMedia === 'function')
 
@@ -24,13 +25,12 @@ export function useMediaQuery(query: string, options: ConfigurableWindow = {}) {
     if (!isSupported.value)
       return
     if (!mediaQuery)
-      mediaQuery = window!.matchMedia(query)
+      mediaQuery = window!.matchMedia(unref(query))
     matches.value = mediaQuery.matches
   }
+  watchEffect(update)
 
   tryOnBeforeMount(() => {
-    update()
-
     if (!mediaQuery)
       return
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

`useMediaQuery()` is allowed to take a `MaybeRef<string>` type query as its first argument.

Also fix #2177 and related issues mentioned in it.

### Additional context

Wrapping a `watchEffect` to `update` function to execute it immediately, so it ensures `useMediaQuery()` to have its proper initial value.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
