### PR TITLE
fix(useElementSize): fix incorrect element size on SVG

### DIFF
--- a/packages/core/useElementSize/index.ts
+++ b/packages/core/useElementSize/index.ts
@@ -1,8 +1,9 @@
-import { ref, watch } from 'vue-demi'
+import { computed, ref, watch } from 'vue-demi'
 import type { MaybeComputedElementRef } from '../unrefElement'
 import type { UseResizeObserverOptions } from '../useResizeObserver'
 import { useResizeObserver } from '../useResizeObserver'
 import { unrefElement } from '../unrefElement'
+import { defaultWindow } from '../_configurable'
 
 export interface ElementSize {
   width: number
@@ -22,7 +23,8 @@ export function useElementSize(
   initialSize: ElementSize = { width: 0, height: 0 },
   options: UseResizeObserverOptions = {},
 ) {
-  const { box = 'content-box' } = options
+  const { window = defaultWindow, box = 'content-box' } = options
+  const isSVG = computed(() => unrefElement(target)?.namespaceURI?.includes('svg'))
   const width = ref(initialSize.width)
   const height = ref(initialSize.height)
 
@@ -35,14 +37,24 @@ export function useElementSize(
           ? entry.contentBoxSize
           : entry.devicePixelContentBoxSize
 
-      if (boxSize) {
-        width.value = boxSize.reduce((acc, { inlineSize }) => acc + inlineSize, 0)
-        height.value = boxSize.reduce((acc, { blockSize }) => acc + blockSize, 0)
+      if (window && isSVG.value) {
+        const $elem = unrefElement(target)
+        if ($elem) {
+          const styles = window.getComputedStyle($elem)
+          width.value = parseFloat(styles.width)
+          height.value = parseFloat(styles.height)
+        }
       }
       else {
-        // fallback
-        width.value = entry.contentRect.width
-        height.value = entry.contentRect.height
+        if (boxSize) {
+          width.value = boxSize.reduce((acc, { inlineSize }) => acc + inlineSize, 0)
+          height.value = boxSize.reduce((acc, { blockSize }) => acc + blockSize, 0)
+        }
+        else {
+          // fallback
+          width.value = entry.contentRect.width
+          height.value = entry.contentRect.height
+        }
       }
     },
     options,


### PR DESCRIPTION
### Description

fix [#2084](https://github.com/vueuse/vueuse/issues/2084)

fix incorrect size on SVG element, due to https://www.w3.org/TR/resize-observer/#calculate-box-size

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
