### PR TITLE
fix(useFetch): `canAbort` flag does not work properly

### DIFF
--- a/packages/core/useFetch/demo.vue
+++ b/packages/core/useFetch/demo.vue
@@ -17,6 +17,7 @@ const {
   isFetching,
   isFinished,
   canAbort,
+  aborted,
   execute,
 } = useFetch(url, { refetch }).get()
 
@@ -24,6 +25,7 @@ const text = stringify(reactive({
   isFinished,
   isFetching,
   canAbort,
+  aborted,
   statusCode,
   error,
   data: computed(() => {
@@ -62,10 +64,10 @@ const text = stringify(reactive({
     </div>
 
     <input v-model="url" type="text">
-    <button @click="execute">
+    <button @click="execute()">
       Execute
     </button>
-    <button @click="toggleRefetch">
+    <button @click="toggleRefetch()">
       <i v-if="refetch" inline-block align-middle i-carbon-checkmark />
       <i v-else inline-block align-middle i-carbon-error />
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description
Steps to reproduce:
1. open demo page https://vueuse.org/core/useFetch/
2. click a few times on `Execute` button before previous request does not finished
3. `Abort` button becomes hidden because `canAbort` works incorrectly. Also you'll get the error: 'The user aborted a request.' and statusCode: 200 at the same time

### Additional context
The `execute` function was refactored to avoid mixed usage of async/await and promise/then/catch

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

copilot:summary

copilot:walkthrough
