### PR TITLE
feat(useConfirmDialog): add a injectionKey for dialog

### DIFF
--- a/packages/core/useConfirmDialog/ChildModal.vue
+++ b/packages/core/useConfirmDialog/ChildModal.vue
@@ -1,0 +1,43 @@
+<script lang="ts">
+import { type PropType, defineComponent, inject, ref } from 'vue-demi'
+import type { UseConfirmDialogReturn } from '@vueuse/core'
+
+export default defineComponent({
+  name: 'ChildModal',
+  props: {
+    token: {
+      required: true,
+      type: Symbol as PropType<UseConfirmDialogReturn<any, any, any >['token']>,
+    },
+  },
+  setup(props) {
+    const { isRevealed, confirm, cancel } = inject(props.token)!
+
+    return { isRevealed, confirm, cancel }
+  },
+})
+</script>
+
+<template>
+  <div v-if="isRevealed" class="child-modal">
+    <div>
+      <div>
+        <p>Confirm or cancel from child</p>
+      </div>
+      <footer>
+        <button @click="confirm">
+          OK
+        </button>
+        <button @click="cancel">
+          Cancel
+        </button>
+      </footer>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.child-modal {
+
+}
+</style>

--- a/packages/core/useConfirmDialog/demo.vue
+++ b/packages/core/useConfirmDialog/demo.vue
@@ -2,12 +2,16 @@
 import { ref } from 'vue'
 import { useConfirmDialog } from '@vueuse/core'
 
-const message = ref('')
-const revaled1 = ref(false)
-const revaled2 = ref(false)
+import ChildModal from './ChildModal.vue'
 
-const dialog1 = useConfirmDialog(revaled1)
-const dialog2 = useConfirmDialog(revaled2)
+const message = ref('')
+const revealed1 = ref(false)
+const revealed2 = ref(false)
+const revealed3 = ref(false)
+
+const dialog1 = useConfirmDialog(revealed1)
+const dialog2 = useConfirmDialog(revealed2)
+const dialog3 = useConfirmDialog(revealed3)
 
 dialog1.onReveal(() => {
   message.value = 'Modal is shown!'
@@ -42,14 +46,14 @@ dialog2.onCancel(() => {
     <span class="text-orange-400">{{ message }}</span>
   </h2>
   <button
-    :disabled="revaled1 || revaled2"
+    :disabled="revealed1 || revealed2"
     @click="dialog1.reveal"
   >
     Click to Show Modal Dialog
   </button>
 
   <!-- First Dialog -->
-  <div v-if="revaled1">
+  <div v-if="revealed1">
     <div>
       <div>
         <p>Show Second Dialog?</p>
@@ -66,7 +70,7 @@ dialog2.onCancel(() => {
   </div>
 
   <!-- Second Dialog -->
-  <div v-if="revaled2">
+  <div v-if="revealed2">
     <div>
       <div>
         <p>Confirm or Reject</p>
@@ -83,6 +87,18 @@ dialog2.onCancel(() => {
         </button>
       </footer>
     </div>
+  </div>
+  <div>
+    <div>
+      Open or cancel child dialog from parent:
+      <button v-if="!revealed3" @click="dialog3.reveal">
+        Open
+      </button>
+      <button v-else @click="dialog3.cancel">
+        Cancel
+      </button>
+    </div>
+    <ChildModal :token="dialog3.token" />
   </div>
 </template>
 

--- a/packages/core/useConfirmDialog/index.ts
+++ b/packages/core/useConfirmDialog/index.ts
@@ -1,5 +1,5 @@
-import type { ComputedRef, Ref } from 'vue-demi'
-import { computed, ref } from 'vue-demi'
+import type { ComputedRef, InjectionKey, Ref } from 'vue-demi'
+import { computed, provide, ref } from 'vue-demi'
 import type { EventHook, EventHookOn } from '@vueuse/shared'
 import { createEventHook, noop } from '@vueuse/shared'
 
@@ -17,6 +17,8 @@ export interface UseConfirmDialogReturn<RevealData, ConfirmData, CancelData> {
    * Revealing state
    */
   isRevealed: ComputedRef<boolean>
+
+  token: InjectionKey<Omit<UseConfirmDialogReturn<RevealData, ConfirmData, CancelData>, 'token' | 'reveal'>>
 
   /**
    * Opens the dialog.
@@ -95,8 +97,22 @@ export function useConfirmDialog<
     _resolve({ data, isCanceled: true })
   }
 
+  const isRevealed = computed(() => revealed.value)
+  const provided = {
+    isRevealed,
+    confirm,
+    cancel,
+    onReveal: revealHook.on,
+    onConfirm: confirmHook.on,
+    onCancel: cancelHook.on,
+  }
+
+  const token: InjectionKey<typeof provided> = Symbol('confirmDialog')
+
+  provide(token, provided)
   return {
-    isRevealed: computed(() => revealed.value),
+    isRevealed,
+    token,
     reveal,
     confirm,
     cancel,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
There is a common scenario:

1. Open a confirm a dialog as a **child component** from a **parent component**.
2. Confirm or Cancel from the child component.

if `useConfirmDialog` provide a injection key, we can get dialog's states and methods easily from child component.  



### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
