### PR TITLE
docs(useInfiniteScroll): demonstrate stopping when there is no more data

### DIFF
--- a/packages/core/useInfiniteScroll/index.md
+++ b/packages/core/useInfiniteScroll/index.md
@@ -41,7 +41,7 @@ To stop infinite scrolling, unset the target element. This will prevent the call
 const isComplete = ref(false)
 
 useInfiniteScroll(
-  computed(() => !isComplete.value && el.value),
+  computed(() => !isComplete.value ? el.value : null),
   async () => {
     if (hasLoadedEverything)
       isComplete.value = true

--- a/packages/core/useInfiniteScroll/index.md
+++ b/packages/core/useInfiniteScroll/index.md
@@ -35,6 +35,22 @@ useInfiniteScroll(
 </template>
 ```
 
+To stop infinite scrolling, unset the target element. This will prevent the callback from firing, and will turn off all scroll listeners.
+
+```js
+const isComplete = ref(false)
+
+useInfiniteScroll(
+  computed(() => !isComplete.value && el.value),
+  async () => {
+    if (hasLoadedEverything)
+      isComplete.value = true
+    else
+      await loadMoreStuff()
+  }
+)
+```
+
 ## Directive Usage
 
 ```html

--- a/packages/core/useScroll/index.md
+++ b/packages/core/useScroll/index.md
@@ -66,6 +66,16 @@ const behavior = computed(() => smooth.value ? 'smooth' : 'auto')
 const { x, y } = useScroll(el, { behavior })
 ```
 
+### Manually re-measuring
+
+When your container changes, you may want to force a re-measurement to occur. This can be done with the returned `measure` function.
+
+```js
+const { measure } = useScroll(el)
+
+measure()
+```
+
 ## Directive Usage
 
 ```html


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Our `useInfiniteScroll` docs don't demonstrate how to stop fetching data, which can lead to infinite loops if you aren't careful ([see conversation here](https://github.com/vueuse/vueuse/issues/3019)). The underlying issue for this has already been fixed by https://github.com/vueuse/vueuse/pull/3030.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 85c21f8</samp>

This pull request improves the documentation of `useInfiniteScroll` and `useScroll` by adding examples and explanations for some common use cases. It shows how to stop infinite scrolling by unsetting the `target` element, and how to re-measure the scroll position and size of the container element using the `measure` function.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 85c21f8</samp>

*  Add `useInfiniteScroll` function to enable infinite scrolling on a target element ()
