### PR TITLE
fix for throwError option for useAsyncState

### DIFF
--- a/packages/core/useAsyncState/index.ts
+++ b/packages/core/useAsyncState/index.ts
@@ -1,6 +1,6 @@
-import { noop, promiseTimeout } from '@vueuse/shared'
-import type { Ref, UnwrapRef } from 'vue-demi'
-import { ref, shallowRef } from 'vue-demi'
+import {noop, promiseTimeout} from '@vueuse/shared'
+import type {Ref, UnwrapRef} from 'vue-demi'
+import {ref, shallowRef} from 'vue-demi'
 
 export interface UseAsyncStateReturn<Data, Shallow extends boolean> {
   state: Shallow extends true ? Ref<Data> : Ref<UnwrapRef<Data>>
@@ -97,22 +97,18 @@ export function useAsyncState<Data, Shallow extends boolean = true>(
     if (delay > 0)
       await promiseTimeout(delay)
 
-    const _promise = typeof promise === 'function'
-      ? promise(...args)
-      : promise
-
     try {
-      const data = await _promise
-      state.value = data
+      const _promise = typeof promise === 'function'
+        ? promise(...args)
+        : promise
+      state.value = await _promise
       isReady.value = true
-    }
-    catch (e) {
+    } catch (e) {
       error.value = e
       onError(e)
       if (throwError)
-        throw error
-    }
-    finally {
+        throw e
+    } finally {
       isLoading.value = false
     }
 

--- a/packages/core/useAsyncState/index.ts
+++ b/packages/core/useAsyncState/index.ts
@@ -88,19 +88,20 @@ export function useAsyncState<Data, Shallow extends boolean = true>(
   const error = ref<unknown | undefined>(undefined)
 
   async function execute(delay = 0, ...args: any[]) {
-    if (resetOnExecute)
-      state.value = initialState
-    error.value = undefined
-    isReady.value = false
-    isLoading.value = true
-
-    if (delay > 0)
-      await promiseTimeout(delay)
-
     try {
+      if (resetOnExecute)
+        state.value = initialState
+      error.value = undefined
+      isReady.value = false
+      isLoading.value = true
+
+      if (delay > 0)
+        await promiseTimeout(delay)
+
       const _promise = typeof promise === 'function'
         ? promise(...args)
         : promise
+
       state.value = await _promise
       isReady.value = true
     } catch (e) {

--- a/packages/core/useAsyncState/index.ts
+++ b/packages/core/useAsyncState/index.ts
@@ -1,6 +1,6 @@
-import {noop, promiseTimeout} from '@vueuse/shared'
-import type {Ref, UnwrapRef} from 'vue-demi'
-import {ref, shallowRef} from 'vue-demi'
+import { noop, promiseTimeout } from '@vueuse/shared'
+import type { Ref, UnwrapRef } from 'vue-demi'
+import { ref, shallowRef } from 'vue-demi'
 
 export interface UseAsyncStateReturn<Data, Shallow extends boolean> {
   state: Shallow extends true ? Ref<Data> : Ref<UnwrapRef<Data>>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

when you set throwError: true, and when an actual error is caught, useAsyncState throws a ref error instead of the actual error.
This happens because throw error is executed instead throw e which would return the actual error in packages/core/useAsyncState/index.ts line 113.  
![image](https://user-images.githubusercontent.com/94362064/201122228-92d957a1-9395-4a9a-b5ca-b1b15adf82fa.png)
Also the try should encompass the rest of the function as well, otherwise `throwError` does not work for non promises.

### Additional context

https://github.com/vueuse/vueuse/issues/2419 issue regarding this fork
---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
