### PR TITLE
feat: `immediateCallback` for `useTimestamp` & `useRafFn`

### DIFF
--- a/packages/core/useRafFn/index.ts
+++ b/packages/core/useRafFn/index.ts
@@ -23,6 +23,13 @@ export interface UseRafFnOptions extends ConfigurableWindow {
    * @default true
    */
   immediate?: boolean
+
+  /**
+   * Execute the callback immediate after calling this function
+   *
+   * @default false
+   */
+  immediateCallback?: boolean
 }
 
 /**
@@ -35,6 +42,7 @@ export interface UseRafFnOptions extends ConfigurableWindow {
 export function useRafFn(fn: (args: UseRafFnCallbackArguments) => void, options: UseRafFnOptions = {}): Pausable {
   const {
     immediate = true,
+    immediateCallback = false,
     window = defaultWindow,
   } = options
 
@@ -56,7 +64,10 @@ export function useRafFn(fn: (args: UseRafFnCallbackArguments) => void, options:
   function resume() {
     if (!isActive.value && window) {
       isActive.value = true
-      rafId = window.requestAnimationFrame(loop)
+      if (immediateCallback)
+        loop(performance.now())
+      else
+        rafId = window.requestAnimationFrame(loop)
     }
   }
 
@@ -70,6 +81,8 @@ export function useRafFn(fn: (args: UseRafFnCallbackArguments) => void, options:
 
   if (immediate)
     resume()
+  else if (immediateCallback)
+    loop(performance.now())
 
   tryOnScopeDispose(pause)
 

--- a/packages/core/useTimestamp/index.ts
+++ b/packages/core/useTimestamp/index.ts
@@ -27,6 +27,13 @@ export interface UseTimestampOptions<Controls extends boolean> {
   immediate?: boolean
 
   /**
+   * Execute the callback immediate after calling this function
+   *
+   * @default false
+   */
+  immediateCallback?: boolean
+
+  /**
    * Update interval, or use requestAnimationFrame
    *
    * @default requestAnimationFrame
@@ -51,6 +58,7 @@ export function useTimestamp(options: UseTimestampOptions<boolean> = {}) {
     controls: exposeControls = false,
     offset = 0,
     immediate = true,
+    immediateCallback = false,
     interval = 'requestAnimationFrame',
     callback,
   } = options
@@ -66,8 +74,8 @@ export function useTimestamp(options: UseTimestampOptions<boolean> = {}) {
     : update
 
   const controls: Pausable = interval === 'requestAnimationFrame'
-    ? useRafFn(cb, { immediate })
-    : useIntervalFn(cb, interval, { immediate })
+    ? useRafFn(cb, { immediate, immediateCallback })
+    : useIntervalFn(cb, interval, { immediate, immediateCallback })
 
   if (exposeControls) {
     return {

--- a/packages/shared/useIntervalFn/index.ts
+++ b/packages/shared/useIntervalFn/index.ts
@@ -61,6 +61,8 @@ export function useIntervalFn(cb: Fn, interval: MaybeComputedRef<number> = 1000,
 
   if (immediate && isClient)
     resume()
+  else if (immediateCallback)
+    cb()
 
   if (isRef(interval) || isFunction(interval)) {
     const stopWatch = watch(interval, () => {


### PR DESCRIPTION
### Description

`immediateCallback` option for `useTimestamp` & `useRafFn` functions

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
