### PR TITLE
fix(useTextareaAutosize): autosize error when changing `input` asynchronously

### DIFF
--- a/packages/core/useTextareaAutosize/index.ts
+++ b/packages/core/useTextareaAutosize/index.ts
@@ -1,7 +1,7 @@
 import type { MaybeRef } from '@vueuse/shared'
 import { toValue } from '@vueuse/shared'
 import type { WatchSource } from 'vue-demi'
-import { ref, watch } from 'vue-demi'
+import { nextTick, ref, watch } from 'vue-demi'
 import { useResizeObserver } from '../useResizeObserver'
 
 export interface UseTextareaAutosizeOptions {
@@ -43,7 +43,7 @@ export function useTextareaAutosize(options?: UseTextareaAutosizeOptions) {
     options?.onResize?.()
   }
 
-  watch([input, textarea], triggerResize, { immediate: true })
+  watch([input, textarea], () => nextTick(triggerResize), { immediate: true })
 
   useResizeObserver(textarea, () => triggerResize())
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

fixes: #3110

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7007fce</samp>

Fix textarea resizing bug with `nextTick` in `useTextareaAutosize` function. Use `vue-demi` to ensure compatibility with both Vue 2 and 3.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7007fce</samp>

* Import `nextTick` function from `vue-demi` to defer callbacks until next DOM update cycle ([link](https://github.com/vueuse/vueuse/pull/3118/files?diff=unified&w=0#diff-45baa8ff0be8f6ff97e364c8e01fad9b7ff6f0a0a8924765a239c8a47c5f02e4L4-R4))
* Wrap `triggerResize` function in `nextTick` call inside `watch` effect to fix textarea resizing bug when value is changed programmatically ([link](https://github.com/vueuse/vueuse/pull/3118/files?diff=unified&w=0#diff-45baa8ff0be8f6ff97e364c8e01fad9b7ff6f0a0a8924765a239c8a47c5f02e4L46-R46))
