### PR TITLE
feat(useWebSocket): improve heartbeat message type

### DIFF
--- a/packages/core/useWebSocket/index.ts
+++ b/packages/core/useWebSocket/index.ts
@@ -25,7 +25,7 @@ export interface UseWebSocketOptions {
      *
      * @default 'ping'
      */
-    message?: string
+    message?: string | ArrayBuffer | Blob
 
     /**
      * Interval, in milliseconds


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

issure: #2218

Change useWebSocket heartbeat message type from `string` to `string | ArrayBuffer | Blob`

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
