### PR TITLE
fix(useFullscreen): `isFullscreen` handling for mutliple fullscreen elements

### DIFF
--- a/packages/core/useFullscreen/index.ts
+++ b/packages/core/useFullscreen/index.ts
@@ -76,14 +76,12 @@ export function useFullscreen(
     ].find(m => (document && m in document) || (targetRef.value && m in targetRef.value)) as any
   })
 
-  const fullscreenElement = computed<'fullscreenElement' | undefined>(() => {
-    return [
-      'fullscreenElement',
-      'webkitFullscreenElement',
-      'mozFullScreenElement',
-      'msFullscreenElement',
-    ].find(m => (document && m in document)) as any
-  })
+  const fullscreenElementMethod = [
+    'fullscreenElement',
+    'webkitFullscreenElement',
+    'mozFullScreenElement',
+    'msFullscreenElement',
+  ].find(m => (document && m in document)) as 'fullscreenElement' | undefined
 
   const isSupported = useSupported(() =>
     targetRef.value
@@ -94,8 +92,8 @@ export function useFullscreen(
   )
 
   const isCurrentElementFullScreen = (): boolean => {
-    if (fullscreenElement.value)
-      return document?.[fullscreenElement.value] === targetRef.value
+    if (fullscreenElementMethod)
+      return document?.[fullscreenElementMethod] === targetRef.value
     return false
   }
 

--- a/packages/core/useFullscreen/index.ts
+++ b/packages/core/useFullscreen/index.ts
@@ -76,6 +76,15 @@ export function useFullscreen(
     ].find(m => (document && m in document) || (targetRef.value && m in targetRef.value)) as any
   })
 
+  const fullscreenElement = computed<'fullscreenElement' | undefined>(() => {
+    return [
+      'fullscreenElement',
+      'webkitFullscreenElement',
+      'mozFullScreenElement',
+      'msFullscreenElement',
+    ].find(m => (document && m in document)) as any
+  })
+
   const isSupported = useSupported(() =>
     targetRef.value
     && document
@@ -83,6 +92,12 @@ export function useFullscreen(
     && exitMethod.value !== undefined
     && fullscreenEnabled.value !== undefined,
   )
+
+  const isCurrentElementFullScreen = (): boolean => {
+    if (fullscreenElement.value)
+      return document?.[fullscreenElement.value] === targetRef.value
+    return false
+  }
 
   const isElementFullScreen = (): boolean => {
     if (fullscreenEnabled.value) {
@@ -139,7 +154,9 @@ export function useFullscreen(
   }
 
   const handlerCallback = () => {
-    isFullscreen.value = isElementFullScreen()
+    const isElementFullScreenValue = isElementFullScreen()
+    if (!isElementFullScreenValue || (isElementFullScreenValue && isCurrentElementFullScreen()))
+      isFullscreen.value = isElementFullScreenValue
   }
 
   useEventListener(document, eventHandlers, handlerCallback, false)


### PR DESCRIPTION
…e levels of full screen

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
solved #2962.
When assigning `true` to `isFullscreen`, there is no check for situations where it is not the current element.
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ad7b77c</samp>

Enhance `useFullscreen` with new features and bug fix. Add `fullscreenElement` to get the current fullscreen element and `isCurrentElementFullScreen` to check if the target element is in fullscreen mode. Fix `toggle` bug when another element enters fullscreen mode.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ad7b77c</samp>

*  Add a computed property `fullscreenElement` to `useFullscreen` that returns the document property for the current fullscreen element ([link](https://github.com/vueuse/vueuse/pull/3000/files?diff=unified&w=0#diff-b85cb76a4419d436753170029b8267a5ba5db30572b4817200fef24b34b1f586R79-R87))
*  Add a helper function `isCurrentElementFullScreen` to `useFullscreen` that checks if the target element is the same as the current fullscreen element ([link](https://github.com/vueuse/vueuse/pull/3000/files?diff=unified&w=0#diff-b85cb76a4419d436753170029b8267a5ba5db30572b4817200fef24b34b1f586R96-R101))
*  Modify the `handlerCallback` function in `toggle` to only update the `isFullscreen` reactive value if the target element is not in fullscreen mode or is the current fullscreen element ([link](https://github.com/vueuse/vueuse/pull/3000/files?diff=unified&w=0#diff-b85cb76a4419d436753170029b8267a5ba5db30572b4817200fef24b34b1f586L142-R159))
