### PR TITLE
refactor(getTimeAgo): rename `getTimeago` to `getTimeAgo`

### DIFF
--- a/packages/core/useTimeAgo/index.ts
+++ b/packages/core/useTimeAgo/index.ts
@@ -129,7 +129,7 @@ export function useTimeAgo(time: MaybeComputedRef<Date | number | string>, optio
   const { abs, round } = Math
   const { now, ...controls } = useNow({ interval: updateInterval, controls: true })
 
-  function getTimeago(from: Date, now: Date) {
+  function getTimeAgo(from: Date, now: Date) {
     const diff = +now - +from
     const absDiff = abs(diff)
 
@@ -167,7 +167,7 @@ export function useTimeAgo(time: MaybeComputedRef<Date | number | string>, optio
     return applyFormat(past ? 'past' : 'future', str, past)
   }
 
-  const timeAgo = computed(() => getTimeago(new Date(resolveUnref(time)), unref(now.value)))
+  const timeAgo = computed(() => getTimeAgo(new Date(resolveUnref(time)), unref(now.value)))
 
   if (exposeControls) {
     return {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

###  Change the getTimeago of  function in useTimeAge component to the getTimeAgo function

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix 
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
