### PR TITLE
fix(useCycleList): correctly wrap list with ref

### DIFF
--- a/packages/core/useCycleList/index.ts
+++ b/packages/core/useCycleList/index.ts
@@ -32,7 +32,7 @@ export function useCycleList<T>(list: MaybeRefOrGetter<T[]>, options?: UseCycleL
 
   const index = computed<number>({
     get() {
-      const targetList = toValue<T[]>(list)
+      const targetList = toValue<T[]>(listRef)
 
       let index = options?.getIndexOf
         ? options.getIndexOf(state.value, targetList)

--- a/packages/core/useCycleList/index.ts
+++ b/packages/core/useCycleList/index.ts
@@ -32,7 +32,7 @@ export function useCycleList<T>(list: MaybeRefOrGetter<T[]>, options?: UseCycleL
 
   const index = computed<number>({
     get() {
-      const targetList = toValue<T[]>(listRef)
+      const targetList = listRef.value
 
       let index = options?.getIndexOf
         ? options.getIndexOf(state.value, targetList)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

hello,  I found that after updating it to `10.0.2`,  this function did not work as expected when I passed in an array of object types that were not wrapped in `ref` 

Here's a concrete reproduction: [Reproduce](https://play.vuejs.org/#eNqNU01v4jAQ/SsjC6kg0Ziye7ICYrXXPe6t7iF1DHFJbMt2+hXlv9cfCW2B0l7ij/fmed5MpkN/tM4eW44Iyi0zQjuw3LV6TaVotDIOOjB8Cz1sjWqAIs+l6APYWv73hdX8n7DunbXxNI9gpkykU8mU9IQ6sFZwSyVAFz4AjsBVqXZX4dTPjwBWuPNALV4LUyaMyrv3FzqwrnB8DkKW/HkOkj+HvFafEp16S9OQy2x2FEfSMlkOAiQt4RyUSPxOlqeKUS2kkeNUR19Bf3C80bUX9CeAvPq1DjwCXZdK0fc59pcJNIDTrhSPcZMidkqVBHJt+PoLDzkO4EEphQ12/Etx9/GpRBj8eULcHRHuW+eUhA2rBduvKAq+pzOKBhxiIQYuTuSD9mgkvTMGPBkldwT+Vzw1peGuUiWwQoKS9Qu4Ys+Bb7ecOX/BeAZDJHWn5qPx5HtM4pL70LFv/J9QzlVgsvxJDXKcOpjjQ/vRHKWRuW4KnT1YJf3Exf+ZDoClyCeT1OKYXZe8EeGSoso5bQnGrdT7XcZUg0d8s8hufmcLXIt7HG1kzYNXiuMSdMZBtFVhePmV2mfW5maRLbLlRb002JfVAueM1jCzPerfABWIdJ0=)

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b3f9459</samp>

Fixed a bug in `useCycleList` that prevented the list from updating when the source changed. Used `listRef` instead of `list` to access the reactive list of items.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b3f9459</samp>

*  Fixed a bug where the list was not updated when the source changed by using `listRef` instead of `list` to access the reactive list of items ([link](https://github.com/vueuse/vueuse/pull/2988/files?diff=unified&w=0#diff-a836200df4d41b1babe4fd9a12ba9c9a8d8ffaf09aae8b8b318bbf2d85166de0L35-R35))
