### PR TITLE
fix(useFirestore): fix falsy type error

### DIFF
--- a/packages/firebase/useFirestore/index.md
+++ b/packages/firebase/useFirestore/index.md
@@ -30,8 +30,8 @@ const posts = useFirestore(postsQuery)
 // you can use the boolean value to tell a query when it is ready to run
 // when it gets falsy value, return the initial value
 const userId = ref('')
-const userQuery = computed(() => !!userId.value && doc(db, 'users', userId.value))
-const userData = useFirestore(userQuery, [])
+const userQuery = computed(() => userId.value && doc(db, 'users', userId.value))
+const userData = useFirestore(userQuery, null)
 ```
 
 ## Share across instances

--- a/packages/firebase/useFirestore/index.ts
+++ b/packages/firebase/useFirestore/index.ts
@@ -33,25 +33,27 @@ function isDocumentReference<T>(docRef: any): docRef is DocumentReference<T> {
   return (docRef.path?.match(/\//g) || []).length % 2 !== 0
 }
 
+type Falsy = false | 0 | '' | null | undefined
+
 export function useFirestore<T extends DocumentData>(
-  maybeDocRef: MaybeRef<DocumentReference<T> | false>,
+  maybeDocRef: MaybeRef<DocumentReference<T> | Falsy>,
   initialValue: T,
   options?: UseFirestoreOptions
 ): Ref<T | null>
 export function useFirestore<T extends DocumentData>(
-  maybeDocRef: MaybeRef<Query<T> | false>,
+  maybeDocRef: MaybeRef<Query<T> | Falsy>,
   initialValue: T[],
   options?: UseFirestoreOptions
 ): Ref<T[]>
 
 // nullable initial values
 export function useFirestore<T extends DocumentData>(
-  maybeDocRef: MaybeRef<DocumentReference<T> | false>,
-  initialValue?: T | undefined,
+  maybeDocRef: MaybeRef<DocumentReference<T> | Falsy>,
+  initialValue?: T | undefined | null,
   options?: UseFirestoreOptions,
 ): Ref<T | undefined | null>
 export function useFirestore<T extends DocumentData>(
-  maybeDocRef: MaybeRef<Query<T> | false>,
+  maybeDocRef: MaybeRef<Query<T> | Falsy>,
   initialValue?: T[],
   options?: UseFirestoreOptions
 ): Ref<T[] | undefined>
@@ -63,7 +65,7 @@ export function useFirestore<T extends DocumentData>(
  * @see https://vueuse.org/useFirestore
  */
 export function useFirestore<T extends DocumentData>(
-  maybeDocRef: MaybeRef<FirebaseDocRef<T> | false>,
+  maybeDocRef: MaybeRef<FirebaseDocRef<T> | Falsy>,
   initialValue: any = undefined,
   options: UseFirestoreOptions = {},
 ) {


### PR DESCRIPTION
### Description

Now you can use only `false` value for dependent query, so I added `Falsy` type.

### Additional context

Also fixed to use `null` value to initial value.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
