### PR TITLE
docs(useToggle): note about events in template

### DIFF
--- a/packages/shared/useToggle/index.md
+++ b/packages/shared/useToggle/index.md
@@ -23,7 +23,11 @@ const isDark = useDark()
 const toggleDark = useToggle(isDark)
 ```
 
-Note: do not directly bind the toggle method as a button's click handler.
-Make sure to use a dynamic expression instead as shown in the demo, as the
-browser will pass the click handler a click event as an argument to your
-toggle method. This will cause the value of the toggle to always be truthy.
+Note: be aware that the toggle function accepts the first argument as the override value. You might want to avoid directly passing the function to events in the template, as the event object will pass in.
+
+```html
+<!-- caution: $event will be pass in -->
+<button @click="toggleDark" />
+<!-- recommended to do this -->
+<button @click="toggleDark()" />
+```

--- a/packages/shared/useToggle/index.md
+++ b/packages/shared/useToggle/index.md
@@ -22,3 +22,8 @@ import { useDark, useToggle } from '@vueuse/core'
 const isDark = useDark()
 const toggleDark = useToggle(isDark)
 ```
+
+Note: do not directly bind the toggle method as a button's click handler.
+Make sure to use a dynamic expression instead as shown in the demo, as the
+browser will pass the click handler a click event as an argument to your
+toggle method. This will cause the value of the toggle to always be truthy.


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This adds a small note in the docs for `useToggle` to be wary of binding directly to a button click, as this will almost definitely result in unintended behavior because of how browsers handle click handlers.

Example of accidental  misbehavior here: https://codesandbox.io/s/objective-tesla-zmpitb?file=/src/App.vue

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other
