### PR TITLE
docs: fix typo

### DIFF
--- a/packages/core/useScroll/index.md
+++ b/packages/core/useScroll/index.md
@@ -55,7 +55,7 @@ const { x, y } = useScroll(el)
 
 Set `behavior: smooth` to enable smooth scrolling. The `behavior` option defaults to `auto`, which means no smooth scrolling. See the `behavior` option on [`window.scrollTo()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollTo) for more information.
 ```ts
-import { useWindowScroll } from '@vueuse/core'
+import { useScroll } from '@vueuse/core'
 
 const el = ref<HTMLElement | null>(null)
 const { x, y } = useScroll(el, { behavior: 'smooth' })


### PR DESCRIPTION
In the example it should import `useScroll` instead of `useWindowScroll`.

<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
