### PR TITLE
fix(useFocus): resolve doesn't update on blur

### DIFF
--- a/packages/core/useFocus/index.ts
+++ b/packages/core/useFocus/index.ts
@@ -33,7 +33,7 @@ export interface UseFocusReturn {
 export function useFocus(target: MaybeElementRef, options: UseFocusOptions = {}): UseFocusReturn {
   const { initialValue = false } = options
 
-  const activeElement = useActiveElement(options)
+  const activeElement = computed(() => unrefElement(useActiveElement(options)))
   const targetElement = computed(() => unrefElement(target))
   const focused = computed({
     get() {


### PR DESCRIPTION
### Description

useFocus doesn't update on blur

### Additional context

issues [2565](https://github.com/vueuse/vueuse/issues/2565)

---

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #2565`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
