### PR TITLE
fix(onClickOutside): put ignore logic on `pointerdown` event

### DIFF
--- a/packages/core/onClickOutside/index.ts
+++ b/packages/core/onClickOutside/index.ts
@@ -54,22 +54,28 @@ export function onClickOutside<T extends OnClickOutsideOptions>(
     if (!el || el === event.target || composedPath.includes(el) || !shouldListen.value)
       return
 
-    if (ignore && ignore.length > 0) {
-      if (ignore.some((target) => {
-        const el = unrefElement(target)
-        return el && (event.target === el || composedPath.includes(el))
-      }))
-        return
-    }
-
     handler(event)
+  }
+
+  const shouldIgnore = (event: PointerEvent): boolean => {
+    if (!ignore || !ignore.length)
+      return false
+
+    const composedPath = event.composedPath()
+    if (ignore.some((target) => {
+      const el = unrefElement(target)
+      return el && (event.target === el || composedPath.includes(el))
+    }))
+      return true
+
+    return false
   }
 
   const cleanup = [
     useEventListener(window, 'click', listener, { passive: true, capture }),
     useEventListener(window, 'pointerdown', (e) => {
       const el = unrefElement(target)
-      shouldListen.value = !!el && !e.composedPath().includes(el)
+      shouldListen.value = !!el && !e.composedPath().includes(el) && !shouldIgnore(e)
     }, { passive: true }),
     useEventListener(window, 'pointerup', (e) => {
       if (e.button === 0) {

--- a/packages/core/onClickOutside/index.ts
+++ b/packages/core/onClickOutside/index.ts
@@ -49,26 +49,18 @@ export function onClickOutside<T extends OnClickOutsideOptions>(
     window.clearTimeout(fallback)
 
     const el = unrefElement(target)
-    const composedPath = event.composedPath()
 
-    if (!el || el === event.target || composedPath.includes(el) || !shouldListen.value)
+    if (!el || el === event.target || event.composedPath().includes(el) || !shouldListen.value)
       return
 
     handler(event)
   }
 
-  const shouldIgnore = (event: PointerEvent): boolean => {
-    if (!ignore || !ignore.length)
-      return false
-
-    const composedPath = event.composedPath()
-    if (ignore.some((target) => {
+  const shouldIgnore = (event: PointerEvent) => {
+    return ignore && ignore.some((target) => {
       const el = unrefElement(target)
-      return el && (event.target === el || composedPath.includes(el))
-    }))
-      return true
-
-    return false
+      return el && (event.target === el || event.composedPath().includes(el))
+    })
   }
 
   const cleanup = [


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
fix #2196 

### Additional context

put ignore logic on `pointerdown` event, making sure the proper behavior.
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
