### PR TITLE
chore(useTimeAgo): remove unnecessary `now.value`

### DIFF
--- a/packages/core/useTimeAgo/index.ts
+++ b/packages/core/useTimeAgo/index.ts
@@ -140,7 +140,7 @@ export function useTimeAgo<UnitNames extends string = UseTimeAgoUnitNamesDefault
   } = options
 
   const { now, ...controls } = useNow({ interval: updateInterval, controls: true })
-  const timeAgo = computed(() => formatTimeAgo(new Date(toValue(time)), options, toValue(now.value)))
+  const timeAgo = computed(() => formatTimeAgo(new Date(toValue(time)), options, toValue(now)))
 
   if (exposeControls) {
     return {


### PR DESCRIPTION
Fixed an unnecessary toValue/unref
```diff
- const timeAgo = computed(() => formatTimeAgo(new Date(toValue(time)), options, toValue(now.value)))
+ const timeAgo = computed(() => formatTimeAgo(new Date(toValue(time)), options, toValue(now)))
```

You either use `now.value` or `toValue(now)`, no need to do both, all you are doing is doing `toValue(a_value)` which just returns 'a_value`

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
I Have done a very rudimentary check through the rest of the codebase  using `toValue\([^)]+\.value\)` regex search.
So unless you guys are doing something such as `toValue(func().value);` this would have picked it up.

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ffa8e75</samp>

Simplify the useTimeAgo function by removing the `.value` property from the `now` ref. This avoids unnecessary unwrapping and makes the code more consistent.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ffa8e75</samp>

* Remove `.value` property from `now` argument in `formatTimeAgo` function ([link](https://github.com/vueuse/vueuse/pull/3068/files?diff=unified&w=0#diff-09e23f6a26bfa650abc3a71af2e74606a0b688c345ebee8df4fd49d3b5e6c91aL143-R143))
