### PR TITLE
feat(createGlobalState): allow passing initial args

### DIFF
--- a/packages/shared/createGlobalState/index.ts
+++ b/packages/shared/createGlobalState/index.ts
@@ -1,6 +1,6 @@
 import { effectScope } from 'vue-demi'
 
-export type CreateGlobalStateReturn<T> = () => T
+export type CreateGlobalStateReturn<T> = (...args: any[]) => T
 
 /**
  * Keep states in the global scope to be reusable across Vue instances.
@@ -9,15 +9,15 @@ export type CreateGlobalStateReturn<T> = () => T
  * @param stateFactory A factory function to create the state
  */
 export function createGlobalState<T>(
-  stateFactory: () => T,
+  stateFactory: (...args: any[]) => T,
 ): CreateGlobalStateReturn<T> {
   let initialized = false
   let state: T
   const scope = effectScope(true)
 
-  return () => {
+  return (...args: any[]) => {
     if (!initialized) {
-      state = scope.run(stateFactory)!
+      state = scope.run(() => stateFactory(...args))!
       initialized = true
     }
     return state

--- a/packages/shared/createGlobalState/index.ts
+++ b/packages/shared/createGlobalState/index.ts
@@ -1,25 +1,23 @@
 import { effectScope } from 'vue-demi'
 
-export type CreateGlobalStateReturn<T> = (...args: any[]) => T
-
 /**
  * Keep states in the global scope to be reusable across Vue instances.
  *
  * @see https://vueuse.org/createGlobalState
  * @param stateFactory A factory function to create the state
  */
-export function createGlobalState<T>(
-  stateFactory: (...args: any[]) => T,
-): CreateGlobalStateReturn<T> {
+export function createGlobalState<Fn extends (...args: any[]) => any>(
+  stateFactory: Fn,
+): Fn {
   let initialized = false
-  let state: T
+  let state: any
   const scope = effectScope(true)
 
-  return (...args: any[]) => {
+  return ((...args: any[]) => {
     if (!initialized) {
       state = scope.run(() => stateFactory(...args))!
       initialized = true
     }
     return state
-  }
+  }) as Fn
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

[`createGlobalState`](https://vueuse.org/shared/createGlobalState/) is nice and I wanted to use it for configuring [Anu](https://anu-vue.netlify.app/) instance when vue uses it as a plugin. However, `createGlobalState` doesn't accepts any initial config for initializing global state based on provided config.

### Additional context

This is really simple change but don't forget to review it 👀 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
