### PR TITLE
docs(useFirestore): return data with user types example

### DIFF
--- a/packages/firebase/useFirestore/index.md
+++ b/packages/firebase/useFirestore/index.md
@@ -34,6 +34,21 @@ const userQuery = computed(() => userId.value && doc(db, 'users', userId.value))
 const userData = useFirestore(userQuery, null)
 ```
 
+## Typescript Example
+```
+const converter = <T>() => ({
+  toFirestore: (data: PartialWithFieldValue<T>) => data,
+  fromFirestore: (snap: QueryDocumentSnapshot) => snap.data() as T,
+});
+
+const userQuery = computed(
+  () =>
+    userId.value &&
+    doc(db, 'users', userId.value).withConverter(converter<UserData>())
+);
+const userData = useFirestore<UserData>(userQuery, null);
+```
+
 ## Share across instances
 
 You can reuse the db reference by passing `autoDispose: false`. You can also set an amount of milliseconds before auto disposing the db reference.


### PR DESCRIPTION
### Description
Added typescript example as it wasn't clear to me just by reading docs how you would add types.

### Additional context
The proposed example was found in stackoverflow answer here: https://stackoverflow.com/questions/74456704/how-to-type-usefirestore-using-typescript-interfaces
---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b868532</samp>

Added a code snippet to `useFirestore` documentation to demonstrate how to use it with Typescript and a custom converter. The converter allows defining and retrieving custom types from Firestore documents.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b868532</samp>

*  Add a code snippet to demonstrate how to use the `useFirestore` hook with Typescript and a custom converter ([link](https://github.com/vueuse/vueuse/pull/3084/files?diff=unified&w=0#diff-381ff8a9ea3d7a69718cca4ec4967098f676658f2f51515d3947e1ff33c67751R37-R51))
