### PR TITLE
feat(useCssVar): introduce `observe` option

### DIFF
--- a/packages/core/useCssVar/index.test.ts
+++ b/packages/core/useCssVar/index.test.ts
@@ -1,0 +1,19 @@
+import { useCssVar } from '.'
+
+describe('useCssVar', () => {
+  it('should be defined', () => {
+    expect(useCssVar).toBeDefined()
+  })
+
+  it('should work', () => {
+    const el = document.createElement('div')
+    const color = '--color'
+    el.style.setProperty(color, 'red')
+    const variable = useCssVar(color, el)
+
+    expect(variable.value).toBe('red')
+
+    el.style.setProperty(color, 'blue')
+    expect(variable.value).toBe('blue')
+  })
+})

--- a/packages/core/useCssVar/index.test.ts
+++ b/packages/core/useCssVar/index.test.ts
@@ -15,13 +15,13 @@ describe('useCssVar', () => {
     expect(variable.value).toBe('red')
   })
 
-  it('should work with sync', async () => {
+  it('should work observe', async () => {
     const window = defaultWindow
     const el = document.createElement('div')
     window?.document.body.appendChild(el)
 
     const color = '--color'
-    const variable = useCssVar(color, el, { initialValue: 'red', sync: true })
+    const variable = useCssVar(color, el, { initialValue: 'red', observe: true })
 
     expect(variable.value).toBe('red')
 

--- a/packages/core/useCssVar/index.test.ts
+++ b/packages/core/useCssVar/index.test.ts
@@ -1,3 +1,5 @@
+import { defaultWindow } from '@vueuse/core'
+import { nextTick } from 'vue-demi'
 import { useCssVar } from '.'
 
 describe('useCssVar', () => {
@@ -8,12 +10,23 @@ describe('useCssVar', () => {
   it('should work', () => {
     const el = document.createElement('div')
     const color = '--color'
-    el.style.setProperty(color, 'red')
-    const variable = useCssVar(color, el)
+    const variable = useCssVar(color, el, { initialValue: 'red' })
+
+    expect(variable.value).toBe('red')
+  })
+
+  it('should work with sync', async () => {
+    const window = defaultWindow
+    const el = document.createElement('div')
+    window?.document.body.appendChild(el)
+
+    const color = '--color'
+    const variable = useCssVar(color, el, { initialValue: 'red', sync: true })
 
     expect(variable.value).toBe('red')
 
     el.style.setProperty(color, 'blue')
+    await nextTick()
     expect(variable.value).toBe('blue')
   })
 })

--- a/packages/core/useCssVar/index.ts
+++ b/packages/core/useCssVar/index.ts
@@ -10,10 +10,10 @@ import { unrefElement } from '../unrefElement'
 export interface UseCssVarOptions extends ConfigurableWindow {
   initialValue?: string
   /**
-   * Whether to update synchronously when CSS variables are modified by other means
+   * Use MutationObserver to monitor variable changes
    * @default false
    */
-  sync?: boolean
+  observe?: boolean
 }
 
 /**
@@ -29,7 +29,7 @@ export function useCssVar(
   target?: MaybeElementRef,
   options: UseCssVarOptions = {},
 ) {
-  const { window = defaultWindow, initialValue = '', sync = false } = options
+  const { window = defaultWindow, initialValue = '', observe = false } = options
   const variable = ref(initialValue)
   const elRef = computed(() => unrefElement(target) || window?.document?.documentElement)
 
@@ -42,7 +42,13 @@ export function useCssVar(
     }
   }
 
-  sync && useMutationObserver(elRef, updateCssVar, { attributes: true, window: defaultWindow })
+  if (observe) {
+    useMutationObserver(elRef, updateCssVar, {
+      attributes:
+      true,
+      window,
+    })
+  }
 
   watch(
     [elRef, () => resolveUnref(prop)],

--- a/packages/core/useCssVar/index.ts
+++ b/packages/core/useCssVar/index.ts
@@ -27,6 +27,16 @@ export function useCssVar(
   const variable = ref(initialValue)
   const elRef = computed(() => unrefElement(target) || window?.document?.documentElement)
 
+  if (elRef.value) {
+    const oldSetProperty = elRef.value?.style?.setProperty
+    elRef.value.style.setProperty = function (...args) {
+      const [key, value] = args
+      if (key === resolveUnref(prop))
+        variable.value = value!
+      return oldSetProperty.apply(this, args)
+    }
+  }
+
   watch(
     [elRef, () => resolveUnref(prop)],
     ([el, prop]) => {

--- a/packages/core/useCssVar/index.ts
+++ b/packages/core/useCssVar/index.ts
@@ -1,6 +1,7 @@
+import { useMutationObserver } from '@vueuse/core'
 import { computed, ref, watch } from 'vue-demi'
 import type { MaybeComputedRef } from '@vueuse/shared'
-import { resolveUnref, tryOnMounted } from '@vueuse/shared'
+import { resolveUnref } from '@vueuse/shared'
 import type { ConfigurableWindow } from '../_configurable'
 import { defaultWindow } from '../_configurable'
 import type { MaybeElementRef } from '../unrefElement'
@@ -8,6 +9,11 @@ import { unrefElement } from '../unrefElement'
 
 export interface UseCssVarOptions extends ConfigurableWindow {
   initialValue?: string
+  /**
+   * Whether to update synchronously when CSS variables are modified by other means
+   * @default false
+   */
+  sync?: boolean
 }
 
 /**
@@ -16,37 +22,31 @@ export interface UseCssVarOptions extends ConfigurableWindow {
  * @see https://vueuse.org/useCssVar
  * @param prop
  * @param target
- * @param initialValue
  * @param options
  */
 export function useCssVar(
   prop: MaybeComputedRef<string>,
   target?: MaybeElementRef,
-  { window = defaultWindow, initialValue = '' }: UseCssVarOptions = {},
+  options: UseCssVarOptions = {},
 ) {
+  const { window = defaultWindow, initialValue = '', sync = false } = options
   const variable = ref(initialValue)
   const elRef = computed(() => unrefElement(target) || window?.document?.documentElement)
 
-  tryOnMounted(() => {
-    if (elRef.value) {
-      const oldSetProperty = elRef.value?.style?.setProperty
-      elRef.value.style.setProperty = function (...args) {
-        const [key, value] = args
-        if (key === resolveUnref(prop) && value !== variable.value)
-          variable.value = value!
-        return oldSetProperty.apply(this, args)
-      }
+  function updateCssVar() {
+    const key = resolveUnref(prop)
+    const el = resolveUnref(elRef)
+    if (el && window) {
+      const value = window.getComputedStyle(el).getPropertyValue(key)?.trim()
+      variable.value = value || initialValue
     }
-  })
+  }
+
+  sync && useMutationObserver(elRef, updateCssVar, { attributes: true, window: defaultWindow })
 
   watch(
     [elRef, () => resolveUnref(prop)],
-    ([el, prop]) => {
-      if (el && window) {
-        const value = window.getComputedStyle(el).getPropertyValue(prop)?.trim()
-        variable.value = value || initialValue
-      }
-    },
+    updateCssVar,
     { immediate: true },
   )
 

--- a/packages/core/useCssVar/index.ts
+++ b/packages/core/useCssVar/index.ts
@@ -32,12 +32,13 @@ export function useCssVar(
       const oldSetProperty = elRef.value?.style?.setProperty
       elRef.value.style.setProperty = function (...args) {
         const [key, value] = args
-        if (key === resolveUnref(prop))
+        if (key === resolveUnref(prop) && value !== variable.value)
           variable.value = value!
         return oldSetProperty.apply(this, args)
       }
     }
   })
+
   watch(
     [elRef, () => resolveUnref(prop)],
     ([el, prop]) => {

--- a/packages/core/usePointerSwipe/demo.vue
+++ b/packages/core/usePointerSwipe/demo.vue
@@ -3,7 +3,7 @@ import { computed, ref } from 'vue'
 import { usePointerSwipe } from '@vueuse/core'
 import type { SwipeDirection } from '@vueuse/core'
 
-const target = ref<Element | null>(null)
+const target = ref<HTMLElement | null>(null)
 const container = ref<HTMLElement | null>(null)
 
 const containerWidth = computed(() => container.value?.offsetWidth)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

> **Warning**: **⚠️ Slowing down new functions**
>
> Due to the growing audience of VueUse, we received a huge amount of feature requests and pull requests. It's become harder and harder and recently a bit beyond our capacity to maintain the project. In the near future, **we could like slowing down on accepting new features and prioritize the stability and quality of existing functions. New functions to VueUse may not be accpected**. If you come up some new ideas, we advice you to have them in your codebase first instead of proposing to VueUse. You may iterate them a few time and see how them suite your needs and how them can be generalized. If you **really** believe they are useful to the community, you can create PR with your usercases, we are still happy to hear and discuss. Thank you for your understanding.

### Description

fixed #2799 

Fix css variables out of sync.

I rewrote the setProperty method for HTMLElement, so that the variable.value can be updated when the css variable is set, but I don't know if this is the best solution, or useMutationObserver to monitor DOM property changes, but I think performance will be worse.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
