### PR TITLE
feat: add reactive window.scrollTo watcher to useWindowScroll

### DIFF
--- a/packages/core/useWindowScroll/demo.vue
+++ b/packages/core/useWindowScroll/demo.vue
@@ -2,6 +2,11 @@
 import { useWindowScroll } from '@vueuse/core'
 
 const { x, y } = useWindowScroll()
+
+function scrollToTop() {
+  x.value = 0
+  y.value = 0
+}
 </script>
 
 <template>
@@ -15,7 +20,11 @@ const { x, y } = useWindowScroll()
         Scroll value
       </note>
       x: {{ x }}<br>
-      y: {{ y }}
+      y: {{ y }}<br>
+
+      <button @click="scrollToTop">
+        Scroll Up
+      </button>
     </div>
   </div>
 </template>

--- a/packages/core/useWindowScroll/index.ts
+++ b/packages/core/useWindowScroll/index.ts
@@ -1,4 +1,4 @@
-import { ref } from 'vue-demi'
+import { ref, watch } from 'vue-demi'
 import { useEventListener } from '../useEventListener'
 import type { ConfigurableWindow } from '../_configurable'
 import { defaultWindow } from '../_configurable'
@@ -19,6 +19,11 @@ export function useWindowScroll({ window = defaultWindow }: ConfigurableWindow =
 
   const x = ref(window.pageXOffset)
   const y = ref(window.pageYOffset)
+
+  watch([x, y], ([newX, newY]) => {
+    if (window)
+      window.scrollTo(newX, newY)
+  })
 
   useEventListener(
     'scroll',


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Add watcher with `window.scrollTo` callback for exported x and y refs, so anyone can make whole page scroll with already exported refs

### Additional context

Currently, exported `x`, and `y` are simple writable refs, so I can write to them without any warning and with no side effect. It makes sense to either make them read-only (computed) or just add `scrollTo` function to handle window scroll on change

Things that are not covered in this PR:
 - scroll behavior (https://vueuse.org/core/useScroll/#smooth-scrolling)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
