### PR TITLE
feat(useIntersectionObserver): support for `Pausable` interface

### DIFF
--- a/packages/core/useIntersectionObserver/demo.vue
+++ b/packages/core/useIntersectionObserver/demo.vue
@@ -6,16 +6,24 @@ const root = ref(null)
 const target = ref(null)
 const isVisible = ref(false)
 
+const enabled = ref(true)
+
 useIntersectionObserver(
   target,
   ([{ isIntersecting }]) => {
     isVisible.value = isIntersecting
   },
-  { root },
+  { enabled, root },
 )
 </script>
 
 <template>
+  <div class="text-center">
+    <label class="checkbox">
+      <input v-model="enabled" type="checkbox" name="enabled">
+      <span>Enabled IntersectionObserver</span>
+    </label>
+  </div>
   <div ref="root" class="root">
     <p class="notice">
       Scroll me down!
@@ -40,7 +48,7 @@ useIntersectionObserver(
 .root {
   border: 2px dashed #ccc;
   height: 200px;
-  margin: 0 2rem 1rem;
+  margin: 2rem 1rem;
   overflow-y: scroll;
 }
 .notice {
@@ -56,5 +64,34 @@ useIntersectionObserver(
   padding: 10px;
   max-height: 150px;
   margin: 0 2rem 400px;
+}
+
+.checkbox {
+  @apply inline-flex items-center my-auto cursor-pointer select-none rounded px-2;
+}
+
+.checkbox input {
+  appearance: none;
+  padding: 0;
+  margin: 0;
+  -webkit-print-color-adjust: exact;
+  color-adjust: exact;
+  display: inline-block;
+  vertical-align: middle;
+  background-origin: border-box;
+  user-select: none;
+  flex-shrink: 0;
+  height: 1rem;
+  width: 1rem;
+  @apply bg-gray-400/30;
+  @apply rounded-md h-4 w-4 select-none;
+}
+
+.checkbox input:checked {
+  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e");
+}
+
+.checkbox span {
+  @apply ml-1.5 text-13px opacity-70;
 }
 </style>

--- a/packages/core/useIntersectionObserver/demo.vue
+++ b/packages/core/useIntersectionObserver/demo.vue
@@ -6,22 +6,23 @@ const root = ref(null)
 const target = ref(null)
 const isVisible = ref(false)
 
-const enabled = ref(true)
-
-useIntersectionObserver(
+const { isActive, pause, resume } = useIntersectionObserver(
   target,
   ([{ isIntersecting }]) => {
     isVisible.value = isIntersecting
   },
-  { enabled, root },
+  { root },
 )
 </script>
 
 <template>
   <div class="text-center">
     <label class="checkbox">
-      <input v-model="enabled" type="checkbox" name="enabled">
-      <span>Enabled IntersectionObserver</span>
+      <input
+        :checked="isActive" type="checkbox" name="enabled"
+        @input="($event.target as HTMLInputElement)!.checked ? resume() : pause() "
+      >
+      <span>Enable</span>
     </label>
   </div>
   <div ref="root" class="root">
@@ -64,34 +65,5 @@ useIntersectionObserver(
   padding: 10px;
   max-height: 150px;
   margin: 0 2rem 400px;
-}
-
-.checkbox {
-  @apply inline-flex items-center my-auto cursor-pointer select-none rounded px-2;
-}
-
-.checkbox input {
-  appearance: none;
-  padding: 0;
-  margin: 0;
-  -webkit-print-color-adjust: exact;
-  color-adjust: exact;
-  display: inline-block;
-  vertical-align: middle;
-  background-origin: border-box;
-  user-select: none;
-  flex-shrink: 0;
-  height: 1rem;
-  width: 1rem;
-  @apply bg-gray-400/30;
-  @apply rounded-md h-4 w-4 select-none;
-}
-
-.checkbox input:checked {
-  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e");
-}
-
-.checkbox span {
-  @apply ml-1.5 text-13px opacity-70;
 }
 </style>

--- a/packages/core/useIntersectionObserver/index.ts
+++ b/packages/core/useIntersectionObserver/index.ts
@@ -65,7 +65,7 @@ export function useIntersectionObserver(
 
   const stopWatch = isSupported.value
     ? watch(
-      () => [unrefElement(target), unrefElement(root)] as const,
+      () => [unrefElement(target), unrefElement(root), isActive.value] as const,
       ([el, root]) => {
         cleanup()
 
@@ -97,6 +97,7 @@ export function useIntersectionObserver(
   const stop = () => {
     cleanup()
     stopWatch()
+    isActive.value = false
   }
 
   tryOnScopeDispose(stop)


### PR DESCRIPTION
### Description

Sometimes we want to conditionally enable or disable `useIntersectionObserver`. In the past, we could only use a watch function to enable it when `enabled` is `true` and clean it up when `enabled` is `false`.

```vue
<script setup lang="ts">
import { useIntersectionObserver } from '@vueuse/core';
import { computed, ref, watch } from 'vue';

const elRef = ref<HTMLElement>();
const enabled = computed(() => {
  // Conditional
  return true; // or false
});

let stop: ReturnType<typeof useIntersectionObserver>['stop'];
watch(enabled, enabled => {
  if (!enabled) {
    stop?.();
  } else {
    ({ stop } = useIntersectionObserver(elRef, () => {
      // Do something
    }));
  }
});
</script>
```

With the introduction of support for enabled: MaybeRef<boolean>, we can simplify our code:

```vue
<script setup lang="ts">
import { useIntersectionObserver } from '@vueuse/core';
import { computed, ref } from 'vue';

const elRef = ref<HTMLElement>();
const enabled = computed(() => {
  // Conditional
  return true; // or false
});

useIntersectionObserver(
  elRef,
  () => {
    // Do something
  },
  {
    enabled,
  }
);
</script>
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
