### PR TITLE
feat(useWebSocket): redefine url / parameter

### DIFF
--- a/packages/core/useWebSocket/index.md
+++ b/packages/core/useWebSocket/index.md
@@ -87,3 +87,14 @@ const { status, data, send, open, close } = useWebSocket('ws://websocketurl', {
   protocols: ['soap'], // ['soap', 'wamp']
 })
 ```
+
+### Adjusting url
+It is possible to adjust the url, e.g. for parametrizing the websocket:
+```js
+import { useWebSocket } from '@vueuse/core'
+
+const ws = useWebSocket('ws://websocketurl?jwt=123', {
+  immediate: false
+})
+ws.open('ws://websocketurl?jwt=456')
+```

--- a/packages/core/useWebSocket/index.md
+++ b/packages/core/useWebSocket/index.md
@@ -89,7 +89,7 @@ const { status, data, send, open, close } = useWebSocket('ws://websocketurl', {
 ```
 
 ### Adjusting url
-It is possible to adjust the url, e.g. for parametrizing the websocket:
+You can update the WebSocket URL during open, e.g. to parameterize the URL:
 ```js
 import { useWebSocket } from '@vueuse/core'
 

--- a/packages/core/useWebSocket/index.ts
+++ b/packages/core/useWebSocket/index.ts
@@ -202,7 +202,10 @@ export function useWebSocket<Data = any>(
     return true
   }
 
-  const _init = () => {
+  const _init = (newUrl?: string) => {
+    if (newUrl && newUrl !== url)
+      url = newUrl
+
     const ws = new WebSocket(url, protocols)
     wsRef.value = ws
     status.value = 'CONNECTING'
@@ -288,10 +291,10 @@ export function useWebSocket<Data = any>(
     tryOnScopeDispose(close)
   }
 
-  const open = () => {
+  const open = (newUrl?: string) => {
     close()
     retried = 0
-    _init()
+    _init(newUrl)
   }
 
   return {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Some Websocket server (e.g. [ditto](https://www.eclipse.org/ditto/basic-auth.html#single-sign-on-sso)) expect a dynamic authorization parameter. This pull requests allows adjusting the (parameter of the) Websocket url.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
