### PR TITLE
feat(useAsyncLoading): add `useAsyncLoading` function

### DIFF
--- a/packages/core/useAsyncLoading/demo.vue
+++ b/packages/core/useAsyncLoading/demo.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import { useAsyncLoading } from '@vueuse/core'
+
+const { asyncLoading, showLoading, hideLoading } = useAsyncLoading()
+
+showLoading()
+
+setTimeout(() => {
+  hideLoading()
+}, 500)
+</script>
+
+<template>
+  <div>
+    <div>
+      {{ asyncLoading }}
+    </div>
+    <!-- if use like `Element-Plus` -->
+    <!-- <div v-loading="asyncLoading"></div> -->
+  </div>
+</template>

--- a/packages/core/useAsyncLoading/index.md
+++ b/packages/core/useAsyncLoading/index.md
@@ -1,0 +1,67 @@
+# useAsyncLoading
+
+When requesting data from the backend, the page needs to display a "loading" state, which should be hidden when the request is complete. 
+However, if the backend data returns too quickly, the "loading" state will flicker and create a poor user experience. 
+To avoid this problem, a compromise solution is to not display the "loading" state if the request time is less than 500ms, but to show it for at least 500ms if the request time is greater than 500ms.
+
+Of course, the timing for displaying the loading and its duration can be adjusted according to business needs.
+
+## Usage
+
+```vue
+<script setup lang="ts">
+import { useAsyncLoading } from '@vueuse/core'
+
+const { asyncLoading, showLoading, hideLoading } = useAsyncLoading()
+
+showLoading()
+
+// some async function
+setTimeout(() => {
+  hideLoading()
+}, 500)
+</script>
+
+<template>
+  <div>
+    <div>
+      {{ asyncLoading }}
+    </div>
+    <!-- if use like `Element-Plus` -->
+    <!-- <div v-loading="asyncLoading"></div> -->
+  </div>
+</template>
+```
+
+If you have used a `loading` in your previous project, you can pass it as a default value to `useAsyncLoading`. 
+It will automatically update the value of `asyncLoading` when the `loading` changes.
+And then replace the `loading` in the template with `asyncLoading`.
+
+```vue
+<script setup lang="ts">
+import { useAsyncLoading } from '@vueuse/core'
+
+const loading = ref(false)
+
+const { asyncLoading, showLoading, hideLoading } = useAsyncLoading({
+  defaultLoading: loading
+})
+
+loading.value = true
+
+// some async function
+setTimeout(() => {
+  loading.value = false
+}, 500)
+</script>
+
+<template>
+  <div>
+    <div>
+      {{ loading }} / {{ asyncLoading }}
+    </div>
+    <!-- if use like `Element-Plus` -->
+    <!-- <div v-loading="asyncLoading"></div> -->
+  </div>
+</template>
+```

--- a/packages/core/useAsyncLoading/index.test.ts
+++ b/packages/core/useAsyncLoading/index.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import { ref } from 'vue-demi'
+import { useAsyncLoading } from '.'
+
+describe('useAsyncLoading', () => {
+  it('should be defined', () => {
+    expect(useAsyncLoading).toBeDefined()
+  })
+
+  it('show loading after `timeout` ms', () => {
+    const timeout = 500
+    const { asyncLoading, showLoading } = useAsyncLoading({
+      timeout,
+    })
+    expect(asyncLoading.value).toBe(false)
+    showLoading()
+
+    setTimeout(() => {
+      expect(asyncLoading.value).toBe(false)
+    }, timeout - 100)
+    setTimeout(() => {
+      expect(asyncLoading.value).toBe(true)
+    }, timeout + 100)
+  })
+
+  it('show loading after at least `delay` ms', () => {
+    const timeout = 500
+    const delay = 500
+    const { asyncLoading, showLoading, hideLoading } = useAsyncLoading({
+      timeout,
+      delay,
+    })
+
+    showLoading()
+    setTimeout(() => {
+      hideLoading()
+    }, timeout + 100)
+
+    setTimeout(() => {
+      expect(asyncLoading.value).toBe(true)
+    }, timeout + delay)
+    setTimeout(() => {
+      expect(asyncLoading.value).toBe(false)
+    }, timeout + delay + 100)
+  })
+
+  it('do not show loading', () => {
+    const timeout = 500
+    const delay = 500
+    const { asyncLoading, showLoading, hideLoading } = useAsyncLoading({
+      timeout,
+      delay,
+    })
+
+    showLoading()
+    setTimeout(() => {
+      hideLoading()
+    }, timeout - 100)
+
+    setTimeout(() => {
+      expect(asyncLoading.value).toBe(false)
+    }, timeout)
+  })
+
+  it('default loading', () => {
+    const defaultLoading = ref(false)
+    const timeout = 500
+    const delay = 500
+    const { asyncLoading } = useAsyncLoading({
+      timeout,
+      delay,
+      defaultLoading,
+    })
+
+    expect(asyncLoading.value).toBe(false)
+    defaultLoading.value = true
+    expect(asyncLoading.value).toBe(false)
+    setTimeout(() => {
+      expect(asyncLoading.value).toBe(true)
+    }, timeout)
+  })
+})

--- a/packages/core/useAsyncLoading/index.ts
+++ b/packages/core/useAsyncLoading/index.ts
@@ -1,0 +1,79 @@
+import { ref, watch } from 'vue-demi'
+import type { Ref } from 'vue-demi'
+
+type Timer = NodeJS.Timeout | null
+
+interface AsyncLoadingOptions {
+  /**
+   * show loading after x ms
+   */
+  timeout?: number
+  /**
+   * if loading is shown, it will be shown for at least x ms
+   */
+  delay?: number
+  /**
+   * default loading
+   */
+  defaultLoading?: Ref<boolean>
+}
+
+export function useAsyncLoading(options?: AsyncLoadingOptions) {
+  const timeout = options?.timeout || 500
+  const delay = options?.delay || 500
+  const defaultLoading = options?.defaultLoading || ref(false)
+
+  const asyncLoading = ref(defaultLoading.value)
+  let showTime = 0
+
+  /**
+   * show loading timer
+   */
+  let timer: Timer = null
+  /**
+   * hide loading timer
+   */
+  let delayTimer: Timer = null
+
+  function showLoading() {
+    if (asyncLoading.value) {
+      delayTimer && clearTimeout(delayTimer)
+      delayTimer = null
+      return
+    }
+
+    timer && clearTimeout(timer)
+    timer = setTimeout(() => {
+      asyncLoading.value = true
+      showTime = Date.now()
+      timer && clearInterval(timer)
+      timer = null
+    }, timeout)
+  }
+
+  function hideLoading() {
+    if (!asyncLoading.value) {
+      timer && clearTimeout(timer)
+      timer = null
+      return
+    }
+
+    delayTimer && clearTimeout(delayTimer)
+    delayTimer = setTimeout(() => {
+      asyncLoading.value = false
+    }, Math.max(0, delay - (Date.now() - showTime)))
+  }
+
+  watch(defaultLoading, (val) => {
+    if (val)
+      showLoading()
+    else
+      hideLoading()
+  })
+
+  return {
+    asyncLoading,
+    showLoading,
+    hideLoading,
+  }
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

When requesting data from the backend, the page needs to display a "loading" state, which should be hidden when the request is complete. 
However, if the backend data returns too quickly, the "loading" state will flicker and create a poor user experience. 
To avoid this problem, a compromise solution is to not display the "loading" state if the request time is less than 500ms, but to show it for at least 500ms if the request time is greater than 500ms.

Of course, the timing for displaying the loading and its duration can be adjusted according to business needs.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

copilot:summary

copilot:walkthrough
