### PR TITLE
fix(refAutoReset): correctly handle delay ref update & add Infinity delay

### DIFF
--- a/packages/shared/refAutoReset/index.test.ts
+++ b/packages/shared/refAutoReset/index.test.ts
@@ -35,7 +35,7 @@ describe('refAutoReset', () => {
     val.value = 'update'
     afterMs.value = 100
 
-    await new Promise(resolve => setTimeout(resolve, 100 + 1))
+    await new Promise(resolve => setTimeout(resolve, 100 - 1))
     expect(val.value).toBe('update')
 
     await new Promise(resolve => setTimeout(resolve, 50))
@@ -59,5 +59,44 @@ describe('refAutoReset', () => {
     scope.stop()
     await promiseTimeout(100)
     expect(val.value).toBe('update')
+  })
+
+  it('should not reset value when Infinity timer is passed', async () => {
+    const val = refAutoReset('default', Infinity)
+    val.value = 'update'
+
+    await new Promise(resolve => setTimeout(resolve, 100))
+    expect(val.value).toBe('update')
+
+    val.value = 'update2'
+
+    await new Promise(resolve => setTimeout(resolve, 100))
+    expect(val.value).toBe('update2')
+  })
+
+  it('should restart timer on afterMs ref update', async () => {
+    const afterMs = ref(150)
+    const val = refAutoReset('default', afterMs)
+    val.value = 'update'
+
+    await new Promise(resolve => setTimeout(resolve, 100))
+    expect(val.value).toBe('update')
+
+    afterMs.value = 151 // values can't be the same in order for update to trigger
+
+    await new Promise(resolve => setTimeout(resolve, 100))
+    expect(val.value).toBe('update')
+
+    await new Promise(resolve => setTimeout(resolve, 100))
+    expect(val.value).toBe('default')
+
+    val.value = 'update2'
+    afterMs.value = 50
+
+    await new Promise(resolve => setTimeout(resolve, 25))
+    afterMs.value = Infinity
+
+    await new Promise(resolve => setTimeout(resolve, 100))
+    expect(val.value).toBe('update2')
   })
 })


### PR DESCRIPTION
### Description

This PR adds proper handling for `afterMs` ref arg.

https://vueuse.org/shared/refautoreset

### Additional context

Updated test case `should change afterMs` was clearly wrong.

It is debatable whether or not `Infinity` delay should be handled this way. Chrome acts like `setTimeout(fn, Infinity)` is the same as `setTimeout(fn, 0)`, but I think cancellation would be useful here and `Infinity` delay is the most obvious way to implement it.

However, once (if) https://github.com/vueuse/vueuse/pull/2385 gets merged, this feature will be less useful.

Probably `Infinity` delay feature should be mentioned in documentation.

If you think that Infinity delay should not be part of this - let me know, I will update PR accordingly.

---

### What is the purpose of this pull request?

- [x] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
