### PR TITLE
fix(useDraggable): write to useStorage

### DIFF
--- a/packages/core/useDraggable/component.ts
+++ b/packages/core/useDraggable/component.ts
@@ -2,7 +2,7 @@ import { computed, defineComponent, h, reactive, ref } from 'vue-demi'
 import type { UseDraggableOptions } from '@vueuse/core'
 import { isClient, useDraggable, useStorage } from '@vueuse/core'
 import { resolveUnref } from '@vueuse/shared'
-import type { RenderableComponent } from '../types'
+import type { Position, RenderableComponent } from '../types'
 
 export interface UseDraggableProps extends UseDraggableOptions, RenderableComponent {
   /**
@@ -34,22 +34,28 @@ export const UseDraggable = defineComponent<UseDraggableProps>({
   setup(props, { slots }) {
     const target = ref()
     const handle = computed(() => props.handle ?? target.value)
-    const initialValue = props.storageKey
-      ? useStorage(
-        props.storageKey,
-        resolveUnref(props.initialValue) || { x: 0, y: 0 },
-        isClient
-          ? props.storageType === 'session'
-            ? sessionStorage
-            : localStorage
-          : undefined,
-      )
-      : props.initialValue || { x: 0, y: 0 }
+    const storageValue = props.storageKey && useStorage(
+      props.storageKey,
+      resolveUnref(props.initialValue) || { x: 0, y: 0 },
+      isClient
+        ? props.storageType === 'session'
+          ? sessionStorage
+          : localStorage
+        : undefined,
+    )
+    const initialValue = storageValue || props.initialValue || { x: 0, y: 0 }
+    const onEnd = (position: Position) => {
+      if (!storageValue)
+        return
+      storageValue.value.x = position.x
+      storageValue.value.y = position.y
+    }
 
     const data = reactive(useDraggable(target, {
       ...props,
       handle,
       initialValue,
+      onEnd,
     }))
 
     return () => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Fixed a bug that "UseDraggable component" does not write to storage even if storage-key and storage-type are passed.

### Additional context

**before**
In the video example, the position has reverted to (860, 199)  after the page change.

<details>
<summary>before video</summary>

https://user-images.githubusercontent.com/7263054/209443102-b21055e0-b628-4c03-bc9b-b0e022409b2a.mp4
</details>

**after**
The position is persistent even after page change.

<details>
<summary>after video</summary>

https://user-images.githubusercontent.com/7263054/209443232-45c0aef2-40d4-4a51-bf74-b0ea7e0510ae.mp4
</details>



---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
