### PR TITLE
feat(useFetch): update data on success

### DIFF
--- a/packages/core/useFetch/index.test.ts
+++ b/packages/core/useFetch/index.test.ts
@@ -200,20 +200,20 @@ describe('useFetch', () => {
       baseUrl: 'https://example.com',
       options: {
         onFetchError(ctx) {
-          ctx.data.title = 'Global'
+          ctx.error = 'Global'
           return ctx
         },
       },
     })
-    const { data } = useMyFetch('test?status=400&json', {
+    const { error } = useMyFetch('test?status=400&json', {
       onFetchError(ctx) {
-        ctx.data.title += ' Local'
+        ctx.error += ' Local'
         return ctx
       },
     }).json()
 
     await retry(() => {
-      expect(data.value).toEqual(expect.objectContaining({ title: 'Global Local' }))
+      expect(error.value).toEqual('Global Local')
     })
   })
 
@@ -272,23 +272,23 @@ describe('useFetch', () => {
       baseUrl: 'https://example.com',
       options: {
         onFetchError(ctx) {
-          ctx.data.title = 'Global'
+          ctx.error = 'Global'
           return ctx
         },
       },
     })
-    const { data } = useMyFetch(
+    const { error } = useMyFetch(
       'test?status=400&json',
       { method: 'GET' },
       {
         onFetchError(ctx) {
-          ctx.data.title += ' Local'
+          ctx.error += ' Local'
           return ctx
         },
       }).json()
 
     await retry(() => {
-      expect(data.value).toEqual(expect.objectContaining({ title: 'Global Local' }))
+      expect(error.value).toEqual('Global Local')
     })
   })
 
@@ -345,21 +345,20 @@ describe('useFetch', () => {
       combination: 'overwrite',
       options: {
         onFetchError(ctx) {
-          ctx.data.global = 'Global'
+          ctx.error = 'Global'
           return ctx
         },
       },
     })
-    const { data } = useMyFetch('test?status=400&json', {
+    const { error } = useMyFetch('test?status=400&json', {
       onFetchError(ctx) {
-        ctx.data.local = 'Local'
+        ctx.error = 'Local'
         return ctx
       },
     }).json()
 
     await retry(() => {
-      expect(data.value).toEqual(expect.objectContaining({ local: 'Local' }))
-      expect(data.value).toEqual(expect.not.objectContaining({ global: 'Global' }))
+      expect(error.value).toEqual('Local')
     })
   })
 
@@ -422,24 +421,23 @@ describe('useFetch', () => {
       combination: 'overwrite',
       options: {
         onFetchError(ctx) {
-          ctx.data.global = 'Global'
+          ctx.error = 'Global'
           return ctx
         },
       },
     })
-    const { data } = useMyFetch(
+    const { error } = useMyFetch(
       'test?status=400&json',
       { method: 'GET' },
       {
         onFetchError(ctx) {
-          ctx.data.local = 'Local'
+          ctx.error = 'Local'
           return ctx
         },
       }).json()
 
     await retry(() => {
-      expect(data.value).toEqual(expect.objectContaining({ local: 'Local' }))
-      expect(data.value).toEqual(expect.not.objectContaining({ global: 'Global' }))
+      expect(error.value).toEqual('Local')
     })
   })
 
@@ -537,23 +535,24 @@ describe('useFetch', () => {
   })
 
   test('should run the onFetchError function', async () => {
-    const { data, statusCode } = useFetch('https://example.com?status=400&json', {
+    const { data, error, statusCode } = useFetch('https://example.com?status=400&json', {
       onFetchError(ctx) {
-        ctx.data.title = 'Hunter x Hunter'
+        ctx.error = 'Internal Server Error'
         return ctx
       },
     }).json()
 
     await retry(() => {
       expect(statusCode.value).toEqual(400)
-      expect(data.value).toEqual(expect.objectContaining({ title: 'Hunter x Hunter' }))
+      expect(error.value).toEqual('Internal Server Error')
+      expect(data.value).toBeNull()
     })
   })
 
   test('should run the onFetchError function when network error', async () => {
-    const { data, statusCode } = useFetch('https://example.com?status=500&text=Internal%20Server%20Error', {
+    const { data, error, statusCode } = useFetch('https://example.com?status=500&text=Internal%20Server%20Error', {
       onFetchError(ctx) {
-        ctx.data = { title: 'Hunter x Hunter' }
+        ctx.error = 'Internal Server Error'
 
         return ctx
       },
@@ -561,7 +560,8 @@ describe('useFetch', () => {
 
     await retry(() => {
       expect(statusCode.value).toStrictEqual(500)
-      expect(data.value).toEqual({ title: 'Hunter x Hunter' })
+      expect(error.value).toEqual('Internal Server Error')
+      expect(data.value).toBeNull()
     })
   })
 

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -442,14 +442,15 @@ export function useFetch<T>(url: MaybeComputedRef<string>, ...args: any[]): UseF
 
           responseData = await fetchResponse[config.type]()
 
-          if (options.afterFetch && statusCode.value >= 200 && statusCode.value < 300)
-            ({ data: responseData } = await options.afterFetch({ data: responseData, response: fetchResponse }))
-
-          data.value = responseData
-
           // see: https://www.tjvantoll.com/2015/09/13/fetch-and-errors/
-          if (!fetchResponse.ok)
+          if (!fetchResponse.ok) {
+            data.value = initialData
             throw new Error(fetchResponse.statusText)
+          }
+
+          if (options.afterFetch)
+            ({ data: responseData } = await options.afterFetch({ data: responseData, response: fetchResponse }))
+          data.value = responseData
 
           responseEvent.trigger(fetchResponse)
           return resolve(fetchResponse)
@@ -458,8 +459,7 @@ export function useFetch<T>(url: MaybeComputedRef<string>, ...args: any[]): UseF
           let errorData = fetchError.message || fetchError.name
 
           if (options.onFetchError)
-            ({ data: responseData, error: errorData } = await options.onFetchError({ data: responseData, error: fetchError, response: response.value }))
-          data.value = responseData
+            ({ error: errorData } = await options.onFetchError({ data: responseData, error: fetchError, response: response.value }))
           error.value = errorData
 
           errorEvent.trigger(fetchError)

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -349,7 +349,7 @@ export function useFetch<T>(url: MaybeComputedRef<string>, ...args: any[]): UseF
   const statusCode = ref<number | null>(null)
   const response = shallowRef<Response | null>(null)
   const error = shallowRef<any>(null)
-  const data = shallowRef<T | null>(initialData)
+  const data = shallowRef<T | null>(initialData || null)
 
   const canAbort = computed(() => supportsAbort && isFetching.value)
 
@@ -444,7 +444,7 @@ export function useFetch<T>(url: MaybeComputedRef<string>, ...args: any[]): UseF
 
           // see: https://www.tjvantoll.com/2015/09/13/fetch-and-errors/
           if (!fetchResponse.ok) {
-            data.value = initialData
+            data.value = initialData || null
             throw new Error(fetchResponse.statusText)
           }
 

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -26,7 +26,7 @@ export interface UseFetchReturn<T> {
   error: Ref<any>
 
   /**
-   * The fetch response body, may either be JSON or text
+   * The fetch response body on success, may either be JSON or text
    */
   data: Ref<T | null>
 


### PR DESCRIPTION
### Description

When people use useFetch, they expect certain type to be returned by the request, ie. an array of options to be provided to the select component. But this data is only present on successfull responses. In case of error, probably a totally different payload is returned. Having this payload set as a data, causes a lot of issues, because it is no longer what client of the useFetch expected.

### Additional context

IMHO data in case of error could be provided as a separate state. But in this PR, data is set to initialData provided in options or null, when an error happens.
Payload, when error happened, is provided to the onFetchError callback, so client of the useFetch composable can do whatever is needed to transform provided payload to some meaningful error.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
