### PR TITLE
fix(useThrottleFn): check negative timeout

### DIFF
--- a/packages/shared/utils/filters.ts
+++ b/packages/shared/utils/filters.ts
@@ -157,9 +157,10 @@ export function throttleFilter(ms: MaybeComputedRef<number>, trailing = true, le
 
     if (elapsed > duration && (leading || !isLeading)) {
       lastExec = Date.now()
-      invoke()
+      return invoke()
     }
     else if (trailing) {
+      const remaining = duration - elapsed
       return new Promise((resolve, reject) => {
         lastRejector = rejectOnCancel ? reject : resolve
         timer = setTimeout(() => {
@@ -167,7 +168,7 @@ export function throttleFilter(ms: MaybeComputedRef<number>, trailing = true, le
           isLeading = true
           resolve(invoke())
           clear()
-        }, duration - elapsed)
+        }, remaining > 0 ? remaining : 0)
       })
     }
 

--- a/packages/shared/utils/filters.ts
+++ b/packages/shared/utils/filters.ts
@@ -157,11 +157,11 @@ export function throttleFilter(ms: MaybeComputedRef<number>, trailing = true, le
 
     if (elapsed > duration && (leading || !isLeading)) {
       lastExec = Date.now()
-      return invoke()
+      invoke()
     }
     else if (trailing) {
       const remaining = duration - elapsed
-      return new Promise((resolve, reject) => {
+      lastValue = new Promise((resolve, reject) => {
         lastRejector = rejectOnCancel ? reject : resolve
         timer = setTimeout(() => {
           lastExec = Date.now()

--- a/packages/shared/utils/filters.ts
+++ b/packages/shared/utils/filters.ts
@@ -160,8 +160,6 @@ export function throttleFilter(ms: MaybeComputedRef<number>, trailing = true, le
       invoke()
     }
     else if (trailing) {
-      const timeout = duration - elapsed
-
       lastValue = new Promise((resolve, reject) => {
         lastRejector = rejectOnCancel ? reject : resolve
         timer = setTimeout(() => {
@@ -169,7 +167,7 @@ export function throttleFilter(ms: MaybeComputedRef<number>, trailing = true, le
           isLeading = true
           resolve(invoke())
           clear()
-        }, timeout > 0 ? timeout : 0)
+        }, Math.max(0, duration - elapsed))
       })
     }
 

--- a/packages/shared/utils/filters.ts
+++ b/packages/shared/utils/filters.ts
@@ -160,7 +160,8 @@ export function throttleFilter(ms: MaybeComputedRef<number>, trailing = true, le
       invoke()
     }
     else if (trailing) {
-      const remaining = duration - elapsed
+      const timeout = duration - elapsed
+
       lastValue = new Promise((resolve, reject) => {
         lastRejector = rejectOnCancel ? reject : resolve
         timer = setTimeout(() => {
@@ -168,7 +169,7 @@ export function throttleFilter(ms: MaybeComputedRef<number>, trailing = true, le
           isLeading = true
           resolve(invoke())
           clear()
-        }, remaining > 0 ? remaining : 0)
+        }, timeout > 0 ? timeout : 0)
       })
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fixes #2618 

### Additional context

caused by a **BIG** negative timeout. Exists in the past versions as well, but only occurs at the first call.
```js
const printHello = () => console.log('hello')
// will not print `hello`
setTimeout(printHello, -1672930567173)

// will print `hello`
setTimeout(printHello, -167293056)
```

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
