### PR TITLE
fix: use ts-ignore instead of ts-expect-error for version-specifc errors

### DIFF
--- a/packages/core/useEventBus/index.ts
+++ b/packages/core/useEventBus/index.ts
@@ -49,7 +49,8 @@ export function useEventBus<T = unknown, P = any>(key: EventBusIdentifier<T>): U
 
     const _off = () => off(listener)
     // auto unsubscribe when scope get disposed
-    // @ts-expect-error vue3 and vue2 mis-align
+    // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+    // @ts-ignore vue3 and vue2 mis-align
     scope?.cleanups?.push(_off)
     return _off
   }


### PR DESCRIPTION
### Description

With `@ts-expect-error`, TypeScript will throw when we switched the project's Vue version to Vue 3 and there are no errors here, which is counter-intuitive.

The corresponding ESLint rule's doc says,

> If you are compiling against multiple versions of TypeScript and using `@ts-ignore` to ignore version-specific type errors, this rule might get in your way.

https://typescript-eslint.io/rules/prefer-ts-expect-error/#when-not-to-use-it

I guess Vue-version-specific type errors should be treated in a similar way.

### Additional context

I found this issue when trying to add VueUse to https://github.com/vuejs/ecosystem-ci

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
