### PR TITLE
chore: resolve path

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -28,7 +28,7 @@ assert(process.cwd() !== __dirname)
 
 async function buildMetaFiles() {
   for (const { name } of packages) {
-    const packageRoot = path.resolve(__dirname, '..', 'packages', name)
+    const packageRoot = path.resolve(rootDir, 'packages', name)
     const packageDist = path.resolve(packageRoot, 'dist')
 
     if (name === 'core')


### PR DESCRIPTION
befor:
const rootDir = path.resolve(__dirname, _'..')
....
const packageRoot = path.resolve(__dirname, '..', 'packages', name)

->

after
const rootDir = path.resolve(__dirname, _'..')
....
const packageRoot = path.resolve(rootDir, 'packages', name)