### PR TITLE
feat(useAsyncValidator): add `manual` option

### DIFF
--- a/packages/integrations/useAsyncValidator/index.test.ts
+++ b/packages/integrations/useAsyncValidator/index.test.ts
@@ -273,32 +273,6 @@ describe('set manual true', () => {
   })
 
   it('manual trigger validator', async () => {
-    const rules: Rules = {
-      name: {
-        type: 'string',
-        min: 5,
-        max: 20,
-        message: 'name length must be 5-20',
-      },
-      age: {
-        type: 'number',
-      },
-    }
-    const { execute } = useAsyncValidator(form, rules, { manual: true })
-    const { pass, errors } = await execute()
-    expect(pass).toBe(false)
-    expect(errors).toMatchInlineSnapshot(`
-    [
-      {
-        "field": "name",
-        "fieldValue": "jelf",
-        "message": "name length must be 5-20",
-      },
-    ]
-  `)
-  })
-
-  it('should reactive after manual trigger', async () => {
     const form = ref({
       name: 'jelf',
       age: 24,
@@ -317,9 +291,26 @@ describe('set manual true', () => {
     }) as Ref<Rules>
 
     const { execute, pass, errors } = useAsyncValidator(form, rules, { manual: true })
+
+    expect(pass.value).toBe(true)
+    expect(errors.value).toMatchObject([])
+
+    // first trigger
     await execute()
+    expect(pass.value).toBe(false)
+    expect(errors.value).toMatchInlineSnapshot(`
+      [
+        {
+          "field": "name",
+          "fieldValue": "jelf",
+          "message": "name length must be 5-20",
+        },
+      ]
+    `)
+
+    // second trigger
     form.value.name = 'okxiaoliang4'
-    await nextTick()
+    await execute()
     expect(pass.value).toBe(true)
     expect(errors.value).toMatchObject([])
   })

--- a/packages/integrations/useAsyncValidator/index.ts
+++ b/packages/integrations/useAsyncValidator/index.ts
@@ -34,7 +34,16 @@ export interface UseAsyncValidatorOptions {
    * @see https://github.com/yiminghe/async-validator#options
    */
   validateOption?: ValidateOption
+  /**
+   * The validation will be triggered right away for the first time.
+   * Only works when `manual` is not set to true.
+   *
+   * @default true
+   */
   immediate?: boolean
+  /**
+   * If set to true, the validation will not be triggered automatically.
+   */
   manual?: boolean
 }
 
@@ -60,14 +69,12 @@ export function useAsyncValidator(
   const errorInfo = shallowRef<AsyncValidatorError | null>(null)
   const isFinished = ref(true)
   const pass = ref(!immediate || manual)
-  const manualRef = ref(manual)
   const errors = computed(() => errorInfo.value?.errors || [])
   const errorFields = computed(() => errorInfo.value?.fields || {})
 
   const validator = computed(() => new AsyncValidatorSchema(resolveUnref(rules)))
 
   const execute = async (): Promise<UseAsyncValidatorExecuteReturn> => {
-    manualRef.value = false
     isFinished.value = false
     pass.value = false
 
@@ -91,14 +98,13 @@ export function useAsyncValidator(
     }
   }
 
-  watch(
-    [valueRef, validator],
-    () => {
-      if (!manualRef.value)
-        execute()
-    },
-    { immediate, deep: true },
-  )
+  if (!manual) {
+    watch(
+      [valueRef, validator],
+      () => execute(),
+      { immediate, deep: true },
+    )
+  }
 
   const shell = {
     isFinished,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description
The watch function does not run until execute is triggered（Set up `{immediate:false}`）

Form values are monitored only after they are manually triggered
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5dd5b9c</samp>

Improved `useAsyncValidator` by adding a `disableWatchRun` variable to control the validation function execution. This fixes some issues with the `immediate` option and stable values or validators.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5dd5b9c</samp>

*  Add a reactive variable `disableWatchRun` to control the validation execution ([link](https://github.com/vueuse/vueuse/pull/2903/files?diff=unified&w=0#diff-a2134b7bd11b86a72044a6ce93711daaa2193cee9eab720b711a9b32ecd44bc9R61))
*  Set `disableWatchRun` to `false` after the first validation run ([link](https://github.com/vueuse/vueuse/pull/2903/files?diff=unified&w=0#diff-a2134b7bd11b86a72044a6ce93711daaa2193cee9eab720b711a9b32ecd44bc9R68))
*  Check `disableWatchRun` before running the validation in the `watch` effect ([link](https://github.com/vueuse/vueuse/pull/2903/files?diff=unified&w=0#diff-a2134b7bd11b86a72044a6ce93711daaa2193cee9eab720b711a9b32ecd44bc9L92-R97))
