### PR TITLE
docs(useMousePressed): fix ts type error

### DIFF
--- a/packages/core/useMousePressed/demo.vue
+++ b/packages/core/useMousePressed/demo.vue
@@ -4,13 +4,11 @@ import { useToggle } from '@vueuse/shared'
 import { computed, reactive, ref } from 'vue'
 import { useMousePressed } from '@vueuse/core'
 
-const el = ref<Element | null>()
+const el = ref<HTMLElement | null>()
 const [withTarget, toggle] = useToggle()
-const target = computed<Element | null>(() => {
-  if (withTarget.value)
-    return el.value
-  return window as any as Element
-})
+const target = computed<HTMLElement | null>(() =>
+  (withTarget.value ? el.value : window) as HTMLElement,
+)
 
 const mouse = reactive(useMousePressed({ target }))
 const text = stringify(mouse)
@@ -25,11 +23,5 @@ const text = stringify(mouse)
         {{ withTarget ? 'Demo section' : 'Entire page' }}
       </button>
     </div>
-    <!-- <div
-      class="h-40 w-40 bg-green-200 text-green-900 p-3 flex flex-row items-center text-center"
-      @drop.prevent="() => {}"
-    >
-      Drop something here to try drag and drop.
-    </div> -->
   </div>
 </template>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Requires a Ref<HTMLElement>, but passed a Ref<Element>.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

useMousePressed

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
