### PR TITLE
feat(useIntersectionObserver): allow multiple targets

### DIFF
--- a/packages/shared/utils/is.ts
+++ b/packages/shared/utils/is.ts
@@ -1,6 +1,7 @@
 /* eslint-disable antfu/top-level-function */
 export const isClient = typeof window !== 'undefined'
 export const isDef = <T = any>(val?: T): val is T => typeof val !== 'undefined'
+export const notNullish = <T = any>(val?: T | null | undefined): val is T => val != null
 export const assert = (condition: boolean, ...infos: any[]) => {
   if (!condition)
     console.warn(...infos)


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

---

### Description

Allow element arrays to be observable when using useIntersectionObserver

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 26f6341</samp>

Enhanced `useIntersectionObserver` hook to allow observing multiple targets with the same settings. Refactored `target` argument to accept an array or a getter function.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 26f6341</samp>

*  Allow observing multiple elements with the same options and callback in `useIntersectionObserver` hook ([link](https://github.com/vueuse/vueuse/pull/2964/files?diff=unified&w=0#diff-83a5f2ed89625b8fb3c7496b7ad419ae2c4a3c71355fbeed68ba6ce98a302b86L3-R7), [link](https://github.com/vueuse/vueuse/pull/2964/files?diff=unified&w=0#diff-83a5f2ed89625b8fb3c7496b7ad419ae2c4a3c71355fbeed68ba6ce98a302b86L49-R49), [link](https://github.com/vueuse/vueuse/pull/2964/files?diff=unified&w=0#diff-83a5f2ed89625b8fb3c7496b7ad419ae2c4a3c71355fbeed68ba6ce98a302b86L68-R78), [link](https://github.com/vueuse/vueuse/pull/2964/files?diff=unified&w=0#diff-83a5f2ed89625b8fb3c7496b7ad419ae2c4a3c71355fbeed68ba6ce98a302b86L86-R97))
