### PR TITLE
docs: remove extra close parentheses.

### DIFF
--- a/packages/core/useElementSize/index.md
+++ b/packages/core/useElementSize/index.md
@@ -31,7 +31,7 @@ export default {
       height,
     }
   }
-})
+}
 </script>
 ```
 

--- a/packages/core/useFocus/index.md
+++ b/packages/core/useFocus/index.md
@@ -58,6 +58,6 @@ export default {
       focused,
     }
   }
-})
+}
 </script>
 ```

--- a/packages/core/useMousePressed/index.md
+++ b/packages/core/useMousePressed/index.md
@@ -45,7 +45,7 @@ export default {
       pressed,
     }
   }
-})
+}
 </script>
 ```
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I've checked all markdown files in search of extra close parentheses and found 3 more.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
