### PR TITLE
docs: fix theme storage key

### DIFF
--- a/packages/.vitepress/theme/composables/dark.ts
+++ b/packages/.vitepress/theme/composables/dark.ts
@@ -1,5 +1,5 @@
 import { useDark } from '@vueuse/core'
 
 export const isDark = useDark({
-  storageKey: 'vue-theme-appearance',
+  storageKey: 'vitepress-theme-appearance',
 })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Refs: 

Vitepress uses [`vitepress-theme-appearance`](https://github.com/vuejs/vitepress/blob/ee37eaa27191faad03c04d60fb3ca8ffbb887fbe/src/shared/shared.ts#L21) as theme `storageKey` and VueUse uses [`vue-theme-appearance`](https://github.com/vueuse/vueuse/blob/2419803235e55e5e19057c4225c30edc571ee4b1/packages/.vitepress/theme/composables/dark.ts#L4). 

Repro the issue:
1. Switch color-scheme to dark
2. Go to [https://vueuse.org/core/useDark/](https://vueuse.org/core/useDark/), color-scheme changed to `light` . Reload the browser you will see it changed to `dark` and then changed to `light`.
3. Go to other route and reload the browser,  color-scheme changed to `dark` again.

### Additional context
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
