### PR TITLE
test(useTitle): remove unecessary warnings thrown during tests

### DIFF
--- a/packages/core/useTitle/index.test.ts
+++ b/packages/core/useTitle/index.test.ts
@@ -1,4 +1,4 @@
-import { computed, ref } from 'vue-demi'
+import { computed, isReadonly, ref } from 'vue-demi'
 import { useTitle } from '.'
 
 describe('useTitle', () => {
@@ -72,16 +72,14 @@ describe('useTitle', () => {
       expect(title.value).toEqual('old title')
       condition.value = true
       expect(title.value).toEqual('new title')
-      // @ts-expect-error readonly
-      title.value = ''
+      expect(isReadonly(title)).toBeTruthy()
     })
 
     it('function', () => {
       const target = () => 'new title'
       const title = useTitle(target)
       expect(title.value).toEqual('new title')
-      // @ts-expect-error readonly
-      title.value = ''
+      expect(isReadonly(title)).toBeTruthy()
     })
   })
 })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When running vitest tests, there is a warning that is being displayed:

```
stderr | packages/core/useTitle/index.test.ts > useTitle > with readonly param > computed
Write operation failed: computed value is readonly
```

This warning is totally genuine, because setting value of a readonly computed value is a noop. Still, it clutters tests summary, and might give the impression that something is not right in the `useTitle` composable, whereas the warnings actually come from the tests themselves in order to verify typings.

I replaced these types verifications with tests, using the `isReactive` vue utility, to remove those warnings.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
