### PR TITLE
refactor(useStorage): reduce redundant type guess

### DIFF
--- a/packages/core/useStorage/guess.ts
+++ b/packages/core/useStorage/guess.ts
@@ -13,9 +13,7 @@ export function guessSerializerType<T extends(string | number | boolean | object
               ? 'string'
               : typeof rawInit === 'object'
                 ? 'object'
-                : Array.isArray(rawInit)
-                  ? 'object'
-                  : !Number.isNaN(rawInit)
-                      ? 'number'
-                      : 'any'
+                : !Number.isNaN(rawInit)
+                    ? 'number'
+                    : 'any'
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

`typeof []` is always `'object'`,  so L16-L17 below is unreachable

https://github.com/vueuse/vueuse/blob/24747b636c61d23fa9c14474ba1a5ce78956dae1/packages/core/useStorage/guess.ts#L14-L17

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
