### PR TITLE
Fix misleading documentation using refetch option

### DIFF
--- a/packages/core/useFetch/index.md
+++ b/packages/core/useFetch/index.md
@@ -37,12 +37,12 @@ const { isFetching, error, data } = await useFetch(url)
 
 ### Refetching on URL change
 
-Using a `ref` for the url parameter will allow the `useFetch` function to automatically trigger another request when the url is changed.
+Using a `ref` for the url parameter will allow the `useFetch` function to automatically trigger another request when the url is changed. However, `url` must be callable.
 
 ```ts
 const url = ref('https://my-api.com/user/1')
 
-const { data } = useFetch(url, { refetch: true })
+const { data } = useFetch(() => url, { refetch: true })
 
 url.value = 'https://my-api.com/user/2' // Will trigger another request
 ```

--- a/packages/core/useFetch/index.md
+++ b/packages/core/useFetch/index.md
@@ -37,7 +37,7 @@ const { isFetching, error, data } = await useFetch(url)
 
 ### Refetching on URL change
 
-Using a `ref` for the url parameter will allow the `useFetch` function to automatically trigger another request when the url is changed. However, `url` must be callable.
+Using a `ref` for the url parameter will allow the `useFetch` function to automatically trigger another request when the url is changed. However, `url` must be passed to `useFetch` as a callable.
 
 ```ts
 const url = ref('https://my-api.com/user/1')


### PR DESCRIPTION
Hello. I noticed that the documentation has left out that the url ref has to be called when using `refetch: true`.

I've tried this in two different projects, and it worked the same in both.  
I'm using `useFetch` from `@vueuse/core`  
If url ref isn't passed as a callable function, no refetching occurs.

Additionally, I've checked the tests, and there isn't a test for `refetch: true` that checks if refetch was called with the new url.