### PR TITLE
fix(useInfiniteScroll): re-measure arrived states when async infinite scroll resolves

### DIFF
--- a/packages/core/useInfiniteScroll/demo.vue
+++ b/packages/core/useInfiniteScroll/demo.vue
@@ -5,8 +5,6 @@ import { useInfiniteScroll } from '@vueuse/core'
 const el = ref<HTMLElement | null>(null)
 const data = ref([1])
 
-console.log('hello world')
-
 useInfiniteScroll(
   el,
   () => {

--- a/packages/core/useInfiniteScroll/demo.vue
+++ b/packages/core/useInfiniteScroll/demo.vue
@@ -5,11 +5,22 @@ import { useInfiniteScroll } from '@vueuse/core'
 const el = ref<HTMLElement | null>(null)
 const data = ref([1])
 
+console.log('hello world')
+
 useInfiniteScroll(
   el,
   () => {
-    const length = data.value.length + 1
-    data.value.push(...Array.from({ length: 5 }, (_, i) => length + i))
+    console.log('fetching data')
+
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        const length = data.value.length + 1
+
+        data.value.push(...Array.from({ length: 5 }, (_, i) => length + i))
+
+        resolve()
+      }, 1000)
+    })
   },
   { distance: 10 },
 )

--- a/packages/core/useInfiniteScroll/demo.vue
+++ b/packages/core/useInfiniteScroll/demo.vue
@@ -8,17 +8,8 @@ const data = ref([1])
 useInfiniteScroll(
   el,
   () => {
-    console.log('fetching data')
-
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        const length = data.value.length + 1
-
-        data.value.push(...Array.from({ length: 5 }, (_, i) => length + i))
-
-        resolve()
-      }, 1000)
-    })
+    const length = data.value.length + 1
+    data.value.push(...Array.from({ length: 5 }, (_, i) => length + i))
   },
   { distance: 10 },
 )

--- a/packages/core/useInfiniteScroll/index.ts
+++ b/packages/core/useInfiniteScroll/index.ts
@@ -58,6 +58,8 @@ export function useInfiniteScroll(
   const isLoading = computed(() => !!promise.value)
 
   function checkAndLoad() {
+    state.measure()
+
     const el = toValue(element) as HTMLElement
     if (!el)
       return
@@ -74,7 +76,6 @@ export function useInfiniteScroll(
         ])
           .finally(() => {
             promise.value = null
-            state.measure()
             nextTick(() => checkAndLoad())
           })
       }

--- a/packages/core/useInfiniteScroll/index.ts
+++ b/packages/core/useInfiniteScroll/index.ts
@@ -74,7 +74,7 @@ export function useInfiniteScroll(
         ])
           .finally(() => {
             promise.value = null
-            el.dispatchEvent(new Event('scroll'))
+            state.measure()
             nextTick(() => checkAndLoad())
           })
       }

--- a/packages/core/useInfiniteScroll/index.ts
+++ b/packages/core/useInfiniteScroll/index.ts
@@ -74,6 +74,7 @@ export function useInfiniteScroll(
         ])
           .finally(() => {
             promise.value = null
+            el.dispatchEvent(new Event('scroll'))
             nextTick(() => checkAndLoad())
           })
       }

--- a/packages/core/useScroll/index.ts
+++ b/packages/core/useScroll/index.ts
@@ -160,20 +160,20 @@ export function useScroll(
   }
   const onScrollEndDebounced = useDebounceFn(onScrollEnd, throttle + idle)
 
-  const onScrollHandler = (e: Event) => {
-    const eventTarget = (
-      e.target === document ? (e.target as Document).documentElement : e.target
+  const setArrivedState = (target: HTMLElement | SVGElement | Window | Document | null | undefined) => {
+    const el = (
+      target === document ? (target as Document).documentElement : target
     ) as HTMLElement
 
-    const { display, flexDirection } = getComputedStyle(eventTarget)
+    const { display, flexDirection } = getComputedStyle(el)
 
-    const scrollLeft = eventTarget.scrollLeft
+    const scrollLeft = el.scrollLeft
     directions.left = scrollLeft < internalX.value
     directions.right = scrollLeft > internalX.value
 
     const left = Math.abs(scrollLeft) <= 0 + (offset.left || 0)
     const right = Math.abs(scrollLeft)
-      + eventTarget.clientWidth >= eventTarget.scrollWidth
+      + el.clientWidth >= el.scrollWidth
       - (offset.right || 0)
       - ARRIVED_STATE_THRESHOLD_PIXELS
 
@@ -188,17 +188,17 @@ export function useScroll(
 
     internalX.value = scrollLeft
 
-    let scrollTop = eventTarget.scrollTop
+    let scrollTop = el.scrollTop
 
     // patch for mobile compatible
-    if (e.target === document && !scrollTop)
+    if (target === document && !scrollTop)
       scrollTop = document.body.scrollTop
 
     directions.top = scrollTop < internalY.value
     directions.bottom = scrollTop > internalY.value
     const top = Math.abs(scrollTop) <= 0 + (offset.top || 0)
     const bottom = Math.abs(scrollTop)
-      + eventTarget.clientHeight >= eventTarget.scrollHeight
+      + el.clientHeight >= el.scrollHeight
       - (offset.bottom || 0)
       - ARRIVED_STATE_THRESHOLD_PIXELS
 
@@ -216,6 +216,14 @@ export function useScroll(
     }
 
     internalY.value = scrollTop
+  }
+
+  const onScrollHandler = (e: Event) => {
+    const eventTarget = (
+      e.target === document ? (e.target as Document).documentElement : e.target
+    ) as HTMLElement
+
+    setArrivedState(eventTarget)
 
     isScrolling.value = true
     onScrollEndDebounced(e)
@@ -242,6 +250,12 @@ export function useScroll(
     isScrolling,
     arrivedState,
     directions,
+    measure() {
+      const _element = toValue(element)
+
+      if (_element)
+        setArrivedState(_element)
+    },
   }
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Issue: https://github.com/vueuse/vueuse/issues/3019

Our `useInfiniteScroll` composable is not working with async functions. This is caused by [`arrivedState[direction]`](https://github.com/vueuse/vueuse/blob/81bcaa9d99bece266bc4351af3aa5147eda0020b/packages/core/useInfiniteScroll/index.ts#L69) never being set to `false` when the container is resized.

This state becomes stuck because the measurement of these values only happens during [`onScrollHandler`](https://github.com/vueuse/vueuse/blob/81bcaa9d99bece266bc4351af3aa5147eda0020b/packages/core/useScroll/index.ts#L163), and so if the user is no longer scrolling, no re-measurement occurs and we enter the infinite loop.

The simplest way to force a measurement is just to fire a scroll event ourselves, but this may not be the fix we want. We might want to let `useScroll` handle observation of it's height, but this would require a larger refactor. Let me know if that's the route we'd rather go and I'll make the changes.

Another solution that might be a happy medium is for `useScroll` to return a function that can force a re-measurement. This might be the most flexible solution, because it would allow for measurements to happen for whatever reason we want 🤔

**Update:** I've made the refactor to return a force-measurement function, I think I like this better, but let me know what you think! If we'd rather force the measurement by just firing a scroll event, we can revert 87d675748bb16134bcd8ffb88c8e7ec66c1adccb

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e44a129</samp>

Fix initial load bug in `useInfiniteScroll` hook. Dispatch scroll event on observed element to trigger fetch function.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e44a129</samp>

* Dispatch scroll event on observed element to trigger initial data load ([link](https://github.com/vueuse/vueuse/pull/3030/files?diff=unified&w=0#diff-f1e18d7fa553054c65bf5b7e4fe4daf0fbfb98fe7224964f3f46661a3770d6a1R77))
