### PR TITLE
feat(useUrlSearchParams): allow custom params delimiter

### DIFF
--- a/packages/core/useUrlSearchParams/index.test.ts
+++ b/packages/core/useUrlSearchParams/index.test.ts
@@ -98,6 +98,34 @@ describe('useUrlSearchParams', () => {
 
         expect(params.customFoo).toEqual(42)
       })
+
+      test('custom delimiter', () => {
+        const delimiter = ':'
+
+        const params = useUrlSearchParams(mode, {
+          delimiter,
+        })
+
+        expect(params).toEqual({})
+
+        if (mode === 'hash')
+          mockPopstate('', '#/test/?foo=bar')
+        else if (mode === 'hash-params')
+          mockPopstate('', '#foo=bar')
+        else
+          mockPopstate('?foo=bar', '')
+
+        expect(params).toEqual({ foo: 'bar' })
+
+        if (mode === 'hash')
+          mockPopstate('', `#/test/?foo=bar${delimiter}baz=qux`)
+        else if (mode === 'hash-params')
+          mockPopstate('', `#foo=bar${delimiter}baz=qux`)
+        else
+          mockPopstate(`?foo=bar${delimiter}baz=qux`, '')
+
+        expect(params).toEqual({ foo: 'bar', baz: 'qux' })
+      })
     })
   })
 

--- a/packages/core/useUrlSearchParams/index.ts
+++ b/packages/core/useUrlSearchParams/index.ts
@@ -28,6 +28,13 @@ export interface UseUrlSearchParamsOptions<T> extends ConfigurableWindow {
    * @default true
    */
   write?: boolean
+
+  /**
+   * Custom params delimiter
+   *
+   * @default "&"
+   */
+  delimiter?: string
 }
 
 /**
@@ -47,6 +54,7 @@ export function useUrlSearchParams<T extends Record<string, any> = UrlParams>(
     removeFalsyValues = false,
     write: enableWrite = true,
     window = defaultWindow!,
+    delimiter = '&',
   } = options
 
   if (!window)
@@ -69,7 +77,7 @@ export function useUrlSearchParams<T extends Record<string, any> = UrlParams>(
   }
 
   function constructQuery(params: URLSearchParams) {
-    const stringified = params.toString()
+    const stringified = params.toString().split('&').join(delimiter)
 
     if (mode === 'history')
       return `${stringified ? `?${stringified}` : ''}${window.location.hash || ''}`
@@ -83,7 +91,7 @@ export function useUrlSearchParams<T extends Record<string, any> = UrlParams>(
   }
 
   function read() {
-    return new URLSearchParams(getRawParams())
+    return new URLSearchParams(getRawParams().split(delimiter).join('&'))
   }
 
   function updateState(params: URLSearchParams) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR allows setting a custom params delimiter instead of the default "&". 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
