### PR TITLE
fix(useFullscreen): handle Safari iOS

### DIFF
--- a/packages/core/useFullscreen/index.ts
+++ b/packages/core/useFullscreen/index.ts
@@ -37,6 +37,15 @@ const functionsMap: FunctionMap[] = [
     'webkitfullscreenchange',
     'webkitfullscreenerror',
   ],
+  // Safari iOS WebKit
+  [
+    'webkitEnterFullscreen',
+    'webkitExitFullscreen',
+    'webkitFullscreenElement',
+    'webkitFullscreenEnabled',
+    'webkitfullscreenchange',
+    'webkitfullscreenerror',
+  ],
   // Old WebKit
   [
     'webkitRequestFullScreen',
@@ -94,8 +103,10 @@ export function useFullscreen(
       return false
     }
     else {
+      const target = unrefElement(targetRef)
+
       for (const m of functionsMap) {
-        if (m[1] in document) {
+        if (m[1] in document || (target && m[1] in target)) {
           map = m
           return true
         }

--- a/packages/core/useFullscreen/index.ts
+++ b/packages/core/useFullscreen/index.ts
@@ -106,7 +106,7 @@ export function useFullscreen(
       const target = unrefElement(targetRef)
 
       for (const m of functionsMap) {
-        if (m[1] in document || (target && m[1] in target)) {
+        if (m[1] in document || (target && m[0] in target)) {
           map = m
           return true
         }


### PR DESCRIPTION
### Description

Apple uses a different webkit function to enter fullscreen. See [HTMLVideoElement](https://developer.apple.com/documentation/webkitjs/htmlvideoelement) and [webkitEnterFullScreen](https://developer.apple.com/documentation/webkitjs/htmlvideoelement/1630649-webkitenterfullscreen) documentation.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
