### PR TITLE
fix(useEventBus)!: fix emit parameters type

### DIFF
--- a/packages/core/useEventBus/demo.vue
+++ b/packages/core/useEventBus/demo.vue
@@ -2,7 +2,8 @@
 import { ref } from 'vue'
 import { useEventBus } from '@vueuse/core'
 
-const { on, emit } = useEventBus<string>('vue-use-event-bus')
+const { on, emit } = useEventBus<typeof listener>('vue-use-event-bus')
+
 const message = ref('')
 const news = [
   'Su Bingtian broke the Asian record and entered the Olympic 100-meter race finals as the first person in China-RTHK',
@@ -11,7 +12,10 @@ const news = [
   'China adds two gold medals in Olympic diving and weightlifting',
   'Tokyo Olympic service provokes athletes sleeping in cardboard suitcases and eating canned food, reviewing the Beijing Olympics god-level arrangements',
 ]
-on(_message => message.value = news[Math.floor(Math.random() * news.length)])
+function listener() {
+  return message.value = news[Math.floor(Math.random() * news.length)]
+}
+on(listener)
 </script>
 
 <template>

--- a/packages/core/useEventBus/index.md
+++ b/packages/core/useEventBus/index.md
@@ -11,7 +11,7 @@ A basic event bus.
 ```ts
 import { useEventBus } from '@vueuse/core'
 
-const bus = useEventBus<string>('news')
+const bus = useEventBus<[string]>('news')
 
 const listener = (event: string) => {
   console.log(`news: ${event}`)
@@ -42,7 +42,7 @@ Using `EventBusKey` is the key to bind the event type to the key, similar to Vue
 // fooKey.ts
 import type { EventBusKey } from '@vueuse/core'
 
-export const fooKey: EventBusKey<{ name: foo }> = Symbol('symbol-key')
+export const fooKey: EventBusIdentifier = Symbol('symbol-key')
 ```
 
 ```ts

--- a/packages/core/useEventBus/index.test.ts
+++ b/packages/core/useEventBus/index.test.ts
@@ -10,15 +10,15 @@ describe('useEventBus', () => {
     events.clear()
   })
   it('on event and off listener', () => {
-    const { on, off } = useEventBus<number>('foo')
     const { inc } = useCounter(0)
+    const { on, off } = useEventBus<typeof inc>('foo')
     on(inc)
     off(inc)
     expect(events).toEqual(emptyMap)
   })
   it('on event', () => {
     let event = false
-    const { emit, on, reset } = useEventBus<boolean>('on-event')
+    const { emit, on, reset } = useEventBus<[boolean]>('on-event')
     on((_event) => {
       event = _event
     })
@@ -28,8 +28,8 @@ describe('useEventBus', () => {
     expect(events).toEqual(emptyMap)
   })
   it('once event', () => {
-    const { once, emit, reset } = useEventBus<number>('foo')
     const { inc, count } = useCounter(0)
+    const { once, emit, reset } = useEventBus<typeof inc>('foo')
     once(inc)
     emit()
     emit()
@@ -40,8 +40,8 @@ describe('useEventBus', () => {
   })
 
   it('not off non-exist listener', () => {
-    const bus1 = useEventBus<number>('foo')
-    const bus2 = useEventBus<number>('bar')
+    const bus1 = useEventBus<[number]>('foo')
+    const bus2 = useEventBus<[number]>('bar')
     const listener = vi.fn()
 
     bus1.on(listener)
@@ -51,8 +51,8 @@ describe('useEventBus', () => {
     expect(events.get('bar')).toBeUndefined()
   })
   it('not off other events listener', () => {
-    const bus1 = useEventBus<number>('foo')
-    const bus2 = useEventBus<number>('bar')
+    const bus1 = useEventBus('foo')
+    const bus2 = useEventBus('bar')
     const listener1 = vi.fn()
     const listener2 = vi.fn()
 
@@ -65,7 +65,7 @@ describe('useEventBus', () => {
     expect(events.get('bar')).toBeDefined()
   })
   it('useEventBus off event', () => {
-    const { emit, on, reset } = useEventBus<number>('useEventBus-off')
+    const { emit, on, reset } = useEventBus('useEventBus-off')
     const { count, inc } = useCounter(0)
     on(inc)
 
@@ -81,8 +81,8 @@ describe('useEventBus', () => {
     expect(events).toEqual(emptyMap)
   })
   it('event off event', () => {
-    const event1 = useEventBus<number>('event-off-1')
-    const event2 = useEventBus<number>('event-off-2')
+    const event1 = useEventBus('event-off-1')
+    const event2 = useEventBus('event-off-2')
     const { count, inc } = useCounter(0)
     event2.on(inc)
     event1.emit() // 1
@@ -117,8 +117,8 @@ describe('useEventBus', () => {
   })
 
   it('should work with payload', async () => {
-    const { on, emit } = useEventBus<'inc' | 'dec', number>('counter')
     const counter = useCounter(0)
+    const { on, emit } = useEventBus<['inc' | 'dec', number]>('counter')
     on((event, payload) => counter[event](payload))
     emit('inc', 3)
     expect(counter.count.value).toBe(3)
@@ -128,7 +128,7 @@ describe('useEventBus', () => {
 
   it('the same key, the same listener, will only be triggered once', () => {
     const listener = vitest.fn()
-    const { on, emit, off } = useEventBus<'inc' | 'dec', number>('counter')
+    const { on, emit, off } = useEventBus('counter')
     on(listener)
     on(listener)
     emit()

--- a/packages/core/useEventBus/internal.ts
+++ b/packages/core/useEventBus/internal.ts
@@ -1,4 +1,4 @@
 import type { EventBusEvents, EventBusIdentifier } from '.'
 
 /* #__PURE__ */
-export const events = new Map<EventBusIdentifier<any>, EventBusEvents<any>>()
+export const events = new Map<EventBusIdentifier, EventBusEvents>()


### PR DESCRIPTION
<!-- Thank you for contributing! -->

> **Warning**: **⚠️ Slowing down new functions**
>
> Due to the growing audience of VueUse, we received a huge amount of feature requests and pull requests. It's become harder and harder and recently a bit beyond our capacity to maintain the project. In the near future, **we could like slowing down on accepting new features and prioritize the stability and quality of existing functions. New functions to VueUse may not be accpected**. If you come up some new ideas, we advice you to have them in your codebase first instead of proposing to VueUse. You may iterate them a few time and see how them suite your needs and how them can be generalized. If you **really** believe they are useful to the community, you can create PR with your usercases, we are still happy to hear and discuss. Thank you for your understanding.

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

I found that when using useEventBus, we enforced a limit of 2 parameters for emit, but in actual use, we may need to pass more parameters, so I changed the generic type of useEventBus to pass a function type or Tuple to limit The parameter type of emit.


### Additional context

Expect:

```ts
const { on, emit } = useEventBus<string, number>('foo')

function listener(name: string, age: number, callback: Function) {
  console.log(name, age)
}
on(listener)

//  success
emit('vi', 18, () => {
  console.log('callback')
})

```

Actual:
```ts

const { on, emit } = useEventBus<string, number>('foo')

function listener(name: string, age: number, callback: Function) {
  callback()
}

// TS2345: Argument of type '(name: string, age: number, callback: Function) => void' is not assignable to parameter of type 'EventBusListener '.
on(listener)

// TS2554: Expected 0-2 arguments, but got 3.
emit('vi', 18, () => {
  console.log('callback')
})
```


After repair:

```ts

// transfer function type Tuple type
const { on, emit } = useEventBus<typeof listener>('foo')

function listener(name: string, age: number, callback: Function) {
  callback()
}
//  success
on(listener)

//  success
emit('vi', 18, () => {
  console.log('callback')
})
```


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
