### PR TITLE
refactor(useVirtualList): deprecate in favor of vue-virtual-scroller

### DIFF
--- a/packages/core/useVirtualList/index.md
+++ b/packages/core/useVirtualList/index.md
@@ -1,6 +1,12 @@
 ---
 category: Component
+deprecated: true
 ---
+
+::: warning
+**Deprecated**. Please use [`vue-virtual-scroller`](https://github.com/Akryum/vue-virtual-scroller) instead.
+:::
+
 
 # useVirtualList
 

--- a/packages/core/useVirtualList/index.ts
+++ b/packages/core/useVirtualList/index.ts
@@ -64,6 +64,9 @@ export interface UseVirtualListReturn<T> {
   }>
 }
 
+/**
+ * @deprecated Please use [`vue-virtual-scroller`](https://github.com/Akryum/vue-virtual-scroller) instead.
+ */
 export function useVirtualList<T = any>(list: MaybeRef<T[]>, options: UseVirtualListOptions): UseVirtualListReturn<T> {
   const { containerStyle, wrapperProps, scrollTo, calculateRange, currentList, containerRef } = 'itemHeight' in options
     ? useVerticalVirtualList(options, list)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Virtual scroll is difficult to get right and comes with many complexities. It seems that it is outside the scope of VueUse and we should suggest users to use more complete and battle tested libraries for this. Currently the best library for this is https://github.com/Akryum/vue-virtual-scroller 

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
