### PR TITLE
feat(useEventBus): optional event key

### DIFF
--- a/packages/core/useEventBus/index.md
+++ b/packages/core/useEventBus/index.md
@@ -1,5 +1,6 @@
 ---
 category: Utilities
+related: createEventHook
 ---
 
 # useEventBus
@@ -12,6 +13,9 @@ A basic event bus.
 import { useEventBus } from '@vueuse/core'
 
 const bus = useEventBus<string>('news')
+
+// Can be created without a key for usage in a single location
+const anonymousBus = useEventBus<string>()
 
 function listener(event: string) {
   console.log(`news: ${event}`)

--- a/packages/core/useEventBus/index.test.ts
+++ b/packages/core/useEventBus/index.test.ts
@@ -10,106 +10,111 @@ describe('useEventBus', () => {
   beforeEach(() => {
     events.clear()
   })
-  it('on event and off listener', () => {
-    const { on, off } = useEventBus<number>('foo')
-    const { inc } = useCounter(0)
-    on(inc)
-    off(inc)
-    expect(events).toEqual(emptyMap)
-  })
-  it('on event', () => {
-    let event = false
-    const { emit, on, reset } = useEventBus<boolean>('on-event')
-    on((_event) => {
-      event = _event
+
+  describe.each(['with', 'without'])('%s key', (withOrWithoutKey) => {
+    const buildKey = (key: any) => withOrWithoutKey === 'with' ? key : undefined
+
+    it('on event and off listener', () => {
+      const { on, off } = useEventBus<number>(buildKey('foo'))
+      const { inc } = useCounter(0)
+      on(inc)
+      off(inc)
+      expect(events).toEqual(emptyMap)
     })
-    emit(true)
-    expect(event).toBe(true)
-    reset()
-    expect(events).toEqual(emptyMap)
-  })
-  it('once event', () => {
-    const { once, emit, reset } = useEventBus<number>('foo')
-    const { inc, count } = useCounter(0)
-    once(inc)
-    emit()
-    emit()
-    emit()
-    expect(count.value).toBe(1)
-    reset()
-    expect(events).toEqual(emptyMap)
-  })
-  it('useEventBus off event', () => {
-    const { emit, on, reset } = useEventBus<number>('useEventBus-off')
-    const { count, inc } = useCounter(0)
-    on(inc)
-
-    emit()
-    reset()
-
-    on(inc)
-
-    emit()
-    reset()
-
-    expect(count.value).toBe(2)
-    expect(events).toEqual(emptyMap)
-  })
-  it('event off event', () => {
-    const event1 = useEventBus<number>('event-off-1')
-    const event2 = useEventBus<number>('event-off-2')
-    const { count, inc } = useCounter(0)
-    event2.on(inc)
-    event1.emit() // 1
-    event2.emit() // 1
-
-    event1.reset()
-
-    event2.on(inc)
-    event1.emit() // 2
-    event2.emit() // 2
-
-    event1.reset()
-    event2.reset()
-
-    expect(count.value).toBe(2)
-    expect(events).toEqual(emptyMap)
-  })
-
-  it('setup unmount off', async () => {
-    const vm = useSetup(() => {
-      const { on } = useEventBus('setup-unmount')
-      on(() => {})
-      on(() => {})
-      on(() => {})
-      on(() => {})
-      on(() => {})
+    it('on event', () => {
+      let event = false
+      const { emit, on, reset } = useEventBus<boolean>(buildKey('on-event'))
+      on((_event) => {
+        event = _event
+      })
+      emit(true)
+      expect(event).toBe(true)
+      reset()
+      expect(events).toEqual(emptyMap)
     })
-    expect(events).not.toEqual(emptyMap)
-    vm.unmount()
-    await nextTick()
-    expect(events).toEqual(emptyMap)
-  })
+    it('once event', () => {
+      const { once, emit, reset } = useEventBus<number>(buildKey('foo'))
+      const { inc, count } = useCounter(0)
+      once(inc)
+      emit()
+      emit()
+      emit()
+      expect(count.value).toBe(1)
+      reset()
+      expect(events).toEqual(emptyMap)
+    })
+    it('useEventBus off event', () => {
+      const { emit, on, reset } = useEventBus<number>(buildKey('useEventBus-off'))
+      const { count, inc } = useCounter(0)
+      on(inc)
 
-  it('should work with payload', async () => {
-    const { on, emit } = useEventBus<'inc' | 'dec', number>('counter')
-    const counter = useCounter(0)
-    on((event, payload) => counter[event](payload))
-    emit('inc', 3)
-    expect(counter.count.value).toBe(3)
-    emit('dec', 1)
-    expect(counter.count.value).toBe(2)
-  })
+      emit()
+      reset()
 
-  it('the same key, the same listener, will only be triggered once', () => {
-    const listener = vi.fn()
-    const { on, emit, off } = useEventBus<'inc' | 'dec', number>('counter')
-    on(listener)
-    on(listener)
-    emit()
-    off(listener)
-    expect(listener).toBeCalledTimes(1)
-    expect(events).toEqual(emptyMap)
+      on(inc)
+
+      emit()
+      reset()
+
+      expect(count.value).toBe(2)
+      expect(events).toEqual(emptyMap)
+    })
+    it('event off event', () => {
+      const event1 = useEventBus<number>(buildKey('event-off-1'))
+      const event2 = useEventBus<number>(buildKey('event-off-2'))
+      const { count, inc } = useCounter(0)
+      event2.on(inc)
+      event1.emit() // 1
+      event2.emit() // 1
+
+      event1.reset()
+
+      event2.on(inc)
+      event1.emit() // 2
+      event2.emit() // 2
+
+      event1.reset()
+      event2.reset()
+
+      expect(count.value).toBe(2)
+      expect(events).toEqual(emptyMap)
+    })
+
+    it('setup unmount off', async () => {
+      const vm = useSetup(() => {
+        const { on } = useEventBus(buildKey('setup-unmount'))
+        on(() => {})
+        on(() => {})
+        on(() => {})
+        on(() => {})
+        on(() => {})
+      })
+      expect(events).not.toEqual(emptyMap)
+      vm.unmount()
+      await nextTick()
+      expect(events).toEqual(emptyMap)
+    })
+
+    it('should work with payload', async () => {
+      const { on, emit } = useEventBus<'inc' | 'dec', number>(buildKey('counter'))
+      const counter = useCounter(0)
+      on((event, payload) => counter[event](payload))
+      emit('inc', 3)
+      expect(counter.count.value).toBe(3)
+      emit('dec', 1)
+      expect(counter.count.value).toBe(2)
+    })
+
+    it('the same key, the same listener, will only be triggered once', () => {
+      const listener = vi.fn()
+      const { on, emit, off } = useEventBus<'inc' | 'dec', number>(buildKey('counter'))
+      on(listener)
+      on(listener)
+      emit()
+      off(listener)
+      expect(listener).toBeCalledTimes(1)
+      expect(events).toEqual(emptyMap)
+    })
   })
 
   describe('off ignores non-existent', () => {

--- a/packages/core/useEventBus/index.test.ts
+++ b/packages/core/useEventBus/index.test.ts
@@ -39,32 +39,6 @@ describe('useEventBus', () => {
     reset()
     expect(events).toEqual(emptyMap)
   })
-
-  it('not off non-exist listener', () => {
-    const bus1 = useEventBus<number>('foo')
-    const bus2 = useEventBus<number>('bar')
-    const listener = vi.fn()
-
-    bus1.on(listener)
-    bus2.off(listener)
-
-    expect(events.get('foo')).toBeDefined()
-    expect(events.get('bar')).toBeUndefined()
-  })
-  it('not off other events listener', () => {
-    const bus1 = useEventBus<number>('foo')
-    const bus2 = useEventBus<number>('bar')
-    const listener1 = vi.fn()
-    const listener2 = vi.fn()
-
-    bus1.on(listener1)
-    bus2.on(listener2)
-    bus1.off(listener2)
-    bus2.off(listener1)
-
-    expect(events.get('foo')).toBeDefined()
-    expect(events.get('bar')).toBeDefined()
-  })
   it('useEventBus off event', () => {
     const { emit, on, reset } = useEventBus<number>('useEventBus-off')
     const { count, inc } = useCounter(0)
@@ -136,5 +110,34 @@ describe('useEventBus', () => {
     off(listener)
     expect(listener).toBeCalledTimes(1)
     expect(events).toEqual(emptyMap)
+  })
+
+  describe('off ignores non-existent', () => {
+    it('not off non-exist listener', () => {
+      const bus1 = useEventBus<number>('foo')
+      const bus2 = useEventBus<number>('bar')
+      const listener = vi.fn()
+
+      bus1.on(listener)
+      bus2.off(listener)
+
+      expect(events.get('foo')).toBeDefined()
+      expect(events.get('bar')).toBeUndefined()
+    })
+
+    it('not off other events listener', () => {
+      const bus1 = useEventBus<number>('foo')
+      const bus2 = useEventBus<number>('bar')
+      const listener1 = vi.fn()
+      const listener2 = vi.fn()
+
+      bus1.on(listener1)
+      bus2.on(listener2)
+      bus1.off(listener2)
+      bus2.off(listener1)
+
+      expect(events.get('foo')).toBeDefined()
+      expect(events.get('bar')).toBeDefined()
+    })
   })
 })

--- a/packages/core/useEventBus/index.ts
+++ b/packages/core/useEventBus/index.ts
@@ -39,12 +39,13 @@ export interface UseEventBusReturn<T, P> {
   reset: () => void
 }
 
-export function useEventBus<T = unknown, P = any>(key: EventBusIdentifier<T>): UseEventBusReturn<T, P> {
+export function useEventBus<T = unknown, P = any>(key?: EventBusIdentifier<T>): UseEventBusReturn<T, P> {
   const scope = getCurrentScope()
+  const resolvedKey = key ?? Symbol('unprovided key') as EventBusIdentifier<T>
   function on(listener: EventBusListener<T, P>) {
-    const listeners = (events.get(key) || new Set())
+    const listeners = (events.get(resolvedKey) || new Set())
     listeners.add(listener)
-    events.set(key, listeners)
+    events.set(resolvedKey, listeners)
 
     const _off = () => off(listener)
     // auto unsubscribe when scope get disposed
@@ -64,7 +65,7 @@ export function useEventBus<T = unknown, P = any>(key: EventBusIdentifier<T>): U
   }
 
   function off(listener: EventBusListener<T>): void {
-    const listeners = events.get(key)
+    const listeners = events.get(resolvedKey)
     if (!listeners)
       return
 
@@ -75,11 +76,11 @@ export function useEventBus<T = unknown, P = any>(key: EventBusIdentifier<T>): U
   }
 
   function reset() {
-    events.delete(key)
+    events.delete(resolvedKey)
   }
 
   function emit(event?: T, payload?: P) {
-    events.get(key)?.forEach(v => v(event, payload))
+    events.get(resolvedKey)?.forEach(v => v(event, payload))
   }
 
   return { on, once, off, emit, reset }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Supports creating an event bus with `useEventBus()` but not providing a key (in which case, one is generated). This allows it to be used as a simple event emitter in a local component. I don't think there are any other equivalent functions when I looked.

### Additional context

Motivation behind this is that `createEventHook()` now has an asynchronous `trigger()` (#2824), which was a breaking change when relying on synchronous behaviour.

Alternatively, `createEventHook()` could be modified to be configurable as synchronous or asynchronous. Defaulting to asynchronous should be backwards compatible, while defaulting to synchronous again would be a breaking change.

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0011b8b</samp>

This pull request enhances the `useEventBus` function by allowing anonymous event buses without a key, fixing some bugs, and improving the documentation and tests. It modifies the files `packages/core/useEventBus/index.md`, `packages/core/useEventBus/index.ts`, and `packages/core/useEventBus/index.test.ts`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0011b8b</samp>

* Make the key optional for `useEventBus` function, allowing anonymous event buses ([link](https://github.com/vueuse/vueuse/pull/3102/files?diff=unified&w=0#diff-9c04e8febb00466ddfeee0848484e45463a27732be568e67c5dfd0e248911e39L42-R48), [link](https://github.com/vueuse/vueuse/pull/3102/files?diff=unified&w=0#diff-9c04e8febb00466ddfeee0848484e45463a27732be568e67c5dfd0e248911e39L67-R68), [link](https://github.com/vueuse/vueuse/pull/3102/files?diff=unified&w=0#diff-9c04e8febb00466ddfeee0848484e45463a27732be568e67c5dfd0e248911e39L78-R83))
  * Use a unique symbol as the internal key if no key is provided ([link](https://github.com/vueuse/vueuse/pull/3102/files?diff=unified&w=0#diff-9c04e8febb00466ddfeee0848484e45463a27732be568e67c5dfd0e248911e39L42-R48))
  * Use the resolved key instead of the key for `off`, `reset`, and `emit` functions ([link](https://github.com/vueuse/vueuse/pull/3102/files?diff=unified&w=0#diff-9c04e8febb00466ddfeee0848484e45463a27732be568e67c5dfd0e248911e39L67-R68), [link](https://github.com/vueuse/vueuse/pull/3102/files?diff=unified&w=0#diff-9c04e8febb00466ddfeee0848484e45463a27732be568e67c5dfd0e248911e39L78-R83))
  * Add an example of using `useEventBus` without a key in `index.md` ([link](https://github.com/vueuse/vueuse/pull/3102/files?diff=unified&w=0#diff-056732068302abe8af0d5b157cddd49cad6c5ab00803a91a42cf7419fc6c1cccR17-R19))
* Refactor the test cases for `useEventBus` to use `describe.each` block with different key parameters ([link](https://github.com/vueuse/vueuse/pull/3102/files?diff=unified&w=0#diff-eddd472d1b518be673c680ee6c53de60b2a17956c859b4dffa42ef42b0676394L13-R146))
  * Use a helper function `buildKey` to create the key or undefined based on the parameter ([link](https://github.com/vueuse/vueuse/pull/3102/files?diff=unified&w=0#diff-eddd472d1b518be673c680ee6c53de60b2a17956c859b4dffa42ef42b0676394L13-R146))
* Add a related link to `createEventHook` function in `index.md`, another way of creating an event bus ([link](https://github.com/vueuse/vueuse/pull/3102/files?diff=unified&w=0#diff-056732068302abe8af0d5b157cddd49cad6c5ab00803a91a42cf7419fc6c1cccR3))
