### PR TITLE
feat(useColorMode): expose `state` to the ref, deprecated `emitAuto`

### DIFF
--- a/packages/core/useColorMode/index.test.ts
+++ b/packages/core/useColorMode/index.test.ts
@@ -117,10 +117,10 @@ describe('useColorMode', () => {
     expect(htmlEl?.className).toMatch(/dark/)
   })
 
-  it('should use state to access mode & preference', () => {
-    const state = useColorMode()
-    expect(state.store.value).toBe('auto')
-    expect(state.system.value).toBe('light')
-    expect(state.value).toBe('light')
+  it('should be able access the store & system preference', () => {
+    const mode = useColorMode()
+    expect(mode.store.value).toBe('auto')
+    expect(mode.system.value).toBe('light')
+    expect(mode.state.value).toBe('light')
   })
 })

--- a/packages/core/useColorMode/index.ts
+++ b/packages/core/useColorMode/index.ts
@@ -1,6 +1,6 @@
-import type { Ref } from 'vue-demi'
+import type { ComputedRef, Ref } from 'vue-demi'
 import { computed, ref, watch } from 'vue-demi'
-import type { MaybeRefOrGetter } from '@vueuse/shared'
+import type { MaybeRef, MaybeRefOrGetter } from '@vueuse/shared'
 import { toValue, tryOnMounted } from '@vueuse/shared'
 import type { StorageLike } from '../ssr-handlers'
 import { getSSRHandler } from '../ssr-handlers'
@@ -9,9 +9,10 @@ import { useStorage } from '../useStorage'
 import { defaultWindow } from '../_configurable'
 import { usePreferredDark } from '../usePreferredDark'
 
-export type BasicColorSchema = 'light' | 'dark' | 'auto'
+export type BasicColorMode = 'light' | 'dark'
+export type BasicColorSchema = BasicColorMode | 'auto'
 
-export interface UseColorModeOptions<T extends string = BasicColorSchema> extends UseStorageOptions<T | BasicColorSchema> {
+export interface UseColorModeOptions<T extends string = BasicColorMode> extends UseStorageOptions<T | BasicColorMode> {
   /**
    * CSS Selector for the target element applying to
    *
@@ -31,7 +32,7 @@ export interface UseColorModeOptions<T extends string = BasicColorSchema> extend
    *
    * @default 'auto'
    */
-  initialValue?: T | BasicColorSchema
+  initialValue?: MaybeRef<T | BasicColorSchema>
 
   /**
    * Prefix when adding value to the attribute
@@ -44,7 +45,7 @@ export interface UseColorModeOptions<T extends string = BasicColorSchema> extend
    *
    * @default undefined
    */
-  onChanged?: (mode: T | BasicColorSchema, defaultHandler:((mode: T | BasicColorSchema) => void)) => void
+  onChanged?: (mode: T | BasicColorMode, defaultHandler:((mode: T | BasicColorMode) => void)) => void
 
   /**
    * Custom storage ref
@@ -76,6 +77,8 @@ export interface UseColorModeOptions<T extends string = BasicColorSchema> extend
    * This is useful when the fact that `auto` mode was selected needs to be known.
    *
    * @default undefined
+   * @deprecated use `store.value` when `auto` mode needs to be known
+   * @see https://vueuse.org/core/useColorMode/#advanced-usage
    */
   emitAuto?: boolean
 
@@ -88,10 +91,11 @@ export interface UseColorModeOptions<T extends string = BasicColorSchema> extend
   disableTransition?: boolean
 }
 
-export type UseColorModeReturn<T extends string = BasicColorSchema> =
-  Ref<T> & {
-    store: Ref<T>
-    system: Ref<'light' | 'dark'>
+export type UseColorModeReturn<T extends string = BasicColorMode> =
+  Ref<T | BasicColorSchema> & {
+    store: Ref<T | BasicColorSchema>
+    system: ComputedRef<BasicColorMode>
+    state: ComputedRef<T | BasicColorMode>
   }
 
 /**
@@ -100,7 +104,7 @@ export type UseColorModeReturn<T extends string = BasicColorSchema> =
  * @see https://vueuse.org/useColorMode
  * @param options
  */
-export function useColorMode<T extends string = BasicColorSchema>(
+export function useColorMode<T extends string = BasicColorMode>(
   options: UseColorModeOptions<T> = {},
 ): UseColorModeReturn<T> {
   const {
@@ -128,18 +132,9 @@ export function useColorMode<T extends string = BasicColorSchema>(
 
   const store = storageRef || (storageKey == null
     ? ref(initialValue) as Ref<T | BasicColorSchema>
-    : useStorage<T | BasicColorSchema>(storageKey, initialValue as BasicColorSchema, storage, { window, listenToStorageChanges }))
+    : useStorage<T | BasicColorSchema>(storageKey, initialValue, storage, { window, listenToStorageChanges }))
 
-  const state = computed<T | BasicColorSchema>({
-    get() {
-      return (store.value === 'auto' && !emitAuto)
-        ? system.value
-        : store.value
-    },
-    set(v) {
-      store.value = v
-    },
-  })
+  const state = computed<T | BasicColorMode>(() => store.value === 'auto' ? system.value : store.value)
 
   const updateHTMLAttrs = getSSRHandler(
     'updateHTMLAttrs',
@@ -181,12 +176,11 @@ export function useColorMode<T extends string = BasicColorSchema>(
       }
     })
 
-  function defaultOnChanged(mode: T | BasicColorSchema) {
-    const resolvedMode = mode === 'auto' ? system.value : mode
-    updateHTMLAttrs(selector, attribute, modes[resolvedMode] ?? resolvedMode)
+  function defaultOnChanged(mode: T | BasicColorMode) {
+    updateHTMLAttrs(selector, attribute, modes[mode] ?? mode)
   }
 
-  function onChanged(mode: T | BasicColorSchema) {
+  function onChanged(mode: T | BasicColorMode) {
     if (options.onChanged)
       options.onChanged(mode, defaultOnChanged)
     else
@@ -195,13 +189,13 @@ export function useColorMode<T extends string = BasicColorSchema>(
 
   watch(state, onChanged, { flush: 'post', immediate: true })
 
-  if (emitAuto)
-    watch(system, () => onChanged(state.value), { flush: 'post' })
-
   tryOnMounted(() => onChanged(state.value))
 
   try {
-    return Object.assign(state, { store, system }) as UseColorModeReturn<T>
+    return Object.assign(computed({
+      get() { return emitAuto ? store.value : state.value },
+      set(v) { store.value = v },
+    }), { store, system, state }) as UseColorModeReturn<T>
   }
   catch (e) {
     // In Vue 2.6, ref might not be extensible

--- a/packages/core/useDark/index.ts
+++ b/packages/core/useDark/index.ts
@@ -1,8 +1,6 @@
 import { computed } from 'vue-demi'
-import { defaultWindow } from '../_configurable'
-import { usePreferredDark } from '../usePreferredDark'
-import type { BasicColorSchema, UseColorModeOptions } from '../useColorMode'
 import { useColorMode } from '../useColorMode'
+import type { BasicColorSchema, UseColorModeOptions } from '../useColorMode'
 
 export interface UseDarkOptions extends Omit<UseColorModeOptions<BasicColorSchema>, 'modes' | 'onChanged'> {
   /**
@@ -38,7 +36,6 @@ export function useDark(options: UseDarkOptions = {}) {
   const {
     valueDark = 'dark',
     valueLight = '',
-    window = defaultWindow,
   } = options
 
   const mode = useColorMode({
@@ -55,17 +52,16 @@ export function useDark(options: UseDarkOptions = {}) {
     },
   })
 
-  const preferredDark = usePreferredDark({ window })
-
   const isDark = computed<boolean>({
     get() {
       return mode.value === 'dark'
     },
     set(v) {
-      if (v === preferredDark.value)
+      const modeVal = v ? 'dark' : 'light'
+      if (mode.system.value === modeVal)
         mode.value = 'auto'
       else
-        mode.value = v ? 'dark' : 'light'
+        mode.value = modeVal
     },
   })
 


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Applied some improvements was done in #2023

- Allow `initialValue` to be passed as `ref`
- Deprecated `emitAuto`, in favor of `store.value` when `auto` mode needs to be known
- Expose `state`, so dev won't need to write `computed(() => store.value === 'auto' ? system.value : store.value)` when extracting the `store` value
- Type improvements and fixes, this will help the dev to know exactly the values of `store`, `system`, `state`
- update `useDark` to use `system.value` instead of importing `usePreferredDark`

### Additional context

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f8e66e3</samp>

This pull request enhances the `useColorMode` function and its test case to provide better type safety, customization, and readability. It also removes some redundant code and improves the naming consistency.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f8e66e3</samp>

*  Introduce `BasicColorMode` type and constrain generic type parameter `T` to extend it ([link](https://github.com/vueuse/vueuse/pull/2980/files?diff=unified&w=0#diff-5d628cd173c95cd5c9a1a70e3299bf4d58cceb8bcc22a31baf0cf7793f9db740L12-R15), [link](https://github.com/vueuse/vueuse/pull/2980/files?diff=unified&w=0#diff-5d628cd173c95cd5c9a1a70e3299bf4d58cceb8bcc22a31baf0cf7793f9db740L47-R48), [link](https://github.com/vueuse/vueuse/pull/2980/files?diff=unified&w=0#diff-5d628cd173c95cd5c9a1a70e3299bf4d58cceb8bcc22a31baf0cf7793f9db740L91-R98), [link](https://github.com/vueuse/vueuse/pull/2980/files?diff=unified&w=0#diff-5d628cd173c95cd5c9a1a70e3299bf4d58cceb8bcc22a31baf0cf7793f9db740L103-R107))
*  Change `initialValue` option to accept `MaybeRef` type and use it directly for `store` variable ([link](https://github.com/vueuse/vueuse/pull/2980/files?diff=unified&w=0#diff-5d628cd173c95cd5c9a1a70e3299bf4d58cceb8bcc22a31baf0cf7793f9db740L1-R3), [link](https://github.com/vueuse/vueuse/pull/2980/files?diff=unified&w=0#diff-5d628cd173c95cd5c9a1a70e3299bf4d58cceb8bcc22a31baf0cf7793f9db740L34-R35), [link](https://github.com/vueuse/vueuse/pull/2980/files?diff=unified&w=0#diff-5d628cd173c95cd5c9a1a70e3299bf4d58cceb8bcc22a31baf0cf7793f9db740L131-R137))
*  Add `state` property to return value and use computed ref to return either `store.value` or `state.value` depending on `emitAuto` option ([link](https://github.com/vueuse/vueuse/pull/2980/files?diff=unified&w=0#diff-5d628cd173c95cd5c9a1a70e3299bf4d58cceb8bcc22a31baf0cf7793f9db740L91-R98), [link](https://github.com/vueuse/vueuse/pull/2980/files?diff=unified&w=0#diff-5d628cd173c95cd5c9a1a70e3299bf4d58cceb8bcc22a31baf0cf7793f9db740L198-R198))
*  Simplify `defaultOnChanged` function and remove `watch` function for `system` value ([link](https://github.com/vueuse/vueuse/pull/2980/files?diff=unified&w=0#diff-5d628cd173c95cd5c9a1a70e3299bf4d58cceb8bcc22a31baf0cf7793f9db740L184-R183), [link](https://github.com/vueuse/vueuse/pull/2980/files?diff=unified&w=0#diff-5d628cd173c95cd5c9a1a70e3299bf4d58cceb8bcc22a31baf0cf7793f9db740L198-R198))
*  Add deprecation notice to `value` property and link to documentation ([link](https://github.com/vueuse/vueuse/pull/2980/files?diff=unified&w=0#diff-5d628cd173c95cd5c9a1a70e3299bf4d58cceb8bcc22a31baf0cf7793f9db740R80-R81))
*  Rename test case and variable to avoid confusion (`packages/core/useColorMode/index.test.ts`, [link](https://github.com/vueuse/vueuse/pull/2980/files?diff=unified&w=0#diff-7811d4dbacf020831d35d217e1b1d3036a472d6a79ede4e1172d06cf9b58937dL120-R124))
