### PR TITLE
fix(onClickOutside): ensure focus on iframe captured in firefox

### DIFF
--- a/packages/core/onClickOutside/index.ts
+++ b/packages/core/onClickOutside/index.ts
@@ -93,12 +93,14 @@ export function onClickOutside<T extends OnClickOutsideOptions>(
         shouldListen = !e.composedPath().includes(el) && !shouldIgnore(e)
     }, { passive: true }),
     detectIframe && useEventListener(window, 'blur', (event) => {
-      const el = unrefElement(target)
-      if (
-        window.document.activeElement?.tagName === 'IFRAME'
-        && !el?.contains(window.document.activeElement)
-      )
-        handler(event as any)
+      setTimeout(() => {
+        const el = unrefElement(target)
+        if (
+          window.document.activeElement?.tagName === 'IFRAME'
+          && !el?.contains(window.document.activeElement)
+        )
+          handler(event as any)
+      }, 0)
     }),
   ].filter(Boolean) as Fn[]
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description
On Firefox when using OnClickOutside with the `detectIframe: true` option the handler will not fire when some iframes are focused.

This appears to be related to Firefox [Bug 1545573](https://bugzilla.mozilla.org/show_bug.cgi?id=1545573), however the behaviour is inconsistent. Some simple documents seem to change the `document.activeElement` before the `blur` handler is triggered, and on some pages it occurs in the frame after the `blur` handler fires.

Unfortunately, I couldn't find any public pages that I could embed in an iframe that still exhibit the issue listed on the Firefox bug, but loading an invalid domain such as `failfail.local`, appears to replicate it. 

There is a [Stackblitz demonstrating the issue here](https://stackblitz.com/edit/vue-gysbfb?devToolsHeight=33&file=src/App.vue), as well as the updated version from this PR. This issue replicates in Firefox 112.

### Additional context

Wrapping the event handler in setTimeout is also how this edge case is handled in [v-click-outside](https://github.com/ndelvalle/v-click-outside/blob/master/src/v-click-outside.js#L37-L40) and this [react hook](https://github.com/wellyshen/react-cool-onclickoutside/blob/master/src/index.ts#L94-L95)

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 972e17d</samp>

Fix `onClickOutside` hook not working with iframes in some browsers. Use `setTimeout` to delay the check for the active element in the `blur` event listener.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 972e17d</samp>

* Fix a bug where `onClickOutside` hook did not trigger handler when clicking on an iframe element in some browsers ([link](https://github.com/vueuse/vueuse/pull/3066/files?diff=unified&w=0#diff-8b308f45dba561e732d94afb100d76cc2aee8b7d265690c72e6fdf1e9dc59925L96-R103))
