### PR TITLE
ci: ensure test coverage for node 19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [16.x, 18.x]
+        node: [16.x, 18.x, 19.x]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
ci: ensure test coverage for node 19

---

### Description

Node v.19 has now been available since October 2022, we should look to add stability to this package by extending the test strategy for Node to includes version 19.x
