### PR TITLE
fix(useWindowScroll): use configured window onScroll

### DIFF
--- a/packages/core/useWindowScroll/index.ts
+++ b/packages/core/useWindowScroll/index.ts
@@ -21,6 +21,7 @@ export function useWindowScroll({ window = defaultWindow }: ConfigurableWindow =
   const y = ref(window.pageYOffset)
 
   useEventListener(
+    window,
     'scroll',
     () => {
       x.value = window.pageXOffset


### PR DESCRIPTION
### Description

makes `useWindowScroll` use the given window for the scroll listener.

fixes #2544 

### Additional context

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
