### PR TITLE
fix(useIDBKeyval): incorrect value init set

### DIFF
--- a/packages/integrations/useIDBKeyval/index.ts
+++ b/packages/integrations/useIDBKeyval/index.ts
@@ -55,8 +55,8 @@ export function useIDBKeyval<T>(
     try {
       const rawValue = await get<T>(key)
       if (rawValue === undefined) {
-        if (rawInit)
-          set(key, rawInit)
+        if (rawInit !== undefined && rawInit !== null)
+          await set(key, rawInit)
       }
       else {
         data.value = rawValue


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

`useIDBKeyval` has some problems in L58-L59. This PR purpose is to solve these problems below.

-  Only `undefined` and `null`  `rawInit` should be ignored to set
- Since `set` is an async method, it is unsafe without `await`(L65-L67 can't catch error when `set` error). 

https://github.com/vueuse/vueuse/blob/0a49ea4dacbd98cdeb6e4be1bba3bc9347a8845a/packages/integrations/useIDBKeyval/index.ts#L54-L70

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Unit test covered.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
