### PR TITLE
fix(usePrecision): fix return type

### DIFF
--- a/packages/math/usePrecision/index.ts
+++ b/packages/math/usePrecision/index.ts
@@ -21,8 +21,8 @@ export function usePrecision(
   value: MaybeComputedRef<number>,
   digits: MaybeComputedRef<number>,
   options?: MaybeComputedRef<UsePrecisionOptions>,
-): ComputedRef<number | string> {
-  return computed<number | string>(() => {
+): ComputedRef<number> {
+  return computed<number>(() => {
     const _value = resolveUnref(value)
     const _digits = resolveUnref(digits)
     const power = 10 ** _digits


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Return type of `usePrecision` was `ComputedRef<number | string>` instead of `ComputedRef<number>`, which was causing typing annoyance.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
