### PR TITLE
docs(useConfirmDialog,useDateFormat): remove useless imports

### DIFF
--- a/packages/core/useConfirmDialog/index.md
+++ b/packages/core/useConfirmDialog/index.md
@@ -54,7 +54,7 @@ If you prefer working with promises:
 
 ```html
 <script setup>
-import { useConfirmDialog, onClickOutside } from '@vueuse/core'
+import { useConfirmDialog } from '@vueuse/core'
 
 const {
   isRevealed,

--- a/packages/shared/useDateFormat/index.md
+++ b/packages/shared/useDateFormat/index.md
@@ -45,7 +45,6 @@ Get the formatted date according to the string of tokens passed in, inspired by 
 ```html
 <script setup lang="ts">
 
-import { ref, computed } from 'vue-demi'
 import { useNow, useDateFormat } from '@vueuse/core'
 
 const formatted = useDateFormat(useNow(), 'YYYY-MM-DD HH:mm:ss')
@@ -62,7 +61,6 @@ const formatted = useDateFormat(useNow(), 'YYYY-MM-DD HH:mm:ss')
 ```html
 <script setup lang="ts">
 
-import { ref, computed } from 'vue-demi'
 import { useNow, useDateFormat } from '@vueuse/core'
 
 const formatted = useDateFormat(useNow(), 'YYYY-MM-DD (ddd)', { locales: 'en-US' })
@@ -79,8 +77,7 @@ const formatted = useDateFormat(useNow(), 'YYYY-MM-DD (ddd)', { locales: 'en-US'
 ```html
 <script setup lang="ts">
 
-import { ref, computed } from 'vue-demi'
-import { useNow, useDateFormat } from '@vueuse/core'
+import { useDateFormat } from '@vueuse/core'
 
 const customMeridiem = (hours: number, minutes: number, isLowercase?: boolean, hasPeriod?: boolean) => {
   const m = hours > 11 ? (isLowercase ? 'μμ' : 'ΜΜ') : (isLowercase ? 'πμ' : 'ΠΜ')


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

These imports are not used

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context
useConfirmDialog useDateFormat
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
