### PR TITLE
fix(useColorMode): remove `tryOnMounted`

### DIFF
--- a/packages/core/useColorMode/index.ts
+++ b/packages/core/useColorMode/index.ts
@@ -1,6 +1,5 @@
 import type { Ref } from 'vue-demi'
 import { computed, ref, watch } from 'vue-demi'
-import { tryOnMounted } from '@vueuse/shared'
 import type { StorageLike } from '../ssr-handlers'
 import { getSSRHandler } from '../ssr-handlers'
 import type { UseStorageOptions } from '../useStorage'
@@ -162,8 +161,6 @@ export function useColorMode<T extends string = BasicColorSchema>(options: UseCo
   watch(state, onChanged, { flush: 'post', immediate: true })
   if (emitAuto)
     watch(preferredMode, () => onChanged(state.value), { flush: 'post' })
-
-  tryOnMounted(() => onChanged(state.value))
 
   return state
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fixes #2035 

See #2035, when page refreshed, `useColorMode` cannot work immediately. This could be solved by removing `  tryOnMounted(() => onChanged(state.value))`

### Additional context

NO

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
