### PR TITLE
feat(useEyeDropper): add throw on Error

### DIFF
--- a/packages/core/useEyeDropper/index.ts
+++ b/packages/core/useEyeDropper/index.ts
@@ -39,9 +39,11 @@ export function useEyeDropper(options: UseEyeDropperOptions = {}) {
     if (!isSupported.value)
       return
     const eyeDropper: EyeDropper = new (window as any).EyeDropper()
-    const result = await eyeDropper.open(openOptions)
-    sRGBHex.value = result.sRGBHex
-    return result
+    try {
+      const result = await eyeDropper.open(openOptions)
+      sRGBHex.value = result.sRGBHex
+      return result
+    } catch {}
   }
 
   return { isSupported, sRGBHex, open }

--- a/packages/core/useEyeDropper/index.ts
+++ b/packages/core/useEyeDropper/index.ts
@@ -22,6 +22,13 @@ export interface UseEyeDropperOptions {
    * @default ''
    */
   initialValue?: string
+
+  /**
+   * Throw error if not supported.
+   *
+   * @default false
+   */
+  throwError?: boolean
 }
 
 /**
@@ -31,7 +38,10 @@ export interface UseEyeDropperOptions {
  * @param initialValue string
  */
 export function useEyeDropper(options: UseEyeDropperOptions = {}) {
-  const { initialValue = '' } = options
+  const {
+    initialValue = '',
+    throwError = false,
+  } = options
   const isSupported = useSupported(() => typeof window !== 'undefined' && 'EyeDropper' in window)
   const sRGBHex = ref(initialValue)
 
@@ -43,10 +53,18 @@ export function useEyeDropper(options: UseEyeDropperOptions = {}) {
       const result = await eyeDropper.open(openOptions)
       sRGBHex.value = result.sRGBHex
       return result
-    } catch {}
+    }
+    catch (e) {
+      if (throwError)
+        throw e
+    }
   }
 
-  return { isSupported, sRGBHex, open }
+  return {
+    isSupported,
+    sRGBHex,
+    open,
+  }
 }
 
 export type UseEyeDropperReturn = ReturnType<typeof useEyeDropper>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
When eyedropper is opened but canceled (eg : Escape), the promise function `open` is rejected, resulting a global error `DOMException: Failed to execute 'open' on 'EyeDropper': The user canceled the selection.` when attached directly to template event listener like `@click="open"`.

This PR resolve this issue by wrapping the promise into try/catch

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0e7088d</samp>

Fixed error handling for `useEyeDropper` hook by adding try-catch block to `open` function. This resolved issue #1022 and followed the browser API spec.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0e7088d</samp>

*  Handle possible errors from `eyeDropper.open` method with a try-catch block ([link](https://github.com/vueuse/vueuse/pull/3113/files?diff=unified&w=0#diff-ba8585e1b77940a97094e847b8ea8e16f0fd12d6a07391c5965940c910dd2b7cL42-R46)). This fixes issue #1022 and follows the browser API specification.
