### PR TITLE
docs(useBreakpoints): add usage restrictions with examples

### DIFF
--- a/packages/core/useBreakpoints/index.md
+++ b/packages/core/useBreakpoints/index.md
@@ -8,6 +8,8 @@ Reactive viewport breakpoints
 
 ## Usage
 
+### Basic API 
+
 ```js
 import { breakpointsTailwind, useBreakpoints } from '@vueuse/core'
 
@@ -30,3 +32,46 @@ const breakpoints = useBreakpoints({
 
 const laptop = breakpoints.between('laptop', 'desktop')
 ```
+
+### Usage Restrictions
+
+The functions that are returned on the breakpoints object are also composables and are required to be called in a component setup context.
+
+#### Correct Usage
+
+```html
+<script setup>
+import { useBreakpoints } from '@vueuse/core'
+
+const breakpoints = useBreakpoints(breakpointsTailwind)
+const smallerThanLarge = breakpoints.smaller('lg')
+const greaterThanSmall = breakpoints.greater('sm')
+
+const location = computed(() => greaterThanSmall.value ? 'top' : 'bottom')
+</script>
+
+<template>
+  <example-component v-if="smallerThanLarge" />
+  <another-component :location="location" />
+</template>
+```
+
+#### Incorrect Usage
+
+```html
+
+<script setup>
+import {useBreakpoints} from '@vueuse/core'
+
+const breakpoints = useBreakpoints(breakpointsTailwind);
+const location = computed(() => breakpoints.greater('sm').value ? 'top' : 'bottom');
+</script>
+
+<template>
+  <example-component v-if="breakpoints.smaller('lg')" />
+  <another-component :location="location" />
+</template>
+
+```
+
+


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Clarify that the functions exposed by `useBreakpoints()` are also required to be called in the setup context.  


### Additional context

Related to issues brought up in #2608 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [NA] Ideally, include relevant tests that fail without this PR but pass with it.
