### PR TITLE
fix(useScrollLock): detect parent with overflow auto

### DIFF
--- a/packages/core/useScrollLock/index.ts
+++ b/packages/core/useScrollLock/index.ts
@@ -6,7 +6,12 @@ import { useEventListener } from '../useEventListener'
 
 function checkOverflowScroll(ele: Element): boolean {
   const style = window.getComputedStyle(ele)
-  if (style.overflowX === 'scroll' || style.overflowY === 'scroll') {
+  if (
+    style.overflowX === 'scroll'
+    || style.overflowY === 'scroll'
+    || (style.overflowX === 'auto' && ele.clientHeight < ele.scrollHeight)
+    || (style.overflowY === 'auto' && ele.clientWidth < ele.scrollWidth)
+  ) {
     return true
   }
   else {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR adds a condition to the `checkOverflowScroll` function for elements that have an overflow value that is `auto`.

See: https://github.com/vueuse/vueuse/pull/2362#issuecomment-1383148124

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
