### PR TITLE
feat(debounce): add `leading` and `trailing` options

### DIFF
--- a/packages/shared/utils/index.test.ts
+++ b/packages/shared/utils/index.test.ts
@@ -134,6 +134,59 @@ describe('filters', () => {
     expect(debouncedFilterSpy).toHaveBeenCalledTimes(2)
   })
 
+  it('should support a `leading` option', () => {
+    const debouncedFilterSpy = vi.fn()
+
+    const filter = createFilterWrapper(
+      debounceFilter(500, { leading: true }),
+      debouncedFilterSpy,
+    )
+
+    filter()
+    filter()
+    expect(debouncedFilterSpy).toHaveBeenCalledTimes(1)
+    vi.runAllTimers()
+    expect(debouncedFilterSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('should support a `maxWait` option', () => {
+    const debouncedFilterSpy = vi.fn()
+    const filter = createFilterWrapper(
+      debounceFilter(100, { maxWait: 200 }),
+      debouncedFilterSpy,
+    )
+
+    filter()
+    filter()
+    expect(debouncedFilterSpy).toHaveBeenCalledTimes(0)
+
+    setTimeout(() => {
+      expect(debouncedFilterSpy).toHaveBeenCalledTimes(1)
+      filter()
+      filter()
+      expect(debouncedFilterSpy).toHaveBeenCalledTimes(1)
+    }, 300)
+
+    vi.runAllTimers()
+    expect(debouncedFilterSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('should queue a trailing call for subsequent debounced calls after `maxWait`', () => {
+    const debouncedFilterSpy = vi.fn()
+
+    const filter = createFilterWrapper(
+      debounceFilter(200, { maxWait: 200 }),
+      debouncedFilterSpy,
+    )
+
+    filter()
+    setTimeout(filter, 190)
+    setTimeout(filter, 200)
+    setTimeout(filter, 210)
+    vi.runAllTimers()
+    expect(debouncedFilterSpy).toHaveBeenCalledTimes(2)
+  })
+
   it('should throttle', () => {
     const throttledFilterSpy = vi.fn()
     const filter = createFilterWrapper(throttleFilter(1000), throttledFilterSpy)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Supports invoking on the leading edge or trailing edge of the timeout, similar to [lodash](https://lodash.com/docs/4.17.15#debounce).

[issues#3099](https://github.com/vueuse/vueuse/issues/3099)

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 851be2f</samp>

This pull request improves the `debounceFilter` and `throttleFilter` functions in `packages/shared/utils/filters.ts` with more options and logic. It also adds tests for the new features of the `debounceFilter` function in `packages/shared/utils/index.test.ts`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 851be2f</samp>

*  Add `leading` and `trailing` options to `DebounceFilterOptions` interface to control the invocation of the debounced function ([link](https://github.com/vueuse/vueuse/pull/3120/files?diff=unified&w=0#diff-cdaaa527823b1185c9de2b274c26403a0b7268f5290f1d56f8af29941be6821dR41-R54))
*  Rewrite `debounceFilter` function to support `leading` and `maxWait` options and handle edge cases ([link](https://github.com/vueuse/vueuse/pull/3120/files?diff=unified&w=0#diff-cdaaa527823b1185c9de2b274c26403a0b7268f5290f1d56f8af29941be6821dL70-R159))
*  Simplify `throttleFilter` function by reusing `debounceFilter` function with `maxWait` option ([link](https://github.com/vueuse/vueuse/pull/3120/files?diff=unified&w=0#diff-cdaaa527823b1185c9de2b274c26403a0b7268f5290f1d56f8af29941be6821dL129-R174))
*  Add test cases for `debounceFilter` function with `leading` and `maxWait` options in `packages/shared/utils/index.test.ts` ([link](https://github.com/vueuse/vueuse/pull/3120/files?diff=unified&w=0#diff-30a78e1d8800a3dd9b975957d964e0f5afe60239e0a0c019777b8a2bc8386f68R137-R189))
