### PR TITLE
feat(usesAsyncState): Adding type inference for execute parameters

### DIFF
--- a/packages/core/useAsyncState/demo.vue
+++ b/packages/core/useAsyncState/demo.vue
@@ -4,8 +4,8 @@ import YAML from 'js-yaml'
 import { useAsyncState } from '@vueuse/core'
 
 const { isLoading, state, isReady, execute } = useAsyncState(
-  (args) => {
-    const id = args?.id || 1
+  (args: { id: number }) => {
+    const id = args.id || 1
     return axios.get(`https://jsonplaceholder.typicode.com/todos/${id}`).then(t => t.data)
   },
   {},

--- a/packages/core/useAsyncState/index.ts
+++ b/packages/core/useAsyncState/index.ts
@@ -2,12 +2,13 @@ import { noop, promiseTimeout } from '@vueuse/shared'
 import type { Ref, UnwrapRef } from 'vue-demi'
 import { ref, shallowRef } from 'vue-demi'
 
-export interface UseAsyncStateReturn<Data, Shallow extends boolean> {
+type ExtractPromiseParams<TPromise> = TPromise extends (args: infer P) => any ? P : any
+export interface UseAsyncStateReturn<Data, TPromiseArgs, Shallow extends boolean> {
   state: Shallow extends true ? Ref<Data> : Ref<UnwrapRef<Data>>
   isReady: Ref<boolean>
   isLoading: Ref<boolean>
   error: Ref<unknown>
-  execute: (delay?: number, ...args: any[]) => Promise<Data>
+  execute: (delay?: number, ...args: TPromiseArgs[]) => Promise<Data>
 }
 
 export interface UseAsyncStateOptions<Shallow extends boolean> {
@@ -68,11 +69,11 @@ export interface UseAsyncStateOptions<Shallow extends boolean> {
  * @param initialState    The initial state, used until the first evaluation finishes
  * @param options
  */
-export function useAsyncState<Data, Shallow extends boolean = true>(
-  promise: Promise<Data> | ((...args: any[]) => Promise<Data>),
+export function useAsyncState<Data, TPromiseArgs, Shallow extends boolean = true>(
+  promise: ((...args: TPromiseArgs[]) => Promise<Data>),
   initialState: Data,
   options?: UseAsyncStateOptions<Shallow>,
-): UseAsyncStateReturn<Data, Shallow> {
+): UseAsyncStateReturn<Data, ExtractPromiseParams<typeof promise>, Shallow> {
   const {
     immediate = true,
     delay = 0,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Improve useAsyncState execute function parameters type inference for better intelligent completion
``` typescript
useAsyncState((args: { id: number }) => {}, {})
execute(2000, { id: 2 }) // now with type suggestion support
```

### Additional context
<!-- e.g. is there anything you'd like reviewers to focus on? -->
Multiple parameters definition couldn't pass the type check but all unit test passed, if two or more parameter defined on execute function the type check would throw error, is there any better practice ?
``` typescript
/**
 * Type "(args: {id: number;}, A2: string)=>Promise<any>"
 * parameter cannot be assigned to type" (... args: (string | {id: number;}) [])=>Promise<any>".
 * The types of parameters' args' and 'args' are incompatible.ts (2345)
 */
useAsyncState((args: { id: number }, a2: string) => {}, {})
```

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
