### PR TITLE
feat(useActiveElement): support shadow roots

### DIFF
--- a/packages/core/_configurable.ts
+++ b/packages/core/_configurable.ts
@@ -11,7 +11,7 @@ export interface ConfigurableDocument {
   /*
    * Specify a custom `document` instance, e.g. working with iframes or in testing environments.
    */
-  document?: Document
+  document?: DocumentOrShadowRoot
 }
 
 export interface ConfigurableNavigator {

--- a/packages/core/_configurable.ts
+++ b/packages/core/_configurable.ts
@@ -11,6 +11,13 @@ export interface ConfigurableDocument {
   /*
    * Specify a custom `document` instance, e.g. working with iframes or in testing environments.
    */
+  document?: Document
+}
+
+export interface ConfigurableDocumentOrShadowRoot {
+  /*
+   * Specify a custom `document` instance or a shadow root, e.g. working with iframes or in testing environments.
+   */
   document?: DocumentOrShadowRoot
 }
 

--- a/packages/core/useActiveElement/index.test.ts
+++ b/packages/core/useActiveElement/index.test.ts
@@ -1,0 +1,61 @@
+import { useActiveElement } from '.'
+
+describe('useActiveElement', () => {
+  let shadowHost: HTMLElement
+  let input: HTMLInputElement
+  let shadowInput: HTMLInputElement
+  let shadowRoot: ShadowRoot
+
+  beforeEach(() => {
+    shadowHost = document.createElement('div')
+    shadowRoot = shadowHost.attachShadow({ mode: 'open' })
+    input = document.createElement('input')
+    shadowInput = input.cloneNode() as HTMLInputElement
+    shadowRoot.appendChild(shadowInput)
+    document.body.appendChild(input)
+    document.body.appendChild(shadowHost)
+  })
+
+  afterEach(() => {
+    shadowHost.remove()
+    input.remove()
+  })
+
+  it('should be defined', () => {
+    expect(useActiveElement).toBeDefined()
+  })
+
+  it('should initialise correctly', () => {
+    const activeElement = useActiveElement()
+
+    expect(activeElement.value).to.equal(document.body)
+  })
+
+  it('should initialise with already-active element', () => {
+    input.focus()
+
+    const activeElement = useActiveElement()
+
+    expect(activeElement.value).to.equal(input)
+  })
+
+  it('should accept custom document', () => {
+    const activeElement = useActiveElement({ document: shadowRoot })
+
+    shadowInput.focus()
+
+    expect(activeElement.value).to.equal(shadowInput)
+  })
+
+  it('should observe focus/blur events', () => {
+    const activeElement = useActiveElement()
+
+    input.focus()
+
+    expect(activeElement.value).to.equal(input)
+
+    input.blur()
+
+    expect(activeElement.value).to.equal(document.body)
+  })
+})

--- a/packages/core/useActiveElement/index.ts
+++ b/packages/core/useActiveElement/index.ts
@@ -1,7 +1,9 @@
 import { computedWithControl } from '@vueuse/shared'
 import { useEventListener } from '../useEventListener'
-import type { ConfigurableWindow } from '../_configurable'
+import type { ConfigurableDocument, ConfigurableWindow } from '../_configurable'
 import { defaultWindow } from '../_configurable'
+
+export type UseActiveElementOptions = ConfigurableWindow & ConfigurableDocument
 
 /**
  * Reactive `document.activeElement`
@@ -9,11 +11,12 @@ import { defaultWindow } from '../_configurable'
  * @see https://vueuse.org/useActiveElement
  * @param options
  */
-export function useActiveElement<T extends HTMLElement>(options: ConfigurableWindow = {}) {
+export function useActiveElement<T extends HTMLElement>(options: UseActiveElementOptions = {}) {
   const { window = defaultWindow } = options
+  const document = options.document ?? window?.document
   const activeElement = computedWithControl(
     () => null,
-    () => window?.document.activeElement as T | null | undefined,
+    () => document?.activeElement as T | null | undefined,
   )
 
   if (window) {

--- a/packages/core/useActiveElement/index.ts
+++ b/packages/core/useActiveElement/index.ts
@@ -1,9 +1,9 @@
 import { computedWithControl } from '@vueuse/shared'
 import { useEventListener } from '../useEventListener'
-import type { ConfigurableDocument, ConfigurableWindow } from '../_configurable'
+import type { ConfigurableDocumentOrShadowRoot, ConfigurableWindow } from '../_configurable'
 import { defaultWindow } from '../_configurable'
 
-export type UseActiveElementOptions = ConfigurableWindow & ConfigurableDocument
+export interface UseActiveElementOptions extends ConfigurableWindow, ConfigurableDocumentOrShadowRoot {}
 
 /**
  * Reactive `document.activeElement`

--- a/packages/core/useEventListener/index.ts
+++ b/packages/core/useEventListener/index.ts
@@ -63,7 +63,7 @@ export function useEventListener<E extends keyof WindowEventMap>(
  * @param options
  */
 export function useEventListener<E extends keyof DocumentEventMap>(
-  target: Document,
+  target: DocumentOrShadowRoot,
   event: Arrayable<E>,
   listener: Arrayable<(this: Document, ev: DocumentEventMap[E]) => any>,
   options?: boolean | AddEventListenerOptions


### PR DESCRIPTION
Assuming you have a DOM structure like so:

```
body
  my-element
    #shadow-root
      input
```

When the `input` becomes active, the outer document's `activeElement` will actually be `my-element`, _not_ the input.

Each shadow root has its own `activeElement` in case you want to get hold of the inner element in these cases.

This adds support to `useActiveElement` such that you can pass a shadow root as the document to observe the active element of.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

---

let me know if there's some reason you wouldn't want this or it needs doing differently and ill update.