### PR TITLE
feat(useEventSource): allow optional string | URL type for url arg

### DIFF
--- a/packages/core/useEventSource/index.ts
+++ b/packages/core/useEventSource/index.ts
@@ -14,7 +14,7 @@ export type UseEventSourceOptions = EventSourceInit
  * @param events
  * @param options
  */
-export function useEventSource(url: string, events: Array<string> = [], options: UseEventSourceOptions = {}) {
+export function useEventSource(url: string | URL, events: Array<string> = [], options: UseEventSourceOptions = {}) {
   const event: Ref<string | null> = ref(null)
   const data: Ref<string | null> = ref(null)
   const status = ref('CONNECTING') as Ref<'OPEN' | 'CONNECTING' | 'CLOSED'>


### PR DESCRIPTION
feat(useEventSoure): allow optional satring | URL type for url arg

---

### Description

This MR allows the url arg type for useEventSource to be of type string or URL, allowing for backward compatibility and a light touch green field MR.

No other changes are needed, as `new EventSource()` accepts a string for URL type as the url arg.