### PR TITLE
feat(useTransition): expose transition utility for manual control

### DIFF
--- a/packages/core/useTransition/index.md
+++ b/packages/core/useTransition/index.md
@@ -103,12 +103,12 @@ useTransition(source, {
 
 To temporarily stop transitioning, define a boolean `disabled` property. Be aware, this is not the same a `duration` of `0`. Disabled transitions track the source value **_synchronously_**. They do not respect a `delay`, and do not fire `onStarted` or `onFinished` callbacks.
 
-For more control, transitions can be executed manually via the `transition` utility. This function returns a promise that resolves upon completion. Manual transitions can be cancelled by defining an `abort` function that returns a truthy value.
+For more control, transitions can be executed manually by using `executeTransition`. This function returns a promise that resolves upon completion. Manual transitions can be cancelled by defining an `abort` function that returns a truthy value.
 
 ```js
-import { transition } from '@vueuse/core'
+import { executeTransition } from '@vueuse/core'
 
-await transition(source, from, to, {
+await executeTransition(source, from, to, {
   duration: 1000,
 })
 ```

--- a/packages/core/useTransition/index.md
+++ b/packages/core/useTransition/index.md
@@ -8,7 +8,7 @@ Transition between values
 
 ## Usage
 
-For simple transitions, provide a numeric source value to watch. When changed, the output will transition to the new value. If the source changes while a transition is in progress, a new transition will begin from where the previous one was interrupted.
+Define a numeric source value to follow, and when changed the output will transition to the new value. If the source changes while a transition is in progress, a new transition will begin from where the previous one was interrupted.
 
 ```js
 import { ref } from 'vue'
@@ -102,3 +102,13 @@ useTransition(source, {
 ```
 
 To temporarily stop transitioning, define a boolean `disabled` property. Be aware, this is not the same a `duration` of `0`. Disabled transitions track the source value **_synchronously_**. They do not respect a `delay`, and do not fire `onStarted` or `onFinished` callbacks.
+
+For more control, transitions can be executed manually via the `transition` utility. This function returns a promise that resolves upon completion. Manual transitions can be cancelled by defining an `abort` function that returns a truthy value.
+
+```js
+import { transition } from '@vueuse/core'
+
+await transition(source, from, to, {
+  duration: 1000,
+})
+```

--- a/packages/core/useTransition/index.test.ts
+++ b/packages/core/useTransition/index.test.ts
@@ -15,7 +15,7 @@ describe('transition', () => {
 
     await promiseTimeout(25)
 
-    expectBetween(source.value, 0, 1)
+    expectBetween(source.value, 0.25, 0.75)
 
     await trans
 

--- a/packages/core/useTransition/index.test.ts
+++ b/packages/core/useTransition/index.test.ts
@@ -39,6 +39,25 @@ describe('transition', () => {
     expect(source.value[1]).toBe(2)
     expect(source.value[2]).toBe(3)
   })
+
+  it('transitions can be aborted', async () => {
+    let abort = false
+
+    const source = ref(0)
+
+    const trans = transition(source, 0, 1, {
+      abort: () => abort,
+      duration: 50,
+    })
+
+    await promiseTimeout(25)
+
+    abort = true
+
+    await trans
+
+    expectBetween(source.value, 0, 1)
+  })
 })
 
 describe('useTransition', () => {

--- a/packages/core/useTransition/index.test.ts
+++ b/packages/core/useTransition/index.test.ts
@@ -280,4 +280,22 @@ describe('useTransition', () => {
     disabled.value = false
     expect(transition.value).toBe(1)
   })
+
+  it('begins transition from where previous transition was interrupted', async () => {
+    const source = ref(0)
+
+    const transition = useTransition(source, {
+      duration: 100,
+    })
+
+    source.value = 1
+
+    await promiseTimeout(50)
+
+    source.value = 0
+
+    await promiseTimeout(25)
+
+    expectBetween(transition.value, 0, 0.5)
+  })
 })

--- a/packages/core/useTransition/index.test.ts
+++ b/packages/core/useTransition/index.test.ts
@@ -1,17 +1,17 @@
 import { promiseTimeout } from '@vueuse/shared'
 import { ref } from 'vue-demi'
-import { transition, useTransition } from '.'
+import { executeTransition, useTransition } from '.'
 
 const expectBetween = (val: number, floor: number, ceiling: number) => {
   expect(val).to.be.greaterThan(floor)
   expect(val).to.be.lessThan(ceiling)
 }
 
-describe('transition', () => {
+describe('executeTransition', () => {
   it('transitions between numbers', async () => {
     const source = ref(0)
 
-    const trans = transition(source, 0, 1, { duration: 50 })
+    const trans = executeTransition(source, 0, 1, { duration: 50 })
 
     await promiseTimeout(25)
 
@@ -25,7 +25,7 @@ describe('transition', () => {
   it('transitions between vectors', async () => {
     const source = ref([0, 0, 0])
 
-    const trans = transition(source, [0, 1, 2], [1, 2, 3], { duration: 50 })
+    const trans = executeTransition(source, [0, 1, 2], [1, 2, 3], { duration: 50 })
 
     await promiseTimeout(25)
 
@@ -45,7 +45,7 @@ describe('transition', () => {
 
     const source = ref(0)
 
-    const trans = transition(source, 0, 1, {
+    const trans = executeTransition(source, 0, 1, {
       abort: () => abort,
       duration: 50,
     })

--- a/packages/core/useTransition/index.test.ts
+++ b/packages/core/useTransition/index.test.ts
@@ -1,11 +1,45 @@
 import { promiseTimeout } from '@vueuse/shared'
 import { ref } from 'vue-demi'
-import { useTransition } from '.'
+import { transition, useTransition } from '.'
 
 const expectBetween = (val: number, floor: number, ceiling: number) => {
   expect(val).to.be.greaterThan(floor)
   expect(val).to.be.lessThan(ceiling)
 }
+
+describe('transition', () => {
+  it('transitions between numbers', async () => {
+    const source = ref(0)
+
+    const trans = transition(source, 0, 1, { duration: 50 })
+
+    await promiseTimeout(25)
+
+    expectBetween(source.value, 0, 1)
+
+    await trans
+
+    expect(source.value).toBe(1)
+  })
+
+  it('transitions between vectors', async () => {
+    const source = ref([0, 0, 0])
+
+    const trans = transition(source, [0, 1, 2], [1, 2, 3], { duration: 50 })
+
+    await promiseTimeout(25)
+
+    expectBetween(source.value[0], 0, 1)
+    expectBetween(source.value[1], 1, 2)
+    expectBetween(source.value[2], 2, 3)
+
+    await trans
+
+    expect(source.value[0]).toBe(1)
+    expect(source.value[1]).toBe(2)
+    expect(source.value[2]).toBe(3)
+  })
+})
 
 describe('useTransition', () => {
   it('transitions between numbers', async () => {

--- a/packages/core/useTransition/index.ts
+++ b/packages/core/useTransition/index.ts
@@ -1,5 +1,5 @@
 import { computed, ref, unref, watch } from 'vue-demi'
-import { isFunction, isNumber, identity as linear, promiseTimeout } from '@vueuse/shared'
+import { isFunction, isNumber, identity as linear, promiseTimeout, tryOnScopeDispose } from '@vueuse/shared'
 import type { ComputedRef, Ref } from 'vue-demi'
 import type { MaybeRef } from '@vueuse/shared'
 
@@ -244,6 +244,10 @@ export function useTransition(
 
       outputRef.value = sourceVal()
     }
+  })
+
+  tryOnScopeDispose(() => {
+    currentId++
   })
 
   return computed(() => unref(options.disabled) ? sourceVal() : outputRef.value)

--- a/packages/core/useTransition/index.ts
+++ b/packages/core/useTransition/index.ts
@@ -139,7 +139,7 @@ export function transition<T extends number | number[]>(
   from: MaybeRef<T>,
   to: MaybeRef<T>,
   options: TransitionOptions = {},
-) {
+): PromiseLike<void> {
   const fromVal = unref(from)
   const toVal = unref(to)
   const v1 = toVec(fromVal)

--- a/packages/core/useTransition/index.ts
+++ b/packages/core/useTransition/index.ts
@@ -134,7 +134,7 @@ const toVec = (t: number | number[] | undefined) => (isNumber(t) ? [t] : t) || [
  * @param to
  * @param options
  */
-export function transition<T extends number | number[]>(
+export function executeTransition<T extends number | number[]>(
   source: Ref<T>,
   from: MaybeRef<T>,
   to: MaybeRef<T>,
@@ -230,7 +230,7 @@ export function useTransition(
 
     options.onStarted?.()
 
-    await transition(outputRef, outputRef.value, toVal, {
+    await executeTransition(outputRef, outputRef.value, toVal, {
       ...options,
       abort: () => id !== currentId || options.abort?.(),
     })

--- a/packages/core/useTransition/index.ts
+++ b/packages/core/useTransition/index.ts
@@ -126,21 +126,28 @@ const lerp = (a: number, b: number, alpha: number) => a + alpha * (b - a)
 
 const toVec = (t: number | number[] | undefined) => (isNumber(t) ? [t] : t) || []
 
+/**
+ * Transition from one value to another.
+ *
+ * @param source
+ * @param from
+ * @param to
+ * @param options
+ */
 export function transition<T extends number | number[]>(
   source: Ref<T>,
   from: MaybeRef<T>,
   to: MaybeRef<T>,
-  opts: TransitionOptions = {},
+  options: TransitionOptions = {},
 ) {
   const fromVal = unref(from)
   const toVal = unref(to)
   const v1 = toVec(fromVal)
   const v2 = toVec(toVal)
-  const duration = unref(opts.duration) ?? 1000
+  const duration = unref(options.duration) ?? 1000
   const startedAt = Date.now()
   const endAt = Date.now() + duration
-
-  const trans = unref(opts.transition) ?? linear
+  const trans = unref(options.transition) ?? linear
 
   const ease = isFunction(trans) ? trans : createEasingFunction(trans)
 
@@ -148,7 +155,7 @@ export function transition<T extends number | number[]>(
     source.value = fromVal
 
     const tick = () => {
-      if (opts.abort?.()) {
+      if (options.abort?.()) {
         resolve()
 
         return
@@ -187,7 +194,7 @@ export function useTransition<T extends MaybeRef<number>[]>(source: [...T], opti
 export function useTransition<T extends Ref<number[]>>(source: T, options?: UseTransitionOptions): ComputedRef<number[]>
 
 /**
- * Transition between values.
+ * Follow value with a transition.
  *
  * @see https://vueuse.org/useTransition
  * @param source

--- a/packages/core/useTransition/index.ts
+++ b/packages/core/useTransition/index.ts
@@ -214,7 +214,7 @@ export function useTransition(
 
   const outputRef = ref(sourceVal())
 
-  watch(source, async (to, from) => {
+  watch(source, async (to) => {
     if (unref(options.disabled))
       return
 
@@ -226,13 +226,11 @@ export function useTransition(
     if (id !== currentId)
       return
 
-    const fromVal = Array.isArray(from) ? from.map(unref) : unref(from)
-
     const toVal = Array.isArray(to) ? to.map(unref) : unref(to)
 
     options.onStarted?.()
 
-    await transition(outputRef, fromVal, toVal, {
+    await transition(outputRef, outputRef.value, toVal, {
       ...options,
       abort: () => id !== currentId || options.abort?.(),
     })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Expose underlying transition logic from `useTransition` to allow for manually transitioning a ref between values. See more information here https://github.com/vueuse/vueuse/issues/2689.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
