### PR TITLE
fix(useActiveElement): ignore if relatedTarget is set

### DIFF
--- a/packages/core/useActiveElement/index.ts
+++ b/packages/core/useActiveElement/index.ts
@@ -18,7 +18,7 @@ export function useActiveElement<T extends HTMLElement>(options: ConfigurableWin
 
   if (window) {
     useEventListener(window, 'blur', (event) => {
-      if (event.relatedTarget === null)
+      if (event.relatedTarget !== null)
         return
 
       activeElement.trigger()


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fixes https://github.com/vueuse/vueuse/issues/2565
fixes https://github.com/vueuse/vueuse/issues/2214

replaces https://github.com/vueuse/vueuse/pull/2591

I'm so sorry!
[My PR](https://github.com/vueuse/vueuse/pull/2540) has actually broken the functionality.

### Additional context

The description was correct, but instead of ignoring the listener if there is a `relatedTarget` the code ignored the listener if the `relatedTarget` is `null`.

There are two other PRs that try to solve this but in a different way:

- https://github.com/vueuse/vueuse/pull/2581 fixes this issue as well, but does this by introducing a scheduler which makes the value incorrect for a (slightly) longer time.
- https://github.com/vueuse/vueuse/pull/2591 adds a new `ignoreBody` which seems not necessary since it increases complexity. On top by merging https://github.com/vueuse/vueuse/pull/2540 an implicit agreement was already established that the active element shouldn't be `<body>` in between if the focus is about to change.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
