### PR TITLE
docs(useFocusTrap): added non-component solution for conditional rendering

### DIFF
--- a/packages/integrations/useFocusTrap/index.md
+++ b/packages/integrations/useFocusTrap/index.md
@@ -57,9 +57,39 @@ const { hasFocus, activate, deactivate } = useFocusTrap(target, { immediate: tru
 </template>
 ```
 
+**Conditional Rendering**
+
+This function can't properly activate focus on elements with conditional rendering using `v-if`. This is because they do not exist in the DOM at the time of the focus activation. To solve this you need to activate on the next tick.
+
+```html
+<script setup>
+import { nextTick, ref } from 'vue'
+
+const target = ref()
+const { activate, deactivate } = useFocusTrap(target, { immediate: true })
+
+const show = ref(false)  
+
+const reveal = async () => {
+  show.value = true
+  
+  await nextTick()
+  activate()
+}
+</script>
+
+<template>
+  <div>
+    <div ref="target" v-if="show">...</div>
+    
+    <button @click="reveal">Reveal and Focus</button>
+  </div>
+</template>
+```
+
 ## Using Component
 
-This function can't properly activate focus on elements with conditional rendering. In this case, you can use the `UseFocusTrap` component. Focus Trap will be activated automatically on mounting this component and deactivated on unmount.
+With the `UseFocusTrap` component, Focus Trap will be activated automatically on mounting this component and deactivated on unmount.
 
 ```html
 <script setup>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Update to documentation for useFocusTrap to include a solution for handling focus on conditional rendered elements that can be done entirely in code, without a component.

### Additional context

Originally, the only documented way this was possible was by using the component.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
