### PR TITLE
feat(useWebSocket): allow undefined ref for url

### DIFF
--- a/packages/core/useWebSocket/index.md
+++ b/packages/core/useWebSocket/index.md
@@ -174,7 +174,7 @@ export interface WebSocketResult<T> {
  * @param url
  */
 export declare function useWebSocket<Data = any>(
-  url: string,
+  url: MaybeComputedRef<string | URL | undefined>,
   options?: WebSocketOptions
 ): WebSocketResult<Data>
 ```

--- a/packages/core/useWebSocket/index.ts
+++ b/packages/core/useWebSocket/index.ts
@@ -143,7 +143,7 @@ function resolveNestedOptions<T>(options: T | true): T {
  * @param url
  */
 export function useWebSocket<Data = any>(
-  url: MaybeComputedRef<string | URL>,
+  url: MaybeComputedRef<string | URL | undefined>,
   options: UseWebSocketOptions = {},
 ): UseWebSocketReturn<Data> {
   const {
@@ -205,7 +205,7 @@ export function useWebSocket<Data = any>(
   }
 
   const _init = () => {
-    if (explicitlyClosed)
+    if (explicitlyClosed || typeof urlRef.value === 'undefined')
       return
 
     const ws = new WebSocket(urlRef.value, protocols)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I want to have a a global WebSocket in my app. Since the introduction of ref passing to useWebSocket, useWebSocket is much more useful for scenarios where you change between servers, since I can always expect the WebSocket to work and be up to date without any manual handling from our side. Everything works thanks to vue ``computed`` (to construct the webSocket url) and a ref to an object which contains the server URL.

However, expecting only URLs or strings makes it really difficult to have that webSocket always globally: there are situations in my app where no server is defined. Without this PR, I need to have a watcher and then instantiate the socket using ``useWebSocket``. This PR solves all this logic.

### Additional context

I also fixed the docs, which were with outdated types

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
   * #2200 is very similar in what this PR wants to aim. However, it's outdated, as it doesn't take into account that url can now be a ``ref``, so my proposed solution for this make it much simpler for this kind of scenarios.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
