### PR TITLE
fix(useWebWorker):  IIFE does not pack the @vueuse/shared package in …

### DIFF
--- a/scripts/rollup.config.ts
+++ b/scripts/rollup.config.ts
@@ -18,6 +18,13 @@ const injectVueDemi: Plugin = {
     return `${VUE_DEMI_IIFE};\n;${code}`
   },
 }
+const injectShare: Plugin = {
+  name: 'inject-shared',
+  renderChunk(code) {
+    const SHARED_IIFE = fs.readFileSync(resolve(__dirname, '../packages/shared/dist/index.iife.js'), 'utf-8')
+    return `${SHARED_IIFE};\n;${code}`
+  },
+}
 
 const esbuildPlugin = esbuild()
 
@@ -90,7 +97,8 @@ for (const { globals, name, external, submodules, iife, build, cjs, mjs, dts, ta
           extend: true,
           globals: iifeGlobals,
           plugins: [
-            injectVueDemi,
+            name === 'shared' ? injectVueDemi : null,
+            name === 'shared' ? null : injectShare,
           ],
         },
         {
@@ -100,7 +108,8 @@ for (const { globals, name, external, submodules, iife, build, cjs, mjs, dts, ta
           extend: true,
           globals: iifeGlobals,
           plugins: [
-            injectVueDemi,
+            name === 'shared' ? injectVueDemi : null,
+            name === 'shared' ? null : injectShare,
             esbuildMinifer({
               minify: true,
             }),

--- a/scripts/rollup.config.ts
+++ b/scripts/rollup.config.ts
@@ -18,7 +18,7 @@ const injectVueDemi: Plugin = {
     return `${VUE_DEMI_IIFE};\n;${code}`
   },
 }
-const injectShare: Plugin = {
+const injectShared: Plugin = {
   name: 'inject-shared',
   renderChunk(code) {
     const SHARED_IIFE = fs.readFileSync(resolve(__dirname, '../packages/shared/dist/index.iife.js'), 'utf-8')
@@ -97,8 +97,7 @@ for (const { globals, name, external, submodules, iife, build, cjs, mjs, dts, ta
           extend: true,
           globals: iifeGlobals,
           plugins: [
-            name === 'shared' ? injectVueDemi : null,
-            name === 'shared' ? null : injectShare,
+            name === 'shared' ? injectVueDemi : injectShared,
           ],
         },
         {
@@ -108,8 +107,7 @@ for (const { globals, name, external, submodules, iife, build, cjs, mjs, dts, ta
           extend: true,
           globals: iifeGlobals,
           plugins: [
-            name === 'shared' ? injectVueDemi : null,
-            name === 'shared' ? null : injectShare,
+            name === 'shared' ? injectVueDemi : injectShared,
             esbuildMinifer({
               minify: true,
             }),


### PR DESCRIPTION
…https://github.com/vueuse/vueuse/issues/2421


<!-- Thank you for contributing! -->
### Description
* 在文件`scripts/rollup.config.ts`中，关于iife的设置仅将`vue-demi`注入了，并没有把shared工具包注入
* 当以**cdn链接**引入`@vueuse/core`包时，使用shared工具包提供的方法或常量均为`undefined`  
* 不仅是`@vueuse/core`，像`@vueuse/rxjs`也是一样的，如果使用了shared工具包均会报错

例如：
`@vueuse/rxjs`中提供的`useSubscription`方法，它需要使用`'@vueuse/shared`提供的`tryOnScopeDispose`方法。
<img width="554" alt="image" src="https://user-images.githubusercontent.com/58327088/201509953-abbd38c1-4cbf-4e7f-b111-6a2a9eb2d728.png">
<img width="1111" alt="image" src="https://user-images.githubusercontent.com/58327088/201509995-7553b949-bb3c-46e4-bf9c-ec50b40d47b3.png">
执行`useSubscription`会报错

解决：
* shared工具包也像`vue-demi`进行注入设置
* 在打包shared工具包自己时，注入操作去除即可

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
