### PR TITLE
docs(useInfiniteScroll): remove unused toRefs

### DIFF
--- a/packages/core/useInfiniteScroll/index.md
+++ b/packages/core/useInfiniteScroll/index.md
@@ -10,7 +10,7 @@ Infinite scrolling of the element.
 
 ```html
 <script setup lang="ts">
-import { ref, toRefs } from 'vue'
+import { ref } from 'vue'
 import { useInfiniteScroll } from '@vueuse/core'
 
 const el = ref<HTMLElement>(null)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Removed unused toRefs in useInfiniteScroll

### Additional context

just removal of unnecessary toRefs was being used in the example of useInfiniteScroll 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [] Ideally, include relevant tests that fail without this PR but pass with it.
