### PR TITLE
docs(useDark): not about default localStorage key

### DIFF
--- a/packages/core/useDark/index.md
+++ b/packages/core/useDark/index.md
@@ -21,7 +21,7 @@ const toggleDark = useToggle(isDark)
 
 ## Behavior
 
-`useDark` combines with `usePreferredDark` and `useStorage`. On start up, it reads the value from localStorage/sessionStorage(the key is configurable) to see if there is a user configured color scheme, if not, it will use users' system preferences. When you change the `isDark` ref, it will update the corresponding element's attribute and then store the preference to storage for persistence.
+`useDark` combines with `usePreferredDark` and `useStorage`. On start up, it reads the value from localStorage/sessionStorage (the key is configurable) to see if there is a user configured color scheme, if not, it will use users' system preferences. When you change the `isDark` ref, it will update the corresponding element's attribute and then store the preference to storage (default key: `vueuse-color-scheme`) for persistence.
 
 > Please note `useDark` only handles the DOM attribute changes for you to apply proper selector in your CSS. It does NOT handle the actual style, theme or CSS for you.
 
@@ -37,7 +37,7 @@ By default, it uses [Tailwind CSS favored dark mode](https://tailwindcss.com/doc
 <html class="dark"> ... </html>
 ```
 
-While you can customize it and make it work for most of the CSS frameworks.
+Stillm you can also customize it to make it work with most CSS frameworks.
 
 For example:
 
@@ -64,7 +64,7 @@ will work like
 </html>
 ```
 
-If the configuration above still not fitting to your needs, you can use `onChanged` options to take full controls over how you handle the updates
+If the configuration above still does not fit your needs, you can use the`onChanged` option to take full control over how you handle updates.
 
 ```ts
 const isDark = useDark({

--- a/packages/core/useDark/index.md
+++ b/packages/core/useDark/index.md
@@ -37,7 +37,7 @@ By default, it uses [Tailwind CSS favored dark mode](https://tailwindcss.com/doc
 <html class="dark"> ... </html>
 ```
 
-Stillm you can also customize it to make it work with most CSS frameworks.
+Still, you can also customize it to make it work with most CSS frameworks.
 
 For example:
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR clarifies the default behavior of the isDark composable, which persists the current value to localStorage under the key `vueuse-color-scheme`, and fixes a few grammatical points in the remainder of the page for clarity.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

While the docs say that this composable reads "the value from localStorage/sessionStorage (the key is configurable) to see if there is a user configured color scheme," it's not illustrated how this key can be configured. I'm not sure how that is done, so I just added information about the default behavior.
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
