### PR TITLE
fix(useRouteHash, useRouteParams, useRouteQuery): override only selected route param

### DIFF
--- a/packages/router/useRouteHash/index.ts
+++ b/packages/router/useRouteHash/index.ts
@@ -16,7 +16,7 @@ export function useRouteHash(
     },
     set(v) {
       nextTick(() => {
-        router[unref(mode)]({ hash: v })
+        router[unref(mode)]({ ...route, hash: v })
       })
     },
   })

--- a/packages/router/useRouteParams/index.ts
+++ b/packages/router/useRouteParams/index.ts
@@ -25,7 +25,7 @@ export function useRouteParams<T extends string | string[]>(
     },
     set(v) {
       nextTick(() => {
-        router[unref(mode)]({ params: { ...route.params, [name]: v } })
+        router[unref(mode)]({ ...route, params: { ...route.params, [name]: v } })
       })
     },
   })

--- a/packages/router/useRouteQuery/index.ts
+++ b/packages/router/useRouteQuery/index.ts
@@ -25,7 +25,7 @@ export function useRouteQuery<T extends string | string[]>(
     },
     set(v) {
       nextTick(() => {
-        router[unref(mode)]({ query: { ...route.query, [name]: v === defaultValue || v === null ? undefined : v } })
+        router[unref(mode)]({ ...route, query: { ...route.query, [name]: v === defaultValue || v === null ? undefined : v } })
       })
     },
   })


### PR DESCRIPTION
### Description

When changing route hash using `useRouteHash`, it resets existing route query if exists. same for all three functions.
The change is pretty simple and is spreading the current route instance (defaults or given)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
