### PR TITLE
fix(useMediaControls): better representation for "waiting" value

### DIFF
--- a/packages/core/useMediaControls/index.ts
+++ b/packages/core/useMediaControls/index.ts
@@ -388,10 +388,15 @@ export function useMediaControls(target: MaybeRef<HTMLMediaElement | null | unde
   useEventListener(target, 'progress', () => buffered.value = timeRangeToArray((toValue(target))!.buffered))
   useEventListener(target, 'seeking', () => seeking.value = true)
   useEventListener(target, 'seeked', () => seeking.value = false)
-  useEventListener(target, 'waiting', () => waiting.value = true)
+  useEventListener(target, ['waiting', 'loadstart'], () => {
+    waiting.value = true
+    ignorePlayingUpdates(() => playing.value = false)
+  })
+  useEventListener(target, 'loadeddata', () => waiting.value = false)
   useEventListener(target, 'playing', () => {
     waiting.value = false
     ended.value = false
+    ignorePlayingUpdates(() => playing.value = true)
   })
   useEventListener(target, 'ratechange', () => rate.value = (toValue(target))!.playbackRate)
   useEventListener(target, 'stalled', () => stalled.value = true)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

---

### Description

"waiting" only fires when there's a lack of data in the middle of the playback. However, it doesn't take into account the lack of data when the source is attached to the element, as "loadeddata" does. I think it's safe to assume people want from "waiting" all possible buffering states. In the probably scarce cases where the user wants more control over the native event handlers, native event handlers can still be used.

"playing" also represents when a current playback is happening now.

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b092cfe</samp>

Improved media controls state handling by `useMediaControls`. Added support for more media events and states, such as `waiting` and `playing`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b092cfe</samp>

*  Update `useMediaControls` function to handle more media events and states ([link](https://github.com/vueuse/vueuse/pull/3072/files?diff=unified&w=0#diff-ecbf7bfd67f67f25217f8c5d36cfba3734d608a1bccdb3a49acba1f17a59401eL391-R399))
