### PR TITLE
fix(useAxios): prevent premature loading refs reset

### DIFF
--- a/packages/integrations/useAxios/index.test.ts
+++ b/packages/integrations/useAxios/index.test.ts
@@ -290,6 +290,23 @@ describe('useAxios', () => {
     expect(error).toBeDefined()
   })
 
+  it('should be loading on re-execute', async () => {
+    const onError = vi.fn()
+    const { isLoading, execute } = useAxios(url, config, { ...options, onError })
+
+    execute().catch(() => {})
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(isLoading.value).toBeTruthy()
+
+    execute().catch(() => {})
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(isLoading.value).toBeTruthy()
+
+    await execute().catch(() => {})
+    expect(isLoading.value).toBeFalsy()
+    expect(onError).toBeCalledTimes(2)
+  })
+
   it('missing url', async () => {
     // prevent stderr in jsdom xhr
     console.error = vi.fn()

--- a/packages/integrations/useAxios/index.ts
+++ b/packages/integrations/useAxios/index.ts
@@ -204,6 +204,7 @@ export function useAxios<T = any, R = AxiosResponse<T>, D = any>(...args: any[])
     catch: (...args) => waitUntilFinished().catch(...args),
   } as Promise<OverallUseAxiosReturn<T, R, D>>
 
+  let executeCounter = 0
   const execute: OverallUseAxiosReturn<T, R, D>['execute'] = (executeUrl: string | AxiosRequestConfig<D> | undefined = url, config: AxiosRequestConfig<D> = {}) => {
     error.value = undefined
     const _url = typeof executeUrl === 'string'
@@ -218,6 +219,10 @@ export function useAxios<T = any, R = AxiosResponse<T>, D = any>(...args: any[])
     resetData()
     abort()
     loading(true)
+
+    executeCounter += 1
+    const currentExecuteCounter = executeCounter
+
     instance(_url, { ...defaultConfig, ...typeof executeUrl === 'object' ? executeUrl : config, cancelToken: cancelToken.token })
       .then((r: any) => {
         response.value = r
@@ -231,7 +236,8 @@ export function useAxios<T = any, R = AxiosResponse<T>, D = any>(...args: any[])
       })
       .finally(() => {
         options.onFinish?.()
-        loading(false)
+        if (currentExecuteCounter === executeCounter)
+          loading(false)
       })
     return promise
   }


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Currently, when the `execute` function is called multiple times in quick succession, every two calls `isLoading` is set back to `false` and so the next request is not properly aborted. This is currently caused by the `loading(false)` call in the `finally` method of the instance.

Steps to reproduce:

1. Go to the `useAxios` demo - <https://vueuse.org/integrations/useAxios/#demo>
2. Open the console on `Network` tab and enable the connection throttling to make sure you have enough time to abort the previous request with your click (or be fast 😁).
3. Click, in quick succession, 3 times on the `Execute` button. You should see on the console that the last 2 calls have been fully executed when only the last one should be and the second-last request should be cancelled. This is caused by the loading refs set to `false` by the `finally` method of the first `execute` call.

### Additional context

To address this issue, I suggest the addition of an `executeCounter` variable that increments itself at each `execute` call. Then, on the `finally` method, add a condition to call `loading(false)` only if `currentExecuteCounter === executeCounter`. This way, the loading refs would be set to false only by the last `execute` call.

```diff
+ let executeCounter = 0
const execute: OverallUseAxiosReturn...
...

+   executeCounter += 1
+   const currentExecuteCounter = executeCounter

...
      .finally(() => {
        options.onFinish?.()
+       if (currentExecuteCounter === executeCounter)
          loading(false)
```

_P.S.: This is my first contributing to an open source repo and my first time writing test 😅 I hope everything is correct._

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

copilot:summary

copilot:walkthrough
