### PR TITLE
feat(watch): `watchImmediate` and `watchDeep` support overloads

### DIFF
--- a/packages/shared/utils/types.ts
+++ b/packages/shared/utils/types.ts
@@ -125,6 +125,8 @@ export interface ConfigurableFlushSync {
 }
 
 // Internal Types
+export type MultiWatchSources = (WatchSource<unknown> | object)[]
+
 export type MapSources<T> = {
   [K in keyof T]: T[K] extends WatchSource<infer V> ? V : never;
 }

--- a/packages/shared/watchDeep/index.ts
+++ b/packages/shared/watchDeep/index.ts
@@ -1,14 +1,41 @@
-import type { WatchCallback, WatchOptions, WatchSource } from 'vue-demi'
+import type { WatchCallback, WatchOptions, WatchSource, WatchStopHandle } from 'vue-demi'
 import { watch } from 'vue-demi'
+
+import type { MapOldSources, MapSources, MultiWatchSources } from '../utils/types'
+
+// overloads
+export function watchDeep<
+  T extends Readonly<MultiWatchSources>,
+  Immediate extends Readonly<boolean> = false,
+>(
+  source: T,
+  cb: WatchCallback<MapSources<T>, MapOldSources<T, Immediate>>,
+  options?: Omit<WatchOptions<Immediate>, 'deep'>
+): WatchStopHandle
+
+export function watchDeep<T, Immediate extends Readonly<boolean> = false>(
+  source: WatchSource<T>,
+  cb: WatchCallback<T, Immediate extends true ? T | undefined : T>,
+  options?: Omit<WatchOptions<Immediate>, 'deep'>
+): WatchStopHandle
+
+export function watchDeep<
+  T extends object,
+  Immediate extends Readonly<boolean> = false,
+>(
+  source: T,
+  cb: WatchCallback<T, Immediate extends true ? T | undefined : T>,
+  options?: Omit<WatchOptions<Immediate>, 'deep'>
+): WatchStopHandle
 
 /**
  * Shorthand for watching value with {deep: true}
  *
  * @see https://vueuse.org/watchDeep
  */
-export function watchDeep<T>(source: WatchSource<T>, cb: WatchCallback<T>, options?: Omit<WatchOptions, 'deep'>) {
+export function watchDeep<T = any, Immediate extends Readonly<boolean> = false>(source: T | WatchSource<T>, cb: any, options?: Omit<WatchOptions<Immediate>, 'deep'>) {
   return watch(
-    source,
+    source as any,
     cb,
     {
       ...options,

--- a/packages/shared/watchImmediate/index.ts
+++ b/packages/shared/watchImmediate/index.ts
@@ -1,14 +1,35 @@
-import type { WatchCallback, WatchOptions, WatchSource } from 'vue-demi'
+import type { WatchCallback, WatchOptions, WatchSource, WatchStopHandle } from 'vue-demi'
 import { watch } from 'vue-demi'
+
+import type { MapOldSources, MapSources, MultiWatchSources } from '../utils/types'
+
+// overloads
+export function watchImmediate<T extends Readonly<MultiWatchSources>>(
+  source: T,
+  cb: WatchCallback<MapSources<T>, MapOldSources<T, true>>,
+  options?: Omit<WatchOptions<true>, 'deep'>
+): WatchStopHandle
+
+export function watchImmediate<T>(
+  source: WatchSource<T>,
+  cb: WatchCallback<T, T | undefined>,
+  options?: Omit<WatchOptions<true>, 'deep'>
+): WatchStopHandle
+
+export function watchImmediate<T extends object>(
+  source: T,
+  cb: WatchCallback<T, T | undefined>,
+  options?: Omit<WatchOptions<true>, 'deep'>
+): WatchStopHandle
 
 /**
  * Shorthand for watching value with {immediate: true}
  *
  * @see https://vueuse.org/watchImmediate
  */
-export function watchImmediate<T>(source: WatchSource<T>, cb: WatchCallback<T>, options?: Omit<WatchOptions, 'immediate'>) {
+export function watchImmediate<T = any>(source: T, cb: any, options?: Omit<WatchOptions, 'immediate'>) {
   return watch(
-    source,
+    source as any,
     cb,
     {
       ...options,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

---

### Description

Currently, the type for watchImmediate and watchDeep do not allow passing an array of multiple data sources. This PR addresses this issue by using overloads."

<img width="827" alt="截圖 2023-04-19 下午3 17 39" src="https://user-images.githubusercontent.com/39984251/232998148-90748110-aec5-4441-b3ac-ef60520cb490.png">

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c6bd046</samp>

This pull request improves the functionality and organization of the `watchDeep` and `watchImmediate` functions, which allow reactive watchers for deep or immediate changes. It introduces a new type `MultiWatchSources` to handle multiple sources, and moves the functions to separate files under `packages/shared`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c6bd046</samp>

*  Add `watchDeep` and `watchImmediate` functions to support watching multiple sources with deep or immediate options ([link](https://github.com/vueuse/vueuse/pull/2998/files?diff=unified&w=0#diff-22bf3f60b449d51004bd542887b4120f4b0abc5613be9ee9381e2e338f9cbccbR128-R129), [link](https://github.com/vueuse/vueuse/pull/2998/files?diff=unified&w=0#diff-166f0be3e0b1ef71d651c84659433142d6517b3c4e5dece0c803c442ba7bc483L1-R30), [link](https://github.com/vueuse/vueuse/pull/2998/files?diff=unified&w=0#diff-89f52c79f027c8ab99475400fe2a56f1efdeb5fabd966d7f417b97699d3a4870L1-R24))
  * Use overloads with `MapSources`, `MapOldSources`, and `Immediate` types to infer source and callback types and omit redundant options ([link](https://github.com/vueuse/vueuse/pull/2998/files?diff=unified&w=0#diff-166f0be3e0b1ef71d651c84659433142d6517b3c4e5dece0c803c442ba7bc483L1-R30), [link](https://github.com/vueuse/vueuse/pull/2998/files?diff=unified&w=0#diff-89f52c79f027c8ab99475400fe2a56f1efdeb5fabd966d7f417b97699d3a4870L1-R24))
  * Use fallback functions with default generic parameters, `any` casts, and relaxed source constraints to handle any arguments ([link](https://github.com/vueuse/vueuse/pull/2998/files?diff=unified&w=0#diff-166f0be3e0b1ef71d651c84659433142d6517b3c4e5dece0c803c442ba7bc483L9-R38), [link](https://github.com/vueuse/vueuse/pull/2998/files?diff=unified&w=0#diff-89f52c79f027c8ab99475400fe2a56f1efdeb5fabd966d7f417b97699d3a4870L9-R32))
* Move `watchDeep` and `watchImmediate` functions from their original files to `packages/shared/utils/types.ts` for better organization ([link](https://github.com/vueuse/vueuse/pull/2998/files?diff=unified&w=0#diff-166f0be3e0b1ef71d651c84659433142d6517b3c4e5dece0c803c442ba7bc483L1-R30), [link](https://github.com/vueuse/vueuse/pull/2998/files?diff=unified&w=0#diff-89f52c79f027c8ab99475400fe2a56f1efdeb5fabd966d7f417b97699d3a4870L1-R24))
