### PR TITLE
feat(useBreakpoints): getting current breakpoints

### DIFF
--- a/packages/core/useBreakpoints/demo.vue
+++ b/packages/core/useBreakpoints/demo.vue
@@ -5,25 +5,25 @@ const breakpoints = useBreakpoints(breakpointsTailwind)
 
 const smWidth = breakpointsTailwind.sm
 
-const activeBreakpoint = breakpoints.getCurrent()
-const sm = breakpoints.smaller('sm')
-const sme = breakpoints.smallerOrEqual('sm')
-const md = breakpoints.between('sm', 'md')
-const lg = breakpoints.between('md', 'lg')
-const xl = breakpoints.between('lg', 'xl')
-const xxl = breakpoints.between('xl', '2xl')
-const xxxl = breakpoints['2xl']
+const current = breakpoints.current()
+const xs = breakpoints.smaller('sm')
+const xse = breakpoints.smallerOrEqual('sm')
+const sm = breakpoints.between('sm', 'md')
+const md = breakpoints.between('md', 'lg')
+const lg = breakpoints.between('lg', 'xl')
+const xl = breakpoints.between('xl', '2xl')
+const xxl = breakpoints['2xl']
 </script>
 
 <template>
   <div class="font-mono">
-    <div> Current breakpoint: {{ activeBreakpoint }} </div>
-    <div> sm(&lt;{{ smWidth }}px): <BooleanDisplay :value="sm" /></div>
-    <div> sm(&lt;={{ smWidth }}px): <BooleanDisplay :value="sme" /></div>
+    <div> Current breakpoints: {{ current }} </div>
+    <div> xs(&lt;{{ smWidth }}px): <BooleanDisplay :value="xs" /></div>
+    <div> xs(&lt;={{ smWidth }}px): <BooleanDisplay :value="xse" /></div>
+    <div> sm: <BooleanDisplay :value="sm" /></div>
     <div> md: <BooleanDisplay :value="md" /></div>
     <div> lg: <BooleanDisplay :value="lg" /></div>
     <div> xl: <BooleanDisplay :value="xl" /></div>
     <div>2xl: <BooleanDisplay :value="xxl" /></div>
-    <div>3xl: <BooleanDisplay :value="xxxl" /></div>
   </div>
 </template>

--- a/packages/core/useBreakpoints/demo.vue
+++ b/packages/core/useBreakpoints/demo.vue
@@ -5,6 +5,7 @@ const breakpoints = useBreakpoints(breakpointsTailwind)
 
 const smWidth = breakpointsTailwind.sm
 
+const activeBreakpoint = breakpoints.getCurrent()
 const sm = breakpoints.smaller('sm')
 const sme = breakpoints.smallerOrEqual('sm')
 const md = breakpoints.between('sm', 'md')
@@ -16,6 +17,7 @@ const xxxl = breakpoints['2xl']
 
 <template>
   <div class="font-mono">
+    <div> Current breakpoint: {{ activeBreakpoint }} </div>
     <div> sm(&lt;{{ smWidth }}px): <BooleanDisplay :value="sm" /></div>
     <div> sm(&lt;={{ smWidth }}px): <BooleanDisplay :value="sme" /></div>
     <div> md: <BooleanDisplay :value="md" /></div>

--- a/packages/core/useBreakpoints/index.md
+++ b/packages/core/useBreakpoints/index.md
@@ -4,7 +4,7 @@ category: Browser
 
 # useBreakpoints
 
-Reactive viewport breakpoints
+Reactive viewport breakpoints.
 
 ## Usage
 

--- a/packages/core/useBreakpoints/index.ts
+++ b/packages/core/useBreakpoints/index.ts
@@ -77,6 +77,9 @@ export function useBreakpoints<K extends string>(breakpoints: Breakpoints<K>, op
     isInBetween(a: K, b: K) {
       return match(`(min-width: ${getValue(a)}) and (max-width: ${getValue(b, -0.1)})`)
     },
+    getCurrent() {
+      return ((Object.entries(shortcutMethods) as [string, Ref<boolean>][]).find(([_k, isActive]) => isActive.value) || [undefined])[0]
+    },
     ...shortcutMethods,
   }
 }
@@ -92,4 +95,5 @@ export type UseBreakpointsReturn<K extends string = string> = {
   isSmaller(k: K): boolean
   isSmallerOrEqual(k: K): boolean
   isInBetween(a: K, b: K): boolean
+  getCurrent: () => string | undefined
 } & Record<K, Ref<boolean>>

--- a/packages/core/useBreakpoints/index.ts
+++ b/packages/core/useBreakpoints/index.ts
@@ -1,5 +1,6 @@
-import type { Ref } from 'vue-demi'
+import type { ComputedRef, Ref } from 'vue-demi'
 import { increaseWithUnit } from '@vueuse/shared'
+import { computed } from 'vue-demi'
 import { useMediaQuery } from '../useMediaQuery'
 import type { ConfigurableWindow } from '../_configurable'
 import { defaultWindow } from '../_configurable'
@@ -48,7 +49,7 @@ export function useBreakpoints<K extends string>(breakpoints: Breakpoints<K>, op
       return shortcuts
     }, {} as Record<K, Ref<boolean>>)
 
-  return {
+  return Object.assign(shortcutMethods, {
     greater(k: K) {
       return useMediaQuery(`(min-width: ${getValue(k, 0.1)})`, options)
     },
@@ -77,23 +78,23 @@ export function useBreakpoints<K extends string>(breakpoints: Breakpoints<K>, op
     isInBetween(a: K, b: K) {
       return match(`(min-width: ${getValue(a)}) and (max-width: ${getValue(b, -0.1)})`)
     },
-    getCurrent() {
-      return ((Object.entries(shortcutMethods) as [string, Ref<boolean>][]).find(([_k, isActive]) => isActive.value) || [undefined])[0]
+    current() {
+      const points = Object.keys(breakpoints).map(i => [i, greaterOrEqual(i as K)] as const)
+      return computed(() => points.filter(([, v]) => v.value).map(([k]) => k))
     },
-    ...shortcutMethods,
-  }
+  })
 }
 
 export type UseBreakpointsReturn<K extends string = string> = {
-  greater: (k: K) => Ref<boolean>
-  greaterOrEqual: (k: K) => Ref<boolean>
-  smaller(k: K): Ref<boolean>
-  smallerOrEqual: (k: K) => Ref<boolean>
-  between(a: K, b: K): Ref<boolean>
+  greater: (k: K) => ComputedRef<boolean>
+  greaterOrEqual: (k: K) => ComputedRef<boolean>
+  smaller(k: K): ComputedRef<boolean>
+  smallerOrEqual: (k: K) => ComputedRef<boolean>
+  between(a: K, b: K): ComputedRef<boolean>
   isGreater(k: K): boolean
   isGreaterOrEqual(k: K): boolean
   isSmaller(k: K): boolean
   isSmallerOrEqual(k: K): boolean
   isInBetween(a: K, b: K): boolean
-  getCurrent: () => string | undefined
-} & Record<K, Ref<boolean>>
+  current(): ComputedRef<string[]>
+} & Record<K, ComputedRef<boolean>>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Tells the current active breakpoint based on provided configuration to `useBreakpoint`.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at db83bf0</samp>

This pull request adds a new feature to `useBreakpoints` that returns the current breakpoint name. It also updates the demo component and the type definition to showcase and support the new feature.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at db83bf0</samp>

* Add a new method `getCurrent` to the `useBreakpoints` function that returns the current breakpoint name or undefined ([link](https://github.com/vueuse/vueuse/pull/2906/files?diff=unified&w=0#diff-25935b5753c91a90a4f387fae1ea6121f0bf710f97938aa906b591dee12146edR80-R82),[link](https://github.com/vueuse/vueuse/pull/2906/files?diff=unified&w=0#diff-25935b5753c91a90a4f387fae1ea6121f0bf710f97938aa906b591dee12146edR98))
* Use the `getCurrent` method in the demo component to create a variable `activeBreakpoint` that reflects the window width ([link](https://github.com/vueuse/vueuse/pull/2906/files?diff=unified&w=0#diff-36e7b9bb81632075337227b9fbfd7d37713e483e122a00fe31fef310bcb31c1cR8))
* Display the value of `activeBreakpoint` in a new `<div>` element in the demo component ([link](https://github.com/vueuse/vueuse/pull/2906/files?diff=unified&w=0#diff-36e7b9bb81632075337227b9fbfd7d37713e483e122a00fe31fef310bcb31c1cR20))
