### PR TITLE
docs(useBluetooth): fix a spelling error

### DIFF
--- a/packages/core/useBluetooth/index.md
+++ b/packages/core/useBluetooth/index.md
@@ -44,7 +44,7 @@ When the device has paired and is connected, you can then work with the server o
 
 This sample illustrates the use of the Web Bluetooth API to read battery level and be notified of changes from a nearby Bluetooth Device advertising Battery information with Bluetooth Low Energy.
 
-Here, we use the characteristicvaluechanged event listener to handle reading battery level characteristic value. This event listener will optionally handle upcoming notifications as well.
+Here, we use the characteristic value changed event listener to handle reading battery level characteristic value. This event listener will optionally handle upcoming notifications as well.
 
 ```ts
 import { pausableWatch, useBluetooth } from '@vueuse/core'


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

A spelling error in `useBluetooth`.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
