### PR TITLE
fix(useWebSocket): don't reconnect WebSocket if `close` issued between retries

### DIFF
--- a/packages/core/useWebSocket/index.ts
+++ b/packages/core/useWebSocket/index.ts
@@ -203,10 +203,12 @@ export function useWebSocket<Data = any>(
   }
 
   const _init = () => {
+    if (explicitlyClosed)
+      return
+
     const ws = new WebSocket(url, protocols)
     wsRef.value = ws
     status.value = 'CONNECTING'
-    explicitlyClosed = false
 
     ws.onopen = () => {
       status.value = 'OPEN'
@@ -290,6 +292,7 @@ export function useWebSocket<Data = any>(
 
   const open = () => {
     close()
+    explicitlyClosed = false
     retried = 0
     _init()
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
