### PR TITLE
fix(useActiveElement): scheduled update

### DIFF
--- a/packages/core/useActiveElement/index.ts
+++ b/packages/core/useActiveElement/index.ts
@@ -17,11 +17,9 @@ export function useActiveElement<T extends HTMLElement>(options: ConfigurableWin
   )
 
   if (window) {
-    useEventListener(window, 'blur', (event) => {
-      if (event.relatedTarget === null)
-        return
-
-      activeElement.trigger()
+    useEventListener(window, 'blur', () => {
+      const schedular = window.requestAnimationFrame || window.setTimeout
+      schedular(() => activeElement.trigger())
     }, true)
     useEventListener(window, 'focus', activeElement.trigger, true)
   }


### PR DESCRIPTION
### Description
replaced by #2600 👍

fixes #2565
fixes #2214

The PR #2540 has actually broken the functionality.

See the demos in current docs, it doesn't update state on blur:
- https://vueuse.org/core/usefocuswithin/#usefocuswithin
- https://vueuse.org/core/usefocus/#usefocus


By the description in #2540, the `activeElement` will be the `<body />` in between(when focus from one element to another element, which will trigger an extra useless update).
This PR is fixing it by using a **schedular** that triggers the getter at next render.


### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
