### PR TITLE
fix(useTextareaAutosize): support changes of element width

### DIFF
--- a/packages/core/useTextareaAutosize/index.ts
+++ b/packages/core/useTextareaAutosize/index.ts
@@ -1,6 +1,7 @@
 import type { MaybeRef } from '@vueuse/shared'
 import type { WatchSource } from 'vue-demi'
 import { ref, watch } from 'vue-demi'
+import useResizeObserver from '../useResizeObserver'
 
 export interface UseTextareaAutosizeOptions {
   /** Textarea element to autosize. */
@@ -28,6 +29,8 @@ export function useTextareaAutosize(options?: UseTextareaAutosizeOptions) {
   }
 
   watch([input, textarea], triggerResize, { immediate: true })
+
+  useResizeObserver(textarea, () => triggerResize())
 
   if (options?.watch)
     watch(options.watch, triggerResize, { immediate: true, deep: true })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

If the size of a textarea is changed by other stuff than the window width `useTextareaAutosize` currently breaks. By watching the textarea via useResizeObserver we make sure a change in width is accounted for.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
