### PR TITLE
fix(useAxios): execute rejects on error

### DIFF
--- a/packages/integrations/useAxios/index.test.ts
+++ b/packages/integrations/useAxios/index.test.ts
@@ -181,9 +181,24 @@ describe('useAxios', () => {
 
     await then((result) => {
       expect(result.data.value.id).toBe(1)
-      expect(isLoading.value).toBeFalsy()
-      expect(onRejected).toBeCalledTimes(0)
     }, onRejected)
+    expect(isLoading.value).toBeFalsy()
+
+    expect(onRejected).toBeCalledTimes(0)
+  })
+
+  test('execute rejects on error', async () => {
+    const { isLoading, then, execute } = useAxios(config, instance)
+    expect(isLoading.value).toBeFalsy()
+    execute(`${path}/wrong-url`)
+    expect(isLoading.value).toBeTruthy()
+    const onResolved = vitest.fn()
+    const onRejected = vitest.fn()
+
+    await then(onResolved, onRejected)
+    expect(isLoading.value).toBeFalsy()
+    expect(onResolved).toBeCalledTimes(0)
+    expect(onRejected).toBeCalledTimes(1)
   })
 
   test('calling axios with config change(param/data etc.) only', async () => {
@@ -277,7 +292,7 @@ describe('useAxios', () => {
     console.error = vi.fn()
     // @ts-expect-error mock undefined url
     const { execute } = useAxios(undefined, config, options)
-    const { error } = await execute()
+    const { error } = await execute().then(undefined, res => res)
     expect(error.value).toBeDefined()
   })
 })

--- a/packages/integrations/useAxios/index.ts
+++ b/packages/integrations/useAxios/index.ts
@@ -168,9 +168,13 @@ export function useAxios<T = any, R = AxiosResponse<T>, D = any>(...args: any[])
   const waitUntilFinished = () =>
     new Promise<OverallUseAxiosReturn<T, R, D>>((resolve, reject) => {
       until(isFinished).toBe(true)
-        // eslint-disable-next-line @typescript-eslint/no-use-before-define
-        .then(() => resolve(result))
-        .catch(reject)
+        .then(() => {
+          /* eslint-disable @typescript-eslint/no-use-before-define */
+          if (error.value)
+            return reject(result)
+          resolve(result)
+          /* eslint-enable @typescript-eslint/no-use-before-define */
+        })
     })
   const then: PromiseLike<OverallUseAxiosReturn<T, R, D>>['then'] = (onFulfilled, onRejected) =>
     waitUntilFinished().then(onFulfilled, onRejected)


### PR DESCRIPTION
### Description

Currently execute method doesn't really follow [the default behaviour of axios in terms of error handling](https://www.npmjs.com/package/axios#handling-errors). It might be beneficial for users to cover this case.

### Additional context

I'd like to get an answer to the question: was the error "silenced" (it's still accessible via error property) by design or not?

If it was - this PR should be closed. If not - we should consider merging it.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
