### PR TITLE
feat(useWebSocket): handle heartbeat timeouts appropriately

### DIFF
--- a/packages/core/useWebSocket/index.ts
+++ b/packages/core/useWebSocket/index.ts
@@ -273,6 +273,7 @@ export function useWebSocket<Data = any>(
         if (pongTimeoutWait != null)
           return
         pongTimeoutWait = setTimeout(() => {
+          wsRef.value?.dispatchEvent(new Event('error'))
           // auto-reconnect will be trigger with ws.onclose()
           close()
         }, pongTimeout)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Fixes #2506

This PR fixes the problems that I described in #2506. It does so by replacing the invocation of the built-in `close()` function with the WebSocket instance's own `close()` method. Additionally, it dispatches a custom generic error which will then be received by the built-in `onError()` function.

To send a proper close reason to the WebSocket server, I added two new configuration keys:

- `heartbeat.pongTimeoutCloseCode?: number` (Default: `3001`)
- `heartbeat.pongTimeoutCloseReason?: string` (Default: `'Did not receive pong to previous ping'`)

I chose the default close code `3001` because the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent/code) states that close codes in the range of `3000-3999` are open for usage in libraries and it seemed most analogous to the generic `1001` _Going Away_ close code.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

The default close code and reason I specified here are just my personal suggestions. If you have better ideas or just prefer different ones, please let me know.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
