### PR TITLE
feat(useElementHover): support delay for hover

### DIFF
--- a/packages/core/useElementHover/demo.vue
+++ b/packages/core/useElementHover/demo.vue
@@ -3,11 +3,18 @@ import { ref } from 'vue'
 import { useElementHover } from '@vueuse/core'
 
 const el = ref<HTMLButtonElement>()
+const elOptions = ref<HTMLButtonElement>()
+
 const isHovered = useElementHover(el)
+const isHoveredOptions = useElementHover(elOptions, { delay: 500 })
 </script>
 
 <template>
   <button ref="el">
     <span>{{ isHovered ? 'Thank you!' : 'Hover me' }}</span>
+  </button>
+
+  <button ref="elOptions">
+    <span>{{ isHoveredOptions ? 'Thank you! (500ms)' : 'Hover me (500ms)' }}</span>
   </button>
 </template>

--- a/packages/core/useElementHover/directive.test.ts
+++ b/packages/core/useElementHover/directive.test.ts
@@ -1,4 +1,4 @@
-import { defineComponent } from 'vue-demi'
+import { defineComponent, isVue3 } from 'vue-demi'
 import type { VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
 import { promiseTimeout } from '@vueuse/shared'
@@ -72,7 +72,7 @@ describe('vElementHover', () => {
       expect(wrapper).toBeDefined()
     })
 
-    it('should trigger hover after 500ms', async () => {
+    it.runIf(isVue3)('should trigger hover after 500ms', async () => {
       const element = wrapper.get('[data-test=element]')
       await element.trigger('mouseenter')
       await promiseTimeout(200)

--- a/packages/core/useElementHover/directive.test.ts
+++ b/packages/core/useElementHover/directive.test.ts
@@ -1,8 +1,10 @@
 import { defineComponent } from 'vue-demi'
 import type { VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
+import { promiseTimeout } from '@vueuse/shared'
 
 import { vElementHover } from './directive'
+import type { UseElementHoverOptions } from '.'
 
 const App = defineComponent({
   props: {
@@ -10,10 +12,15 @@ const App = defineComponent({
       type: Function,
       required: true,
     },
+    options: {
+      type: Object,
+      require: false,
+    },
   },
 
   template: `<template>
-  <div v-element-hover="onHover">Hover me</div>
+  <div data-test="element" v-if="options" v-element-hover="[onHover, { delay: 500 }]">Hover me (500ms)</div>
+  <div v-else v-element-hover="onHover">Hover me</div>
   </template>
   `,
 })
@@ -22,21 +29,56 @@ describe('vElementHover', () => {
   let onHover = vi.fn()
   let wrapper: VueWrapper<any>
 
-  beforeEach(() => {
-    onHover = vi.fn()
-    wrapper = mount(App, {
-      props: {
-        onHover,
-      },
-      global: {
-        directives: {
-          elementHover: vElementHover,
+  describe('given no options', () => {
+    beforeEach(() => {
+      onHover = vi.fn()
+      wrapper = mount(App, {
+        props: {
+          onHover,
         },
-      },
+        global: {
+          directives: {
+            elementHover: vElementHover,
+          },
+        },
+      })
+    })
+
+    it('should be defined', () => {
+      expect(wrapper).toBeDefined()
     })
   })
 
-  it('should be defined', () => {
-    expect(wrapper).toBeDefined()
+  describe('given options', () => {
+    beforeEach(() => {
+      onHover = vi.fn()
+      const options: UseElementHoverOptions = {
+        delay: 500,
+      }
+      wrapper = mount(App, {
+        props: {
+          onHover,
+          options,
+        },
+        global: {
+          directives: {
+            elementHover: vElementHover,
+          },
+        },
+      })
+    })
+
+    it('should be defined', () => {
+      expect(wrapper).toBeDefined()
+    })
+
+    it('should trigger hover after 500ms', async () => {
+      const element = wrapper.get('[data-test=element]')
+      await element.trigger('mouseenter')
+      await promiseTimeout(200)
+      expect(onHover).toHaveBeenCalledTimes(0)
+      await promiseTimeout(300)
+      expect(onHover).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/packages/core/useElementHover/directive.ts
+++ b/packages/core/useElementHover/directive.ts
@@ -1,18 +1,30 @@
 import { watch } from 'vue-demi'
 import { directiveHooks } from '@vueuse/shared'
 import type { ObjectDirective } from 'vue-demi'
+import type { UseElementHoverOptions } from '.'
 import { useElementHover } from '.'
 
 type BindingValueFunction = (state: boolean) => void
 
+type BindingValueArray = [
+  BindingValueFunction,
+  UseElementHoverOptions,
+]
+
 export const vElementHover: ObjectDirective<
-HTMLElement,
-BindingValueFunction
+  HTMLElement,
+  BindingValueFunction | BindingValueArray
 > = {
   [directiveHooks.mounted](el, binding) {
     if (typeof binding.value === 'function') {
       const isHovered = useElementHover(el)
-      watch(isHovered, v => binding.value(v))
+      const handler = binding.value
+      watch(isHovered, v => handler(v))
+    }
+    else {
+      const [handler, options] = binding.value
+      const isHovered = useElementHover(el, options)
+      watch(isHovered, v => handler(v))
     }
   },
 }

--- a/packages/core/useElementHover/index.md
+++ b/packages/core/useElementHover/index.md
@@ -40,5 +40,10 @@ function onHover(state: boolean) {
   <button v-element-hover="onHover">
     {{ isHovered ? 'Thank you!' : 'Hover me' }}
   </button>
+
+  <!-- with options -->
+  <button v-element-hover="[onHover, { delay: 500 }]">
+    {{ isHovered ? 'Thank you! (500ms)' : 'Hover me (500ms)' }}
+  </button>
 </template>
 ```

--- a/packages/core/useElementHover/index.ts
+++ b/packages/core/useElementHover/index.ts
@@ -3,11 +3,45 @@ import { ref } from 'vue-demi'
 import type { MaybeComputedRef } from '@vueuse/shared'
 import { useEventListener } from '../useEventListener'
 
-export function useElementHover(el: MaybeComputedRef<EventTarget | null | undefined>): Ref<boolean> {
+export interface UseElementHoverOptions {
+  /**
+   * Time in ms of hovered over the element
+   */
+  delay?: number
+}
+
+export function useElementHover(el: MaybeComputedRef<EventTarget | null | undefined>, options: UseElementHoverOptions = {}): Ref<boolean> {
   const isHovered = ref(false)
 
-  useEventListener(el, 'mouseenter', () => isHovered.value = true)
-  useEventListener(el, 'mouseleave', () => isHovered.value = false)
+  let timeout: ReturnType<typeof setTimeout> | undefined
+
+  function clear() {
+    if (timeout) {
+      clearTimeout(timeout)
+      timeout = undefined
+    }
+  }
+
+  function onHover() {
+    clear()
+
+    if (options?.delay) {
+      timeout = setTimeout(() => {
+        isHovered.value = true
+      }, options?.delay)
+    }
+    else {
+      isHovered.value = true
+    }
+  }
+
+  function onLeave() {
+    clear()
+    isHovered.value = false
+  }
+
+  useEventListener(el, 'mouseenter', onHover)
+  useEventListener(el, 'mouseleave', onLeave)
 
   return isHovered
 }

--- a/packages/core/useElementHover/index.ts
+++ b/packages/core/useElementHover/index.ts
@@ -1,16 +1,20 @@
 import type { Ref } from 'vue-demi'
-import { ref } from 'vue-demi'
-import type { MaybeComputedRef } from '@vueuse/shared'
+import { ref, unref } from 'vue-demi'
+import type { MaybeComputedRef, MaybeRef } from '@vueuse/shared'
 import { useEventListener } from '../useEventListener'
 
 export interface UseElementHoverOptions {
   /**
    * Time in ms of hovered over the element
+   *
+   * @default 0
    */
-  delay?: number
+  delay?: MaybeRef<number>
 }
 
 export function useElementHover(el: MaybeComputedRef<EventTarget | null | undefined>, options: UseElementHoverOptions = {}): Ref<boolean> {
+  const { delay = 0 } = options
+
   const isHovered = ref(false)
 
   let timeout: ReturnType<typeof setTimeout> | undefined
@@ -25,10 +29,10 @@ export function useElementHover(el: MaybeComputedRef<EventTarget | null | undefi
   function onHover() {
     clear()
 
-    if (options?.delay) {
+    if (unref(delay)) {
       timeout = setTimeout(() => {
         isHovered.value = true
-      }, options?.delay)
+      }, unref(delay))
     }
     else {
       isHovered.value = true


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Support delay for useElementHover, sometimes we don't want the levitation event to trigger too sensitively, so it may be useful to add a delay option.

**[Demo](https://codesandbox.io/p/sandbox/useelementhover-viy481)**
In this scnece, if want to select pane C, the mouse may move over pane B and causing display. After adding an appropriate delay time, the pane you want to select can be displayed accurately.

https://user-images.githubusercontent.com/25719069/195824046-07ca076c-b119-40df-8e80-ac1dc66ebb4c.mov

**Use**
```ts
const el = ref<HTMLButtonElement>()

const isHovered = useElementHover(el, { delay: 500 })
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
