### PR TITLE
feat(useVolumeReader): gets approximate volume of an audioTrack

### DIFF
--- a/packages/core/useVolumeReader/index.ts
+++ b/packages/core/useVolumeReader/index.ts
@@ -1,0 +1,76 @@
+import { ref } from 'vue-demi'
+import { tryOnBeforeUnmount } from '@vueuse/core'
+
+export interface UseVolumeReaderOptions {
+  track: MediaStreamTrack | undefined
+  context?: AudioContext
+  interval?: number
+}
+
+export function useVolumeReader(options: UseVolumeReaderOptions) {
+  let track = options.track
+  const interval = options.interval || 33
+  const context = options.context || new AudioContext()
+
+  const volume = ref(0)
+  let readInterval: number | undefined
+
+  let analyserNode: AnalyserNode | undefined
+  let sourceNode: MediaStreamAudioSourceNode | undefined
+
+  async function _start() {
+    if (!track)
+      return
+    if (context.state !== 'running')
+      await context.resume().catch(console.warn)
+
+    analyserNode = context.createAnalyser()
+    analyserNode.minDecibels = -90
+    analyserNode.maxDecibels = -10
+    analyserNode.smoothingTimeConstant = 0.85
+
+    sourceNode = context.createMediaStreamSource(new MediaStream([track]))
+    sourceNode.connect(analyserNode)
+    const pcmData = new Float32Array(analyserNode.fftSize)
+
+    const readVolumeFn = () => {
+      if (!analyserNode) {
+        volume.value = 0
+        return
+      }
+
+      analyserNode.getFloatTimeDomainData(pcmData)
+      let sumSquares = 0.0
+      for (const amplitude of pcmData)
+        sumSquares += amplitude * amplitude
+
+      volume.value = Math.sqrt(sumSquares / pcmData.length) * 100
+    }
+
+    readInterval = window.setInterval(readVolumeFn, interval)
+  }
+
+  function stop() {
+    clearInterval(readInterval)
+    analyserNode?.disconnect()
+    sourceNode?.disconnect()
+    analyserNode = undefined
+    sourceNode = undefined
+  }
+
+  function changeTrack(newTrack: MediaStreamTrack | undefined) {
+    stop()
+    track = newTrack
+    _start()
+  }
+
+  tryOnBeforeUnmount(stop)
+
+  _start()
+
+  return {
+    volume,
+    stop,
+    changeTrack,
+  }
+}


### PR DESCRIPTION
### Description

Call with a MediaStreamTrack and get back a volume value between 0-10+

### Additional context

It's not the greatest method to approximate volume and there's no extensive TS scripting or demo, But I thought I'll just throw this out here and see if anyone wants to convert it to something usable.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
