### PR TITLE
fix(useActiveElement): ignore blur for relatedTarget

### DIFF
--- a/packages/core/useActiveElement/index.ts
+++ b/packages/core/useActiveElement/index.ts
@@ -17,7 +17,12 @@ export function useActiveElement<T extends HTMLElement>(options: ConfigurableWin
   )
 
   if (window) {
-    useEventListener(window, 'blur', activeElement.trigger, true)
+    useEventListener(window, 'blur', (event) => {
+      if (event.relatedTarget === null)
+        return
+
+      activeElement.trigger()
+    }, true)
     useEventListener(window, 'focus', activeElement.trigger, true)
   }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

If a blur event has a `relatedTarget` [that element will receive focus](https://developer.mozilla.org/en-US/docs/Web/API/FocusEvent/relatedTarget). For the short time between blur and focus the `document.activeElement` will be the body element. By ignoring the blur event here we simply wait for the computedWithControl to be triggered by the focus event that will follow as we know. By then the new element will have focus.

By doing this we prevent e.g. that stuff will be triggered that depends on the activeElement being inside a specific element. E.g. `useFocusWithin` will profit from this, since the focus will not be reset to `<body>` in between.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
