### PR TITLE
feat(useMouse): support custom event extractor

### DIFF
--- a/packages/core/useMouse/demo.vue
+++ b/packages/core/useMouse/demo.vue
@@ -1,12 +1,26 @@
 <script setup lang="ts">
 import { reactive } from 'vue'
 import { stringify } from '@vueuse/docs-utils'
-import { useMouse } from '@vueuse/core'
+import { type UseMouseExtractFn, useMouse, useParentElement } from '@vueuse/core'
 
-const mouse = reactive(useMouse())
-const text = stringify(mouse)
+const parentEl = useParentElement()
+
+const mouseDefault = reactive(useMouse())
+const textDefault = stringify(mouseDefault)
+
+const extractor: UseMouseExtractFn = event => (
+  event instanceof Touch
+    ? null
+    : { x: event.offsetX, y: event.offsetY }
+)
+
+const mouseWithExtractor = reactive(useMouse({ target: parentEl, type: extractor }))
+const textWithExtractor = stringify(mouseWithExtractor)
 </script>
 
 <template>
-  <pre lang="yaml">{{ text }}</pre>
+  <p>Basic Usage</p>
+  <pre lang="yaml">{{ textDefault }}</pre>
+  <p>Extractor Usage</p>
+  <pre lang="yaml">{{ textWithExtractor }}</pre>
 </template>

--- a/packages/core/useMouse/demo.vue
+++ b/packages/core/useMouse/demo.vue
@@ -1,17 +1,18 @@
 <script setup lang="ts">
 import { reactive } from 'vue'
 import { stringify } from '@vueuse/docs-utils'
-import { type UseMouseExtractFn, useMouse, useParentElement } from '@vueuse/core'
+import { useMouse, useParentElement } from '@vueuse/core'
+import type { UseMouseEventExtractor } from '@vueuse/core'
 
 const parentEl = useParentElement()
 
 const mouseDefault = reactive(useMouse())
 const textDefault = stringify(mouseDefault)
 
-const extractor: UseMouseExtractFn = event => (
+const extractor: UseMouseEventExtractor = event => (
   event instanceof Touch
     ? null
-    : { x: event.offsetX, y: event.offsetY }
+    : [event.offsetX, event.offsetY]
 )
 
 const mouseWithExtractor = reactive(useMouse({ target: parentEl, type: extractor }))

--- a/packages/core/useMouse/index.md
+++ b/packages/core/useMouse/index.md
@@ -21,17 +21,19 @@ The `dragover` event is used to track mouse position while dragging.
 const { x, y } = useMouse({ touch: false })
 ```
 
-## Usage With Extractor
+## Custom Extractor
+
+It's also possible to provide a custom extractor function to get the position from the event.
 
 ```js
-import { type UseMouseExtractFn, useMouse, useParentElement } from '@vueuse/core'
+import { type UseMouseEventExtractor, useMouse, useParentElement } from '@vueuse/core'
 
 const parentEl = useParentElement()
 
-const extractor: UseMouseExtractFn = event => (
+const extractor: UseMouseEventExtractor = event => (
   event instanceof Touch
     ? null
-    : { x: event.offsetX, y: event.offsetY }
+    : [event.offsetX, event.offsetY]
 )
 
 const { x, y, sourceType } = useMouse({ target: parentEl, type: extractor })

--- a/packages/core/useMouse/index.md
+++ b/packages/core/useMouse/index.md
@@ -21,6 +21,29 @@ The `dragover` event is used to track mouse position while dragging.
 const { x, y } = useMouse({ touch: false })
 ```
 
+## Usage With Extractor
+
+```js
+import { type UseMouseExtractFn, useMouse, useParentElement } from '@vueuse/core'
+
+const parentEl = useParentElement()
+
+const extractor: UseMouseExtractFn = event => (
+  event instanceof Touch
+    ? null
+    : { x: event.offsetX, y: event.offsetY }
+)
+
+const { x, y, sourceType } = useMouse({ target: parentEl, type: extractor })
+```
+
+Touch is enabled by default. To only detect mouse changes, set `touch` to `false`.
+The `dragover` event is used to track mouse position while dragging.
+
+```js
+const { x, y } = useMouse({ touch: false })
+```
+
 ## Component Usage
 
 ```html

--- a/packages/core/useMouse/index.ts
+++ b/packages/core/useMouse/index.ts
@@ -1,9 +1,13 @@
 import { ref } from 'vue-demi'
-import type { ConfigurableEventFilter } from '@vueuse/shared'
+import type { ConfigurableEventFilter, MaybeRefOrGetter } from '@vueuse/shared'
 import { useEventListener } from '../useEventListener'
 import type { ConfigurableWindow } from '../_configurable'
 import { defaultWindow } from '../_configurable'
 import type { Position } from '../types'
+
+export type MouseCoordType = 'page' | 'client' | 'screen' | 'movement'
+export type MouseSourceType = 'mouse' | 'touch' | null
+export type UseMouseExtractFn = (event: MouseEvent | Touch) => { x: number; y: number } | null | undefined
 
 export interface UseMouseOptions extends ConfigurableWindow, ConfigurableEventFilter {
   /**
@@ -11,7 +15,14 @@ export interface UseMouseOptions extends ConfigurableWindow, ConfigurableEventFi
    *
    * @default 'page'
    */
-  type?: 'page' | 'client' | 'screen' | 'movement'
+  type?: MouseCoordType | UseMouseExtractFn
+
+  /**
+   * Listen events on `target` element
+   *
+   * @default 'Window'
+   */
+  target?: MaybeRefOrGetter<Window | EventTarget | null | undefined>
 
   /**
    * Listen to `touchmove` events
@@ -33,7 +44,16 @@ export interface UseMouseOptions extends ConfigurableWindow, ConfigurableEventFi
   initialValue?: Position
 }
 
-export type MouseSourceType = 'mouse' | 'touch' | null
+const EXTRACTORS: Record<MouseCoordType, UseMouseExtractFn> = {
+  page: event => ({ x: event.pageX, y: event.pageY }),
+  client: event => ({ x: event.clientX, y: event.clientY }),
+  screen: event => ({ x: event.screenX, y: event.screenY }),
+  movement: event => (
+    event instanceof Touch
+      ? null
+      : { x: event.movementX, y: event.movementY }
+  ),
+} as const
 
 /**
  * Reactive mouse position.
@@ -48,6 +68,7 @@ export function useMouse(options: UseMouseOptions = {}) {
     resetOnTouchEnds = false,
     initialValue = { x: 0, y: 0 },
     window = defaultWindow,
+    target = window,
     eventFilter,
   } = options
 
@@ -55,64 +76,51 @@ export function useMouse(options: UseMouseOptions = {}) {
   const y = ref(initialValue.y)
   const sourceType = ref<MouseSourceType>(null)
 
+  const extractor = typeof type === 'function'
+    ? type
+    : EXTRACTORS[type]
+
   const mouseHandler = (event: MouseEvent) => {
-    if (type === 'page') {
-      x.value = event.pageX
-      y.value = event.pageY
+    const xyValue = extractor(event)
+
+    if (xyValue) {
+      ({ x: x.value, y: y.value } = xyValue)
+      sourceType.value = 'mouse'
     }
-    else if (type === 'client') {
-      x.value = event.clientX
-      y.value = event.clientY
-    }
-    else if (type === 'screen') {
-      x.value = event.screenX
-      y.value = event.screenY
-    }
-    else if (type === 'movement') {
-      x.value = event.movementX
-      y.value = event.movementY
-    }
-    sourceType.value = 'mouse'
   }
+
+  const touchHandler = (event: TouchEvent) => {
+    if (event.touches.length > 0) {
+      const xyValue = extractor(event.touches[0])
+
+      if (xyValue) {
+        ({ x: x.value, y: y.value } = xyValue)
+        sourceType.value = 'touch'
+      }
+    }
+  }
+
   const reset = () => {
     x.value = initialValue.x
     y.value = initialValue.y
   }
-  const touchHandler = (event: TouchEvent) => {
-    if (event.touches.length > 0) {
-      const touch = event.touches[0]
-      if (type === 'page') {
-        x.value = touch.pageX
-        y.value = touch.pageY
-      }
-      else if (type === 'client') {
-        x.value = touch.clientX
-        y.value = touch.clientY
-      }
-      else if (type === 'screen') {
-        x.value = touch.screenX
-        y.value = touch.screenY
-      }
-      sourceType.value = 'touch'
-    }
-  }
 
-  const mouseHandlerWrapper = (event: MouseEvent) => {
-    return eventFilter === undefined ? mouseHandler(event) : eventFilter(() => mouseHandler(event), {} as any)
-  }
+  const mouseHandlerWrapper = eventFilter
+    ? (event: MouseEvent) => eventFilter(() => mouseHandler(event), {} as any)
+    : (event: MouseEvent) => mouseHandler(event)
 
-  const touchHandlerWrapper = (event: TouchEvent) => {
-    return eventFilter === undefined ? touchHandler(event) : eventFilter(() => touchHandler(event), {} as any)
-  }
+  const touchHandlerWrapper = eventFilter
+    ? (event: TouchEvent) => eventFilter(() => touchHandler(event), {} as any)
+    : (event: TouchEvent) => touchHandler(event)
 
-  if (window) {
-    useEventListener(window, 'mousemove', mouseHandlerWrapper, { passive: true })
-    useEventListener(window, 'dragover', mouseHandlerWrapper, { passive: true })
+  if (target) {
+    useEventListener(target, 'mousemove', mouseHandlerWrapper, { passive: true })
+    useEventListener(target, 'dragover', mouseHandlerWrapper, { passive: true })
     if (touch && type !== 'movement') {
-      useEventListener(window, 'touchstart', touchHandlerWrapper, { passive: true })
-      useEventListener(window, 'touchmove', touchHandlerWrapper, { passive: true })
+      useEventListener(target, 'touchstart', touchHandlerWrapper, { passive: true })
+      useEventListener(target, 'touchmove', touchHandlerWrapper, { passive: true })
       if (resetOnTouchEnds)
-        useEventListener(window, 'touchend', reset, { passive: true })
+        useEventListener(target, 'touchend', reset, { passive: true })
     }
   }
 

--- a/packages/core/useMousePressed/index.ts
+++ b/packages/core/useMousePressed/index.ts
@@ -2,7 +2,7 @@ import { computed, ref } from 'vue-demi'
 import type { MaybeElementRef } from '../unrefElement'
 import { unrefElement } from '../unrefElement'
 import { useEventListener } from '../useEventListener'
-import type { MouseSourceType } from '../useMouse'
+import type { UseMouseSourceType } from '../useMouse'
 import type { ConfigurableWindow } from '../_configurable'
 import { defaultWindow } from '../_configurable'
 
@@ -49,7 +49,7 @@ export function useMousePressed(options: MousePressedOptions = {}) {
   } = options
 
   const pressed = ref(initialValue)
-  const sourceType = ref<MouseSourceType>(null)
+  const sourceType = ref<UseMouseSourceType>(null)
 
   if (!window) {
     return {
@@ -58,7 +58,7 @@ export function useMousePressed(options: MousePressedOptions = {}) {
     }
   }
 
-  const onPressed = (srcType: MouseSourceType) => () => {
+  const onPressed = (srcType: UseMouseSourceType) => () => {
     pressed.value = true
     sourceType.value = srcType
   }


### PR DESCRIPTION
Add `target` option and `type` enhancement

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description
- Added a new `target` option to listen for events only on the target element and not on `window`. It's helpful for performance improvement to do not triggers refs update then you not need it. Also it's allows to use some event properties which relative to target element (e.g. `event.offsetX`)
- Allows the `type` option to be used as a function that retrieves the `x` and `y` values from the event object. If the function returns `null | undefined` refs will not be updated.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0d9e2ac</samp>

Enhanced `useMouse` function to support custom elements and coordinate extractors. Updated demo, types, and documentation accordingly.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0d9e2ac</samp>

*  Add and document `target` and `type` options to `useMouse` function ([link](https://github.com/vueuse/vueuse/pull/2991/files?diff=unified&w=0#diff-acac08f31319ce15064e72bec03f921b9731164f2022b1a17ed4c09ba2864540L14-R27), [link](https://github.com/vueuse/vueuse/pull/2991/files?diff=unified&w=0#diff-acac08f31319ce15064e72bec03f921b9731164f2022b1a17ed4c09ba2864540R71), [link](https://github.com/vueuse/vueuse/pull/2991/files?diff=unified&w=0#diff-aa44e4b735aa00c6a536ae6409a76a1198cdb167c255f481c5eacbbf807d8904R24-R46))
  * The `target` option allows specifying a custom element to listen to mouse events, using a direct value or a function that returns a value ([link](https://github.com/vueuse/vueuse/pull/2991/files?diff=unified&w=0#diff-acac08f31319ce15064e72bec03f921b9731164f2022b1a17ed4c09ba2864540L2-R2), [link](https://github.com/vueuse/vueuse/pull/2991/files?diff=unified&w=0#diff-acac08f31319ce15064e72bec03f921b9731164f2022b1a17ed4c09ba2864540L14-R27), [link](https://github.com/vueuse/vueuse/pull/2991/files?diff=unified&w=0#diff-acac08f31319ce15064e72bec03f921b9731164f2022b1a17ed4c09ba2864540R71))
  * The `type` option allows providing a custom function to extract the mouse coordinates from the event, or choosing from predefined coordinate systems ([link](https://github.com/vueuse/vueuse/pull/2991/files?diff=unified&w=0#diff-acac08f31319ce15064e72bec03f921b9731164f2022b1a17ed4c09ba2864540R8-R11), [link](https://github.com/vueuse/vueuse/pull/2991/files?diff=unified&w=0#diff-acac08f31319ce15064e72bec03f921b9731164f2022b1a17ed4c09ba2864540L14-R27), [link](https://github.com/vueuse/vueuse/pull/2991/files?diff=unified&w=0#diff-acac08f31319ce15064e72bec03f921b9731164f2022b1a17ed4c09ba2864540L36-R56), [link](https://github.com/vueuse/vueuse/pull/2991/files?diff=unified&w=0#diff-acac08f31319ce15064e72bec03f921b9731164f2022b1a17ed4c09ba2864540L58-R123), [link](https://github.com/vueuse/vueuse/pull/2991/files?diff=unified&w=0#diff-aa44e4b735aa00c6a536ae6409a76a1198cdb167c255f481c5eacbbf807d8904R24-R46))
* Refactor and simplify event handlers and listeners in `useMouse` function ([link](https://github.com/vueuse/vueuse/pull/2991/files?diff=unified&w=0#diff-acac08f31319ce15064e72bec03f921b9731164f2022b1a17ed4c09ba2864540L58-R123), [link](https://github.com/vueuse/vueuse/pull/2991/files?diff=unified&w=0#diff-acac08f31319ce15064e72bec03f921b9731164f2022b1a17ed4c09ba2864540R71))
  * Use the `extractor` variable to store the function that gets the mouse coordinates from the event, either from the `type` option or from the `EXTRACTORS` object ([link](https://github.com/vueuse/vueuse/pull/2991/files?diff=unified&w=0#diff-acac08f31319ce15064e72bec03f921b9731164f2022b1a17ed4c09ba2864540L36-R56), [link](https://github.com/vueuse/vueuse/pull/2991/files?diff=unified&w=0#diff-acac08f31319ce15064e72bec03f921b9731164f2022b1a17ed4c09ba2864540L58-R123))
  * Update the `x`, `y`, and `sourceType` refs with the mouse coordinates and the event source ([link](https://github.com/vueuse/vueuse/pull/2991/files?diff=unified&w=0#diff-acac08f31319ce15064e72bec03f921b9731164f2022b1a17ed4c09ba2864540R8-R11), [link](https://github.com/vueuse/vueuse/pull/2991/files?diff=unified&w=0#diff-acac08f31319ce15064e72bec03f921b9731164f2022b1a17ed4c09ba2864540L58-R123))
  * Use the `eventFilter` option if provided, or directly call the handler functions otherwise ([link](https://github.com/vueuse/vueuse/pull/2991/files?diff=unified&w=0#diff-acac08f31319ce15064e72bec03f921b9731164f2022b1a17ed4c09ba2864540L58-R123))
  * Use the `target` parameter instead of the `window` object for the `useEventListener` hooks ([link](https://github.com/vueuse/vueuse/pull/2991/files?diff=unified&w=0#diff-acac08f31319ce15064e72bec03f921b9731164f2022b1a17ed4c09ba2864540R71))
* Update the demo.vue file to show the usage of the new `target` and `type` options ([link](https://github.com/vueuse/vueuse/pull/2991/files?diff=unified&w=0#diff-c7648f1e157ab7012a7ccaa00616fb7fdef3a495db768c748a0225c8b880ec06L4-R25))
  * Show the difference between the default usage and the usage with an extractor function that only returns the offset coordinates of the mouse relative to the parent element ([link](https://github.com/vueuse/vueuse/pull/2991/files?diff=unified&w=0#diff-c7648f1e157ab7012a7ccaa00616fb7fdef3a495db768c748a0225c8b880ec06L4-R25))
