### PR TITLE
fix(useFetch): doesn't work with formData payload

### DIFF
--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -95,7 +95,6 @@ type Combination = 'overwrite' | 'chain'
 const payloadMapping: Record<string, string> = {
   json: 'application/json',
   text: 'text/plain',
-  formData: 'multipart/form-data',
 }
 
 export interface BeforeFetchContext {
@@ -532,9 +531,9 @@ export function useFetch<T>(url: MaybeComputedRef<string>, ...args: any[]): UseF
         }
 
         const rawPayload = resolveUnref(config.payload)
-        // Set the payload to json type only if it's not provided and a literal object is provided
+        // Set the payload to json type only if it's not provided and a literal object is provided and the object is not `formData`
         // The only case we can deduce the content type and `fetch` can't
-        if (!payloadType && rawPayload && Object.getPrototypeOf(rawPayload) === Object.prototype)
+        if (!payloadType && rawPayload && Object.getPrototypeOf(rawPayload) === Object.prototype && !(rawPayload instanceof FormData))
           config.payloadType = 'json'
 
         return {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #1734.
Content-Type should not be set for payload of formData type,  leave alone and let the browser do.

### Additional context

reference: [Automatic Content-Type for FormData uploads](https://github.com/axios/axios/commit/2f4d0b8b45dbb766a3348200fdff02ee00d9d6c0)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
