### PR TITLE
feat(useMousePressed): Add options.mouseButton to support capture spec…

### DIFF
--- a/packages/core/useMouse/index.ts
+++ b/packages/core/useMouse/index.ts
@@ -7,8 +7,14 @@ import type { Position } from '../types'
 
 export type UseMouseCoordType = 'page' | 'client' | 'screen' | 'movement'
 export type UseMouseSourceType = 'mouse' | 'touch' | null
+export type UseMouseButton = 'left' | 'right' | 'mid'
 export type UseMouseEventExtractor = (event: MouseEvent | Touch) => [x: number, y: number] | null | undefined
 
+export const MouseButtonMap: { [key: string]: number } = {
+  left: 0,
+  middle: 1,
+  right: 2,
+}
 export interface UseMouseOptions extends ConfigurableWindow, ConfigurableEventFilter {
   /**
    * Mouse position based by page, client, screen, or relative to previous position

--- a/packages/core/useMousePressed/index.md
+++ b/packages/core/useMousePressed/index.md
@@ -20,6 +20,12 @@ Touching is enabled by default. To make it only detects mouse changes, set `touc
 const { pressed } = useMousePressed({ touch: false })
 ```
 
+To only capture `mousedown` and `mouseup` on specific mouse button, set `mouseButton` to `left` or `mid` or `right` 
+
+```js
+const { pressed } = useMousePressed({ mouseButton: 'left' })
+```
+
 To only capture `mousedown` and `touchstart` on specific element, you can specify `target` by passing a ref of the element. 
 
 

--- a/packages/core/useMousePressed/index.ts
+++ b/packages/core/useMousePressed/index.ts
@@ -78,7 +78,7 @@ export function useMousePressed(options: MousePressedOptions = {}) {
   }
   const onReleased = (e: MouseEvent) => {
     const mouseButton = MouseButtonMap[options.mouseButton || '']
-    if (mouseButton !== undefined && mouseButton !== e.button && options.mouseButton !== 'right')
+    if (mouseButton !== undefined && mouseButton !== e.button)
       return
     pressed.value = false
     sourceType.value = null


### PR DESCRIPTION
Detail in #3074 
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] fix issue #3074 
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

`const { pressed } = useMousePressed({ mouseButton = 'left' } ) // or 'right'  or 'mid'
`
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
when we click right mouse button, the contextmenu event will prevent the mouseup event, so I prevent contextmenu when click right button.

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 39a3c52</samp>

Added a new option to the `useMousePressed` hook to let users choose which mouse button to track. Updated the `useMouse` module and the documentation to support this feature.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 39a3c52</samp>

*  Add `mouseButton` option to `useMousePressed` hook to filter mouse events by button ([link](https://github.com/vueuse/vueuse/pull/3083/files?diff=unified&w=0#diff-ee257ef23e7179575b10826475e362b4b1ba68bfadae08f82365f3172964896bL5-R6), [link](https://github.com/vueuse/vueuse/pull/3083/files?diff=unified&w=0#diff-ee257ef23e7179575b10826475e362b4b1ba68bfadae08f82365f3172964896bR36-R40), [link](https://github.com/vueuse/vueuse/pull/3083/files?diff=unified&w=0#diff-ee257ef23e7179575b10826475e362b4b1ba68bfadae08f82365f3172964896bL61-R86))
  * Import `UseMouseButton` type and `MouseButtonMap` object from `useMouse` module ([link](https://github.com/vueuse/vueuse/pull/3083/files?diff=unified&w=0#diff-ee257ef23e7179575b10826475e362b4b1ba68bfadae08f82365f3172964896bL5-R6))
  * Define `mouseButton` option as an optional `UseMouseButton` value in `UseMousePressedOptions` interface ([link](https://github.com/vueuse/vueuse/pull/3083/files?diff=unified&w=0#diff-ee257ef23e7179575b10826475e362b4b1ba68bfadae08f82365f3172964896bR36-R40))
  * Compare `mouseButton` option with `event.button` property in `onPressed` and `onReleased` handlers and return early if they do not match ([link](https://github.com/vueuse/vueuse/pull/3083/files?diff=unified&w=0#diff-ee257ef23e7179575b10826475e362b4b1ba68bfadae08f82365f3172964896bL61-R86))
  * Prevent default context menu if `mouseButton` option is set to `right` ([link](https://github.com/vueuse/vueuse/pull/3083/files?diff=unified&w=0#diff-ee257ef23e7179575b10826475e362b4b1ba68bfadae08f82365f3172964896bL61-R86))
* Update documentation for `useMousePressed` hook to include `mouseButton` option example ([link](https://github.com/vueuse/vueuse/pull/3083/files?diff=unified&w=0#diff-03f9421f2996023a911f40597187e70144e6a193453a25c65e01552f5a4ad731R23-R28))
* Add `UseMouseButton` type and `MouseButtonMap` object to `useMouse` module ([link](https://github.com/vueuse/vueuse/pull/3083/files?diff=unified&w=0#diff-acac08f31319ce15064e72bec03f921b9731164f2022b1a17ed4c09ba2864540L10-R17))
