### PR TITLE
feat(useImage): support more image properties

### DIFF
--- a/packages/core/useImage/component.ts
+++ b/packages/core/useImage/component.ts
@@ -11,6 +11,10 @@ export const UseImage = /*#__PURE__*/ defineComponent<UseImageOptions & Renderab
     'srcset',
     'sizes',
     'as',
+    'alt',
+    'class',
+    'loading',
+    'crossorigin',
   ] as unknown as undefined,
   setup(props, { slots }) {
     const data = reactive(useImage(props))

--- a/packages/core/useImage/index.ts
+++ b/packages/core/useImage/index.ts
@@ -16,7 +16,7 @@ export interface UseImageOptions {
   /** Image classes */
   class?: string
   /** Image loading */
-  loading?: string (lazy, use-credentials)
+  loading?: HTMLImageElement['loading']
   /** Image CORS settings */
   crossorigin?: string
 }
@@ -24,24 +24,24 @@ export interface UseImageOptions {
 async function loadImage(options: UseImageOptions): Promise<HTMLImageElement> {
   return new Promise((resolve, reject) => {
     const img = new Image()
-    const { src, srcset, sizes, class, loading, crossorigin } = options
+    const { src, srcset, sizes, class: clazz, loading, crossorigin } = options
 
     img.src = src
-  
+
     if (srcset)
       img.srcset = srcset
-  
+
     if (sizes)
       img.sizes = sizes
-  
-    if (class)
-      img.class = class
-  
+
+    if (clazz)
+      img.className = clazz
+
     if (loading)
       img.loading = loading
-  
+
     if (crossorigin)
-      img.crossorigin = crossorigin
+      img.crossOrigin = crossorigin
 
     img.onload = () => resolve(img)
     img.onerror = reject

--- a/packages/core/useImage/index.ts
+++ b/packages/core/useImage/index.ts
@@ -11,18 +11,37 @@ export interface UseImageOptions {
   srcset?: string
   /** Image sizes for different page layouts */
   sizes?: string
+  /** Image alternative information */
+  alt?: string
+  /** Image classes */
+  class?: string
+  /** Image loading */
+  loading?: string (lazy, use-credentials)
+  /** Image CORS settings */
+  crossorigin?: string
 }
 
 async function loadImage(options: UseImageOptions): Promise<HTMLImageElement> {
   return new Promise((resolve, reject) => {
     const img = new Image()
-    const { src, srcset, sizes } = options
+    const { src, srcset, sizes, class, loading, crossorigin } = options
 
     img.src = src
+  
     if (srcset)
       img.srcset = srcset
+  
     if (sizes)
       img.sizes = sizes
+  
+    if (class)
+      img.class = class
+  
+    if (loading)
+      img.loading = loading
+  
+    if (crossorigin)
+      img.crossorigin = crossorigin
 
     img.onload = () => resolve(img)
     img.onerror = reject


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

```
Extraneous non-props attributes (alt, class, crossorigin, loading) were passed to component but could not be automatically inherited because component renders fragment or text root nodes. 
```

```
<UseImage
  alt="Fallback Information"
  :src="item.thumbnail"
  class="relative w-full h-full rounded"
  crossorigin="use-credentials"
  loading="lazy"
/>
```

### Additional context

I think these properties are useful, as you would like to overrule the `img` tag when needed.

Maybe you could do a merge with `reactivePick`? As it now conflicts with `class` for example.
What are you thoughts about this?

Thanks!

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d1fbbaa</samp>

This pull request adds new props to the `UseImage` component and the `loadImage` function to support more attributes for the `img` element. This enhances the image loading feature with better accessibility, performance, and customization options.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d1fbbaa</samp>

*  Add four new props to `UseImage` component to allow users to pass additional attributes to the underlying `img` element ([link](https://github.com/vueuse/vueuse/pull/3021/files?diff=unified&w=0#diff-32fd7d1c4c3f7c82af6bdf0d97c0d0499c321c64acb40301246f0f450fde698aR14-R17))
*  Add corresponding properties to `UseImageOptions` interface and assign them to the `img` element's attributes in the `loadImage` function in `packages/core/useImage/index.ts` ([link](https://github.com/vueuse/vueuse/pull/3021/files?diff=unified&w=0#diff-0a7dec6cf195dd83bfd113eff15344208c1270e80a54d6db288b258c4c8885f6R14-R21), [link](https://github.com/vueuse/vueuse/pull/3021/files?diff=unified&w=0#diff-0a7dec6cf195dd83bfd113eff15344208c1270e80a54d6db288b258c4c8885f6L19-R44))
