### PR TITLE
docs: fix function name matching

### DIFF
--- a/packages/.vitepress/plugins/markdownTransform.ts
+++ b/packages/.vitepress/plugins/markdownTransform.ts
@@ -34,7 +34,7 @@ export function MarkdownTransform(): Plugin {
 
       const [pkg, _name, i] = id.split('/').slice(-3)
 
-      const name = functionNames.find(n => n.toLowerCase() === _name.toLowerCase())
+      const name = functionNames.find(n => n.toLowerCase() === _name.toLowerCase()) || _name
 
       if (functionNames.includes(name) && i === 'index.md') {
         const frontmatterEnds = code.indexOf('---\n\n') + 4

--- a/packages/.vitepress/plugins/markdownTransform.ts
+++ b/packages/.vitepress/plugins/markdownTransform.ts
@@ -32,7 +32,9 @@ export function MarkdownTransform(): Plugin {
       // convert links to relative
       code = code.replace(/https?:\/\/vueuse\.org\//g, '/')
 
-      const [pkg, name, i] = id.split('/').slice(-3)
+      const [pkg, _name, i] = id.split('/').slice(-3)
+
+      const name = functionNames.find(n => n.toLowerCase() === _name.toLowerCase())
 
       if (functionNames.includes(name) && i === 'index.md') {
         const frontmatterEnds = code.indexOf('---\n\n') + 4


### PR DESCRIPTION
### Description

When using algolia search(in `dev`) to jump to the specific function page, `demo` and other markdown details were disappeared, but everything works fine by manually clicking on the right nav-bar of the function.

because function name in `url` returned from algolia is in lowercase, but it's uppercase in generated `packages/metadata/index.json`.

### Additional context

This only happens in dev mode.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
