### PR TITLE
feat(shared): add array utility function

### DIFF
--- a/packages/core/onKeyStroke/index.ts
+++ b/packages/core/onKeyStroke/index.ts
@@ -1,5 +1,5 @@
 import type { MaybeRefOrGetter } from '@vueuse/shared'
-import { toValue } from '@vueuse/shared'
+import { isArray, toValue } from '@vueuse/shared'
 import { useEventListener } from '../useEventListener'
 import { defaultWindow } from '../_configurable'
 
@@ -25,7 +25,7 @@ function createKeyPredicate(keyFilter: KeyFilter): KeyPredicate {
   else if (typeof keyFilter === 'string')
     return (event: KeyboardEvent) => event.key === keyFilter
 
-  else if (Array.isArray(keyFilter))
+  else if (isArray(keyFilter))
     return (event: KeyboardEvent) => keyFilter.includes(event.key)
 
   return () => true

--- a/packages/core/useBase64/serialization.ts
+++ b/packages/core/useBase64/serialization.ts
@@ -1,3 +1,5 @@
+import { isArray } from '@vueuse/shared'
+
 const defaults = {
   array: (v: unknown[]) => JSON.stringify(v),
   object: (v: Record<string, unknown>) => JSON.stringify(v),
@@ -14,7 +16,7 @@ export function getDefaultSerialization<T extends Object>(target: T) {
     return defaults.map
   else if (target instanceof Set)
     return defaults.set
-  else if (Array.isArray(target))
+  else if (isArray(target))
     return defaults.array
   else
     return defaults.object

--- a/packages/core/useElementSize/index.ts
+++ b/packages/core/useElementSize/index.ts
@@ -1,4 +1,5 @@
 import { computed, ref, watch } from 'vue-demi'
+import { isArray } from '@vueuse/shared'
 import type { MaybeComputedElementRef } from '../unrefElement'
 import type { UseResizeObserverOptions } from '../useResizeObserver'
 import { useResizeObserver } from '../useResizeObserver'
@@ -47,7 +48,7 @@ export function useElementSize(
       }
       else {
         if (boxSize) {
-          const formatBoxSize = Array.isArray(boxSize) ? boxSize : [boxSize]
+          const formatBoxSize = isArray(boxSize) ? boxSize : [boxSize]
           width.value = formatBoxSize.reduce((acc, { inlineSize }) => acc + inlineSize, 0)
           height.value = formatBoxSize.reduce((acc, { blockSize }) => acc + blockSize, 0)
         }

--- a/packages/core/useEventListener/index.ts
+++ b/packages/core/useEventListener/index.ts
@@ -1,5 +1,5 @@
 import type { Arrayable, Fn, MaybeRefOrGetter } from '@vueuse/shared'
-import { noop, toValue, tryOnScopeDispose } from '@vueuse/shared'
+import { isArray, noop, toValue, tryOnScopeDispose } from '@vueuse/shared'
 import { watch } from 'vue-demi'
 import type { MaybeElementRef } from '../unrefElement'
 import { unrefElement } from '../unrefElement'
@@ -111,7 +111,7 @@ export function useEventListener(...args: any[]) {
   let listeners: Arrayable<Function>
   let options: MaybeRefOrGetter<boolean | AddEventListenerOptions> | undefined
 
-  if (typeof args[0] === 'string' || Array.isArray(args[0])) {
+  if (typeof args[0] === 'string' || isArray(args[0])) {
     [events, listeners, options] = args
     target = defaultWindow
   }
@@ -122,9 +122,9 @@ export function useEventListener(...args: any[]) {
   if (!target)
     return noop
 
-  if (!Array.isArray(events))
+  if (!isArray(events))
     events = [events]
-  if (!Array.isArray(listeners))
+  if (!isArray(listeners))
     listeners = [listeners]
 
   const cleanups: Function[] = []

--- a/packages/core/useIntersectionObserver/index.ts
+++ b/packages/core/useIntersectionObserver/index.ts
@@ -1,7 +1,7 @@
 import type { Ref } from 'vue-demi'
 import { ref, watch } from 'vue-demi'
 import type { MaybeRefOrGetter, Pausable } from '@vueuse/shared'
-import { noop, notNullish, toValue, tryOnScopeDispose } from '@vueuse/shared'
+import { isArray, noop, notNullish, toValue, tryOnScopeDispose } from '@vueuse/shared'
 import { computed } from '@vue/reactivity'
 import type { ConfigurableWindow } from '../_configurable'
 import { defaultWindow } from '../_configurable'
@@ -62,7 +62,7 @@ export function useIntersectionObserver(
   const isSupported = useSupported(() => window && 'IntersectionObserver' in window)
   const targets = computed(() => {
     const _target = toValue(target)
-    return (Array.isArray(_target) ? _target : [_target]).map(unrefElement).filter(notNullish)
+    return (isArray(_target) ? _target : [_target]).map(unrefElement).filter(notNullish)
   })
 
   let cleanup = noop

--- a/packages/core/useMediaControls/index.ts
+++ b/packages/core/useMediaControls/index.ts
@@ -1,6 +1,6 @@
 import { ref, watch, watchEffect } from 'vue-demi'
 import type { Fn, MaybeRef, MaybeRefOrGetter } from '@vueuse/shared'
-import { createEventHook, isObject, toValue, tryOnScopeDispose, watchIgnorable } from '@vueuse/shared'
+import { createEventHook, isArray, isObject, toValue, tryOnScopeDispose, watchIgnorable } from '@vueuse/shared'
 import { useEventListener } from '../useEventListener'
 import type { ConfigurableDocument } from '../_configurable'
 import { defaultDocument } from '../_configurable'
@@ -256,7 +256,7 @@ export function useMediaControls(target: MaybeRef<HTMLMediaElement | null | unde
     // Merge sources into an array
     if (typeof src === 'string')
       sources = [{ src }]
-    else if (Array.isArray(src))
+    else if (isArray(src))
       sources = src
     else if (isObject(src))
       sources = [src]

--- a/packages/core/useResizeObserver/index.ts
+++ b/packages/core/useResizeObserver/index.ts
@@ -1,4 +1,4 @@
-import { tryOnScopeDispose } from '@vueuse/shared'
+import { isArray, tryOnScopeDispose } from '@vueuse/shared'
 import { computed, watch } from 'vue-demi'
 import type { MaybeComputedElementRef } from '../unrefElement'
 import { unrefElement } from '../unrefElement'
@@ -63,7 +63,7 @@ export function useResizeObserver(
   }
 
   const targets = computed(() =>
-    Array.isArray(target)
+    isArray(target)
       ? target.map(el => unrefElement(el))
       : [unrefElement(target)],
   )

--- a/packages/core/useStepper/index.ts
+++ b/packages/core/useStepper/index.ts
@@ -1,4 +1,5 @@
 import type { MaybeRef } from '@vueuse/shared'
+import { isArray } from '@vueuse/shared'
 import type { ComputedRef, Ref } from 'vue-demi'
 import { computed, ref } from 'vue-demi'
 
@@ -47,7 +48,7 @@ export function useStepper<T extends string | number>(steps: MaybeRef<T[]>, init
 export function useStepper<T extends Record<string, any>>(steps: MaybeRef<T>, initialStep?: keyof T): UseStepperReturn<Exclude<keyof T, symbol>, T, T[keyof T]>
 export function useStepper(steps: any, initialStep?: any): UseStepperReturn<any, any, any> {
   const stepsRef = ref<any[]>(steps)
-  const stepNames = computed<any[]>(() => Array.isArray(stepsRef.value) ? stepsRef.value : Object.keys(stepsRef.value))
+  const stepNames = computed<any[]>(() => isArray(stepsRef.value) ? stepsRef.value : Object.keys(stepsRef.value))
   const index = ref(stepNames.value.indexOf(initialStep ?? stepNames.value[0]))
   const current = computed(() => at(index.value))
   const isFirst = computed(() => index.value === 0)
@@ -56,7 +57,7 @@ export function useStepper(steps: any, initialStep?: any): UseStepperReturn<any,
   const previous = computed(() => stepNames.value[index.value - 1])
 
   function at(index: number) {
-    if (Array.isArray(stepsRef.value))
+    if (isArray(stepsRef.value))
       return stepsRef.value[index]
 
     return stepsRef.value[stepNames.value[index]]

--- a/packages/core/useStorage/index.ts
+++ b/packages/core/useStorage/index.ts
@@ -1,6 +1,6 @@
 import { nextTick, ref, shallowRef } from 'vue-demi'
 import type { Awaitable, ConfigurableEventFilter, ConfigurableFlush, MaybeRefOrGetter, RemovableRef } from '@vueuse/shared'
-import { pausableWatch, toValue } from '@vueuse/shared'
+import { isArray, pausableWatch, toValue } from '@vueuse/shared'
 import type { StorageLike } from '../ssr-handlers'
 import { getSSRHandler } from '../ssr-handlers'
 import { useEventListener } from '../useEventListener'
@@ -224,7 +224,7 @@ export function useStorage<T extends(string | number | boolean | object | null)>
       const value = serializer.read(rawValue)
       if (typeof mergeDefaults === 'function')
         return mergeDefaults(value, rawInit)
-      else if (type === 'object' && !Array.isArray(value))
+      else if (type === 'object' && !isArray(value))
         return { ...rawInit as any, ...value }
       return value
     }

--- a/packages/core/useStorageAsync/index.ts
+++ b/packages/core/useStorageAsync/index.ts
@@ -1,5 +1,5 @@
 import type { MaybeRefOrGetter, RemovableRef } from '@vueuse/shared'
-import { toValue, watchWithFilter } from '@vueuse/shared'
+import { isArray, toValue, watchWithFilter } from '@vueuse/shared'
 import type { Ref } from 'vue-demi'
 import { ref, shallowRef } from 'vue-demi'
 import type { StorageLikeAsync } from '../ssr-handlers'
@@ -82,7 +82,7 @@ export function useStorageAsync<T extends(string | number | boolean | object | n
         const value = await serializer.read(rawValue)
         if (typeof mergeDefaults === 'function')
           data.value = mergeDefaults(value, rawInit)
-        else if (type === 'object' && !Array.isArray(value))
+        else if (type === 'object' && !isArray(value))
           data.value = { ...(rawInit as any), ...value }
         else data.value = value
       }

--- a/packages/core/useTransition/index.ts
+++ b/packages/core/useTransition/index.ts
@@ -1,5 +1,5 @@
 import { computed, ref, watch } from 'vue-demi'
-import { identity as linear, promiseTimeout, toValue, tryOnScopeDispose } from '@vueuse/shared'
+import { isArray, identity as linear, promiseTimeout, toValue, tryOnScopeDispose } from '@vueuse/shared'
 import type { ComputedRef, Ref } from 'vue-demi'
 import type { MaybeRef, MaybeRefOrGetter } from '@vueuse/shared'
 
@@ -168,7 +168,7 @@ export function executeTransition<T extends number | number[]>(
       const alpha = ease((now - startedAt) / duration)
       const arr = toVec(source.value).map((n, i) => lerp(v1[i], v2[i], alpha))
 
-      if (Array.isArray(source.value))
+      if (isArray(source.value))
         (source.value as number[]) = arr.map((n, i) => lerp(v1[i] ?? 0, v2[i] ?? 0, alpha))
       else if (typeof source.value === 'number')
         (source.value as number) = arr[0]
@@ -231,7 +231,7 @@ export function useTransition(
     if (id !== currentId)
       return
 
-    const toVal = Array.isArray(to) ? to.map(toValue<number>) : toValue(to)
+    const toVal = isArray(to) ? to.map(toValue<number>) : toValue(to)
 
     options.onStarted?.()
 

--- a/packages/core/useUrlSearchParams/index.ts
+++ b/packages/core/useUrlSearchParams/index.ts
@@ -1,5 +1,5 @@
 import { reactive } from 'vue-demi'
-import { pausableWatch } from '@vueuse/shared'
+import { isArray, pausableWatch } from '@vueuse/shared'
 import { useEventListener } from '../useEventListener'
 import type { ConfigurableWindow } from '../_configurable'
 import { defaultWindow } from '../_configurable'
@@ -104,7 +104,7 @@ export function useUrlSearchParams<T extends Record<string, any> = UrlParams>(
       const params = new URLSearchParams('')
       Object.keys(state).forEach((key) => {
         const mapEntry = state[key]
-        if (Array.isArray(mapEntry))
+        if (isArray(mapEntry))
           mapEntry.forEach(value => params.append(key, value))
         else if (removeNullishValues && mapEntry == null)
           params.delete(key)

--- a/packages/core/useVirtualList/component.ts
+++ b/packages/core/useVirtualList/component.ts
@@ -1,6 +1,6 @@
 import { defineComponent, h, toRefs } from 'vue-demi'
 import type { UseVirtualListOptions } from '@vueuse/core'
-import { useVirtualList } from '@vueuse/core'
+import { isArray, useVirtualList } from '@vueuse/core'
 
 export interface UseVirtualListProps {
   /**
@@ -36,7 +36,7 @@ export const UseVirtualList = /*#__PURE__*/ defineComponent<UseVirtualListProps>
     const { list, containerProps, wrapperProps, scrollTo } = useVirtualList(listRef, props.options)
     expose({ scrollTo })
 
-    typeof containerProps.style === 'object' && !Array.isArray(containerProps.style) && (containerProps.style.height = props.height || '300px')
+    typeof containerProps.style === 'object' && !isArray(containerProps.style) && (containerProps.style.height = props.height || '300px')
 
     return () => h('div',
       { ...containerProps },

--- a/packages/integrations/useIDBKeyval/index.ts
+++ b/packages/integrations/useIDBKeyval/index.ts
@@ -1,5 +1,5 @@
 import type { ConfigurableFlush, MaybeRefOrGetter, RemovableRef } from '@vueuse/shared'
-import { toValue } from '@vueuse/shared'
+import { isArray, toValue } from '@vueuse/shared'
 import type { Ref } from 'vue-demi'
 import { ref, shallowRef, watch } from 'vue-demi'
 import { del, get, set, update } from 'idb-keyval'
@@ -86,7 +86,7 @@ export function useIDBKeyval<T>(
       }
       else {
         // IndexedDB does not support saving proxies, convert from proxy before saving
-        if (Array.isArray(data.value))
+        if (isArray(data.value))
           await update(key, () => (JSON.parse(JSON.stringify(data.value))))
         else if (typeof data.value === 'object')
           await update(key, () => ({ ...data.value }))

--- a/packages/math/utils.ts
+++ b/packages/math/utils.ts
@@ -1,5 +1,5 @@
 import type { MaybeRefOrGetter } from '@vueuse/shared'
-import { toValue } from '@vueuse/shared'
+import { isArray, toValue } from '@vueuse/shared'
 
 export type MaybeComputedRefArgs<T> = MaybeRefOrGetter<T>[] | [MaybeRefOrGetter<MaybeRefOrGetter<T>[]>]
 
@@ -7,7 +7,7 @@ export function toValueArgsFlat<T>(args: MaybeComputedRefArgs<T>): T[] {
   return args
     .flatMap((i: any) => {
       const v = toValue(i)
-      if (Array.isArray(v))
+      if (isArray(v))
         return v.map(i => toValue(i))
       return [v]
     })

--- a/packages/metadata/scripts/update.ts
+++ b/packages/metadata/scripts/update.ts
@@ -4,6 +4,7 @@ import matter from 'gray-matter'
 import type { PackageIndexes, VueUseFunction, VueUsePackage } from '@vueuse/metadata'
 import fg from 'fast-glob'
 import Git from 'simple-git'
+import { isArray } from '@vueuse/shared'
 import { packages } from '../../../meta/packages'
 import { ecosystemFunctions } from '../../../meta/ecosystem-functions'
 import { getCategories } from '../utils'
@@ -90,7 +91,7 @@ export async function readMetadata() {
       let related = frontmatter.related
       if (typeof related === 'string')
         related = related.split(',').map(s => s.trim()).filter(Boolean)
-      else if (Array.isArray(related))
+      else if (isArray(related))
         related = related.map(s => s.trim()).filter(Boolean)
 
       let description = (md

--- a/packages/router/useRouteQuery/index.test.ts
+++ b/packages/router/useRouteQuery/index.test.ts
@@ -1,3 +1,4 @@
+import { isArray } from '@vueuse/shared'
 import { useRouteQuery } from '.'
 
 describe('useRouteQuery', () => {
@@ -21,7 +22,7 @@ describe('useRouteQuery', () => {
     const router = {} as any
     const route = getRoute()
     const transform = Number
-    const toArray = (param: string | string[] | null) => Array.isArray(param) ? param : [param]
+    const toArray = (param: string | string[] | null) => isArray(param) ? param : [param]
 
     const page = useRouteQuery('page', '1', { transform, route, router })
     const perPage = useRouteQuery('perPage', '15', { transform, route, router })

--- a/packages/shared/reactifyObject/index.ts
+++ b/packages/shared/reactifyObject/index.ts
@@ -1,6 +1,7 @@
 import type { Reactified, ReactifyOptions } from '../reactify'
 import { reactify } from '../reactify'
 import type { AnyFn } from '../utils'
+import { isArray } from '../utils'
 
 export type ReactifyNested<T, Keys extends keyof T = keyof T, S extends boolean = true> = { [K in Keys]: T[K] extends AnyFn ? Reactified<T[K], S> : T[K] }
 
@@ -22,7 +23,7 @@ export function reactifyObject<T extends object, S extends boolean = true>(obj: 
 export function reactifyObject<T extends object, S extends boolean = true>(obj: T, optionsOrKeys: ReactifyObjectOptions<S> | (keyof T)[] = {}): ReactifyNested<T, keyof T, S> {
   let keys: string[] = []
   let options: ReactifyOptions<S> | undefined
-  if (Array.isArray(optionsOrKeys)) {
+  if (isArray(optionsOrKeys)) {
     keys = optionsOrKeys as string[]
   }
   else {

--- a/packages/shared/toRefs/index.ts
+++ b/packages/shared/toRefs/index.ts
@@ -1,6 +1,7 @@
 import type { ToRefs } from 'vue-demi'
 import { toRefs as _toRefs, customRef, isRef } from 'vue-demi'
 import type { MaybeRef } from '../utils'
+import { isArray } from '../utils'
 
 /**
  * Extended `toRefs` that also accepts refs of an object.
@@ -14,7 +15,7 @@ export function toRefs<T extends object>(
   if (!isRef(objectRef))
     return _toRefs(objectRef)
 
-  const result: any = Array.isArray(objectRef.value)
+  const result: any = isArray(objectRef.value)
     ? new Array(objectRef.value.length)
     : {}
 
@@ -24,7 +25,7 @@ export function toRefs<T extends object>(
         return objectRef.value[key]
       },
       set(v) {
-        if (Array.isArray(objectRef.value)) {
+        if (isArray(objectRef.value)) {
           const copy: any = [...objectRef.value]
           copy[key] = v
           objectRef.value = copy

--- a/packages/shared/until/index.ts
+++ b/packages/shared/until/index.ts
@@ -2,7 +2,7 @@ import type { WatchOptions, WatchSource } from 'vue-demi'
 import { isRef, watch } from 'vue-demi'
 import { toValue } from '../toValue'
 import type { ElementOf, MaybeRefOrGetter, ShallowUnwrapRef } from '../utils'
-import { promiseTimeout } from '../utils'
+import { isArray, promiseTimeout } from '../utils'
 
 export interface UntilToMatchOptions {
   /**
@@ -177,7 +177,7 @@ function createUntil<T>(r: any, isNot = false) {
     }, options)
   }
 
-  if (Array.isArray(toValue(r))) {
+  if (isArray(toValue(r))) {
     const instance: UntilArrayInstance<T> = {
       toMatch,
       toContains,

--- a/packages/shared/useToggle/index.test.ts
+++ b/packages/shared/useToggle/index.test.ts
@@ -1,5 +1,6 @@
 import { isRef, ref } from 'vue-demi'
 import { toValue } from '../toValue'
+import { isArray } from '../utils'
 import { useToggle } from '.'
 
 describe('useToggle', () => {
@@ -11,7 +12,7 @@ describe('useToggle', () => {
     const result = useToggle()
     const [value, toggle] = result
 
-    expect(Array.isArray(result)).toBe(true)
+    expect(isArray(result)).toBe(true)
     expect(result.length).toBe(2)
 
     expect(typeof toggle).toBe('function')
@@ -23,7 +24,7 @@ describe('useToggle', () => {
     const result = useToggle(true)
     const [value, toggle] = result
 
-    expect(Array.isArray(result)).toBe(true)
+    expect(isArray(result)).toBe(true)
     expect(result.length).toBe(2)
 
     expect(typeof toggle).toBe('function')

--- a/packages/shared/utils/is.ts
+++ b/packages/shared/utils/is.ts
@@ -1,6 +1,7 @@
 /* eslint-disable antfu/top-level-function */
 export const isClient = typeof window !== 'undefined'
 export const isDef = <T = any>(val?: T): val is T => typeof val !== 'undefined'
+export const isArray = Array.isArray
 export const notNullish = <T = any>(val?: T | null | undefined): val is T => val != null
 export const assert = (condition: boolean, ...infos: any[]) => {
   if (!condition)

--- a/packages/shared/watchArray/index.ts
+++ b/packages/shared/watchArray/index.ts
@@ -1,6 +1,7 @@
 import type { WatchOptions, WatchSource } from 'vue-demi'
 import { watch } from 'vue-demi'
 import { toValue } from '../toValue'
+import { isArray } from '../utils'
 
 export declare type WatchArrayCallback<V = any, OV = any> = (value: V, oldValue: OV, added: V, removed: OV, onCleanup: (cleanupFn: () => void) => void) => any
 
@@ -18,7 +19,7 @@ export function watchArray<T, Immediate extends Readonly<boolean> = false>(
     ? []
     : [...(source instanceof Function
         ? source()
-        : Array.isArray(source)
+        : isArray(source)
           ? source
           : toValue(source)),
       ]

--- a/packages/shared/watchTriggerable/index.ts
+++ b/packages/shared/watchTriggerable/index.ts
@@ -1,6 +1,7 @@
 import type { WatchSource } from 'vue-demi'
 import { isReactive } from 'vue-demi'
 import type { MapOldSources, MapSources } from '../utils'
+import { isArray } from '../utils'
 import type { WatchIgnorableReturn } from '../watchIgnorable'
 import { watchIgnorable } from '../watchIgnorable'
 import type { WatchWithFilterOptions } from '../watchWithFilter'
@@ -72,14 +73,14 @@ export function watchTriggerable<Immediate extends Readonly<boolean> = false>(
 function getWatchSources(sources: any) {
   if (isReactive(sources))
     return sources
-  if (Array.isArray(sources))
+  if (isArray(sources))
     return sources.map(item => toValue(item))
   return toValue(sources)
 }
 
 // For calls triggered by trigger, the old value is unknown, so it cannot be returned
 function getOldValue(source: any) {
-  return Array.isArray(source)
+  return isArray(source)
     ? source.map(() => undefined)
     : undefined
 }


### PR DESCRIPTION
There is a large amount of judgment on whether it is an array in the project, so it has been extracted into a utility function and added to `is.ts`. This way, when using it, only `isArray()` judgment is needed, `without Array.isArray()`