### PR TITLE
feat(computedAsync): introduce `shadow` option

### DIFF
--- a/packages/core/computedAsync/index.md
+++ b/packages/core/computedAsync/index.md
@@ -83,3 +83,5 @@ const userInfo = computedAsync(
 - Just like Vue's built-in `computed` function, `computedAsync` does dependency tracking and is automatically re-evaluated when dependencies change. Note however that only dependency referenced in the first call stack are considered for this. In other words: **Dependencies that are accessed asynchronously will not trigger re-evaluation of the async computed value.**
 
 - As opposed to Vue's built-in `computed` function, re-evaluation of the async computed value is triggered whenever dependencies are changing, regardless of whether its result is currently being tracked or not.
+
+- The default value of the `shallow` will be changed to `true` in the next major version.

--- a/packages/core/computedAsync/index.ts
+++ b/packages/core/computedAsync/index.ts
@@ -1,7 +1,7 @@
 import type { Fn } from '@vueuse/shared'
 import { noop } from '@vueuse/shared'
-import type { Ref } from 'vue-demi'
-import { computed, isRef, ref, watchEffect } from 'vue-demi'
+import type { Ref, ShallowRef } from 'vue-demi'
+import { computed, isRef, ref, shallowReadonly, shallowRef, watchEffect } from 'vue-demi'
 
 /**
  * Handle overlapping async evaluations.
@@ -41,7 +41,7 @@ export function computedAsync<T>(
   evaluationCallback: (onCancel: AsyncComputedOnCancel) => T | Promise<T>,
   initialState?: T,
   optionsOrRef?: Ref<boolean> | AsyncComputedOptions,
-): Ref<T> {
+): Readonly<ShallowRef<T>> {
   let options: AsyncComputedOptions
 
   if (isRef(optionsOrRef)) {
@@ -60,7 +60,7 @@ export function computedAsync<T>(
   } = options
 
   const started = ref(!lazy)
-  const current = ref(initialState) as Ref<T>
+  const current = shallowRef(initialState) as ShallowRef<T>
   let counter = 0
 
   watchEffect(async (onInvalidate) => {
@@ -111,7 +111,7 @@ export function computedAsync<T>(
     })
   }
   else {
-    return current
+    return shallowReadonly(current)
   }
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Use `shallowRef` and mark the return value as `readonly` to conform to the `computed` ideas.

issues #2117 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
