### PR TITLE
fix(useIntervalFn): watch computed refs instead of just refs

### DIFF
--- a/packages/shared/useIntervalFn/index.ts
+++ b/packages/shared/useIntervalFn/index.ts
@@ -2,7 +2,7 @@ import { isRef, ref, unref, watch } from 'vue-demi'
 import { resolveUnref } from '../resolveUnref'
 import { tryOnScopeDispose } from '../tryOnScopeDispose'
 import type { Fn, MaybeComputedRef, Pausable } from '../utils'
-import { isClient } from '../utils'
+import { isClient, isFunction } from '../utils'
 
 export interface UseIntervalFnOptions {
   /**
@@ -61,7 +61,7 @@ export function useIntervalFn(cb: Fn, interval: MaybeComputedRef<number> = 1000,
   if (immediate && isClient)
     resume()
 
-  if (isRef(interval)) {
+  if (isRef(interval) || isFunction(interval)) {
     const stopWatch = watch(interval, () => {
       if (isActive.value && isClient)
         resume()


### PR DESCRIPTION
`useIntervalFn`'s `interval` option has the ability to be watched to dynamically change the interval. However, the check to add the watcher uses `isRef`, even though `interval` is of type `MaybeComputedRef`, which allows it to be a function, which is a valid watch value.

This pull request changes the check to ensure `interval` is either a `Ref` or a `Function`, so the following is also valid:

```ts
const $props = defineProps<{
  interval?: number
}>()

useIntervalFn(() => { /** ... **/ }, () => $props.interval ?? 5000)
```