### PR TITLE
fix(useElementBounding): update on scroll

### DIFF
--- a/packages/core/useElementBounding/index.ts
+++ b/packages/core/useElementBounding/index.ts
@@ -93,7 +93,7 @@ export function useElementBounding(
   watch(() => unrefElement(target), ele => !ele && update())
 
   if (windowScroll)
-    useEventListener('scroll', update, { passive: true })
+    useEventListener('scroll', update, true, { passive: true })
   if (windowResize)
     useEventListener('resize', update, { passive: true })
 

--- a/packages/core/useElementBounding/index.ts
+++ b/packages/core/useElementBounding/index.ts
@@ -93,7 +93,7 @@ export function useElementBounding(
   watch(() => unrefElement(target), ele => !ele && update())
 
   if (windowScroll)
-    useEventListener('scroll', update, true, { passive: true })
+    useEventListener('scroll', update, { capture: true, passive: true })
   if (windowResize)
     useEventListener('resize', update, { passive: true })
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes #2319, The Scrolling of useElementBounding didn't work when a div gets scrolled, only when the window was scrolled. Now it works.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
