### PR TITLE
fix: temporarily work around the type error in vue 3.3

### DIFF
--- a/packages/core/createTemplatePromise/index.ts
+++ b/packages/core/createTemplatePromise/index.ts
@@ -119,6 +119,8 @@ export function createTemplatePromise<Return, Args extends any[] = []>(
     return renderList
   })
 
+  // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+  // @ts-ignore There's a breaking type change in Vue 3.3 <https://github.com/vuejs/core/pull/7963>
   component.start = start
 
   return component as any


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

`vuejs/ecosystem-ci` is currently failing because Vue 3.3 ships with a breaking type change in https://github.com/vuejs/core/pull/7963

https://github.com/vuejs/ecosystem-ci/actions/runs/4817698215/jobs/8578738981#step:7:9593

### Additional context

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a080cf9</samp>

Added a `@ts-ignore` comment to `createTemplatePromise` to fix a TypeScript error with Vue 3.3. This allows the function to work with the new template ref type introduced in Vue 3.3.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a080cf9</samp>

* Add `@ts-ignore` comment to suppress TypeScript error in Vue 3.3 ([link](https://github.com/vueuse/vueuse/pull/3042/files?diff=unified&w=0#diff-6b215e6a67c1677aa2eead94e80ea97c25ab5f22b1e02d939177312788e96815R122-R123))
