### PR TITLE
docs:  useTimeoutFn miss Usage title

### DIFF
--- a/packages/shared/useTimeoutFn/index.md
+++ b/packages/shared/useTimeoutFn/index.md
@@ -6,6 +6,8 @@ category: Animation
 
 Wrapper for `setTimeout` with controls.
 
+## Usage
+
 ```js
 import { useTimeoutFn } from '@vueuse/core'
 


### PR DESCRIPTION
### Description

https://vueuse.org/shared/useTimeoutFn/

![image](https://user-images.githubusercontent.com/19297757/211179568-09a0b471-53c6-4c13-bd86-4e6e4ead19b0.png)

From the figure above, we can see that the location of the `Demo` and `useTimeoutFn` is wrong.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
