### PR TITLE
fix: make `useGeolocation` respect the `immediate` option

### DIFF
--- a/packages/core/useGeolocation/index.ts
+++ b/packages/core/useGeolocation/index.ts
@@ -61,7 +61,8 @@ export function useGeolocation(options: UseGeolocationOptions = {}) {
     }
   }
 
-  resume()
+  if (immediate)
+      resume()
 
   function pause() {
     if (watcher && navigator)


### PR DESCRIPTION
fixes #2524

### Description

as described in #2524 this fix allows the `useGeolocation` to not be called immediatly

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
