### PR TITLE
fix(onClickOutside): missing options for component

### DIFF
--- a/packages/core/onClickOutside/component.ts
+++ b/packages/core/onClickOutside/component.ts
@@ -1,16 +1,21 @@
 import { defineComponent, h, ref } from 'vue-demi'
 import { onClickOutside } from '@vueuse/core'
 import type { RenderableComponent } from '../types'
+import type { OnClickOutsideOptions } from '.'
 
-export const OnClickOutside = defineComponent<RenderableComponent>({
+export interface OnClickOutsideProps extends RenderableComponent {
+  options?: OnClickOutsideOptions
+}
+
+export const OnClickOutside = defineComponent<OnClickOutsideProps>({
   name: 'OnClickOutside',
-  props: ['as'] as unknown as undefined,
+  props: ['as', 'options'] as unknown as undefined,
   emits: ['trigger'],
   setup(props, { slots, emit }) {
     const target = ref()
     onClickOutside(target, (e) => {
       emit('trigger', e)
-    })
+    }, props.options)
 
     return () => {
       if (slots.default)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

It adds support for the options property when using onClickOutside via component.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
