### PR TITLE
style(useAsyncState): random responses with colored states

### DIFF
--- a/packages/core/useAsyncState/demo.vue
+++ b/packages/core/useAsyncState/demo.vue
@@ -5,7 +5,6 @@ import { useAsyncState } from '@vueuse/core'
 
 const { isLoading, state, isReady, execute } = useAsyncState(
   (args) => {
-    console.log(args)
     const id = args?.id || 200
     return axios.get(`https://jsonplaceholder.typicode.com/todos/${id}`).then(t => t.data)
   },

--- a/packages/core/useAsyncState/demo.vue
+++ b/packages/core/useAsyncState/demo.vue
@@ -5,7 +5,8 @@ import { useAsyncState } from '@vueuse/core'
 
 const { isLoading, state, isReady, execute } = useAsyncState(
   (args) => {
-    const id = args?.id || 1
+    console.log(args)
+    const id = args?.id || 200
     return axios.get(`https://jsonplaceholder.typicode.com/todos/${id}`).then(t => t.data)
   },
   {},
@@ -18,11 +19,31 @@ const { isLoading, state, isReady, execute } = useAsyncState(
 
 <template>
   <div>
-    <note>Ready: {{ isReady.toString() }}</note>
-    <note>Loading: {{ isLoading.toString() }}</note>
+    <note :class="{ 'is-ready': isReady }">
+      Ready: {{ isReady.toString() }}
+    </note>
+    <note :class="{ 'is-loading': isLoading }">
+      Loading: {{ isLoading.toString() }}
+    </note>
     <pre lang="json" class="ml-2">{{ YAML.dump(state) }}</pre>
-    <button @click="execute(2000, { id: 2 })">
+    <button @click="execute(2000, { id: ~~(Math.random() * 200) })">
       Execute
     </button>
   </div>
 </template>
+
+<style scoped>
+.is-loading {
+  transition: 0.3s cubic-bezier(0.215, 0.610, 0.355, 1);
+  color: #d67e36;
+}
+
+.is-ready {
+  color: var(--vp-c-brand);
+  transition: 0.3s cubic-bezier(0.215, 0.610, 0.355, 1);
+}
+
+.note {
+  transition: 0.3s cubic-bezier(0.215, 0.610, 0.355, 1);
+}
+</style>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

There was only one static request so I made it random from 1 to 200  to make requests more obvious (since the API has only  200 ToDos)
with colored isLoading and isReady  with a little bit of transition.

note: there is exact same thing in useAxios too.



### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
