### PR TITLE
fix(useMediaControls): ended status not updating

### DIFF
--- a/packages/core/useMediaControls/index.ts
+++ b/packages/core/useMediaControls/index.ts
@@ -389,7 +389,10 @@ export function useMediaControls(target: MaybeRef<HTMLMediaElement | null | unde
   useEventListener(target, 'seeking', () => seeking.value = true)
   useEventListener(target, 'seeked', () => seeking.value = false)
   useEventListener(target, 'waiting', () => waiting.value = true)
-  useEventListener(target, 'playing', () => waiting.value = false)
+  useEventListener(target, 'playing', () => {
+    waiting.value = false
+    ended.value = false
+  })
   useEventListener(target, 'ratechange', () => rate.value = (resolveUnref(target))!.playbackRate)
   useEventListener(target, 'stalled', () => stalled.value = true)
   useEventListener(target, 'ended', () => ended.value = true)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When the media element ends playing, the ``ended`` status is set to true. However, if the media element status change, changing the ``ended`` status variable is not taken into consideration.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
