### PR TITLE
fix(useFetch): fix incorrect `chainCallbacks` behavior

### DIFF
--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -216,11 +216,10 @@ function headersToObject(headers: HeadersInit | undefined) {
 
 function chainCallbacks<T = any>(...callbacks: (((ctx: T) => void | Partial<T> | Promise<void | Partial<T>>) | undefined)[]) {
   return async (ctx: T) => {
-    await callbacks.reduce(async (prevCallback, callback) => {
-      await prevCallback
+    await callbacks.reduce((prevCallback, callback) => prevCallback.then(async () => {
       if (callback)
         ctx = { ...ctx, ...(await callback(ctx)) }
-    }, Promise.resolve())
+    }), Promise.resolve())
     return ctx
   }
 }

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -216,10 +216,11 @@ function headersToObject(headers: HeadersInit | undefined) {
 
 function chainCallbacks<T = any>(...callbacks: (((ctx: T) => void | Partial<T> | Promise<void | Partial<T>>) | undefined)[]) {
   return async (ctx: T) => {
-    await Promise.all(callbacks.map(async (callback) => {
+    await callbacks.reduce(async (prevCallback, callback) => {
+      await prevCallback
       if (callback)
         ctx = { ...ctx, ...(await callback(ctx)) }
-    }))
+    }, Promise.resolve())
     return ctx
   }
 }

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -216,10 +216,10 @@ function headersToObject(headers: HeadersInit | undefined) {
 
 function chainCallbacks<T = any>(...callbacks: (((ctx: T) => void | Partial<T> | Promise<void | Partial<T>>) | undefined)[]) {
   return async (ctx: T) => {
-    for await (const callback of callbacks) {
+    await Promise.all(callbacks.map(async (callback) => {
       if (callback)
-        ctx = { ...ctx, ...(callback(ctx)) }
-    }
+        ctx = { ...ctx, ...(await callback(ctx)) }
+    }))
     return ctx
   }
 }

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -215,11 +215,11 @@ function headersToObject(headers: HeadersInit | undefined) {
 }
 
 function chainCallbacks<T = any>(...callbacks: (((ctx: T) => void | Partial<T> | Promise<void | Partial<T>>) | undefined)[]) {
-  return (ctx: T) => {
-    callbacks.forEach(async (callback) => {
+  return async (ctx: T) => {
+    for await (const callback of callbacks) {
       if (callback)
-        ctx = { ...ctx, ...(await callback(ctx)) }
-    })
+        ctx = { ...ctx, ...(callback(ctx)) }
+    }
     return ctx
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fixes #2225, #1310 

### Additional context

~~Like @imaverickk metioned in #2225, there's another solution: use `Promise.all()`. I'm not sure which one is better~~

> Transforming for-await loops to the configured target environment ("es2017") is not supported yet. Thus `Promise.all()` seems to be the only solution?
---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
