### PR TITLE
fix(useMagicKeys): also clear 'current' on @focus|@blur

### DIFF
--- a/packages/core/useMagicKeys/index.ts
+++ b/packages/core/useMagicKeys/index.ts
@@ -96,6 +96,7 @@ export function useMagicKeys(options: UseMagicKeysOptions<boolean> = {}): any {
   }
 
   function reset() {
+    current.clear()
     for (const key of usedKeys)
       setRefs(key, false)
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

On macos when some keys are pressed in combo(cmd+p) open a dialog and the keyup is not triggered and the _current_ keep a wrong state.
This fix now also clears the `current: Set<string>` with the existing `reset()` function (added in prior https://github.com/vueuse/vueuse/pull/1755).

fixes https://github.com/vueuse/vueuse/issues/1350

### Additional context

ref: https://github.com/vueuse/vueuse/pull/1755

Testing / Reproduction, see description of https://github.com/vueuse/vueuse/issues/1350...

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.