### PR TITLE
fix: dialog mask add z-index

### DIFF
--- a/packages/core/createTemplatePromise/demo.vue
+++ b/packages/core/createTemplatePromise/demo.vue
@@ -38,7 +38,7 @@ function asyncFn() {
     </button>
   </div>
   <TemplatePromise v-slot="{ resolve, args, isResolving }">
-    <div class="fixed inset-0 bg-black/10 flex items-center">
+    <div class="fixed inset-0 bg-black/10 flex items-center z-30">
       <dialog open class="border-gray/10 shadow rounded ma">
         <div>Dialog {{ args[0] }}</div>
         <p>Open console to see logs</p>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Fix the style error, the dialog mask needs to have a `z-index`, not the demo component itself.

Current:
<img width="1280" alt="c41e5c7cad99e0acd4c244ee525b091" src="https://user-images.githubusercontent.com/62941121/233350656-0e3b438d-1a4e-462d-9b32-c6a4b28b8580.png">

Expected to be:
<img width="1280" alt="cf8be71d20ecbe7f536ee6b5539e711" src="https://user-images.githubusercontent.com/62941121/233350633-e452020d-1b58-4da8-bb25-679d615cac9a.png">


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

copilot:summary

copilot:walkthrough
