### PR TITLE
chore: use `node:` protocol when importing built-in modules

### DIFF
--- a/packages/.vitepress/plugins/markdownTransform.ts
+++ b/packages/.vitepress/plugins/markdownTransform.ts
@@ -1,4 +1,4 @@
-import { join, resolve } from 'path'
+import { join, resolve } from 'node:path'
 import type { Plugin } from 'vite'
 import fs from 'fs-extra'
 import { packages } from '../../../meta/packages'

--- a/packages/vite.config.ts
+++ b/packages/vite.config.ts
@@ -1,4 +1,4 @@
-import { resolve } from 'path'
+import { resolve } from 'node:path'
 import { defineConfig } from 'vite'
 import Icons from 'unplugin-icons/vite'
 import IconsResolver from 'unplugin-icons/resolver'

--- a/playgrounds/nuxt3/nuxt.config.mjs
+++ b/playgrounds/nuxt3/nuxt.config.mjs
@@ -1,5 +1,5 @@
-import { dirname, resolve } from 'path'
-import { fileURLToPath } from 'url'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { defineNuxtConfig } from 'nuxt'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))

--- a/playgrounds/vite/vite.config.ts
+++ b/playgrounds/vite/vite.config.ts
@@ -1,4 +1,4 @@
-import { resolve } from 'path'
+import { resolve } from 'node:path'
 import { defineConfig } from 'vite'
 import Vue from '@vitejs/plugin-vue'
 

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,4 +1,4 @@
-import path from 'path'
+import path from 'node:path'
 import assert from 'assert'
 import { execSync as exec } from 'child_process'
 import fs from 'fs-extra'

--- a/scripts/export-size.ts
+++ b/scripts/export-size.ts
@@ -1,4 +1,4 @@
-import { join, resolve } from 'path'
+import { join, resolve } from 'node:path'
 import { markdownTable } from 'markdown-table'
 import { getExportsSize } from 'export-size'
 import filesize from 'filesize'

--- a/scripts/post-docs.ts
+++ b/scripts/post-docs.ts
@@ -1,4 +1,4 @@
-import { basename, dirname } from 'path'
+import { basename, dirname } from 'node:path'
 import fg from 'fast-glob'
 import fs from 'fs-extra'
 import sharp from 'sharp'

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'child_process'
-import path from 'path'
+import path from 'node:path'
 import consola from 'consola'
 import { version } from '../package.json'
 import { packages } from '../meta/packages'

--- a/scripts/rollup.config.ts
+++ b/scripts/rollup.config.ts
@@ -1,5 +1,5 @@
-import fs from 'fs'
-import { resolve } from 'path'
+import fs from 'node:fs'
+import { resolve } from 'node:path'
 import type { Options as ESBuildOptions } from 'rollup-plugin-esbuild'
 import esbuild from 'rollup-plugin-esbuild'
 import dts from 'rollup-plugin-dts'

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -1,4 +1,4 @@
-import { join, resolve } from 'path'
+import { join, resolve } from 'node:path'
 import fs from 'fs-extra'
 import matter from 'gray-matter'
 import YAML from 'js-yaml'

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { resolve } from 'path'
+import { resolve } from 'node:path'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({


### PR DESCRIPTION
`
import path from 'path'
`

->
`
import path from 'node:path'
`

By theway, we can more clearly identify which modules were imported from Node