### PR TITLE
fix(useRouteHash,useRouteQuery,useRouteParams): re-evaluates the value immediately

### DIFF
--- a/packages/router/_types.ts
+++ b/packages/router/_types.ts
@@ -1,7 +1,9 @@
 import type { MaybeRef } from '@vueuse/shared'
-import type { useRoute, useRouter } from 'vue-router'
+import type { RouteParamValueRaw, useRoute, useRouter } from 'vue-router'
 
-export type RouteDefaultValue = null | undefined | string | string[]
+export type RouteQueryValueRaw = RouteParamValueRaw | string[]
+
+export type RouteHashValueRaw = string | null | undefined
 
 export interface ReactiveRouteOptions {
   /**

--- a/packages/router/_types.ts
+++ b/packages/router/_types.ts
@@ -1,7 +1,7 @@
 import type { MaybeRef } from '@vueuse/shared'
 import type { useRoute, useRouter } from 'vue-router'
 
-export type RouterQueryValue = null | undefined | string | string[]
+export type RouteDefaultValue = null | undefined | string | string[]
 
 export interface ReactiveRouteOptions {
   /**

--- a/packages/router/useRouteHash/index.test.ts
+++ b/packages/router/useRouteHash/index.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { useRouteHash } from '.'
+
+describe('useRouteHash', () => {
+  const getRoute = (hash = '') => ({
+    query: {},
+    fullPath: '',
+    hash,
+    matched: [],
+    meta: {},
+    name: '',
+    params: {},
+    path: '',
+    redirectedFrom: undefined,
+  })
+
+  it('should return current value', () => {
+    const router = {} as any
+    const route = getRoute('header')
+
+    const hash = useRouteHash(null, { route, router })
+
+    expect(hash.value).toBe(route.hash)
+  })
+
+  it('should re-evaluate the value immediately', () => {
+    const router = { replace: () => {} } as any
+    const route = getRoute('header')
+
+    const hash = useRouteHash(null, { route, router })
+
+    hash.value = 'footer'
+
+    expect(hash.value).toBe('footer')
+  })
+})

--- a/packages/router/useRouteHash/index.test.ts
+++ b/packages/router/useRouteHash/index.test.ts
@@ -1,8 +1,9 @@
+import { nextTick } from 'vue-demi'
 import { describe, expect, it } from 'vitest'
 import { useRouteHash } from '.'
 
 describe('useRouteHash', () => {
-  const getRoute = (hash = '') => ({
+  const getRoute = (hash?: any) => ({
     query: {},
     fullPath: '',
     hash,
@@ -14,9 +15,13 @@ describe('useRouteHash', () => {
     redirectedFrom: undefined,
   })
 
+  it('should export', () => {
+    expect(useRouteHash).toBeDefined()
+  })
+
   it('should return current value', () => {
-    const router = {} as any
-    const route = getRoute('header')
+    let route = getRoute('header')
+    const router = { replace: (r: any) => route = r } as any
 
     const hash = useRouteHash(null, { route, router })
 
@@ -24,13 +29,37 @@ describe('useRouteHash', () => {
   })
 
   it('should re-evaluate the value immediately', () => {
-    const router = { replace: () => {} } as any
-    const route = getRoute('header')
+    let route = getRoute('header')
+    const router = { replace: (r: any) => route = r } as any
 
     const hash = useRouteHash(null, { route, router })
 
     hash.value = 'footer'
 
     expect(hash.value).toBe('footer')
+  })
+
+  it('should update the route', async () => {
+    let route = getRoute('foo')
+    const router = { replace: (r: any) => route = r } as any
+
+    const hash = useRouteHash(null, { route, router })
+
+    hash.value = 'footer'
+
+    await nextTick()
+
+    expect(hash.value).toBe('footer')
+    expect(route.hash).toBe('footer')
+  })
+
+  it('should return default value', () => {
+    let route = getRoute()
+    const router = { replace: (r: any) => route = r } as any
+
+    const hash = useRouteHash('baz', { route, router })
+
+    expect(hash.value).toBe('baz')
+    expect(route.hash).toBeUndefined()
   })
 })

--- a/packages/router/useRouteHash/index.ts
+++ b/packages/router/useRouteHash/index.ts
@@ -1,23 +1,28 @@
-import { computed, nextTick } from 'vue-demi'
+import type { Ref } from 'vue-demi'
+import { computed, nextTick, ref } from 'vue-demi'
 import { useRoute, useRouter } from 'vue-router'
 import { toValue } from '@vueuse/shared'
-import type { ReactiveRouteOptions } from '../_types'
+import type { ReactiveRouteOptions, RouteDefaultValue } from '../_types'
 
 export function useRouteHash(
-  defaultValue?: string,
+  defaultValue?: RouteDefaultValue,
   {
     mode = 'replace',
     route = useRoute(),
     router = useRouter(),
   }: ReactiveRouteOptions = {},
 ) {
+  const _hash: Ref<any> = ref(route.hash ?? defaultValue)
+
   return computed<string>({
     get() {
-      return route.hash ?? defaultValue
+      return _hash.value
     },
     set(v) {
+      _hash.value = (v === defaultValue || v === null) ? undefined : v
+
       nextTick(() => {
-        router[toValue(mode)]({ ...route, hash: v })
+        router[toValue(mode)]({ ...route, hash: _hash.value })
       })
     },
   })

--- a/packages/router/useRouteParams/index.test.ts
+++ b/packages/router/useRouteParams/index.test.ts
@@ -1,17 +1,29 @@
+import type { Ref } from 'vue-demi'
 import { describe, expect, it } from 'vitest'
 import { useRouteParams } from '.'
 
 describe('useRouteQuery', () => {
   const getRoute = (params: Record<string, any> = {}) => ({
+    params,
     query: {},
     fullPath: '',
     hash: '',
     matched: [],
     meta: {},
     name: '',
-    params: { id: '1', ...params },
     path: '',
     redirectedFrom: undefined,
+  })
+
+  it('should return current value', () => {
+    const router = {} as any
+    const route = getRoute({
+      id: '1',
+    })
+
+    const id = useRouteParams('id', null, { route, router })
+
+    expect(id.value).toBe('1')
   })
 
   it('should return transformed value', () => {
@@ -21,5 +33,16 @@ describe('useRouteQuery', () => {
     const id = useRouteParams('id', '1', { transform: Number, route, router })
 
     expect(id.value).toBe(1)
+  })
+
+  it('should re-evaluate the value immediately', () => {
+    const router = { replace: () => {} } as any
+    const route = getRoute()
+
+    const slug: Ref<any> = useRouteParams('slug', 'foo', { route, router })
+
+    slug.value = 'bar'
+
+    expect(slug.value).toBe('bar')
   })
 })

--- a/packages/router/useRouteParams/index.test.ts
+++ b/packages/router/useRouteParams/index.test.ts
@@ -1,5 +1,6 @@
-import type { Ref } from 'vue-demi'
+import { nextTick } from 'vue-demi'
 import { describe, expect, it } from 'vitest'
+import type { Ref } from 'vue-demi'
 import { useRouteParams } from '.'
 
 describe('useRouteQuery', () => {
@@ -15,6 +16,10 @@ describe('useRouteQuery', () => {
     redirectedFrom: undefined,
   })
 
+  it('should export', () => {
+    expect(useRouteParams).toBeDefined()
+  })
+
   it('should return current value', () => {
     const router = {} as any
     const route = getRoute({
@@ -27,8 +32,8 @@ describe('useRouteQuery', () => {
   })
 
   it('should return transformed value', () => {
-    const router = {} as any
     const route = getRoute()
+    const router = {} as any
 
     const id = useRouteParams('id', '1', { transform: Number, route, router })
 
@@ -36,13 +41,52 @@ describe('useRouteQuery', () => {
   })
 
   it('should re-evaluate the value immediately', () => {
-    const router = { replace: () => {} } as any
-    const route = getRoute()
+    let route = getRoute()
+    const router = { replace: (r: any) => route = r } as any
 
     const slug: Ref<any> = useRouteParams('slug', 'foo', { route, router })
+    const id: Ref<any> = useRouteParams('id', '123', { route, router })
+    const page: Ref<any> = useRouteParams('page', null, { route, router })
 
     slug.value = 'bar'
+    id.value = '456'
+    page.value = '2'
 
     expect(slug.value).toBe('bar')
+    expect(id.value).toBe('456')
+    expect(page.value).toBe('2')
+  })
+
+  it('should update the route', async () => {
+    let route = getRoute()
+    const router = { replace: (r: any) => route = r } as any
+
+    const code: Ref<any> = useRouteParams('code', null, { route, router })
+    const page: Ref<any> = useRouteParams('page', null, { route, router })
+    const lang: Ref<any> = useRouteParams('lang', null, { route, router })
+
+    code.value = 'bar'
+    page.value = '1'
+    lang.value = 'en'
+
+    await nextTick()
+
+    expect(code.value).toBe('bar')
+    expect(route.params.code).toBe('bar')
+    expect(page.value).toBe('1')
+    expect(route.params.page).toBe('1')
+    expect(lang.value).toBe('en')
+    expect(route.params.lang).toBe('en')
+  })
+
+  it('should return default value', () => {
+    let route = getRoute()
+    const router = { replace: (r: any) => route = r } as any
+
+    const page: Ref<any> = useRouteParams('page', 10, { route, router })
+    const lang: Ref<any> = useRouteParams('lang', 'pt-BR', { route, router })
+
+    expect(page.value).toBe(10)
+    expect(lang.value).toBe('pt-BR')
   })
 })

--- a/packages/router/useRouteParams/index.ts
+++ b/packages/router/useRouteParams/index.ts
@@ -1,15 +1,15 @@
 import type { Ref } from 'vue-demi'
-import { computed, nextTick } from 'vue-demi'
+import { computed, nextTick, ref } from 'vue-demi'
 import { useRoute, useRouter } from 'vue-router'
 import { toValue } from '@vueuse/shared'
-import type { ReactiveRouteOptionsWithTransform, RouterQueryValue } from '../_types'
+import type { ReactiveRouteOptionsWithTransform, RouteDefaultValue } from '../_types'
 
 export function useRouteParams(
   name: string
 ): Ref<null | string | string[]>
 
 export function useRouteParams<
-  T extends RouterQueryValue = RouterQueryValue,
+  T extends RouteDefaultValue = RouteDefaultValue,
   K = T,
 >(
   name: string,
@@ -18,7 +18,7 @@ export function useRouteParams<
 ): Ref<K>
 
 export function useRouteParams<
-  T extends RouterQueryValue = RouterQueryValue,
+  T extends RouteDefaultValue = RouteDefaultValue,
   K = T,
 >(
   name: string,
@@ -31,15 +31,17 @@ export function useRouteParams<
     router = useRouter(),
     transform = value => value as any as K,
   } = options
+  const _param: Ref<any> = ref(route.params[name] ?? defaultValue)
 
   return computed<any>({
     get() {
-      const data = route.params[name] ?? defaultValue
-      return transform(data as T)
+      return transform(_param.value ?? defaultValue)
     },
     set(v) {
+      _param.value = (v === defaultValue || v === null) ? undefined : v
+
       nextTick(() => {
-        router[toValue(mode)]({ ...route, params: { ...route.params, [name]: v } })
+        router[toValue(mode)]({ ...route, params: { ...route.params, [name]: _param.value } })
       })
     },
   })

--- a/packages/router/useRouteParams/index.ts
+++ b/packages/router/useRouteParams/index.ts
@@ -5,7 +5,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { toValue, tryOnScopeDispose } from '@vueuse/shared'
 import type { ReactiveRouteOptionsWithTransform } from '../_types'
 
-let _params: Record<string, any> = {}
+const _cache = new WeakMap()
 
 export function useRouteParams(
   name: string
@@ -35,26 +35,31 @@ export function useRouteParams<
     transform = value => value as any as K,
   } = options
 
-  _params[name] = route.params[name]
+  if (!_cache.has(route))
+    _cache.set(route, new Map())
+
+  const _params: Map<string, any> = _cache.get(route)
 
   tryOnScopeDispose(() => {
-    _params = {}
+    _params.delete(name)
   })
+
+  _params.set(name, route.params[name])
 
   return customRef<any>((track, trigger) => ({
     get() {
       track()
 
-      const data = _params[name] ?? defaultValue
+      const data = _params.get(name) ?? defaultValue
       return transform(data as T)
     },
     set(v) {
-      _params[name] = (v === defaultValue || v === null) ? undefined : v
+      _params.set(name, (v === defaultValue || v === null) ? undefined : v)
 
       trigger()
 
       nextTick(() => {
-        router[toValue(mode)]({ ...route, params: { ...route.params, ..._params } })
+        router[toValue(mode)]({ ...route, params: { ...route.params, ...Object.fromEntries(_params.entries()) } })
       })
     },
   }))

--- a/packages/router/useRouteQuery/index.test.ts
+++ b/packages/router/useRouteQuery/index.test.ts
@@ -1,13 +1,10 @@
+import type { Ref } from 'vue-demi'
 import { describe, expect, it } from 'vitest'
 import { useRouteQuery } from '.'
 
 describe('useRouteQuery', () => {
   const getRoute = (query: Record<string, any> = {}) => ({
-    query: {
-      search: 'vue3',
-      page: '1',
-      ...query,
-    },
+    query,
     fullPath: '',
     hash: '',
     matched: [],
@@ -20,7 +17,10 @@ describe('useRouteQuery', () => {
 
   it('should return transformed value', () => {
     const router = {} as any
-    const route = getRoute()
+    const route = getRoute({
+      search: 'vue3',
+      page: '1',
+    })
     const transform = Number
     const toArray = (param: string | string[] | null) => Array.isArray(param) ? param : [param]
 
@@ -31,5 +31,20 @@ describe('useRouteQuery', () => {
     expect(page.value).toBe(1)
     expect(perPage.value).toBe(15)
     expect(tags.value).toEqual(['vite'])
+  })
+
+  it('should re-evaluate the value immediately', () => {
+    const router = { replace: () => {} } as any
+    const route = getRoute({
+      search: 'vue3',
+    })
+
+    const code: Ref<any> = useRouteQuery('code', 'foo', { route, router })
+    const search: Ref<any> = useRouteQuery('search', null, { route, router })
+
+    code.value = 'bar'
+
+    expect(code.value).toBe('bar')
+    expect(search.value).toBe('vue3')
   })
 })

--- a/packages/router/useRouteQuery/index.test.ts
+++ b/packages/router/useRouteQuery/index.test.ts
@@ -1,5 +1,6 @@
-import type { Ref } from 'vue-demi'
+import { nextTick } from 'vue-demi'
 import { describe, expect, it } from 'vitest'
+import type { Ref } from 'vue-demi'
 import { useRouteQuery } from '.'
 
 describe('useRouteQuery', () => {
@@ -13,6 +14,10 @@ describe('useRouteQuery', () => {
     params: {},
     path: '',
     redirectedFrom: undefined,
+  })
+
+  it('should export', () => {
+    expect(useRouteQuery).toBeDefined()
   })
 
   it('should return transformed value', () => {
@@ -34,10 +39,10 @@ describe('useRouteQuery', () => {
   })
 
   it('should re-evaluate the value immediately', () => {
-    const router = { replace: () => {} } as any
-    const route = getRoute({
+    let route = getRoute({
       search: 'vue3',
     })
+    const router = { replace: (r: any) => route = r } as any
 
     const code: Ref<any> = useRouteQuery('code', 'foo', { route, router })
     const search: Ref<any> = useRouteQuery('search', null, { route, router })
@@ -46,5 +51,38 @@ describe('useRouteQuery', () => {
 
     expect(code.value).toBe('bar')
     expect(search.value).toBe('vue3')
+  })
+
+  it('should update the route', async () => {
+    let route = getRoute()
+    const router = { replace: (r: any) => route = r } as any
+
+    const code: Ref<any> = useRouteQuery('code', null, { route, router })
+    const page: Ref<any> = useRouteQuery('page', null, { route, router })
+    const lang: Ref<any> = useRouteQuery('lang', null, { route, router })
+
+    code.value = 'bar'
+    page.value = '1'
+    lang.value = 'en'
+
+    await nextTick()
+
+    expect(code.value).toBe('bar')
+    expect(route.query.code).toBe('bar')
+    expect(page.value).toBe('1')
+    expect(route.query.page).toBe('1')
+    expect(lang.value).toBe('en')
+    expect(route.query.lang).toBe('en')
+  })
+
+  it('should return default value', () => {
+    let route = getRoute()
+    const router = { replace: (r: any) => route = r } as any
+
+    const page: Ref<any> = useRouteQuery('page', 2, { route, router })
+    const lang: Ref<any> = useRouteQuery('lang', 'pt-BR', { route, router })
+
+    expect(page.value).toBe(2)
+    expect(lang.value).toBe('pt-BR')
   })
 })

--- a/packages/router/useRouteQuery/index.ts
+++ b/packages/router/useRouteQuery/index.ts
@@ -1,17 +1,15 @@
 import type { Ref } from 'vue-demi'
-import { computed, nextTick } from 'vue-demi'
+import { computed, nextTick, ref } from 'vue-demi'
 import { toValue } from '@vueuse/shared'
 import { useRoute, useRouter } from 'vue-router'
-import type { ReactiveRouteOptionsWithTransform, RouterQueryValue } from '../_types'
-
-let _queue: Record<string, any> = {}
+import type { ReactiveRouteOptionsWithTransform, RouteDefaultValue } from '../_types'
 
 export function useRouteQuery(
   name: string
 ): Ref<null | string | string[]>
 
 export function useRouteQuery<
-  T extends RouterQueryValue = RouterQueryValue,
+  T extends RouteDefaultValue = RouteDefaultValue,
   K = T,
 >(
   name: string,
@@ -20,7 +18,7 @@ export function useRouteQuery<
 ): Ref<K>
 
 export function useRouteQuery<
-  T extends RouterQueryValue = RouterQueryValue,
+  T extends RouteDefaultValue = RouteDefaultValue,
   K = T,
 >(
   name: string,
@@ -33,18 +31,17 @@ export function useRouteQuery<
     router = useRouter(),
     transform = value => value as any as K,
   } = options
+  const _query: Ref<any> = ref(route.query[name] ?? defaultValue)
 
   return computed<any>({
     get() {
-      const data = route.query[name] ?? defaultValue
-      return transform(data as T)
+      return transform(_query.value ?? defaultValue)
     },
     set(v) {
-      _queue[name] = (v === defaultValue || v === null) ? undefined : v
+      _query.value = (v === defaultValue || v === null) ? undefined : v
 
       nextTick(() => {
-        router[toValue(mode)]({ ...route, query: { ...route.query, ..._queue } })
-        nextTick(() => _queue = {})
+        router[toValue(mode)]({ ...route, query: { ...route.query, [name]: _query.value } })
       })
     },
   })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

It will re-evaluate the value immediately.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

By default, Vue.js caches the result of a computed property and only re-evaluates it if one of its dependencies has changed. But currently, it seems that it is not updating or getting the correct value on the same tick. These updates will force a re-evaluation after the value has been updated.

Example:
```js
import { useRouteQuery } from '@vueuse/router'

const page = useRouteQuery('page', 1)
const userId = useRouteQuery('user')

const fetch = () => {
   // ... send page and userId as parameters.
}

const searchByUserId(id) {
   page.value = 1
   userId.value = id
   
   fetch()
}
```

[live code](https://codesandbox.io/s/vueuse-useroutequery-same-tick-forked-0poe2r?file=/src/Home.vue)
---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a4035ad</samp>

This pull request refactors and improves the router composables `useRouteHash`, `useRouteParams`, and `useRouteQuery`, by enhancing their reactivity, consistency, and type support. It also adds or updates the corresponding test files to verify their functionality and behavior. Additionally, it renames the `RouterQueryValue` type to `RouteDefaultValue` to avoid confusion.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a4035ad</samp>

*  Rename `RouterQueryValue` type to `RouteDefaultValue` to avoid confusion ([link](https://github.com/vueuse/vueuse/pull/3002/files?diff=unified&w=0#diff-032bcb6a37e926c15ba48d2d57a0ae069ed89d948d9531d3b16327c6c87c9ca9L4-R4), [link](https://github.com/vueuse/vueuse/pull/3002/files?diff=unified&w=0#diff-f657fa605a6d4b2a9769faa5835fde4154c39c4a01a09cf8ae63e9dac446fcd8L12-R12), [link](https://github.com/vueuse/vueuse/pull/3002/files?diff=unified&w=0#diff-f657fa605a6d4b2a9769faa5835fde4154c39c4a01a09cf8ae63e9dac446fcd8L21-R21), [link](https://github.com/vueuse/vueuse/pull/3002/files?diff=unified&w=0#diff-3a643af876b64ca6e9d5db979bfc2cfb0af8d46845a7cd6bfe4b1e41e5a369b5L14-R12), [link](https://github.com/vueuse/vueuse/pull/3002/files?diff=unified&w=0#diff-3a643af876b64ca6e9d5db979bfc2cfb0af8d46845a7cd6bfe4b1e41e5a369b5L23-R21))
*  Move route-related composables from individual files to `_types.ts` for consistency ([link](https://github.com/vueuse/vueuse/pull/3002/files?diff=unified&w=0#diff-fc3a7ce9d8a27367785d6851f036fec95e5b08c3af89152d498b11e8089c8554L1-R8), [link](https://github.com/vueuse/vueuse/pull/3002/files?diff=unified&w=0#diff-f657fa605a6d4b2a9769faa5835fde4154c39c4a01a09cf8ae63e9dac446fcd8L2-R5), [link](https://github.com/vueuse/vueuse/pull/3002/files?diff=unified&w=0#diff-3a643af876b64ca6e9d5db979bfc2cfb0af8d46845a7cd6bfe4b1e41e5a369b5L2-R6))
*  Refactor `useRouteHash`, `useRouteParams`, and `useRouteQuery` to use local refs instead of directly modifying the route object, to improve reactivity and avoid side effects ([link](https://github.com/vueuse/vueuse/pull/3002/files?diff=unified&w=0#diff-fc3a7ce9d8a27367785d6851f036fec95e5b08c3af89152d498b11e8089c8554L14-R25), [link](https://github.com/vueuse/vueuse/pull/3002/files?diff=unified&w=0#diff-f657fa605a6d4b2a9769faa5835fde4154c39c4a01a09cf8ae63e9dac446fcd8L34-R44), [link](https://github.com/vueuse/vueuse/pull/3002/files?diff=unified&w=0#diff-3a643af876b64ca6e9d5db979bfc2cfb0af8d46845a7cd6bfe4b1e41e5a369b5L36-R44))
*  Add test file for `useRouteHash` composable, with two test cases to check the initial and updated values of the hash ([link](https://github.com/vueuse/vueuse/pull/3002/files?diff=unified&w=0#diff-82691b0ea2a3b2f357738c7235bb1e21656b0c86f5d8c7acef6f59c07a784d99R1-R36))
*  Update test file for `useRouteParams` composable, to import `Ref` type, add `params` argument to `getRoute` helper, and add two test cases to check the initial and updated values of the param ([link](https://github.com/vueuse/vueuse/pull/3002/files?diff=unified&w=0#diff-a57f86ebcafcb55d44126c69a48bd1f5c88e513a80fddd3241ecd3ae34ba76ddR1), [link](https://github.com/vueuse/vueuse/pull/3002/files?diff=unified&w=0#diff-a57f86ebcafcb55d44126c69a48bd1f5c88e513a80fddd3241ecd3ae34ba76ddR7), [link](https://github.com/vueuse/vueuse/pull/3002/files?diff=unified&w=0#diff-a57f86ebcafcb55d44126c69a48bd1f5c88e513a80fddd3241ecd3ae34ba76ddL12-R28), [link](https://github.com/vueuse/vueuse/pull/3002/files?diff=unified&w=0#diff-a57f86ebcafcb55d44126c69a48bd1f5c88e513a80fddd3241ecd3ae34ba76ddR37-R47))
*  Update test file for `useRouteQuery` composable, to import `Ref` type, simplify `getRoute` helper, and add a test case to check the updated value of the query ([link](https://github.com/vueuse/vueuse/pull/3002/files?diff=unified&w=0#diff-faa7aba85ff895209572d55a507c772d3fbc8ff9530641d792cd69d5eeb0101aR1), [link](https://github.com/vueuse/vueuse/pull/3002/files?diff=unified&w=0#diff-faa7aba85ff895209572d55a507c772d3fbc8ff9530641d792cd69d5eeb0101aL6-R7), [link](https://github.com/vueuse/vueuse/pull/3002/files?diff=unified&w=0#diff-faa7aba85ff895209572d55a507c772d3fbc8ff9530641d792cd69d5eeb0101aL23-R23), [link](https://github.com/vueuse/vueuse/pull/3002/files?diff=unified&w=0#diff-faa7aba85ff895209572d55a507c772d3fbc8ff9530641d792cd69d5eeb0101aR35-R49))
