### PR TITLE
fix(nuxt): disable useImage in the Nuxt package for auto imports

### DIFF
--- a/packages/nuxt/index.ts
+++ b/packages/nuxt/index.ts
@@ -14,6 +14,7 @@ const disabledFunctions = [
   'useHead',
   'useTitle',
   'useStorage',
+  'useImage',
 ]
 
 const packages = [


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #2537

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
