### PR TITLE
feat(useIdle): add `reset` capability

### DIFF
--- a/packages/core/useIdle/index.md
+++ b/packages/core/useIdle/index.md
@@ -16,6 +16,26 @@ const { idle, lastActive } = useIdle(5 * 60 * 1000) // 5 min
 console.log(idle.value) // true or false
 ```
 
+Programatically resetting:
+
+
+```js
+import { watch } from 'vue'
+import { useCounter, useIdle } from '@vueuse/core'
+
+const { inc, count } = useCounter()
+
+const { idle, lastActive, reset } = useIdle(5 * 60 * 1000) // 5 min
+
+watch(idle, (idleValue) => {
+  if (idleValue) {
+    inc()
+    console.log(`Triggered ${count.value} times`)
+    reset() // restarts the idle timer. Does not change lastActive value
+  }
+})
+```
+
 ## Component Usage
 
 ```html

--- a/packages/core/useIdle/index.ts
+++ b/packages/core/useIdle/index.ts
@@ -69,10 +69,8 @@ export function useIdle(
   const onEvent = createFilterWrapper(
     eventFilter,
     () => {
-      idle.value = false
       lastActive.value = timestamp()
-      clearTimeout(timer)
-      timer = setTimeout(() => idle.value = true, timeout)
+      reset()
     },
   )
 
@@ -87,9 +85,13 @@ export function useIdle(
           onEvent()
       })
     }
+
+    reset()
   }
 
-  timer = setTimeout(() => idle.value = true, timeout)
-
-  return { idle, lastActive, reset }
+  return {
+    idle,
+    lastActive,
+    reset,
+  }
 }

--- a/packages/core/useIdle/index.ts
+++ b/packages/core/useIdle/index.ts
@@ -34,6 +34,7 @@ export interface UseIdleOptions extends ConfigurableWindow, ConfigurableEventFil
 export interface UseIdleReturn {
   idle: Ref<boolean>
   lastActive: Ref<number>
+  reset: () => void
 }
 
 /**
@@ -58,6 +59,12 @@ export function useIdle(
   const lastActive = ref(timestamp())
 
   let timer: any
+
+  const reset = () => {
+    idle.value = false
+    clearTimeout(timer)
+    timer = setTimeout(() => idle.value = true, timeout)
+  }
 
   const onEvent = createFilterWrapper(
     eventFilter,
@@ -84,5 +91,5 @@ export function useIdle(
 
   timer = setTimeout(() => idle.value = true, timeout)
 
-  return { idle, lastActive }
+  return { idle, lastActive, reset }
 }


### PR DESCRIPTION
### Description

Add a functionality to reset the timer in useIdle so it can trigger multiple times without user input.
Currently this behaviour can be mimicked by triggering a fake event in the DOM, but this requires knowledge of internals and may have side-effects.

### Additional context

'lastActive' intentionally left untouched when resetted.
Small example included in docs.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
