### PR TITLE
feat(useClipboard): support legacy copy

### DIFF
--- a/packages/core/useClipboard/index.ts
+++ b/packages/core/useClipboard/index.ts
@@ -2,8 +2,8 @@
 
 import type { MaybeComputedRef } from '@vueuse/shared'
 import { resolveUnref, useTimeoutFn } from '@vueuse/shared'
-import { computed, ComputedRef, Ref } from 'vue-demi'
-import { ref } from 'vue-demi'
+import type { ComputedRef, Ref } from 'vue-demi'
+import { computed, ref } from 'vue-demi'
 import type { WindowEventName } from '../useEventListener'
 import { useEventListener } from '../useEventListener'
 import { useSupported } from '../useSupported'

--- a/packages/core/useClipboard/index.ts
+++ b/packages/core/useClipboard/index.ts
@@ -2,7 +2,7 @@
 
 import type { MaybeComputedRef } from '@vueuse/shared'
 import { resolveUnref, useTimeoutFn } from '@vueuse/shared'
-import type { ComputedRef, Ref } from 'vue-demi'
+import { computed, ComputedRef, Ref } from 'vue-demi'
 import { ref } from 'vue-demi'
 import type { WindowEventName } from '../useEventListener'
 import { useEventListener } from '../useEventListener'
@@ -29,6 +29,13 @@ export interface UseClipboardOptions<Source> extends ConfigurableNavigator {
    * @default 1500
    */
   copiedDuring?: number
+
+  /**
+   * Whether fallback to document.execCommand('copy') if clipboard is undefined.
+   *
+   * @default false
+   */
+  legacy?: boolean
 }
 
 export interface UseClipboardReturn<Optional> {
@@ -52,19 +59,25 @@ export function useClipboard(options: UseClipboardOptions<MaybeComputedRef<strin
     read = false,
     source,
     copiedDuring = 1500,
+    legacy = false,
   } = options
 
   const events = ['copy', 'cut']
-  const isSupported = useSupported(() => navigator && 'clipboard' in navigator)
+  const isClipboardApiSupported = useSupported(() => (navigator && 'clipboard' in navigator))
+  const isSupported = computed(() => isClipboardApiSupported.value || legacy)
   const text = ref('')
   const copied = ref(false)
-
   const timeout = useTimeoutFn(() => copied.value = false, copiedDuring)
 
   function updateText() {
-    navigator!.clipboard.readText().then((value) => {
-      text.value = value
-    })
+    if (isClipboardApiSupported.value) {
+      navigator!.clipboard.readText().then((value) => {
+        text.value = value
+      })
+    }
+    else {
+      text.value = legacyRead()
+    }
   }
 
   if (isSupported.value && read) {
@@ -74,11 +87,30 @@ export function useClipboard(options: UseClipboardOptions<MaybeComputedRef<strin
 
   async function copy(value = resolveUnref(source)) {
     if (isSupported.value && value != null) {
-      await navigator!.clipboard.writeText(value)
+      if (isClipboardApiSupported.value)
+        await navigator!.clipboard.writeText(value)
+      else
+        legacyCopy(value)
+
       text.value = value
       copied.value = true
       timeout.start()
     }
+  }
+
+  function legacyCopy(value: string) {
+    const ta = document.createElement('textarea')
+    ta.value = value ?? ''
+    ta.style.position = 'absolute'
+    ta.style.opacity = '0'
+    document.body.appendChild(ta)
+    ta.select()
+    document.execCommand('copy')
+    ta.remove()
+  }
+
+  function legacyRead() {
+    return document?.getSelection?.()?.toString() ?? ''
   }
 
   return {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Add `legacy: boolean` option. 
It will fallback to legacy methods `document.execCommand('copy')` if ClipboardApi is not allowed, for scenes like hosting website with IP adress, especially during development.
Relate to #1276


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
