### PR TITLE
feat: conditionalScope

### DIFF
--- a/packages/core/conditionalScope/demo.vue
+++ b/packages/core/conditionalScope/demo.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import { useEventListener } from '@vueuse/core'
+import { ref } from 'vue'
+import { conditionalScope } from '.'
+
+const isActive = ref(true)
+const pointerX = ref(0)
+
+conditionalScope(isActive, () => {
+  useEventListener('pointermove', (e) => {
+    pointerX.value = e.clientX
+  })
+})
+</script>
+
+<template>
+  <div>
+    <div grid grid-cols-2>
+      <label>
+        <input v-model="isActive" type="checkbox">
+        Active
+      </label>
+      <div>
+        PoniterX = {{ pointerX }}
+      </div>
+    </div>
+  </div>
+</template>

--- a/packages/core/conditionalScope/index.md
+++ b/packages/core/conditionalScope/index.md
@@ -1,0 +1,27 @@
+---
+category: Reactivity
+---
+
+# conditionalScope
+
+Creates a conditional [scope](https://vuejs.org/api/reactivity-advanced.html#effectscope) that is disposed when the conditions are not met.
+
+## Usage
+
+```ts
+import { conditionalScope, useEventListener } from '@vueuse/core'
+
+const props = defineProps<{ disabled?: boolean }>()
+
+conditionalScope(() => !props.disabled, () => {
+  // listen to scroll event, only if `props.disabled` is falsy.
+  useEventListener('scroll', () => {
+    // ...
+  })
+
+  // watch language ref, only if `props.disabled` is falsy.
+  watch(language, (lang) => {
+    // ...
+  })
+})
+```

--- a/packages/core/conditionalScope/index.test.ts
+++ b/packages/core/conditionalScope/index.test.ts
@@ -1,0 +1,38 @@
+import { effectScope, nextTick, onScopeDispose, ref } from 'vue-demi'
+import { conditionalScope } from '.'
+
+describe('conditionalScope', () => {
+  it('should works', async () => {
+    const active = ref(false)
+    let isDisposed = false
+
+    conditionalScope(active, () => {
+      onScopeDispose(() => {
+        isDisposed = true
+      })
+    })
+
+    active.value = false
+    await nextTick()
+    expect(isDisposed).toBe(true)
+  })
+
+  it('should be disposed based on its parent scope', () => {
+    const active = ref(false)
+    let isDisposed = false
+
+    const currentScope = effectScope()
+
+    currentScope.run(() => {
+      conditionalScope(active, () => {
+        onScopeDispose(() => {
+          isDisposed = true
+        })
+      })
+    })
+
+    currentScope.stop()
+
+    expect(isDisposed).toBe(true)
+  })
+})

--- a/packages/core/conditionalScope/index.ts
+++ b/packages/core/conditionalScope/index.ts
@@ -1,0 +1,27 @@
+import type { EffectScope, WatchSource } from 'vue-demi'
+import { effectScope, getCurrentScope, watch } from 'vue-demi'
+
+export function conditionalScope<T>(source: WatchSource<T>, callback: () => void) {
+  let scope: EffectScope | undefined
+  const parentScope = getCurrentScope()
+
+  function start() {
+    if (scope)
+      return
+    scope = parentScope?.run(() => effectScope()) || effectScope()
+    scope.run(callback)
+  }
+
+  function stop() {
+    if (!scope)
+      return
+    scope.stop()
+    scope = undefined
+  }
+
+  watch(source, (condition) => {
+    if (condition)
+      start()
+    else stop()
+  }, { immediate: true })
+}

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1,5 +1,6 @@
 export * from './computedAsync'
 export * from './computedInject'
+export * from './conditionalScope'
 export * from './createUnrefFn'
 export * from './onClickOutside'
 export * from './onKeyStroke'


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

#### conditionalScope
Creates a conditional [effectScope](https://vuejs.org/api/reactivity-advanced.html#effectscope) that is disposed when the conditions are not met.

We can deactivate some composable functions based on other reactive states.

```ts
import { conditionalScope, useEventListener } from '@vueuse/core'

const props = defineProps<{ disabled?: boolean }>()

conditionalScope(() => !props.disabled, () => {
  // listen to scroll event, only if `props.disabled` is falsy.
  useEventListener('scroll', () => {
    // ...
  })

  // watch language ref, only if `props.disabled` is falsy.
  watch(language, (lang) => {
    // ...
  })
})
```

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
