### PR TITLE
docs(useMagicKeys): fix 'and' in demo

### DIFF
--- a/packages/core/useMagicKeys/index.md
+++ b/packages/core/useMagicKeys/index.md
@@ -102,10 +102,11 @@ By default, we have some [preconfigured alias for common practices](https://gith
 
 ### Conditionally Disable
 
-You might have some `<input />` elements in your apps, and you don't want to trigger the magic keys handling when users focused on those inputs. There is an example of using `useActiveElement` and `and` to do that.
+You might have some `<input />` elements in your apps, and you don't want to trigger the magic keys handling when users focused on those inputs. There is an example of using `useActiveElement` and `logicAnd` to do that.
 
 ```ts
-import { and, useActiveElement, useMagicKeys, whenever } from '@vueuse/core'
+import { useActiveElement, useMagicKeys, whenever } from '@vueuse/core'
+import { logicAnd } from '@vueuse/math'
 
 const activeElement = useActiveElement()
 const notUsingInput = computed(() =>
@@ -115,7 +116,7 @@ const notUsingInput = computed(() =>
 
 const { tab } = useMagicKeys()
 
-whenever(and(tab, notUsingInput), () => {
+whenever(logicAnd(tab, notUsingInput), () => {
   console.log('Tab has been pressed outside of inputs!')
 })
 ```


### PR DESCRIPTION
'and' is now available as 'logicAnd' in '@vueuse/math'.

<!-- Thank you for contributing! -->

### Description

The Conditionally Disable example is broken due to `and` not existing in `@vueuse/core`. `and` is now available as `logicAnd` in `@vueuse/math`.

This PR fixes the "Conditionally Disable" example.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
