### PR TITLE
feat(useAxios): add option for choosing shallowRef or ref

### DIFF
--- a/packages/integrations/useAxios/index.ts
+++ b/packages/integrations/useAxios/index.ts
@@ -92,6 +92,12 @@ export interface UseAxiosOptions {
    *
    */
   immediate?: boolean
+    /**
+   * Use shallowRef.
+   *
+   * @default true
+   */
+   shallow?: boolean
 }
 type OverallUseAxiosReturn<T, D> = StrictUseAxiosReturn<T, D> | EasyUseAxiosReturn<T, D>
 
@@ -112,7 +118,7 @@ export function useAxios<T = any, D = any>(...args: any[]): OverallUseAxiosRetur
   const argsPlaceholder = isString(url) ? 1 : 0
   let defaultConfig: AxiosRequestConfig<D> = {}
   let instance: AxiosInstance = axios
-  let options: UseAxiosOptions = { immediate: !!argsPlaceholder }
+  let options: UseAxiosOptions = { immediate: !!argsPlaceholder,shallow:true }
 
   const isAxiosInstance = (val: any) => !!val?.request
 
@@ -139,7 +145,7 @@ export function useAxios<T = any, D = any>(...args: any[]): OverallUseAxiosRetur
     options = args[args.length - 1]
 
   const response = shallowRef<AxiosResponse<T>>()
-  const data = shallowRef<T>()
+  const data = options.shallow ? shallowRef<T>() : ref<T>();
   const isFinished = ref(false)
   const isLoading = ref(false)
   const isAborted = ref(false)

--- a/packages/integrations/useAxios/index.ts
+++ b/packages/integrations/useAxios/index.ts
@@ -92,12 +92,12 @@ export interface UseAxiosOptions {
    *
    */
   immediate?: boolean
-    /**
+  /**
    * Use shallowRef.
    *
    * @default true
    */
-   shallow?: boolean
+  shallow?: boolean
 }
 type OverallUseAxiosReturn<T, D> = StrictUseAxiosReturn<T, D> | EasyUseAxiosReturn<T, D>
 
@@ -118,7 +118,7 @@ export function useAxios<T = any, D = any>(...args: any[]): OverallUseAxiosRetur
   const argsPlaceholder = isString(url) ? 1 : 0
   let defaultConfig: AxiosRequestConfig<D> = {}
   let instance: AxiosInstance = axios
-  let options: UseAxiosOptions = { immediate: !!argsPlaceholder,shallow:true }
+  let options: UseAxiosOptions = { immediate: !!argsPlaceholder, shallow: true }
 
   const isAxiosInstance = (val: any) => !!val?.request
 
@@ -145,7 +145,7 @@ export function useAxios<T = any, D = any>(...args: any[]): OverallUseAxiosRetur
     options = args[args.length - 1]
 
   const response = shallowRef<AxiosResponse<T>>()
-  const data = options.shallow ? shallowRef<T>() : ref<T>();
+  const data = options.shallow ? shallowRef<T>() : ref<T>()
   const isFinished = ref(false)
   const isLoading = ref(false)
   const isAborted = ref(false)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Perhaps there should be more options for data than just shallowRef, which may not be sufficient in certain scenarios

closes #2250

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
