### PR TITLE
chore: use node: protocol when importing built-in modules

### DIFF
--- a/packages/metadata/scripts/update.ts
+++ b/packages/metadata/scripts/update.ts
@@ -1,4 +1,4 @@
-import { join, relative, resolve } from 'path'
+import { join, relative, resolve } from 'node:path'
 import fs from 'fs-extra'
 import matter from 'gray-matter'
 import type { PackageIndexes, VueUseFunction, VueUsePackage } from '@vueuse/metadata'

--- a/packages/nuxt/index.ts
+++ b/packages/nuxt/index.ts
@@ -1,5 +1,5 @@
-import { dirname, resolve } from 'path'
-import { fileURLToPath } from 'url'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { isPackageExists } from 'local-pkg'
 import { defineNuxtModule } from '@nuxt/kit'
 import { metadata } from '@vueuse/metadata'

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import assert from 'assert'
+import assert from 'node:assert'
 import { execSync as exec } from 'child_process'
 import fs from 'fs-extra'
 import fg from 'fast-glob'

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process'
+import { execSync } from 'node:child_process'
 import path from 'node:path'
 import consola from 'consola'
 import { version } from '../package.json'

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process'
+import { execSync } from 'node:child_process'
 import { readJSONSync } from 'fs-extra'
 import { updateContributors } from './utils'
 


### PR DESCRIPTION
import assert from 'assert'
import { execSync } from 'child_process'
->
import assert from 'node:assert'
import { execSync } from 'node:child_process'

