### PR TITLE
chore: fix typo

### DIFF
--- a/packages/core/useStorage/index.md
+++ b/packages/core/useStorage/index.md
@@ -41,7 +41,7 @@ localStorage.setItem('my-store', '{"hello": "hello"}')
 
 const state = useStorage('my-store', { hello: 'hi', greeting: 'hello' }, localStorage)
 
-console.log(state.greeting) // undefined, since the value is not presented in storage
+console.log(state.value.greeting) // undefined, since the value is not presented in storage
 ```
 
 To solve that, you can enable `mergeDefaults` option.


### PR DESCRIPTION
### Description

`state` is a `Ref` so it doesn't make sense call `state.greeting`.

```diff
- console.log(state.greeting) // undefined, since the value is not presented in storage
+ console.log(state.value.greeting) // undefined, since the value is not presented in storage
```


### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other
