### PR TITLE
docs(useAuth): fixed signInWithPopup() example in docs

### DIFF
--- a/packages/firebase/useAuth/index.md
+++ b/packages/firebase/useAuth/index.md
@@ -16,9 +16,10 @@ import { GoogleAuthProvider, getAuth, signInWithPopup } from 'firebase/auth'
 import { useAuth } from '@vueuse/firebase/useAuth'
 
 const app = initializeApp({ /* config */ })
-const { isAuthenticated, user } = useAuth(getAuth(app))
+const auth = getAuth(app);
+const { isAuthenticated, user } = useAuth(auth)
 
-const signIn = () => signInWithPopup(new GoogleAuthProvider())
+const signIn = () => signInWithPopup(auth, new GoogleAuthProvider())
 </script>
 
 <template>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Fixed documentation to correct Firebase's signInWithPopup() method to take the required 'auth' parameter. 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
