### PR TITLE
feat(useCycleList): allow receiving reactive list

### DIFF
--- a/packages/core/useCycleList/demo.vue
+++ b/packages/core/useCycleList/demo.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { useCycleList } from '@vueuse/core'
+import { ref } from 'vue'
 
-const list = [
+const list = ref([
   'Dog',
   'Cat',
   'Lizard',
@@ -10,7 +11,7 @@ const list = [
   'Dolphin',
   'Octopus',
   'Seal',
-]
+])
 
 const { state, next, prev } = useCycleList(list)
 </script>

--- a/packages/core/useCycleList/index.md
+++ b/packages/core/useCycleList/index.md
@@ -13,7 +13,7 @@ Cycle through a list of items.
 ```ts
 import { useCycleList } from '@vueuse/core'
 
-const list = ref([
+const { state, next, prev } = useCycleList([
   'Dog',
   'Cat',
   'Lizard',
@@ -23,7 +23,6 @@ const list = ref([
   'Octopus',
   'Seal',
 ])
-const { state, next, prev } = useCycleList(list)
 
 console.log(state.value) // 'Dog'
 

--- a/packages/core/useCycleList/index.md
+++ b/packages/core/useCycleList/index.md
@@ -13,7 +13,7 @@ Cycle through a list of items.
 ```ts
 import { useCycleList } from '@vueuse/core'
 
-const { state, next, prev } = useCycleList([
+const list = ref([
   'Dog',
   'Cat',
   'Lizard',
@@ -23,6 +23,7 @@ const { state, next, prev } = useCycleList([
   'Octopus',
   'Seal',
 ])
+const { state, next, prev } = useCycleList(list)
 
 console.log(state.value) // 'Dog'
 

--- a/packages/core/useCycleList/index.test.ts
+++ b/packages/core/useCycleList/index.test.ts
@@ -1,0 +1,74 @@
+import { ref } from 'vue-demi'
+import { useCycleList } from '.'
+
+describe('useCycleList', () => {
+  it('should work with array', () => {
+    const { state, next, prev, index } = useCycleList(['foo', 'bar', 'fooBar'])
+
+    expect(state.value).toBe('foo')
+    expect(index.value).toBe(0)
+
+    next()
+
+    expect(state.value).toBe('bar')
+    expect(index.value).toBe(1)
+
+    prev()
+
+    expect(state.value).toBe('foo')
+    expect(index.value).toBe(0)
+
+    index.value = 2
+
+    expect(state.value).toBe('fooBar')
+    expect(index.value).toBe(2)
+
+    state.value = 'foo'
+
+    expect(state.value).toBe('foo')
+    expect(index.value).toBe(0)
+  })
+
+  it('should work with ref', () => {
+    const list = ref(['foo', 'bar', 'fooBar'])
+
+    const { state, next, prev, index } = useCycleList(list)
+
+    expect(state.value).toBe('foo')
+    expect(index.value).toBe(0)
+
+    next()
+
+    expect(state.value).toBe('bar')
+    expect(index.value).toBe(1)
+
+    prev()
+
+    expect(state.value).toBe('foo')
+    expect(index.value).toBe(0)
+
+    index.value = 2
+
+    expect(state.value).toBe('fooBar')
+    expect(index.value).toBe(2)
+
+    state.value = 'foo'
+
+    expect(state.value).toBe('foo')
+    expect(index.value).toBe(0)
+  })
+
+  describe('when list empty', () => {
+    it('returns the correctly data', () => {
+      const list = ref(['foo', 'bar', 'fooBar'])
+
+      const { state, index } = useCycleList(list)
+
+      list.value = []
+      index.value = 2
+
+      expect(state.value).toBeUndefined()
+      expect(index.value).toBe(0)
+    })
+  })
+})

--- a/packages/core/useCycleList/index.ts
+++ b/packages/core/useCycleList/index.ts
@@ -1,5 +1,7 @@
-import { type Ref, computed, shallowRef, watch } from 'vue-demi'
-import { type MaybeRef, resolveUnref } from '@vueuse/shared'
+import type { Ref } from 'vue-demi'
+import { computed, shallowRef, watch } from 'vue-demi'
+import { resolveRef, resolveUnref } from '@vueuse/shared'
+import type { MaybeComputedRef, MaybeRef } from '@vueuse/shared'
 
 export interface UseCycleListOptions<T> {
   /**
@@ -24,8 +26,9 @@ export interface UseCycleListOptions<T> {
  *
  * @see https://vueuse.org/useCycleList
  */
-export function useCycleList<T>(list: MaybeRef<T[]>, options?: UseCycleListOptions<T>): UseCycleListReturn<T> {
+export function useCycleList<T>(list: MaybeComputedRef<T[]>, options?: UseCycleListOptions<T>): UseCycleListReturn<T> {
   const state = shallowRef(getInitialValue()) as Ref<T>
+  const listRef = resolveRef(list)
 
   const index = computed<number>({
     get() {
@@ -46,7 +49,7 @@ export function useCycleList<T>(list: MaybeRef<T[]>, options?: UseCycleListOptio
   })
 
   function set(i: number) {
-    const targetList = resolveUnref<T[]>(list)
+    const targetList = listRef.value
     const length = targetList.length
     const index = (i % length + length) % length
     const value = targetList[index]
@@ -70,7 +73,7 @@ export function useCycleList<T>(list: MaybeRef<T[]>, options?: UseCycleListOptio
     return resolveUnref(options?.initialValue ?? resolveUnref<T[]>(list)[0]) ?? undefined
   }
 
-  watch(shallowRef(list), () => set(index.value))
+  watch(listRef, () => set(index.value))
 
   return {
     state,


### PR DESCRIPTION


### Description

Allow useCycleList to receive a "ref" list value, this will allow the cycle list to be reactive

### Additional context

This also adds unit tests for useCycleList

---

### What is the purpose of this pull request?

- [ ] Bug fix
- [x] New Feature
- [x] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
