### PR TITLE
fix(usePointerSwipe): handle secondary clicks properly

### DIFF
--- a/packages/core/usePointerSwipe/index.ts
+++ b/packages/core/usePointerSwipe/index.ts
@@ -13,22 +13,22 @@ export interface UsePointerSwipeOptions {
   threshold?: number
 
   /**
-   * Callback on swipe start
+   * Callback on swipe start.
    */
   onSwipeStart?: (e: PointerEvent) => void
 
   /**
-   * Callback on swipe move
+   * Callback on swipe move.
    */
   onSwipe?: (e: PointerEvent) => void
 
   /**
-   * Callback on swipe end
+   * Callback on swipe end.
    */
   onSwipeEnd?: (e: PointerEvent, direction: SwipeDirection) => void
 
   /**
-   * Pointer types that listen to.
+   * Pointer types to listen to.
    *
    * @default ['mouse', 'touch', 'pen']
    */
@@ -100,15 +100,15 @@ export function usePointerSwipe(
     }
   })
 
-  const filterEvent = (e: PointerEvent) => {
-    if (options.pointerTypes)
-      return options.pointerTypes.includes(e.pointerType as PointerType)
-    return true
+  const eventIsAllowed = (e: PointerEvent): boolean => {
+    const isReleasingButton = e.buttons === 0
+    const isPrimaryButton = e.buttons === 1
+    return options.pointerTypes?.includes(e.pointerType as PointerType) ?? (isReleasingButton || isPrimaryButton) ?? true
   }
 
   const stops = [
     useEventListener(target, 'pointerdown', (e: PointerEvent) => {
-      if (!filterEvent(e))
+      if (!eventIsAllowed(e))
         return
       isPointerDown.value = true
       // Disable scroll on for TouchEvents
@@ -123,7 +123,7 @@ export function usePointerSwipe(
     }),
 
     useEventListener(target, 'pointermove', (e: PointerEvent) => {
-      if (!filterEvent(e))
+      if (!eventIsAllowed(e))
         return
       if (!isPointerDown.value)
         return
@@ -137,7 +137,7 @@ export function usePointerSwipe(
     }),
 
     useEventListener(target, 'pointerup', (e: PointerEvent) => {
-      if (!filterEvent(e))
+      if (!eventIsAllowed(e))
         return
       if (isSwiping.value)
         onSwipeEnd?.(e, direction.value)


### PR DESCRIPTION
### Description

Fix issue where a secondary click (the right button on a right-handed mouse) on an element using usePointerSwipe() is treated as if the primary button (left click on a right-handed mouse) has started a drag.

- Rename filterEvent() to eventIsAllowed() for better clarity
- Fix typo in docs and make punctuation consistent

Fixes #2338

#### Before

1. Right click on the button
2. Hit the Escape key to dismiss the context menu
3. Without clicking, move the mouse around over the button. The button behaves as if it is being dragged.

![CleanShot 2022-10-29 at 12 06 01](https://user-images.githubusercontent.com/3038600/198844174-860ffec2-c391-418c-8ec8-63ad82365169.gif)


#### After

A right click does nothing other than open the context menu as usual. 

![CleanShot 2022-10-29 at 12 08 22](https://user-images.githubusercontent.com/3038600/198844265-094afea6-7ee3-43da-9bdd-3d566d708452.gif)


### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
