### PR TITLE
Make capture mode configurable for useDraggable

### DIFF
--- a/packages/core/useDraggable/component.ts
+++ b/packages/core/useDraggable/component.ts
@@ -27,6 +27,7 @@ export const UseDraggable = defineComponent<UseDraggableProps>({
     'exact',
     'preventDefault',
     'stopPropagation',
+    'useCapture',
     'pointerTypes',
     'as',
     'handle',

--- a/packages/core/useDraggable/demo.vue
+++ b/packages/core/useDraggable/demo.vue
@@ -26,7 +26,7 @@ const { x, y, style } = useDraggable(el, {
       border="~ gray-400/30 rounded"
       shadow="~ hover:lg"
       class="fixed bg-$vp-c-bg select-none cursor-move z-10"
-      style="touch-action:none;"
+      style="touch-action: none"
       :style="style"
     >
       👋 Drag me!
@@ -73,6 +73,45 @@ const { x, y, style } = useDraggable(el, {
       </div>
       <div class="text-sm opacity-50">
         I am at {{ Math.round(x) }}, {{ Math.round(y) }}
+      </div>
+    </Draggable>
+
+    <Draggable
+      v-slot="{ x, y }"
+      p="x-4 y-2"
+      border="~ gray-400/30 rounded"
+      shadow="~ hover:lg"
+      class="fixed bg-$vp-c-bg select-none cursor-move z-10"
+      :initial-value="{ x: innerWidth / 3.3, y: 330 }"
+      :use-capture="false"
+      :prevent-default="true"
+    >
+      Renderless component with nested child
+
+      <Draggable
+        v-slot="{ x, y }"
+        p="x-4 y-2"
+        border="~ gray-400/30 rounded"
+        shadow="~ hover:lg"
+        class="fixed bg-$vp-c-bg select-none z-10"
+        :initial-value="{ x: innerWidth / 3.0, y: 420 }"
+        :prevent-default="true"
+        :stop-propagation="true"
+        :use-capture="false"
+      >
+        <div class="cursor-move">
+          👋 Drag me (I'm a nested component)!
+        </div>
+        <div class="text-sm opacity-50">
+          I am at {{ Math.round(x) }}, {{ Math.round(y) }}
+        </div>
+      </Draggable>
+
+      <div class="text-xs opacity-50">
+        Child element can move independently
+      </div>
+      <div class="text-sm opacity-50">
+        {{ Math.round(x) }}, {{ Math.round(y) }}
       </div>
     </Draggable>
   </div>

--- a/packages/core/useDraggable/index.ts
+++ b/packages/core/useDraggable/index.ts
@@ -142,7 +142,7 @@ export function useDraggable(target: MaybeComputedRef<HTMLElement | SVGElement |
   }
 
   if (isClient) {
-    const useCapture = options.useCapture || options.useCapture === null
+    const useCapture = options.useCapture ?? true
     useEventListener(draggingHandle, 'pointerdown', start, useCapture)
     useEventListener(draggingElement, 'pointermove', move, useCapture)
     useEventListener(draggingElement, 'pointerup', end, useCapture)

--- a/packages/core/useDraggable/index.ts
+++ b/packages/core/useDraggable/index.ts
@@ -142,7 +142,7 @@ export function useDraggable(target: MaybeComputedRef<HTMLElement | SVGElement |
   }
 
   if (isClient) {
-    const useCapture = options.useCapture ?? true
+    const useCapture = resolveUnref(options.useCapture) ?? true
     useEventListener(draggingHandle, 'pointerdown', start, useCapture)
     useEventListener(draggingElement, 'pointermove', move, useCapture)
     useEventListener(draggingElement, 'pointerup', end, useCapture)

--- a/packages/core/useDraggable/index.ts
+++ b/packages/core/useDraggable/index.ts
@@ -28,6 +28,13 @@ export interface UseDraggableOptions {
   stopPropagation?: MaybeComputedRef<boolean>
 
   /**
+   * Use event capture instead of event bubbling
+   *
+   * @default true
+   */
+  useCapture?: MaybeComputedRef<boolean>
+
+  /**
    * Element to attach `pointermove` and `pointerup` events to.
    *
    * @default window
@@ -135,9 +142,10 @@ export function useDraggable(target: MaybeComputedRef<HTMLElement | SVGElement |
   }
 
   if (isClient) {
-    useEventListener(draggingHandle, 'pointerdown', start, true)
-    useEventListener(draggingElement, 'pointermove', move, true)
-    useEventListener(draggingElement, 'pointerup', end, true)
+    const useCapture = options.useCapture || options.useCapture === null
+    useEventListener(draggingHandle, 'pointerdown', start, useCapture)
+    useEventListener(draggingElement, 'pointermove', move, useCapture)
+    useEventListener(draggingElement, 'pointerup', end, useCapture)
   }
 
   return {

--- a/packages/core/useDraggable/index.ts
+++ b/packages/core/useDraggable/index.ts
@@ -32,7 +32,7 @@ export interface UseDraggableOptions {
    *
    * @default true
    */
-  useCapture?: MaybeComputedRef<boolean>
+  useCapture?: boolean
 
   /**
    * Element to attach `pointermove` and `pointerup` events to.
@@ -142,7 +142,7 @@ export function useDraggable(target: MaybeComputedRef<HTMLElement | SVGElement |
   }
 
   if (isClient) {
-    const useCapture = resolveUnref(options.useCapture) ?? true
+    const useCapture = options.useCapture ?? true
     useEventListener(draggingHandle, 'pointerdown', start, useCapture)
     useEventListener(draggingElement, 'pointermove', move, useCapture)
     useEventListener(draggingElement, 'pointerup', end, useCapture)


### PR DESCRIPTION
### Description

I wanted to use multiple nested draggable element, where the selected element is the only element that should move.
I didn't manage to do this because `useDraggable` sets the `useCapture` option to `true`.
I've made the capture mode configurable and added an example to the demo.vue file that lets users drag a child component without also dragging the parent component (please let me know if I missed another way to do this).

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
