### PR TITLE
feat(useTimeAgo): add `floor` and `ceil` value calculation

### DIFF
--- a/packages/core/useTimeAgo/index.ts
+++ b/packages/core/useTimeAgo/index.ts
@@ -57,6 +57,13 @@ export interface UseTimeAgoOptions<Controls extends boolean> {
    * @default false
    */
   showSecond?: boolean
+
+  /**
+   * Function to apply to the diff to computed the time ago.
+   *
+   * @default 'round'
+   */
+  diffEval?: 'round' | 'ceil' | 'floor'
 }
 
 interface UseTimeAgoUnit {
@@ -124,9 +131,11 @@ export function useTimeAgo(time: MaybeComputedRef<Date | number | string>, optio
     messages = DEFAULT_MESSAGES,
     fullDateFormatter = DEFAULT_FORMATTER,
     showSecond = false,
+    diffEval = 'round',
   } = options
 
-  const { abs, round } = Math
+  const { abs } = Math
+  const evalDiff = Math[diffEval]
   const { now, ...controls } = useNow({ interval: updateInterval, controls: true })
 
   function getTimeAgo(from: Date, now: Date) {
@@ -160,7 +169,7 @@ export function useTimeAgo(time: MaybeComputedRef<Date | number | string>, optio
   }
 
   function format(diff: number, unit: UseTimeAgoUnit) {
-    const val = round(abs(diff) / unit.value)
+    const val = evalDiff(abs(diff) / unit.value)
     const past = diff > 0
 
     const str = applyFormat(unit.name, val, past)

--- a/packages/core/useTimeAgo/index.ts
+++ b/packages/core/useTimeAgo/index.ts
@@ -59,11 +59,11 @@ export interface UseTimeAgoOptions<Controls extends boolean> {
   showSecond?: boolean
 
   /**
-   * Function to apply to the diff to computed the time ago.
+   * Rounding method to apply.
    *
    * @default 'round'
    */
-  diffEval?: 'round' | 'ceil' | 'floor'
+  rounding?: 'round' | 'ceil' | 'floor'
 }
 
 interface UseTimeAgoUnit {
@@ -131,11 +131,11 @@ export function useTimeAgo(time: MaybeComputedRef<Date | number | string>, optio
     messages = DEFAULT_MESSAGES,
     fullDateFormatter = DEFAULT_FORMATTER,
     showSecond = false,
-    diffEval = 'round',
+    rounding = 'round',
   } = options
 
   const { abs } = Math
-  const evalDiff = Math[diffEval]
+  const roundFn = Math[rounding]
   const { now, ...controls } = useNow({ interval: updateInterval, controls: true })
 
   function getTimeAgo(from: Date, now: Date) {
@@ -169,7 +169,7 @@ export function useTimeAgo(time: MaybeComputedRef<Date | number | string>, optio
   }
 
   function format(diff: number, unit: UseTimeAgoUnit) {
-    const val = evalDiff(abs(diff) / unit.value)
+    const val = roundFn(abs(diff) / unit.value)
     const past = diff > 0
 
     const str = applyFormat(unit.name, val, past)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The value is always rounded on format calculation.

closes #2542

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
