### PR TITLE
fix(useTimeoutFn): respect callback parameters in start function

### DIFF
--- a/packages/shared/useTimeoutFn/index.ts
+++ b/packages/shared/useTimeoutFn/index.ts
@@ -20,11 +20,11 @@ export interface UseTimeoutFnOptions {
  * @param interval
  * @param options
  */
-export function useTimeoutFn(
-  cb: (...args: unknown[]) => any,
+export function useTimeoutFn<CallbackFn extends(...args: any[]) => any>(
+  cb: CallbackFn,
   interval: MaybeComputedRef<number>,
   options: UseTimeoutFnOptions = {},
-): Stoppable {
+): Stoppable<Parameters<CallbackFn> | []> {
   const {
     immediate = true,
   } = options
@@ -45,7 +45,7 @@ export function useTimeoutFn(
     clear()
   }
 
-  function start(...args: unknown[]) {
+  function start(...args: Parameters<CallbackFn> | []) {
     clear()
     isPending.value = true
     timer = setTimeout(() => {

--- a/packages/shared/utils/types.ts
+++ b/packages/shared/utils/types.ts
@@ -97,7 +97,7 @@ export interface Pausable {
   resume: Fn
 }
 
-export interface Stoppable {
+export interface Stoppable<StartFnArgs extends any[] = any[]> {
   /**
    * A ref indicate whether a stoppable instance is executing
    */
@@ -111,7 +111,7 @@ export interface Stoppable {
   /**
    * Start the effects
    */
-  start: Fn
+  start: (...args: StartFnArgs) => void
 }
 
 /**


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fixes #2691

### Additional context

On L62 of useTimeoutFn, `start()` is used without any parameters. What if user defines a callback that requires arguments to work? Maybe a new option like `defaultArguments` could be introduced?

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
