### PR TITLE
fix(useAsyncValidator): incorrect condition for choosing constructor

### DIFF
--- a/packages/integrations/useAsyncValidator/index.ts
+++ b/packages/integrations/useAsyncValidator/index.ts
@@ -6,7 +6,7 @@ import type { Ref } from 'vue-demi'
 import { computed, ref, watchEffect } from 'vue-demi'
 
 // @ts-expect-error Schema.default is exist in ssr mode
-const AsyncValidatorSchema = Schema || Schema.default
+const AsyncValidatorSchema = Schema.default || Schema
 
 export type AsyncValidatorError = Error & {
   errors: ValidateError[]


### PR DESCRIPTION

### Description

I made a stupid mistake on #2761 😔, my solution is based on my comment on the issue https://github.com/vueuse/vueuse/issues/2497#issuecomment-1416852748. 
![image](https://user-images.githubusercontent.com/32102033/219880397-b2688931-a0db-46df-b954-eec73d3f0dcd.png)

I try to get the constructor from the default attribute (it exists on SSR mode), if doesn't exist use Schema like before PR. 
Nothing broke because it didn't work before, but it is good to fix one. 


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
