### PR TITLE
feat(useDraggable): introduce `axis` option

### DIFF
--- a/packages/core/useDraggable/component.ts
+++ b/packages/core/useDraggable/component.ts
@@ -30,6 +30,7 @@ export const UseDraggable = /* #__PURE__ */ defineComponent<UseDraggableProps>({
     'pointerTypes',
     'as',
     'handle',
+    'axis',
   ] as unknown as undefined,
   setup(props, { slots }) {
     const target = ref()

--- a/packages/core/useDraggable/index.ts
+++ b/packages/core/useDraggable/index.ts
@@ -69,6 +69,11 @@ export interface UseDraggableOptions {
    * Callback when dragging end.
    */
   onEnd?: (position: Position, event: PointerEvent) => void
+
+  /**
+   * Axis to drag on.
+   */
+  axis?: 'x' | 'y' | 'both'
 }
 
 /**
@@ -78,36 +83,54 @@ export interface UseDraggableOptions {
  * @param target
  * @param options
  */
-export function useDraggable(target: MaybeComputedRef<HTMLElement | SVGElement | null | undefined>, options: UseDraggableOptions = {}) {
-  const draggingElement = options.draggingElement ?? defaultWindow
-  const draggingHandle = options.handle ?? target
-  const position = ref<Position>(resolveUnref(options.initialValue) ?? { x: 0, y: 0 })
+export function useDraggable(
+  target: MaybeComputedRef<HTMLElement | SVGElement | null | undefined>,
+  options: UseDraggableOptions = {},
+) {
+  const {
+    pointerTypes,
+    preventDefault,
+    stopPropagation,
+    exact,
+    onMove,
+    onEnd,
+    onStart,
+    initialValue,
+    axis = 'both',
+    draggingElement = defaultWindow,
+    handle: draggingHandle = target,
+  } = options
+
+  const position = ref<Position>(
+    resolveUnref(initialValue) ?? { x: 0, y: 0 },
+  )
+
   const pressedDelta = ref<Position>()
 
   const filterEvent = (e: PointerEvent) => {
-    if (options.pointerTypes)
-      return options.pointerTypes.includes(e.pointerType as PointerType)
+    if (pointerTypes)
+      return pointerTypes.includes(e.pointerType as PointerType)
     return true
   }
 
   const handleEvent = (e: PointerEvent) => {
-    if (resolveUnref(options.preventDefault))
+    if (resolveUnref(preventDefault))
       e.preventDefault()
-    if (resolveUnref(options.stopPropagation))
+    if (resolveUnref(stopPropagation))
       e.stopPropagation()
   }
 
   const start = (e: PointerEvent) => {
     if (!filterEvent(e))
       return
-    if (resolveUnref(options.exact) && e.target !== resolveUnref(target))
+    if (resolveUnref(exact) && e.target !== resolveUnref(target))
       return
     const rect = resolveUnref(target)!.getBoundingClientRect()
     const pos = {
       x: e.clientX - rect.left,
       y: e.clientY - rect.top,
     }
-    if (options.onStart?.(pos, e) === false)
+    if (onStart?.(pos, e) === false)
       return
     pressedDelta.value = pos
     handleEvent(e)
@@ -117,11 +140,17 @@ export function useDraggable(target: MaybeComputedRef<HTMLElement | SVGElement |
       return
     if (!pressedDelta.value)
       return
+
+    let { x, y } = position.value
+    if (axis === 'x' || axis === 'both')
+      x = e.clientX - pressedDelta.value.x
+    if (axis === 'y' || axis === 'both')
+      y = e.clientY - pressedDelta.value.y
     position.value = {
-      x: e.clientX - pressedDelta.value.x,
-      y: e.clientY - pressedDelta.value.y,
+      x,
+      y,
     }
-    options.onMove?.(position.value, e)
+    onMove?.(position.value, e)
     handleEvent(e)
   }
   const end = (e: PointerEvent) => {
@@ -130,7 +159,7 @@ export function useDraggable(target: MaybeComputedRef<HTMLElement | SVGElement |
     if (!pressedDelta.value)
       return
     pressedDelta.value = undefined
-    options.onEnd?.(position.value, e)
+    onEnd?.(position.value, e)
     handleEvent(e)
   }
 
@@ -144,7 +173,9 @@ export function useDraggable(target: MaybeComputedRef<HTMLElement | SVGElement |
     ...toRefs(position),
     position,
     isDragging: computed(() => !!pressedDelta.value),
-    style: computed(() => `left:${position.value.x}px;top:${position.value.y}px;`),
+    style: computed(
+      () => `left:${position.value.x}px;top:${position.value.y}px;`,
+    ),
   }
 }
 

--- a/packages/core/useDraggable/index.ts
+++ b/packages/core/useDraggable/index.ts
@@ -72,6 +72,8 @@ export interface UseDraggableOptions {
 
   /**
    * Axis to drag on.
+   *
+   * @default 'both'
    */
   axis?: 'x' | 'y' | 'both'
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Introduce `axis` option to control the dragging direction.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 52196d8</samp>

This pull request adds a new feature to the `useDraggable` function and component, which lets users limit the drag movement to a horizontal or vertical axis. It also improves the code quality and readability of the `useDraggable` implementation.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 52196d8</samp>

*  Add `axis` option to `useDraggable` to enable dragging on specific axis ([link](https://github.com/vueuse/vueuse/pull/2948/files?diff=unified&w=0#diff-f48b1abc8c017b01094c501d677f5bc97cdd1a5d0bd155876ce2a4ff9a8d64faR33), [link](https://github.com/vueuse/vueuse/pull/2948/files?diff=unified&w=0#diff-f4ddcc2e5f178f71f5420d35c60a8b7a2df9d397154e21e85d5dcb1abf6c0ceeR72-R76))
*  Destructure `options` parameter into individual variables for readability and conciseness ([link](https://github.com/vueuse/vueuse/pull/2948/files?diff=unified&w=0#diff-f4ddcc2e5f178f71f5420d35c60a8b7a2df9d397154e21e85d5dcb1abf6c0ceeL81-R119))
*  Replace `options.*` with destructured variables in `useDraggable` logic ([link](https://github.com/vueuse/vueuse/pull/2948/files?diff=unified&w=0#diff-f4ddcc2e5f178f71f5420d35c60a8b7a2df9d397154e21e85d5dcb1abf6c0ceeL103-R126), [link](https://github.com/vueuse/vueuse/pull/2948/files?diff=unified&w=0#diff-f4ddcc2e5f178f71f5420d35c60a8b7a2df9d397154e21e85d5dcb1abf6c0ceeL110-R133), [link](https://github.com/vueuse/vueuse/pull/2948/files?diff=unified&w=0#diff-f4ddcc2e5f178f71f5420d35c60a8b7a2df9d397154e21e85d5dcb1abf6c0ceeL133-R162))
*  Update `position` value according to `axis` option in `onPointerMove` handler ([link](https://github.com/vueuse/vueuse/pull/2948/files?diff=unified&w=0#diff-f4ddcc2e5f178f71f5420d35c60a8b7a2df9d397154e21e85d5dcb1abf6c0ceeL120-R153))
*  Add line break to `style` computed property in `useDraggableComponent` for formatting ([link](https://github.com/vueuse/vueuse/pull/2948/files?diff=unified&w=0#diff-f4ddcc2e5f178f71f5420d35c60a8b7a2df9d397154e21e85d5dcb1abf6c0ceeL147-R178))
