### PR TITLE
fix(useScrollLock): fix scrollable children check

### DIFF
--- a/packages/core/useScrollLock/index.ts
+++ b/packages/core/useScrollLock/index.ts
@@ -9,8 +9,8 @@ function checkOverflowScroll(ele: Element): boolean {
   if (
     style.overflowX === 'scroll'
     || style.overflowY === 'scroll'
-    || (style.overflowX === 'auto' && ele.clientHeight < ele.scrollHeight)
-    || (style.overflowY === 'auto' && ele.clientWidth < ele.scrollWidth)
+    || (style.overflowX === 'auto' && ele.clientWidth < ele.scrollWidth)
+    || (style.overflowY === 'auto' && ele.clientHeight < ele.scrollHeight)
   ) {
     return true
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Scrollable elements check, which has been implemented in https://github.com/vueuse/vueuse/pull/2699, was not working properly, as element's heights were comparing in case of horizontal scroll and widths were comparing in case of vertical scroll. So the check did not pass if an element had vertical scroll, because its `clientWidth` and `scrollWidth` remained equal

### Additional context

Scroll was not working inside scrollable children with `overflow-x: hidden; overflow-y: auto;` properties

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c4d7a86</samp>

Fixed a bug in `useScrollLock` hook that caused incorrect behavior for elements with only horizontal scroll. Swapped the order of overflow scroll checks in `useScrollLock/index.ts`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c4d7a86</samp>

*  Swap the order of checking horizontal and vertical scroll overflow in `isScrollable` function ([link](https://github.com/vueuse/vueuse/pull/3065/files?diff=unified&w=0#diff-ee711f99aedfd3706e831df7c3f4578f8db0acbf17bc3990c888b28d6c4d2206L12-R13)) to fix a bug in `useScrollLock` hook
