### PR TITLE
feat(useMagicKeys): add support for repeated key events

### DIFF
--- a/packages/core/useMagicKeys/index.md
+++ b/packages/core/useMagicKeys/index.md
@@ -154,3 +154,16 @@ const keys = useMagicKeys({ reactive: true })
   </div>
 </template>
 ```
+
+### Repeated Key Events
+
+You can also register repeated `KeyboardEvent`s.
+
+```ts
+import { useMagicKeys, whenever } from '@vueuse/core'
+
+const { current } = useMagicKeys({ repeat: true })
+const keys = computed(() => Array.from(current))
+
+whenever(keys, () => console.log('keys', keys.value))
+```


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Add support for registering repeated key events in `useMagicKeys()`

### Additional context

- Not entirely sure if this works with the current implementation for proxied values.
- Doesn't register repeated events of **only** modifier keys (ie, if you hold `Shift` on its own it will not fire repeated events, but this is also the way browsers handle it)
- Does register repeated modifier keys when they are accompanied with other keys (eg `Shift+S`),  for this it uses the modifier keys defined in `useKeyModifier()`
---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
