### PR TITLE
fix(useWindowScroll): use `scrollX` instead of `pageXOffset`

### DIFF
--- a/packages/core/useWindowScroll/index.md
+++ b/packages/core/useWindowScroll/index.md
@@ -1,12 +1,6 @@
 ---
 category: Elements
-deprecated: true
 ---
-
-::: warning
-**Deprecated**. Please use `usescroll` instead.
-:::
-
 
 # useWindowScroll
 

--- a/packages/core/useWindowScroll/index.ts
+++ b/packages/core/useWindowScroll/index.ts
@@ -17,15 +17,15 @@ export function useWindowScroll({ window = defaultWindow }: ConfigurableWindow =
     }
   }
 
-  const x = ref(window.pageXOffset)
-  const y = ref(window.pageYOffset)
+  const x = ref(window.scrollX)
+  const y = ref(window.scrollY)
 
   useEventListener(
     window,
     'scroll',
     () => {
-      x.value = window.pageXOffset
-      y.value = window.pageYOffset
+      x.value = window.scrollX
+      y.value = window.scrollY
     },
     {
       capture: false,

--- a/packages/core/useWindowScroll/index.ts
+++ b/packages/core/useWindowScroll/index.ts
@@ -4,7 +4,10 @@ import type { ConfigurableWindow } from '../_configurable'
 import { defaultWindow } from '../_configurable'
 
 /**
- * @deprecated Please use [`usescroll`](https://vueuse.org/core/usescroll/#usescroll) instead.
+ * Reactive window scroll.
+ *
+ * @see https://vueuse.org/useWindowScroll
+ * @param options
  */
 export function useWindowScroll({ window = defaultWindow }: ConfigurableWindow = {}) {
   if (!window) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

> **Warning**: **⚠️ Slowing down new functions**
>
> Due to the growing audience of VueUse, we received a huge amount of feature requests and pull requests. It's become harder and harder and recently a bit beyond our capacity to maintain the project. In the near future, **we could like slowing down on accepting new features and prioritize the stability and quality of existing functions. New functions to VueUse may not be accpected**. If you come up some new ideas, we advice you to have them in your codebase first instead of proposing to VueUse. You may iterate them a few time and see how them suite your needs and how them can be generalized. If you **really** believe they are useful to the community, you can create PR with your usercases, we are still happy to hear and discuss. Thank you for your understanding.

### Description

see https://github.com/vueuse/vueuse/discussions/2726.
I think we should keep the `useWindowScroll`.This PR revert this https://github.com/vueuse/vueuse/pull/2659 and use the `window.scrollX` `window.scrollY` to replace `window.pageXOffset` and `window.pageYOffset`, because they are depercated.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
