### PR TITLE
chore(useWebSocket): skip call to clearTimeout when heartbeat disabled

### DIFF
--- a/packages/core/useWebSocket/index.ts
+++ b/packages/core/useWebSocket/index.ts
@@ -168,7 +168,7 @@ export function useWebSocket<Data = any>(
 
   let bufferedData: (string | ArrayBuffer | Blob)[] = []
 
-  let pongTimeoutWait: ReturnType<typeof setTimeout>
+  let pongTimeoutWait: ReturnType<typeof setTimeout> | undefined
 
   // Status code 1000 -> Normal Closure https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent/code
   const close: WebSocket['close'] = (code = 1000, reason) => {
@@ -242,9 +242,8 @@ export function useWebSocket<Data = any>(
     }
 
     ws.onmessage = (e: MessageEvent) => {
-      resetHeartbeat()
-      // Heartbeat response will be skipped
       if (options.heartbeat) {
+        resetHeartbeat()
         const {
           message = DEFAULT_PING_MESSAGE,
         } = resolveNestedOptions(options.heartbeat)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The call `clearTimeout(undefined)` was dominating my program runtime, even though I didn't enable heartbeats. Skip this call when heartbeats disabled.

### Additional context

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
