### PR TITLE
feat(useAsyncState): add support directly await

### DIFF
--- a/packages/core/useAsyncState/index.test.ts
+++ b/packages/core/useAsyncState/index.test.ts
@@ -27,6 +27,13 @@ describe('useAsyncState', () => {
     expect(state.value).toBe(2)
   })
 
+  it('should work with await', async () => {
+    const asyncState = useAsyncState(p1, 0, { immediate: true })
+    expect(asyncState.isLoading.value).toBeTruthy()
+    await asyncState
+    expect(asyncState.isLoading.value).toBeFalsy()
+  })
+
   it('should work with isLoading', () => {
     const { execute, isLoading } = useAsyncState(p1, 0, { immediate: false })
     expect(isLoading.value).toBeFalsy()


### PR DESCRIPTION
Add initialized in the [useAsyncState](https://vueuse.org/core/useAsyncState/).

### Description

Sometimes, using only `isReady` or `isLoading`  is not very convenient. 

For example, in scenarios where multiple events rely on state being triggered, and the `execute` may not have been completed yet.

We need to use `await initialized` to ensure that subsequent operations are executed only after the state has been initialized.

### Example

```vue


<script lang="ts" setup>
const { initialized, state } = useAsyncState(p1, 0, { immediate: true })

const eventA = async () => {
  await initialized.value
  // do something with the state...
}
const eventB = async () => {
  await initialized.value
  // do something with the state ...
}
</script>
```