### PR TITLE
fix(useDrauu): pass on node argument in committed event hook

### DIFF
--- a/packages/integrations/useDrauu/index.ts
+++ b/packages/integrations/useDrauu/index.ts
@@ -45,7 +45,7 @@ export function useDrauu(
 
   const onChangedHook = createEventHook<void>()
   const onCanceledHook = createEventHook<void>()
-  const onCommittedHook = createEventHook<void>()
+  const onCommittedHook = createEventHook<SVGElement | undefined>()
   const onStartHook = createEventHook<void>()
   const onEndHook = createEventHook<void>()
   const canUndo = ref(false)
@@ -108,7 +108,7 @@ export function useDrauu(
 
       disposables = [
         drauuInstance.value.on('canceled', () => onCanceledHook.trigger()),
-        drauuInstance.value.on('committed', () => onCommittedHook.trigger()),
+        drauuInstance.value.on('committed', (node: SVGElement | undefined) => onCommittedHook.trigger(node)),
         drauuInstance.value.on('start', () => onStartHook.trigger()),
         drauuInstance.value.on('end', () => onEndHook.trigger()),
         drauuInstance.value.on('changed', () => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->


### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Fixes #3046 

> The committed event fired by drauu has an argument that it provides to hooks which useDrauu doesn't pass on in the composable

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0c0f592</samp>

Added a new feature to `useDrauu` integration that allows accessing the SVG element from the `onCommittedHook` event hook. Updated the `packages/integrations/useDrauu/index.ts` file to implement this feature.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0c0f592</samp>

*  Add an optional `SVGElement` parameter to the `onCommittedHook` event hook to expose the drawn element to the consumers of `useDrauu` ([link](https://github.com/vueuse/vueuse/pull/3047/files?diff=unified&w=0#diff-2d151128ab9ce5f75c32c469c81b388f8af678e928740aba1a4f742f06450734L48-R48))
*  Pass the `node` argument from the `drauuInstance.value.on('committed')` event listener to the `onCommittedHook.trigger` function to provide the `SVGElement` parameter to the hook ([link](https://github.com/vueuse/vueuse/pull/3047/files?diff=unified&w=0#diff-2d151128ab9ce5f75c32c469c81b388f8af678e928740aba1a4f742f06450734L111-R111))
