### PR TITLE
fix(useTransition): fix regression with non-linear transition functions

### DIFF
--- a/packages/core/useTransition/index.test.ts
+++ b/packages/core/useTransition/index.test.ts
@@ -158,6 +158,26 @@ describe('useTransition', () => {
     expect(transition.value).toBe(1)
   })
 
+  it('supports non-linear custom easing functions', async () => {
+    const source = ref(0)
+    const easeInQuad = vi.fn(n => n * n)
+    const transition = useTransition(source, {
+      duration: 100,
+      transition: easeInQuad,
+    })
+
+    expect(easeInQuad).not.toBeCalled()
+
+    source.value = 1
+
+    await promiseTimeout(50)
+    expect(easeInQuad).toBeCalled()
+    expectBetween(transition.value, 0, 1)
+
+    await promiseTimeout(100)
+    expect(transition.value).toBe(1)
+  })
+
   it('supports delayed transitions', async () => {
     const source = ref(0)
 

--- a/packages/core/useTransition/index.ts
+++ b/packages/core/useTransition/index.ts
@@ -148,7 +148,9 @@ export function executeTransition<T extends number | number[]>(
   const duration = toValue(options.duration) ?? 1000
   const startedAt = Date.now()
   const endAt = Date.now() + duration
-  const trans = toValue(options.transition) ?? linear
+  const trans = typeof options.transition === 'function'
+    ? options.transition
+    : (toValue(options.transition) ?? linear)
 
   const ease = typeof trans === 'function'
     ? trans


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

There was a regression with [`useTransition`](https://vueuse.org/core/useTransition/) during the change from [`unref` &rarr; `toValue`](https://github.com/vueuse/vueuse/commit/8ec39007b632ec3770d1a83c39d427decb051283#diff-ec536fa62d58e4354eb990775c1a8c9be28c5f8e5c54e1685ae14439e9372df6L151-R151). Non-linear custom easing functions were returning `NaN`. This is due to `toValue` first doing [it's own function check](https://github.com/vueuse/vueuse/blob/main/packages/shared/toValue/index.ts#L9-L11), and returning the output of that function rather than the function itself.

This didn't break linear transitions because those are essentially just identity-functions, which return `undefined` when no input is provided. This led to using the right side of `toValue(...) ?? linear`, and therefor the default linear transition. With _non-linear_ transitions however, that numeric input is necessary, and without it we end up doing arithmetic on `undefined`, which leads to the `NaN`.

I've fixed this with a manual function check, and included a test to cover this situation. Alternatively, we could use the default `unref` function here to avoid the redundant type checking.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fe1ec45</samp>

This pull request adds support for custom easing functions to the `useTransition` function. It modifies the `executeTransition` function to handle function parameters and adds a test case to verify the functionality.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fe1ec45</samp>

*  Allow custom easing functions for `useTransition` ([link](https://github.com/vueuse/vueuse/pull/2973/files?diff=unified&w=0#diff-ec536fa62d58e4354eb990775c1a8c9be28c5f8e5c54e1685ae14439e9372df6L151-R153), [link](https://github.com/vueuse/vueuse/pull/2973/files?diff=unified&w=0#diff-b12566e941bbfd7f93da9e50bb00219458426da2de85d46d64967421002ced1eR161-R180))
  - Add a test case to verify non-linear easing with `easeInQuad` function ([link](https://github.com/vueuse/vueuse/pull/2973/files?diff=unified&w=0#diff-b12566e941bbfd7f93da9e50bb00219458426da2de85d46d64967421002ced1eR161-R180))
