### PR TITLE
feat(useAsyncState): get a promise function parameter type declaration

### DIFF
--- a/packages/core/useAsyncState/index.ts
+++ b/packages/core/useAsyncState/index.ts
@@ -2,12 +2,12 @@ import { noop, promiseTimeout } from '@vueuse/shared'
 import type { Ref, UnwrapRef } from 'vue-demi'
 import { ref, shallowRef } from 'vue-demi'
 
-export interface UseAsyncStateReturn<Data,Params extends any[] ,Shallow extends boolean> {
+export interface UseAsyncStateReturn<Data, Params extends any[], Shallow extends boolean> {
   state: Shallow extends true ? Ref<Data> : Ref<UnwrapRef<Data>>
   isReady: Ref<boolean>
   isLoading: Ref<boolean>
   error: Ref<unknown>
-  execute: (delay?:number,...args: Params) => Promise<Data>
+  execute: (delay?: number, ...args: Params) => Promise<Data>
 }
 
 export interface UseAsyncStateOptions<Shallow extends boolean, D = any> {
@@ -74,11 +74,11 @@ export interface UseAsyncStateOptions<Shallow extends boolean, D = any> {
  * @param initialState    The initial state, used until the first evaluation finishes
  * @param options
  */
-export function useAsyncState<Data,Params extends any[], Shallow extends boolean = true>(
+export function useAsyncState<Data, Params extends any[], Shallow extends boolean = true>(
   promise: Promise<Data> | ((...args: Params) => Promise<Data>),
   initialState: Data,
   options?: UseAsyncStateOptions<Shallow, Data>,
-): UseAsyncStateReturn<Data,Params, Shallow> {
+): UseAsyncStateReturn<Data, Params, Shallow> {
   const {
     immediate = true,
     delay = 0,

--- a/packages/core/useAsyncState/index.ts
+++ b/packages/core/useAsyncState/index.ts
@@ -2,12 +2,12 @@ import { noop, promiseTimeout } from '@vueuse/shared'
 import type { Ref, UnwrapRef } from 'vue-demi'
 import { ref, shallowRef } from 'vue-demi'
 
-export interface UseAsyncStateReturn<Data, Shallow extends boolean> {
+export interface UseAsyncStateReturn<Data,Params extends any[] ,Shallow extends boolean> {
   state: Shallow extends true ? Ref<Data> : Ref<UnwrapRef<Data>>
   isReady: Ref<boolean>
   isLoading: Ref<boolean>
   error: Ref<unknown>
-  execute: (delay?: number, ...args: any[]) => Promise<Data>
+  execute: (delay?:number,...args: Params) => Promise<Data>
 }
 
 export interface UseAsyncStateOptions<Shallow extends boolean, D = any> {
@@ -74,11 +74,11 @@ export interface UseAsyncStateOptions<Shallow extends boolean, D = any> {
  * @param initialState    The initial state, used until the first evaluation finishes
  * @param options
  */
-export function useAsyncState<Data, Shallow extends boolean = true>(
-  promise: Promise<Data> | ((...args: any[]) => Promise<Data>),
+export function useAsyncState<Data,Params extends any[], Shallow extends boolean = true>(
+  promise: Promise<Data> | ((...args: Params) => Promise<Data>),
   initialState: Data,
   options?: UseAsyncStateOptions<Shallow, Data>,
-): UseAsyncStateReturn<Data, Shallow> {
+): UseAsyncStateReturn<Data,Params, Shallow> {
   const {
     immediate = true,
     delay = 0,
@@ -104,7 +104,7 @@ export function useAsyncState<Data, Shallow extends boolean = true>(
       await promiseTimeout(delay)
 
     const _promise = typeof promise === 'function'
-      ? promise(...args)
+      ? promise(...args as Params)
       : promise
 
     try {

--- a/packages/core/useAsyncState/index.ts
+++ b/packages/core/useAsyncState/index.ts
@@ -74,7 +74,7 @@ export interface UseAsyncStateOptions<Shallow extends boolean, D = any> {
  * @param initialState    The initial state, used until the first evaluation finishes
  * @param options
  */
-export function useAsyncState<Data, Params extends any[], Shallow extends boolean = true>(
+export function useAsyncState<Data, Params extends any[] = [], Shallow extends boolean = true>(
   promise: Promise<Data> | ((...args: Params) => Promise<Data>),
   initialState: Data,
   options?: UseAsyncStateOptions<Shallow, Data>,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Add a generic parameter to obtain the type definition of the argument passed to a Promise function.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
