### PR TITLE
fix(watchImmediate): fix overload signature

### DIFF
--- a/packages/shared/watchImmediate/index.ts
+++ b/packages/shared/watchImmediate/index.ts
@@ -7,19 +7,19 @@ import type { MapOldSources, MapSources, MultiWatchSources } from '../utils/type
 export function watchImmediate<T extends Readonly<MultiWatchSources>>(
   source: T,
   cb: WatchCallback<MapSources<T>, MapOldSources<T, true>>,
-  options?: Omit<WatchOptions<true>, 'deep'>
+  options?: Omit<WatchOptions<true>, 'immediate'>
 ): WatchStopHandle
 
 export function watchImmediate<T>(
   source: WatchSource<T>,
   cb: WatchCallback<T, T | undefined>,
-  options?: Omit<WatchOptions<true>, 'deep'>
+  options?: Omit<WatchOptions<true>, 'immediate'>
 ): WatchStopHandle
 
 export function watchImmediate<T extends object>(
   source: T,
   cb: WatchCallback<T, T | undefined>,
-  options?: Omit<WatchOptions<true>, 'deep'>
+  options?: Omit<WatchOptions<true>, 'immediate'>
 ): WatchStopHandle
 
 /**


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Fixes the overload signature of the `watchImmediate` function, which incorrectly omitted the `deep` property when it should have omitted the `immediate` property.
<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d190404</samp>

Refactor `watchImmediate` function to remove unnecessary `immediate` option. Simplify the type definition and usage of `WatchOptions` in `packages/shared/watchImmediate/index.ts`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d190404</samp>

*  Omit the `immediate` option from the `WatchOptions` type for the `watchImmediate` function and its overloads, since it is always true for this function (`packages/shared/watchImmediate/index.ts`, [link](https://github.com/vueuse/vueuse/pull/3114/files?diff=unified&w=0#diff-89f52c79f027c8ab99475400fe2a56f1efdeb5fabd966d7f417b97699d3a4870L10-R10), [link](https://github.com/vueuse/vueuse/pull/3114/files?diff=unified&w=0#diff-89f52c79f027c8ab99475400fe2a56f1efdeb5fabd966d7f417b97699d3a4870L16-R16), [link](https://github.com/vueuse/vueuse/pull/3114/files?diff=unified&w=0#diff-89f52c79f027c8ab99475400fe2a56f1efdeb5fabd966d7f417b97699d3a4870L22-R22))
