### PR TITLE
fix(useGeolocation): Implement immediate option

### DIFF
--- a/packages/core/useGeolocation/index.ts
+++ b/packages/core/useGeolocation/index.ts
@@ -23,6 +23,7 @@ export function useGeolocation(options: UseGeolocationOptions = {}) {
     maximumAge = 30000,
     timeout = 27000,
     navigator = defaultNavigator,
+    immediate = true,
   } = options
 
   const isSupported = useSupported(() => navigator && 'geolocation' in navigator)
@@ -61,7 +62,8 @@ export function useGeolocation(options: UseGeolocationOptions = {}) {
     }
   }
 
-  resume()
+  if (immediate)
+    resume()
 
   function pause() {
     if (watcher && navigator)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The immediate option from the useGeolocation is declared as an option but not used. 

### Additional context

https://github.com/vueuse/vueuse/pull/2376

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

I could not find the relevant tests :(
