### PR TITLE
feat(useIDBKeyval)!: return format changed, add `isFinished`

### DIFF
--- a/packages/integrations/useIDBKeyval/index.md
+++ b/packages/integrations/useIDBKeyval/index.md
@@ -19,7 +19,7 @@ npm install idb-keyval
 import { useIDBKeyval } from '@vueuse/integrations/useIDBKeyval'
 
 // bind object
-const storedObject = useIDBKeyval('my-idb-keyval-store', { hello: 'hi', greeting: 'Hello' })
+const { data: storedObject } = useIDBKeyval('my-idb-keyval-store', { hello: 'hi', greeting: 'Hello' })
 
 // update object
 storedObject.value.hello = 'hola'

--- a/packages/integrations/useIDBKeyval/index.md
+++ b/packages/integrations/useIDBKeyval/index.md
@@ -19,7 +19,7 @@ npm install idb-keyval
 import { useIDBKeyval } from '@vueuse/integrations/useIDBKeyval'
 
 // bind object
-const { data: storedObject } = useIDBKeyval('my-idb-keyval-store', { hello: 'hi', greeting: 'Hello' })
+const { data: storedObject, isFinished } = useIDBKeyval('my-idb-keyval-store', { hello: 'hi', greeting: 'Hello' })
 
 // update object
 storedObject.value.hello = 'hola'

--- a/packages/integrations/useIDBKeyval/index.test.ts
+++ b/packages/integrations/useIDBKeyval/index.test.ts
@@ -100,7 +100,7 @@ describe('useIDBKeyval', () => {
     expect(console.error).toHaveBeenCalledTimes(1)
   })
   it ('isFinished', async () => {
-    const { isFinished } = useIDBKeyval(KEY4, 'test', { writeDefaults: false })
+    const { isFinished } = useIDBKeyval(KEY4, 'test')
     expect(isFinished.value).toBe(false)
 
     await promiseTimeout(50)

--- a/packages/integrations/useIDBKeyval/index.test.ts
+++ b/packages/integrations/useIDBKeyval/index.test.ts
@@ -6,7 +6,7 @@ const cache = {} as any
 
 vi.mock('idb-keyval', () => ({
   get: (key: string) => Promise.resolve(cache[key]),
-  set: (key: string, value: any) => new Promise((resolve, reject) => {
+  set: vi.fn((key: string, value: any) => new Promise((resolve, reject) => {
     if (value === 'error') {
       reject(new Error('set error'))
       return
@@ -15,7 +15,7 @@ vi.mock('idb-keyval', () => ({
     cache[key] = value
 
     resolve(undefined)
-  }),
+  })),
   update: (key: string, updater: () => any) => new Promise((resolve, reject) => {
     const value = updater()
     if (value === 'error') {
@@ -35,16 +35,18 @@ vi.mock('idb-keyval', () => ({
 const KEY1 = 'vue-use-idb-keyval-1'
 const KEY2 = 'vue-use-idb-keyval-2'
 const KEY3 = 'vue-use-idb-keyval-3'
+const KEY4 = 'vue-use-idb-keyval-4'
 describe('useIDBKeyval', () => {
   beforeEach(() => {
+    vi.clearAllMocks()
     console.error = vi.fn()
   })
 
   set(KEY3, 'hello')
 
-  const data1 = useIDBKeyval(KEY1, { count: 0 })
-  const data2 = useIDBKeyval(KEY2, ['foo', 'bar'])
-  const data3 = useIDBKeyval(KEY3, 'world', { shallow: true })
+  const { data: data1 } = useIDBKeyval(KEY1, { count: 0 })
+  const { data: data2 } = useIDBKeyval(KEY2, ['foo', 'bar'])
+  const { data: data3 } = useIDBKeyval(KEY3, 'world', { shallow: true })
 
   it('get/set', async () => {
     expect(data1.value).toEqual({ count: 0 })
@@ -96,5 +98,20 @@ describe('useIDBKeyval', () => {
     await promiseTimeout(50)
 
     expect(console.error).toHaveBeenCalledTimes(1)
+  })
+  it ('isFinished', async () => {
+    const { isFinished } = useIDBKeyval(KEY4, 'test', { writeDefaults: false })
+    expect(isFinished.value).toBe(false)
+
+    await promiseTimeout(50)
+
+    expect(isFinished.value).toBe(true)
+  })
+  it('writeDefaults false', async () => {
+    useIDBKeyval(KEY4, 'test', { writeDefaults: false })
+
+    await promiseTimeout(50)
+
+    expect(set).toHaveBeenCalledTimes(0)
   })
 })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Adds an `isFinished` ref returned from `useIDBKeyval` to indicate if that data has finished loading from Indexed DB. Along with a new option `writeDefaults` which allows you to not write the default value to the indexedDb 

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

This is a breaking change, but I was looking to keep this consistent with other composable in the repo. An alternative is to create a `onSuccess` callback and manage this isLoading ref outside of vueuse. 

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
