### PR TITLE
feat(useFetch): cancel previous request

### DIFF
--- a/packages/core/useFetch/index.test.ts
+++ b/packages/core/useFetch/index.test.ts
@@ -1,5 +1,5 @@
 import { until } from '@vueuse/shared'
-import { ref } from 'vue-demi'
+import { nextTick, ref } from 'vue-demi'
 import type { SpyInstance } from 'vitest'
 import { retry } from '../../.test'
 import { createFetch, useFetch } from '.'
@@ -657,5 +657,40 @@ describe('useFetch', () => {
 
     expect(data.value).toEqual(jsonMessage)
     expect(fetchSpy).toBeCalledTimes(1)
+  })
+
+  test('should abort previous request', async () => {
+    const { onFetchResponse, execute } = useFetch('https://example.com', { immediate: false })
+
+    onFetchResponse(onFetchResponseSpy)
+
+    execute()
+    execute()
+    execute()
+    execute()
+
+    await retry(() => {
+      expect(onFetchResponseSpy).toBeCalledTimes(1)
+    })
+  })
+
+  it('should listen url ref change abort previous request', async () => {
+    const url = ref('https://example.com')
+    const { onFetchResponse } = useFetch(url, { refetch: true, immediate: false })
+
+    onFetchResponse(onFetchResponseSpy)
+
+    url.value = 'https://example.com?t=1'
+    await nextTick()
+    url.value = 'https://example.com?t=2'
+    await nextTick()
+    url.value = 'https://example.com?t=3'
+
+    await retry(() => {
+      expect(onFetchResponseSpy).toBeCalledTimes(1)
+    }, {
+      interval: 1,
+      timeout: 2000,
+    })
   })
 })

--- a/packages/core/useFetch/index.test.ts
+++ b/packages/core/useFetch/index.test.ts
@@ -688,9 +688,6 @@ describe('useFetch', () => {
 
     await retry(() => {
       expect(onFetchResponseSpy).toBeCalledTimes(1)
-    }, {
-      interval: 1,
-      timeout: 2000,
     })
   })
 })

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -357,8 +357,10 @@ export function useFetch<T>(url: MaybeComputedRef<string>, ...args: any[]): UseF
   let timer: Stoppable | undefined
 
   const abort = () => {
-    if (supportsAbort && controller)
+    if (supportsAbort && controller) {
       controller.abort()
+      controller = undefined
+    }
   }
 
   const loading = (isLoading: boolean) => {
@@ -374,9 +376,9 @@ export function useFetch<T>(url: MaybeComputedRef<string>, ...args: any[]): UseF
     error.value = null
     statusCode.value = null
     aborted.value = false
-    controller = undefined
 
     if (supportsAbort) {
+      abort()
       controller = new AbortController()
       controller.signal.onabort = () => aborted.value = true
       fetchOptions = {


### PR DESCRIPTION
<!-- Thank you for contributing! -->


### Description

closes #2677 

When executing requests continuously or monitoring url ref changes, the previous request will be automatically terminated to ensure that the obtained data is the most current requested data.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

useFetch

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
