### PR TITLE
docs: error when frontmatter does not exist

### DIFF
--- a/packages/.vitepress/plugins/markdownTransform.ts
+++ b/packages/.vitepress/plugins/markdownTransform.ts
@@ -37,9 +37,11 @@ export function MarkdownTransform(): Plugin {
       const name = functionNames.find(n => n.toLowerCase() === _name.toLowerCase()) || _name
 
       if (functionNames.includes(name) && i === 'index.md') {
-        const frontmatterEnds = code.indexOf('---\n\n') + 4
+        const frontmatterEnds = code.indexOf('---\n\n')
         const firstSubheader = code.search(/\n## \w/)
-        const sliceIndex = firstSubheader < 0 ? frontmatterEnds : firstSubheader
+        const sliceIndex = firstSubheader < 0
+          ? (frontmatterEnds < 0 ? 0 : frontmatterEnds + 5)
+          : firstSubheader
 
         const { footer, header } = await getFunctionMarkdown(pkg, name)
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

The value of sliceIndex is wrong when firstSubheader returns -1 and no frontmatter exists.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
