### PR TITLE
docs(useSortable): explain the need for nextTick after moving array elements

### DIFF
--- a/packages/integrations/useSortable/index.md
+++ b/packages/integrations/useSortable/index.md
@@ -95,7 +95,7 @@ useSortable(el, list, {
   onUpdate: (e) => {
     // do something
     moveArrayElement(list.value, e.oldIndex, e.newIndex)
-    useTick(() =>  /* do something */ ) // useTick required here as moveArrayElement is executed in a microtask, so we need to wait until the next tick until that is finished.
+    nextTick(() =>  /* do something */ ) // useTick required here as moveArrayElement is executed in a microtask, so we need to wait until the next tick until that is finished.
   }
 })
 ```

--- a/packages/integrations/useSortable/index.md
+++ b/packages/integrations/useSortable/index.md
@@ -95,7 +95,7 @@ useSortable(el, list, {
   onUpdate: (e) => {
     // do something
     moveArrayElement(list.value, e.oldIndex, e.newIndex)
-    // do something
+    useTick(() =>  /* do something */ ) // useTick required here as moveArrayElement is executed in a microtask, so we need to wait until the next tick until that is finished.
   }
 })
 ```

--- a/packages/integrations/useSortable/index.md
+++ b/packages/integrations/useSortable/index.md
@@ -95,7 +95,7 @@ useSortable(el, list, {
   onUpdate: (e) => {
     // do something
     moveArrayElement(list.value, e.oldIndex, e.newIndex)
-    nextTick(() =>  /* do something */ ) // useTick required here as moveArrayElement is executed in a microtask, so we need to wait until the next tick until that is finished.
+    nextTick(() =>  /* do something */ ) // nextTick required here as moveArrayElement is executed in a microtask, so we need to wait until the next tick until that is finished.
   }
 })
 ```


### PR DESCRIPTION
### Description

Add explanation on how nextTick is required after moving an element or else the element being moved won't be visible.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9364f3c</samp>

Updated code comment in `useSortable` integration example to explain the use of `useTick` utility. This improves the documentation and clarity of the code.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9364f3c</samp>

* Update the code comment for `useTick` in the `useSortable` example to explain its purpose ([link](https://github.com/vueuse/vueuse/pull/3067/files?diff=unified&w=0#diff-31ad09b88cb57f0342edc1423d5140279b35ef2c379f684b3611bcb2ece4c69fL98-R98))
