### PR TITLE
feat(useVirutalList): expose `scrollTo` in component

### DIFF
--- a/packages/core/useVirtualList/component.ts
+++ b/packages/core/useVirtualList/component.ts
@@ -30,11 +30,12 @@ export const UseVirtualList = defineComponent<UseVirtualListProps>({
     'options',
     'height',
   ] as unknown as undefined,
-  setup(props, { slots }) {
+  setup(props, { slots, expose }) {
     const { list: listRef } = toRefs(props)
 
-    const { list, containerProps, wrapperProps } = useVirtualList(listRef, props.options)
-
+    const { list, containerProps, wrapperProps, scrollTo } = useVirtualList(listRef, props.options)
+    expose({ scrollTo })
+    
     typeof containerProps.style === 'object' && !Array.isArray(containerProps.style) && (containerProps.style.height = props.height || '300px')
 
     return () => h('div',

--- a/packages/core/useVirtualList/index.md
+++ b/packages/core/useVirtualList/index.md
@@ -101,3 +101,5 @@ const { list, containerProps, wrapperProps } = useVirtualList(
   </template>
 </UseVirtualList>
 ```
+
+To scroll to a specific element, the component exposes `scrollTo(index: number) => void`.


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Expose `scrollTo` in the virtual list component. So far, this feature wasn't accessible in the component version of virtual lists.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
