### PR TITLE
fix(useScroll): handle reverse flex direction

### DIFF
--- a/packages/core/useScroll/index.ts
+++ b/packages/core/useScroll/index.ts
@@ -160,12 +160,19 @@ export function useScroll(
       e.target === document ? (e.target as Document).documentElement : e.target
     ) as HTMLElement
 
+    const { flexDirection } = window.getComputedStyle(eventTarget)
+    const reverseY = flexDirection === 'column-reverse'
+    const reverseX = flexDirection === 'row-reverse'
+
     const scrollLeft = eventTarget.scrollLeft
     directions.left = scrollLeft < internalX.value
     directions.right = scrollLeft > internalY.value
-    arrivedState.left = scrollLeft <= 0 + (offset.left || 0)
-    arrivedState.right
-      = scrollLeft + eventTarget.clientWidth >= eventTarget.scrollWidth - (offset.right || 0) - ARRIVED_STATE_THRESHOLD_PIXELS
+
+    const isLeft = (negative = false) => (negative ? -1 : 1) * scrollLeft <= 0 + (offset.left || 0)
+    const isRight = (negative = false) => (negative ? -1 : 1) * scrollLeft + eventTarget.clientWidth >= eventTarget.scrollWidth - (offset.right || 0) - ARRIVED_STATE_THRESHOLD_PIXELS
+
+    arrivedState.left = reverseX ? isRight(true) : isLeft()
+    arrivedState.right = reverseX ? isLeft(true) : isRight()
     internalX.value = scrollLeft
 
     let scrollTop = eventTarget.scrollTop
@@ -176,9 +183,12 @@ export function useScroll(
 
     directions.top = scrollTop < internalY.value
     directions.bottom = scrollTop > internalY.value
-    arrivedState.top = scrollTop <= 0 + (offset.top || 0)
-    arrivedState.bottom
-      = scrollTop + eventTarget.clientHeight >= eventTarget.scrollHeight - (offset.bottom || 0) - ARRIVED_STATE_THRESHOLD_PIXELS
+
+    const isTop = (negative = false) => (negative ? -1 : 1) * scrollTop <= 0 + (offset.top || 0)
+    const isBottom = (negative = false) => (negative ? -1 : 1) * scrollTop + eventTarget.clientHeight >= eventTarget.scrollHeight - (offset.bottom || 0) - ARRIVED_STATE_THRESHOLD_PIXELS
+
+    arrivedState.top = reverseY ? isBottom(true) : isTop()
+    arrivedState.bottom = reverseY ? isTop(true) : isBottom()
     internalY.value = scrollTop
 
     isScrolling.value = true

--- a/packages/core/useScroll/index.ts
+++ b/packages/core/useScroll/index.ts
@@ -2,8 +2,10 @@ import { computed, reactive, ref } from 'vue-demi'
 import type { MaybeComputedRef } from '@vueuse/shared'
 import { noop, resolveUnref, useDebounceFn, useThrottleFn } from '@vueuse/shared'
 import { useEventListener } from '../useEventListener'
+import type { ConfigurableWindow } from '../_configurable'
+import { defaultWindow } from '../_configurable'
 
-export interface UseScrollOptions {
+export interface UseScrollOptions extends ConfigurableWindow {
   /**
    * Throttle time for scroll event, it’s disabled by default.
    *
@@ -94,7 +96,28 @@ export function useScroll(
       passive: true,
     },
     behavior = 'auto',
+    window = defaultWindow,
   } = options
+
+  if (!window) {
+    return {
+      x: ref(0),
+      y: ref(0),
+      isScrolling: ref(false),
+      arrivedState: reactive({
+        left: true,
+        right: false,
+        top: true,
+        bottom: false,
+      }),
+      directions: reactive({
+        left: false,
+        right: false,
+        top: false,
+        bottom: false,
+      }),
+    }
+  }
 
   const internalX = ref(0)
   const internalY = ref(0)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fixes https://github.com/vueuse/vueuse/issues/2737

When defining the `flex-direction` style of the html element as `column-reverse` or `row-reverse`, the `arrivedState` property must change the way its properties are calculated

### Additional context

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
