### PR TITLE
refactor(useVirtualList): remove deprecated tag

### DIFF
--- a/packages/core/useVirtualList/index.md
+++ b/packages/core/useVirtualList/index.md
@@ -1,10 +1,9 @@
 ---
 category: Component
-deprecated: true
 ---
 
-::: warning
-**Deprecated**. Please use [`vue-virtual-scroller`](https://github.com/Akryum/vue-virtual-scroller) instead.
+::: info
+Please consider using [`vue-virtual-scroller`](https://github.com/Akryum/vue-virtual-scroller) if you are looking for more features.
 :::
 
 

--- a/packages/core/useVirtualList/index.ts
+++ b/packages/core/useVirtualList/index.ts
@@ -65,7 +65,7 @@ export interface UseVirtualListReturn<T> {
 }
 
 /**
- * @deprecated Please use [`vue-virtual-scroller`](https://github.com/Akryum/vue-virtual-scroller) instead.
+ * Please consider using [`vue-virtual-scroller`](https://github.com/Akryum/vue-virtual-scroller) if you are looking for more features.
  */
 export function useVirtualList<T = any>(list: MaybeRef<T[]>, options: UseVirtualListOptions): UseVirtualListReturn<T> {
   const { containerStyle, wrapperProps, scrollTo, calculateRange, currentList, containerRef } = 'itemHeight' in options


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Remove the `deprecated` tag and link out to `vue-virtual-scroller` as discussed in this topic #2683 .
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
