### PR TITLE
docs(useFocusTrap): improve the documentation

### DIFF
--- a/packages/integrations/useFocusTrap/index.md
+++ b/packages/integrations/useFocusTrap/index.md
@@ -8,6 +8,12 @@ Reactive wrapper for [`focus-trap`](https://github.com/focus-trap/focus-trap).
 
 For more information on what options can be passed, see [`createOptions`](https://github.com/focus-trap/focus-trap#createfocustrapelement-createoptions) in the `focus-trap` documentation.
 
+## Install 
+
+```bash
+npm i focus-trap
+```
+
 ## Usage
 
 **Basic Usage**

--- a/packages/integrations/useNProgress/index.md
+++ b/packages/integrations/useNProgress/index.md
@@ -6,6 +6,12 @@ category: '@Integrations'
 
 Reactive wrapper for [`nprogress`](https://github.com/rstacruz/nprogress).
 
+## Install 
+
+```bash
+npm i nprogress
+```
+
 ## Usage
 
 ```js {6}


### PR DESCRIPTION
Even though `useFocusTrap` is categorized as an integration and described to be a "reactive wrapper for [focus-trap](https://github.com/focus-trap/focus-trap).", I think it'd be better to specify that you need to install `focus-trap` as a dependency.
Also, other integrations do this, just before the "Usage" section.