### PR TITLE
fix(nuxt): wrap ssr plugin in defineNuxtPlugin

### DIFF
--- a/packages/nuxt/ssr-plugin.mjs
+++ b/packages/nuxt/ssr-plugin.mjs
@@ -1,5 +1,5 @@
 import { setSSRHandler } from '@vueuse/core'
-import { useCookie, useMeta, defineNuxtPlugin } from '#imports'
+import { defineNuxtPlugin, useCookie, useMeta } from '#imports'
 
 setSSRHandler('getDefaultStorage', () => {
   const cookieMap = new Map()

--- a/packages/nuxt/ssr-plugin.mjs
+++ b/packages/nuxt/ssr-plugin.mjs
@@ -1,5 +1,5 @@
 import { setSSRHandler } from '@vueuse/core'
-import { useCookie, useMeta } from '#imports'
+import { useCookie, useMeta, defineNuxtPlugin } from '#imports'
 
 setSSRHandler('getDefaultStorage', () => {
   const cookieMap = new Map()
@@ -37,4 +37,4 @@ if (process.server) {
   })
 }
 
-export default () => { }
+export default defineNuxtPlugin(() => { })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When using the `nuxt` package, the console outputs the warning:

```bash
[warn] [nuxt] You are using a plugin that has not been wrapped in `defineNuxtPlugin`. It is advised to wrap your plugins as in the future this may enable enhancements: () => { }
```

This pull request simply wraps the ssr-plugin file export with `defineNuxtPlugin`

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
