### PR TITLE
docs: fix typo in the refThrottled doc

### DIFF
--- a/packages/shared/refThrottled/index.md
+++ b/packages/shared/refThrottled/index.md
@@ -29,7 +29,7 @@ const throttled = refThrottled(input, 1000, false)
 
 ### Leading
 
-Allows the callback to be invoked immediately (on the leading edge of the `ms` timeout). If you don't want this begavior, set 4rd param `false` (it's `true` by default):
+Allows the callback to be invoked immediately (on the leading edge of the `ms` timeout). If you don't want this behavior, set the 4th param `false` (it's `true` by default):
 
 ```js
 import { refThrottled } from '@vueuse/core'


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix a typo in the [refthrottled](https://vueuse.netlify.app/shared/refthrottled/#usage) doc


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
