### PR TITLE
fix(useStyleTag): allow multiline CSS

### DIFF
--- a/packages/core/useStyleTag/demo.vue
+++ b/packages/core/useStyleTag/demo.vue
@@ -1,7 +1,12 @@
 <script setup lang="ts">
 import { useStyleTag } from '@vueuse/core'
 
-const { id, css, load, unload, isLoaded } = useStyleTag('.demo { background: #ad4c2e50 }')
+const customCSS = `
+.demo { background: #ad4c2e50; }
+.demo textarea { background: lightyellow; }
+`.trim()
+
+const { id, css, load, unload, isLoaded } = useStyleTag(customCSS)
 </script>
 
 <template>

--- a/packages/core/useStyleTag/index.ts
+++ b/packages/core/useStyleTag/index.ts
@@ -87,7 +87,7 @@ export function useStyleTag(
     stop = watch(
       cssRef,
       (value) => {
-        el.innerText = value
+        el.textContent = value
       },
       { immediate: true },
     )


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The current implementation of `useStyleTag` uses `el.innerText` to set the `<style>` elements content. As per the spec, this `innerText` method [replaces line-breaks with `<br>` tags](https://html.spec.whatwg.org/multipage/dom.html#the-innertext-idl-attribute) on set, which prevents `useStyleTag` from supporting multi-line CSS as the injected `<br>` will break the CSS parsing.

From the [spec](https://html.spec.whatwg.org/multipage/dom.html#the-innertext-idl-attribute):
> element.[innerText](https://html.spec.whatwg.org/multipage/dom.html#dom-innertext) [ = value ]
Returns the element's text content "as rendered".
>
> Can be set, to replace the element's children with the given value, **but with line breaks converted to [br](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-br-element) elements**.

This PR replaces innerText with [textContent](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent#differences_from_innertext) which is text only & doesn't try to interpret the contents.

### Additional context

I have updated the demo to show multi-line CSS is supported.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
