### PR TITLE
fix(useTimeAgo): add `showSecond` prop to component

### DIFF
--- a/packages/core/useTimeAgo/component.ts
+++ b/packages/core/useTimeAgo/component.ts
@@ -9,7 +9,7 @@ interface UseTimeAgoComponentOptions extends Omit<UseTimeAgoOptions<true>, 'cont
 
 export const UseTimeAgo = defineComponent<UseTimeAgoComponentOptions>({
   name: 'UseTimeAgo',
-  props: ['time', 'updateInterval', 'max', 'fullDateFormatter', 'messages'] as unknown as undefined,
+  props: ['time', 'updateInterval', 'max', 'fullDateFormatter', 'messages', 'showSecond'] as unknown as undefined,
   setup(props, { slots }) {
     const data = reactive(useTimeAgo(() => props.time as number, { ...props, controls: true }))
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The `showSecond` option added in PR #2209 is missing from the UseTimeAgo component.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
