### PR TITLE
feat: useWindowSize could optional return accurate doubles

### DIFF
--- a/packages/core/useWindowSize/index.test.ts
+++ b/packages/core/useWindowSize/index.test.ts
@@ -53,4 +53,15 @@ describe('useWindowSize', () => {
     expect(call[0]).toEqual('orientationchange')
     expect(call[2]).toEqual({ passive: true })
   })
+
+  it('should return double values with `includeScrollbar` and `roundedValue` both set false', () => {
+    const { width, height } = useWindowSize({ initialWidth: 100.5, initialHeight: 200.5, includeScrollbar: false, roundedValue: false })
+
+    const viewport = window.visualViewport
+
+    if (viewport) {
+      expect(width.value).toEqual(viewport.width)
+      expect(height.value).toEqual(viewport.height)
+    }
+  })
 })

--- a/packages/core/useWindowSize/index.ts
+++ b/packages/core/useWindowSize/index.ts
@@ -19,6 +19,13 @@ export interface UseWindowSizeOptions extends ConfigurableWindow {
    * @default true
    */
   includeScrollbar?: boolean
+
+  /**
+   * Whether rounded integers or double values should be returned
+   * @default true
+   * @description Takes effects only when `includeScrollbar` is `false`
+   */
+  roundedValue?: boolean
 }
 
 /**
@@ -34,6 +41,7 @@ export function useWindowSize(options: UseWindowSizeOptions = {}) {
     initialHeight = Infinity,
     listenOrientation = true,
     includeScrollbar = true,
+    roundedValue = true,
   } = options
 
   const width = ref(initialWidth)
@@ -45,9 +53,15 @@ export function useWindowSize(options: UseWindowSizeOptions = {}) {
         width.value = window.innerWidth
         height.value = window.innerHeight
       }
-      else {
+      else if (roundedValue) {
         width.value = window.document.documentElement.clientWidth
         height.value = window.document.documentElement.clientHeight
+      }
+      else {
+        // For certain cases that users want accurate double values instead of rounded integers (see #2486)
+        // https://developer.mozilla.org/en-US/docs/Web/API/VisualViewport
+        width.value = window.visualViewport?.width ?? window.document.documentElement.clientWidth
+        height.value = window.visualViewport?.height ?? window.document.documentElement.clientHeight
       }
     }
   }

--- a/packages/core/useWindowSize/index.ts
+++ b/packages/core/useWindowSize/index.ts
@@ -60,8 +60,11 @@ export function useWindowSize(options: UseWindowSizeOptions = {}) {
       else {
         // For certain cases that users want accurate double values instead of rounded integers (see #2486)
         // https://developer.mozilla.org/en-US/docs/Web/API/VisualViewport
-        width.value = window.visualViewport?.width ?? window.document.documentElement.clientWidth
-        height.value = window.visualViewport?.height ?? window.document.documentElement.clientHeight
+        const viewport = window.visualViewport
+        if (viewport) {
+          width.value = window.visualViewport.width
+          height.value = window.visualViewport.height
+        }
       }
     }
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Close #2486.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

Added optional `roundedValue` property for `useWindowSize` function.

When both `includeScrollbar` and `roundedValue` are set `false`, the function returns doubles instead of integers.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
