### PR TITLE
feat(useVModel): improve types overload

### DIFF
--- a/packages/core/useVModel/index.ts
+++ b/packages/core/useVModel/index.ts
@@ -1,17 +1,17 @@
 import { isDef } from '@vueuse/shared'
-import type { UnwrapRef } from 'vue-demi'
+import type { Ref, UnwrapRef, WritableComputedRef } from 'vue-demi'
 import { computed, getCurrentInstance, isVue2, ref, watch } from 'vue-demi'
 import type { CloneFn } from '../useCloned'
 import { cloneFnJSON } from '../useCloned'
 
-export interface UseVModelOptions<T> {
+export interface UseVModelOptions<T, Passive extends boolean = false> {
   /**
    * When passive is set to `true`, it will use `watch` to sync with props and ref.
    * Instead of relying on the `v-model` or `.sync` to work.
    *
    * @default false
    */
-  passive?: boolean
+  passive?: Passive
   /**
    * When eventName is set, it's value will be used to overwrite the emit event name.
    *
@@ -48,6 +48,20 @@ export interface UseVModelOptions<T> {
   shouldEmit?: (v: T) => boolean
 }
 
+export function useVModel<P extends object, K extends keyof P, Name extends string>(
+  props: P,
+  key?: K,
+  emit?: (name: Name, ...args: any[]) => void,
+  options?: UseVModelOptions<P[K], false>,
+): WritableComputedRef<P[K]>
+
+export function useVModel<P extends object, K extends keyof P, Name extends string>(
+  props: P,
+  key?: K,
+  emit?: (name: Name, ...args: any[]) => void,
+  options?: UseVModelOptions<P[K], true>,
+): Ref<UnwrapRef<P[K]>>
+
 /**
  * Shorthand for v-model binding, props + emit -> ref
  *
@@ -56,11 +70,11 @@ export interface UseVModelOptions<T> {
  * @param key (default 'value' in Vue 2 and 'modelValue' in Vue 3)
  * @param emit
  */
-export function useVModel<P extends object, K extends keyof P, Name extends string>(
+export function useVModel<P extends object, K extends keyof P, Name extends string, Passive extends boolean>(
   props: P,
   key?: K,
   emit?: (name: Name, ...args: any[]) => void,
-  options: UseVModelOptions<P[K]> = {},
+  options: UseVModelOptions<P[K], Passive> = {},
 ) {
   const {
     clone = false,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

---

### Description

In Vue 3.3.0-beta.3, the following code will throw type error

```vue
<script lang="ts">
const InjectKeySymbol: InjectionKey<{
  value: WritableComputedRef<number>;
}> = Symbol();
</script>

<script setup lang="ts">
import { provide, ref } from 'vue';
import { useVModel } from '@vueuse/core';

import type { InjectionKey, WritableComputedRef } from 'vue';

interface Props {
  modelValue: number;
}

interface Emits {
  (event: 'update:modelValue', value: number): void;
}

const props = withDefaults(defineProps<Props>(), {});
const emit = defineEmits<Emits>();

const modelValueWritable =  useVModel(props, 'modelValue', emit); 

provide(InjectKeySymbol, {
  value: modelValueWritable,
});
</script>
```

error message

```
- error TS2322: Type 'Ref<number> | WritableComputedRef<number>' is not assignable to type 'WritableComputedRef<any>'.
  Property 'effect' is missing in type 'Ref<number>' but required in type 'WritableComputedRef<any>'.

26   modelValue: modelValueWritable,
     ~~~~~~~~~~
```

Perhaps we can clearly distinguish when to use `WritableComputedRef<number>` or `Ref<number>`.

```ts
// These is `WritableComputedRef<number>`
const modelValueWritable =  useVModel(props, 'modelValue', emit)
const modelValueWritable =  useVModel(props, 'modelValue', emit, { passive: false })

// This is `Ref<number>`
const modelValueWritable =  useVModel(props, 'modelValue', emit, { passive: true })
```

I have opened an issue in https://github.com/vuejs/core/issues/8228#issue-1695798516 and the purpose of this PR is to attempt to use overload to solve the problem.

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 060be5b</samp>

Enhanced `useVModel` function with a `passive` option and better type support. This allows users to control the prop synchronization and event emission behavior of `useVModel` and benefit from more accurate type inference and checking.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 060be5b</samp>

*  Add function overloads and generic parameter for `useVModel` to support `passive` option ([link](https://github.com/vueuse/vueuse/pull/3055/files?diff=unified&w=0#diff-7498649841a9ec6669429e17009646d9ee7417a939422e5c9d4511cc9c440344L2-R7), [link](https://github.com/vueuse/vueuse/pull/3055/files?diff=unified&w=0#diff-7498649841a9ec6669429e17009646d9ee7417a939422e5c9d4511cc9c440344L14-R14), [link](https://github.com/vueuse/vueuse/pull/3055/files?diff=unified&w=0#diff-7498649841a9ec6669429e17009646d9ee7417a939422e5c9d4511cc9c440344R51-R64), [link](https://github.com/vueuse/vueuse/pull/3055/files?diff=unified&w=0#diff-7498649841a9ec6669429e17009646d9ee7417a939422e5c9d4511cc9c440344L59-R77))
  * Import `Ref` and `WritableComputedRef` types from `vue-demi` in `packages/core/useVModel/index.ts` ([link](https://github.com/vueuse/vueuse/pull/3055/files?diff=unified&w=0#diff-7498649841a9ec6669429e17009646d9ee7417a939422e5c9d4511cc9c440344L2-R7))
  * Make `UseVModelOptions` interface generic with `Passive` parameter that extends `boolean` ([link](https://github.com/vueuse/vueuse/pull/3055/files?diff=unified&w=0#diff-7498649841a9ec6669429e17009646d9ee7417a939422e5c9d4511cc9c440344L2-R7), [link](https://github.com/vueuse/vueuse/pull/3055/files?diff=unified&w=0#diff-7498649841a9ec6669429e17009646d9ee7417a939422e5c9d4511cc9c440344L14-R14))
  * Define two function overloads for `useVModel`, one for `passive: false` and one for `passive: true` ([link](https://github.com/vueuse/vueuse/pull/3055/files?diff=unified&w=0#diff-7498649841a9ec6669429e17009646d9ee7417a939422e5c9d4511cc9c440344R51-R64))
    * Return `WritableComputedRef` when `passive: false`, allowing prop value update and event emission ([link](https://github.com/vueuse/vueuse/pull/3055/files?diff=unified&w=0#diff-7498649841a9ec6669429e17009646d9ee7417a939422e5c9d4511cc9c440344R51-R64))
    * Return `Ref` when `passive: true`, syncing with prop value and not emitting event ([link](https://github.com/vueuse/vueuse/pull/3055/files?diff=unified&w=0#diff-7498649841a9ec6669429e17009646d9ee7417a939422e5c9d4511cc9c440344R51-R64))
  * Make `useVModel` function generic with `Passive` parameter and use `UseVModelOptions` type for `options` parameter ([link](https://github.com/vueuse/vueuse/pull/3055/files?diff=unified&w=0#diff-7498649841a9ec6669429e17009646d9ee7417a939422e5c9d4511cc9c440344L59-R77))
