### PR TITLE
fix(useTransition): 禁用状态调用 pause() 停止 useRafFn

### DIFF
--- a/packages/.vitepress/plugins/utils.ts
+++ b/packages/.vitepress/plugins/utils.ts
@@ -6,6 +6,7 @@ export const stringify = reactify(
     skipInvalid: true,
     forceQuotes: true,
     condenseFlow: true,
+    noCompatMode: true,
     quotingType: '\'',
   }),
 )

--- a/packages/core/useTransition/index.ts
+++ b/packages/core/useTransition/index.ts
@@ -199,15 +199,17 @@ export function useTransition(
   const timeout = useTimeoutFn(start, delay, { immediate: false })
 
   watch(sourceVector, () => {
-    if (unref(disabled)) {
-      outputVector.value = sourceVector.value.slice(0)
-    }
-    else {
-      if (unref(delay) <= 0)
-        start()
-      else timeout.start()
-    }
+    if (unref(delay) <= 0)
+      start()
+    else timeout.start()
   }, { deep: true })
+
+  watch(() => unref(disabled), (v) => {
+    if (v) {
+      outputVector.value = sourceVector.value.slice(0)
+      pause()
+    }
+  })
 
   return computed(() => {
     const targetVector = unref(disabled) ? sourceVector : outputVector


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

禁用状态应当调用 `pause()` 以停止 `useRafFn`

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
