### PR TITLE
Sticky element has been added to the `useVirtualList` method.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -39,5 +39,11 @@
   "vite.vitepressBase": "packages",
   "vite.vitepressAutoRouting": true,
   "vite.buildCommand": "npm run docs:build",
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "nuxt.isNuxtApp": false,
+  "workbench.colorCustomizations": {
+    "activityBar.background": "#0C332E",
+    "titleBar.activeBackground": "#114741",
+    "titleBar.activeForeground": "#F2FCFB"
+  }
 }

--- a/packages/core/useVirtualList/demo.vue
+++ b/packages/core/useVirtualList/demo.vue
@@ -1,33 +1,3 @@
-<script setup lang="ts">
-import type { Ref } from 'vue'
-import { computed, ref } from 'vue'
-import { useVirtualList } from '@vueuse/core'
-
-const index: Ref = ref()
-const search = ref('')
-
-const allItems = Array.from(Array(99999).keys())
-  .map(i => ({
-    height: i % 2 === 0 ? 42 : 84,
-    size: i % 2 === 0 ? 'small' : 'large',
-  }))
-
-const filteredItems = computed(() => {
-  return allItems.filter(i => i.size.startsWith(search.value.toLowerCase()))
-})
-
-const { list, containerProps, wrapperProps, scrollTo } = useVirtualList(
-  filteredItems,
-  {
-    itemHeight: i => (filteredItems.value[i].height + 8),
-    overscan: 10,
-  },
-)
-function handleScrollTo() {
-  scrollTo(index.value)
-}
-</script>
-
 <template>
   <div>
     <div>
@@ -45,22 +15,74 @@ function handleScrollTo() {
         <input v-model="search" placeholder="e.g. small, medium, large" type="search">
       </div>
     </div>
-    <div v-bind="containerProps" class="h-300px overflow-auto p-2 bg-gray-500/5 rounded">
+    <div v-bind="containerProps" class="h-[500px] overflow-auto p-2 bg-gray-500/5 rounded">
+      <template v-if="stickyItem">
+        <div class="border border-$c-divider mb-2 sticky top-0 z-50 bg-red-300 text-white" :style="{
+          height: `${stickyItem.data.height}px`,
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+        }">
+          Row {{ stickyItem.index }} <span opacity="70" m="l-1">({{ stickyItem.data.size }})</span>
+        </div>
+      </template>
       <div v-bind="wrapperProps">
-        <div
-          v-for="{ index, data } in list"
-          :key="index"
-          class="border border-$c-divider mb-2"
-          :style="{
-            height: `${data.height}px`,
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
-          }"
-        >
+        <div v-for="{ index, data } in showedItems" :key="index" class="border border-$c-divider mb-2" :style="{
+          height: `${data.height}px`,
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+        }">
           Row {{ index }} <span opacity="70" m="l-1">({{ data.size }})</span>
         </div>
       </div>
     </div>
   </div>
 </template>
+
+<script setup lang="ts">
+import type { Ref } from 'vue'
+import { computed, ref } from 'vue'
+import { useVirtualList } from '@vueuse/core';
+
+
+const index: Ref = ref()
+const search = ref('')
+
+const allItems = Array.from(Array(99999).keys())
+  .map(i => ({
+    id: i,
+    height: i % 2 === 0 ? 42 : 84,
+    size: i % 2 === 0 ? 'small' : 'large',
+  }))
+
+const filteredItems = computed(() => {
+  return allItems.filter(i => i.size.startsWith(search.value.toLowerCase()))
+})
+
+
+const showedItems = computed(() => {
+  return list.value.filter(i => i.data.id != stickyItem.value.data.id);
+})
+
+const stickyItem = computed(() => {
+  return list.value[0];
+});
+
+const { list, containerProps, wrapperProps, scrollTo } = useVirtualList(
+  filteredItems,
+  {
+    findStickyItem: (items: any[]) => {
+      return items.find((i: any) => i.index % 2 == 0)
+    },
+    itemHeight: i => (filteredItems.value[i].height + 8),
+    overscan: 10,
+  },
+)
+
+function handleScrollTo() {
+  scrollTo(index.value)
+}
+</script>
+
+

--- a/packages/core/useVirtualList/index.md
+++ b/packages/core/useVirtualList/index.md
@@ -96,6 +96,67 @@ const { list, containerProps, wrapperProps } = useVirtualList(
 </template>
 ```
 
+### Sticky Header
+
+
+Puts the value returned from the `findStickyItem` method at the beginning of the `list`.
+
+#### Param
+
+
+- `items`:  `source.value.slice(0, state.value.start)`
+
+- items between the source list and the visible list start
+
+```html
+  <div v-bind="containerProps" class="h-[500px] overflow-auto p-2 bg-gray-500/5 rounded">
+      <template v-if="stickyItem">
+        <div class="border border-$c-divider mb-2 sticky top-0 z-50 bg-red-300 text-white" :style="{
+          height: `${stickyItem.data.height}px`,
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+        }">
+          Row {{ stickyItem.index }} <span opacity="70" m="l-1">({{ stickyItem.data.size }})</span>
+        </div>
+      </template>
+      <div v-bind="wrapperProps">
+        <div v-for="{ index, data } in showedItems" :key="index" class="border border-$c-divider mb-2" :style="{
+          height: `${data.height}px`,
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+        }">
+          Row {{ index }} <span opacity="70" m="l-1">({{ data.size }})</span>
+        </div>
+      </div>
+    </div>
+```
+
+```typescript
+
+const showedItems = computed(() => {
+  return list.value.filter(i => i.data.id != stickyItem.value.data.id);
+})
+
+const stickyItem = computed(() => {
+  return list.value[0];
+});
+
+const { list, containerProps, wrapperProps, scrollTo } = useVirtualList(
+  filteredItems,
+  {
+    findStickyItem: (items: any[]) => {
+      return items.find((i: any) => i.index % 2 == 0)
+    },
+    itemHeight: i => (filteredItems.value[i].height + 8),
+    overscan: 10,
+  },
+)
+
+```
+
+
 ## Component Usage
 
 ```html


### PR DESCRIPTION
The findStickyElement function i added to the useVirtualList method will always add the element found based on the given condition to the beginning of the visible list.

To access the sticky element, you can define a computed property stickyItem using the Vue.js computed function, as shown in your code example:

```ts
const stickyItem = computed(() => {
  return list.value[0];
});
```

You can render the sticky element in HTML using the following code:

```html
<div v-bind="containerProps" class="h-[500px] overflow-auto p-2 bg-gray-500/5 rounded">
  <template v-if="stickyItem">
    <div class="border border-$c-divider mb-2 sticky top-0 z-50 bg-red-300 text-white" :style="{
      height: `${stickyItem.data.height}px`,
      display: 'flex',
      justifyContent: 'center',
      alignItems: 'center',
    }">
      Row {{ stickyItem.index }} <span opacity="70" m="l-1">({{ stickyItem.data.size }})</span>
    </div>
  </template>
  <div v-bind="wrapperProps">
<div/>
....
```

To render the visible list, you can define another computed property showedItems that filters out the sticky element from the list array, as shown in the following code:

```ts
const showedItems = computed(() => {
  return list.value.filter(i => i.data.id != stickyItem.value.data.id);
});
```

