### PR TITLE
feat(useMounted)!: add `mounted` function

### DIFF
--- a/packages/core/useMounted/demo.vue
+++ b/packages/core/useMounted/demo.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useMounted } from '@vueuse/core'
 
-const isMounted = useMounted()
+const { isMounted } = useMounted()
 </script>
 
 <template>

--- a/packages/core/useMounted/index.md
+++ b/packages/core/useMounted/index.md
@@ -11,7 +11,7 @@ Mounted state in ref.
 ```js
 import { useMounted } from '@vueuse/core'
 
-const isMounted = useMounted()
+const { isMounted, mounted } = useMounted()
 ```
 
 Which is essentially a shorthand of:
@@ -22,4 +22,13 @@ const isMounted = ref(false)
 onMounted(() => {
   isMounted.value = true
 })
+
+function mounted() {
+  return new Promise((resolve) => {
+    if (isMounted.value)
+      resolve()
+    else
+      onMounted(resolve)
+  })
+}
 ```

--- a/packages/core/useMounted/index.ts
+++ b/packages/core/useMounted/index.ts
@@ -16,5 +16,17 @@ export function useMounted() {
     })
   }
 
-  return isMounted
+  function mounted() {
+    return new Promise<void>((resolve) => {
+      if (isMounted.value)
+        resolve()
+      else if (getCurrentInstance())
+        onMounted(resolve)
+    })
+  }
+
+  return {
+    isMounted,
+    mounted,
+  }
 }

--- a/packages/core/useSupported/index.ts
+++ b/packages/core/useSupported/index.ts
@@ -2,7 +2,7 @@ import { computed } from 'vue-demi'
 import { useMounted } from '../useMounted'
 
 export function useSupported(callback: () => unknown) {
-  const isMounted = useMounted()
+  const { isMounted } = useMounted()
 
   return computed(() => {
     // to trigger the ref


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

With `mounted` function, we can perform some operations that need to be executed after the component is mounted, without using an additional
```js
watchEffect(() => {
  if(isMounted.value){
    // ...
  }
})
```

#### Differences from `tryOnMounted`

We can simply use `await mounted()` in an async function without wrapping the function that needs to be executed after `onMounted` in another funciton. like
```js
async function doOnMounted(){
  await mounted()
  // ...
}
```

But this will lead to a breaking change. I'm not sure if these changes are necessary.


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9d75ddf</samp>

The `useMounted` function was enhanced to return an object with a `isMounted` ref and a `mounted` promise. The documentation and the demo were updated accordingly. The `useSupported` function was also refactored to use the new `useMounted` function.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9d75ddf</samp>

* Change the `useMounted` function to return an object with `isMounted` and `mounted` properties ([link](https://github.com/vueuse/vueuse/pull/2935/files?diff=unified&w=0#diff-f153eaf61235d3744c246751dd4a0991e44efda56e2eba4b511aeebf712ce78cL4-R4), [link](https://github.com/vueuse/vueuse/pull/2935/files?diff=unified&w=0#diff-25763ea953d049a096d4d787e3287d5a0a93ffc2a64083e67ead99c051befdcaL19-R31))
* Update the documentation and the demo of the `useMounted` function to reflect the new return value and usage ([link](https://github.com/vueuse/vueuse/pull/2935/files?diff=unified&w=0#diff-fa834b4861786e38ea822fd82656c9b18b90aae4db03bbdd7b9f2fada1efd3e4L14-R14), [link](https://github.com/vueuse/vueuse/pull/2935/files?diff=unified&w=0#diff-fa834b4861786e38ea822fd82656c9b18b90aae4db03bbdd7b9f2fada1efd3e4R25-R33), [link](https://github.com/vueuse/vueuse/pull/2935/files?diff=unified&w=0#diff-f153eaf61235d3744c246751dd4a0991e44efda56e2eba4b511aeebf712ce78cL4-R4))
* Update the `useSupported` function to use the destructured `isMounted` property from the `useMounted` function ([link](https://github.com/vueuse/vueuse/pull/2935/files?diff=unified&w=0#diff-85f391cd10ff3a4a77c0202fb2cac9c91d0c945d405054e77ec63170ad0f08a8L5-R5))
