### PR TITLE
fix(useScroll): the expected result cannot be returned after setting the throttle parameter

### DIFF
--- a/packages/core/useScroll/index.ts
+++ b/packages/core/useScroll/index.ts
@@ -189,7 +189,7 @@ export function useScroll(
   useEventListener(
     element,
     'scroll',
-    throttle ? useThrottleFn(onScrollHandler, throttle) : onScrollHandler,
+    throttle ? useThrottleFn(onScrollHandler, throttle, true, false) : onScrollHandler,
     eventListenerOptions,
   )
 


### PR DESCRIPTION
## Fixes #2389

<!-- Thank you for contributing! -->

### Description

I first ran into this problem when using the `useInfiniteScroll` function, which caused the list to not load more contents once it was scrolled to the bottom.
The reason for this bug is that the `useThrottleFn` used in `useScroll` is not configured properly with: `[trailing=true]` and `[leading=false]`,where it ensures that the function must be executed once after the scrolling ends.


#### The way the bug is reproduced:

https://user-images.githubusercontent.com/19204772/199266546-7594cf50-0fee-4a61-9e9f-4d04f013875a.mov

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
