### PR TITLE
fix(onClickOutside): call handler if `click` event is fired by a keypress

### DIFF
--- a/packages/core/onClickOutside/index.ts
+++ b/packages/core/onClickOutside/index.ts
@@ -52,8 +52,13 @@ export function onClickOutside<T extends OnClickOutsideOptions>(
 
     const el = unrefElement(target)
 
-    if (!el || el === event.target || event.composedPath().includes(el) || !shouldListen.value)
+    if (!el || el === event.target || event.composedPath().includes(el))
       return
+
+    if (!shouldListen.value) {
+      shouldListen.value = true
+      return
+    }
 
     handler(event)
   }
@@ -69,7 +74,8 @@ export function onClickOutside<T extends OnClickOutsideOptions>(
     useEventListener(window, 'click', listener, { passive: true, capture }),
     useEventListener(window, 'pointerdown', (e) => {
       const el = unrefElement(target)
-      shouldListen.value = !!el && !e.composedPath().includes(el) && !shouldIgnore(e)
+      if (el)
+        shouldListen.value = !e.composedPath().includes(el) && !shouldIgnore(e)
     }, { passive: true }),
     useEventListener(window, 'pointerup', (e) => {
       if (e.button === 0) {

--- a/packages/core/onClickOutside/index.ts
+++ b/packages/core/onClickOutside/index.ts
@@ -1,5 +1,4 @@
 import type { Fn } from '@vueuse/shared'
-import { ref } from 'vue-demi'
 import type { MaybeElementRef } from '../unrefElement'
 import { unrefElement } from '../unrefElement'
 import { useEventListener } from '../useEventListener'
@@ -43,7 +42,7 @@ export function onClickOutside<T extends OnClickOutsideOptions>(
   if (!window)
     return
 
-  const shouldListen = ref(true)
+  let shouldListen = true
 
   let fallback: number
 
@@ -55,8 +54,8 @@ export function onClickOutside<T extends OnClickOutsideOptions>(
     if (!el || el === event.target || event.composedPath().includes(el))
       return
 
-    if (!shouldListen.value) {
-      shouldListen.value = true
+    if (!shouldListen) {
+      shouldListen = true
       return
     }
 
@@ -75,7 +74,7 @@ export function onClickOutside<T extends OnClickOutsideOptions>(
     useEventListener(window, 'pointerdown', (e) => {
       const el = unrefElement(target)
       if (el)
-        shouldListen.value = !e.composedPath().includes(el) && !shouldIgnore(e)
+        shouldListen = !e.composedPath().includes(el) && !shouldIgnore(e)
     }, { passive: true }),
     useEventListener(window, 'pointerup', (e) => {
       if (e.button === 0) {


### PR DESCRIPTION

<!-- Thank you for contributing! -->

### Description

Reproduction: https://vueuse.org/core/onclickoutside/

1. Click "Open Modal"
2. Press `Tab`, your focus is now on "Toggle Dropdown" button
3. Press Space. Dropdown opens but Modal is still there, it should be closed since a `click` event is fired outside the modal.

Try the same thing by clicking "Toggle Dropdown" first. It works as expected. This PR fixes that inconsistency.


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
