### PR TITLE
feat(useDark): passthrough default handler from `useColorSchema`

### DIFF
--- a/packages/core/useDark/index.ts
+++ b/packages/core/useDark/index.ts
@@ -25,7 +25,7 @@ export interface UseDarkOptions extends Omit<UseColorModeOptions<BasicColorSchem
    *
    * @default undefined
    */
-  onChanged?: (isDark: boolean) => void
+  onChanged?: (isDark: boolean, defaultHandler: ((mode: T | BasicColorSchema) => void), mode: T | BasicColorSchema) => void
 }
 
 /**

--- a/packages/core/useDark/index.ts
+++ b/packages/core/useDark/index.ts
@@ -25,7 +25,7 @@ export interface UseDarkOptions extends Omit<UseColorModeOptions<BasicColorSchem
    *
    * @default undefined
    */
-  onChanged?: (isDark: boolean, defaultHandler: ((mode: T | BasicColorSchema) => void), mode: T | BasicColorSchema) => void
+  onChanged?: (isDark: boolean, defaultHandler: ((mode: BasicColorSchema) => void), mode: BasicColorSchema) => void
 }
 
 /**

--- a/packages/core/useDark/index.ts
+++ b/packages/core/useDark/index.ts
@@ -45,7 +45,7 @@ export function useDark(options: UseDarkOptions = {}) {
     ...options,
     onChanged: (mode, defaultHandler) => {
       if (options.onChanged)
-        options.onChanged?.(mode === 'dark')
+        options.onChanged?.(mode === 'dark', defaultHandler, mode)
       else
         defaultHandler(mode)
     },


### PR DESCRIPTION
### Description

Sometimes you want to hook into the onChanged functionality when the mode is changed, but you still want the default handler to happen.  Currently that is not possible. 

### Additional context

An example of what I was trying to do that caused me to need this functionality:
```js
const isDark = useDark({
    onChanged(dark?: boolean) {
        cookies.set('darkmode', dark ? 1 : 0, { path: '/', sameSite: true });
    },
});
```

Currently, this would cause dark mode to not function because the onChanged removes the default functionality of adding a class to the html tag.

Instead I had to do the following:
```js
const isDark = useDark({
    onChanged(dark?: boolean) {
        if (dark) {
            document.querySelector('html')?.classList.add('dark');
        } else {
            document.querySelector('html')?.classList.remove('dark');
        }
        cookies.set('darkmode', dark ? 1 : 0, { path: '/', sameSite: true });
    },
});
```

However, this is a little terse especially when this functionality is already done behind the scenes with the default hook.  Instead this pull request adds the ability to do the following:
```js
const isDark = useDark({
    onChanged(dark?: boolean, defaultHook, mode) {
        cookies.set('darkmode', dark ? 1 : 0, { path: '/', sameSite: true });
        defaultHook(mode);
    },
});
```

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
