### PR TITLE
chore: typo

### DIFF
--- a/packages/guide/best-practice.md
+++ b/packages/guide/best-practice.md
@@ -2,7 +2,7 @@
 
 ### Destructuring
 
-Most of the functions in VueUse return an **object of refs** that you can use [ES6's object destructure](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) syntax to take what you need. For example:
+Most of the functions in VueUse return an **object of refs** that you can use [ES6's object destructure](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) syntax on to take what you need. For example:
 
 ```ts
 import { useMouse } from '@vueuse/core'

--- a/packages/guide/best-practice.md
+++ b/packages/guide/best-practice.md
@@ -2,7 +2,7 @@
 
 ### Destructuring
 
-Most of the functions in VueUse returns an **object of refs** that you can use [ES6's object destructure](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) syntax to take what you need. For example:
+Most of the functions in VueUse return an **object of refs** that you can use [ES6's object destructure](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) syntax to take what you need. For example:
 
 ```ts
 import { useMouse } from '@vueuse/core'


### PR DESCRIPTION
### Description

Pluralization agreement: "Most of the functions returns an object..." → "Most of the functions return an object..."
Preposition reference (not sure what the rule for this is): "That you can use [destructuring] to..." → "That you can use [destructuring] on to..."

I'm not particularly confident in the phrasing of the latter part of the sentence, but not sure what would be more simple and clear while also not introducing a grammatical snag. Another example would be "...return an object of refs on which you can use destructuring to...". Or you could split it and say "...return an object of refs, and you can use destructuring to...".

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
