### PR TITLE
feat(useActiveElement): optionally ignore active <body> element

### DIFF
--- a/packages/core/useActiveElement/index.ts
+++ b/packages/core/useActiveElement/index.ts
@@ -1,7 +1,12 @@
+import type { MaybeRef } from '@vueuse/shared'
 import { computedWithControl } from '@vueuse/shared'
 import { useEventListener } from '../useEventListener'
 import type { ConfigurableWindow } from '../_configurable'
 import { defaultWindow } from '../_configurable'
+
+export interface UseActiveElementOptions extends ConfigurableWindow {
+  ignoreBody?: MaybeRef<boolean>
+}
 
 /**
  * Reactive `document.activeElement`
@@ -9,8 +14,8 @@ import { defaultWindow } from '../_configurable'
  * @see https://vueuse.org/useActiveElement
  * @param options
  */
-export function useActiveElement<T extends HTMLElement>(options: ConfigurableWindow = {}) {
-  const { window = defaultWindow } = options
+export function useActiveElement<T extends HTMLElement>(options: UseActiveElementOptions = {}) {
+  const { window = defaultWindow, ignoreBody } = options
   const activeElement = computedWithControl(
     () => null,
     () => window?.document.activeElement as T | null | undefined,
@@ -21,9 +26,17 @@ export function useActiveElement<T extends HTMLElement>(options: ConfigurableWin
       if (event.relatedTarget === null)
         return
 
+      if (ignoreBody && window?.document.activeElement?.tagName === 'BODY')
+        return
+
       activeElement.trigger()
     }, true)
-    useEventListener(window, 'focus', activeElement.trigger, true)
+    useEventListener(window, 'focus', () => {
+      if (ignoreBody && window?.document.activeElement?.tagName === 'BODY')
+        return
+
+      activeElement.trigger()
+    }, true)
   }
 
   return activeElement

--- a/packages/core/useFocusWithin/demo.vue
+++ b/packages/core/useFocusWithin/demo.vue
@@ -4,22 +4,20 @@ import { useFocusWithin } from '@vueuse/core'
 
 const target = ref()
 
-const { focused } = useFocusWithin(target)
+const { focused } = useFocusWithin(target, { ignoreBody: true })
 </script>
 
 <template>
   <div class="flex flex-col items-center">
-    <form
-      ref="target"
-      class="shadow bg-base border-main rounded max-w-96 mx-auto p-8"
-    >
+    <form ref="target" class="shadow bg-base border-main rounded max-w-96 mx-auto p-8">
       <input type="text" placeholder="First Name">
       <input type="text" placeholder="Last Name">
       <input type="text" placeholder="Email">
       <input type="text" placeholder="Password">
     </form>
     <div mt2>
-      Focus in form: <BooleanDisplay :value="focused" />
+      Focus in form:
+      <BooleanDisplay :value="focused" />
     </div>
   </div>
 </template>

--- a/packages/core/useFocusWithin/index.ts
+++ b/packages/core/useFocusWithin/index.ts
@@ -2,8 +2,8 @@ import type { ComputedRef } from 'vue-demi'
 import { computed } from 'vue-demi'
 import type { MaybeElementRef } from '../unrefElement'
 import { unrefElement } from '../unrefElement'
+import type { UseActiveElementOptions } from '../useActiveElement'
 import { useActiveElement } from '../useActiveElement'
-import type { ConfigurableWindow } from '../_configurable'
 export interface UseFocusWithinReturn {
   /**
    * True if the element or any of its descendants are focused
@@ -18,7 +18,8 @@ export interface UseFocusWithinReturn {
  * @param target The target element to track
  * @param options Focus within options
  */
-export function useFocusWithin(target: MaybeElementRef, options: ConfigurableWindow = {}): UseFocusWithinReturn {
+
+export function useFocusWithin(target: MaybeElementRef, options: UseActiveElementOptions = {}): UseFocusWithinReturn {
   const activeElement = useActiveElement(options)
   const targetElement = computed(() => unrefElement(target))
   const focused = computed(() => targetElement.value && activeElement.value ? targetElement.value.contains(activeElement.value) : false)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

When focus is switched from some element, `elOne` to some other element, `elTwo` to another, the activeElement ref briefly changes to `<body>`. i.e. the value goes `elOne` -> `<body>` -> `elTwo`. This causes other composables that rely on `useActiveElement` to also update. e.g. https://github.com/vueuse/vueuse/issues/2214 (useFocusWithin).

While the useActiveElement composable is accurately reflecting what is happening with [Document.activeElement](https://developer.mozilla.org/en-US/docs/Web/API/Document/activeElement), I think that more often than not, this is not the desired outcome. The developer generally thinks:

> I am switching from one input in my form to another within my form, therefore I can use `useFocusWithin` and this should stay true throughout the focus switch.

I added an additional option to `useActiveElement`, called `ignoreBody`, which when set to true, will **not update activeElement when the focus switches to a (the) body tag**. This option is then inherited by `useFocusWithin`, so that we have:

```vue
<script lang="ts" setup>
const { focusedOriginal } = useFocusWithin(target)
// switching focus from elOne to elTwo, focusedOriginal values are the following:
// true -> false -> true

const { focusedNew } = useFocusWithin(target, { ignoreBody: true })
// switching focus from elOne to elTwo, focusedNew values are the following:
// true -> true (unchanged)
</script>

<template>
<form ref="target">
  <input ref="elOne">
  <input ref="elTwo">
</form>
</template>
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
