### PR TITLE
fix(useFetch): Add option to use stock FetchAPI error-like status codes behavior (non-breaking alternative)

### DIFF
--- a/packages/core/useFetch/index.md
+++ b/packages/core/useFetch/index.md
@@ -128,6 +128,21 @@ const { data } = useFetch(url, {
 })
 ```
 
+### Swallowing errors
+
+You can disable the `throwOnErrCodes` option to handle error-codes like the native FetchAPI does, which is to just accept them.
+
+By default, `useFetch` skips parsing the body and throws early to provide the `error`
+object when it encounters any response code that is not `200: Ok`; disabling `throwOnErrCodes` continues parsing
+like a normal success when it encounters error codes.
+
+You can implement your own error-detection yourself by throwing inside the `afterFetch()` function.
+
+```ts
+const { data } = useFetch('bad-url/400', { throwOnErrCodes: false })
+console.log(data.value) // null
+```
+
 ### Setting the request method and return type
 
 The request method and return type can be set by adding the appropriate methods to the end of `useFetch`

--- a/packages/core/useFetch/index.test.ts
+++ b/packages/core/useFetch/index.test.ts
@@ -92,6 +92,15 @@ describe('useFetch', () => {
     })
   })
 
+  it('should not have an error on when not throwOnErrCodes', async () => {
+    const { error, statusCode, data } = useFetch('https://example.com?status=400', { throwOnErrCodes: false })
+    await retry(() => {
+      expect(data.value).toBe('')
+      expect(statusCode.value).toBe(400)
+      expect(error.value).toBe(null)
+    })
+  })
+
   it('should throw error', async () => {
     const options = { immediate: false }
     const error1 = await useFetch('https://example.com?status=400', options).execute(true).catch(err => err)

--- a/packages/core/useFetch/index.test.ts
+++ b/packages/core/useFetch/index.test.ts
@@ -578,6 +578,22 @@ describe('useFetch', () => {
     })
   })
 
+  it('should act like error code on custom throw inside afterFetch', async () => {
+    const { error, statusCode, data } = useFetch('https://example.com?status=400',
+      {
+        throwOnErrCodes: false,
+        afterFetch(ctx) {
+          throw new Error('custom fetch error')
+          return ctx
+        },
+      })
+    await retry(() => {
+      expect(data.value).toBeNull()
+      expect(statusCode.value).toStrictEqual(400)
+      expect(error.value).toBe('custom fetch error')
+    })
+  })
+
   it('should emit onFetchResponse event', async () => {
     const onResponseSpy = vi.fn()
     const { onFetchResponse } = useFetch('https://example.com')

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -164,6 +164,14 @@ export interface UseFetchOptions {
   timeout?: number
 
   /**
+   * Throw if the http status code is not a 2xx code.
+   * (this deviates from stock FetchAPI behavior)
+   *
+   * @default true
+   */
+  throwOnErrCodes?: boolean
+
+  /**
    * Will run immediately before the fetch request is dispatched
    */
   beforeFetch?: (ctx: BeforeFetchContext) => Promise<Partial<BeforeFetchContext> | void> | Partial<BeforeFetchContext> | void
@@ -211,7 +219,7 @@ export interface CreateFetchOptions {
  * to include the new options
  */
 function isFetchOptions(obj: object): obj is UseFetchOptions {
-  return obj && containsProp(obj, 'immediate', 'refetch', 'initialData', 'timeout', 'beforeFetch', 'afterFetch', 'onFetchError', 'fetch')
+  return obj && containsProp(obj, 'immediate', 'refetch', 'initialData', 'timeout', 'throwOnErrCodes', 'beforeFetch', 'afterFetch', 'onFetchError', 'fetch')
 }
 
 // A URL is considered absolute if it begins with "<scheme>://" or "//" (protocol-relative URL).
@@ -444,7 +452,7 @@ export function useFetch<T>(url: MaybeRefOrGetter<string>, ...args: any[]): UseF
           responseData = await fetchResponse[config.type]()
 
           // see: https://www.tjvantoll.com/2015/09/13/fetch-and-errors/
-          if (!fetchResponse.ok) {
+          if (options.throwOnErrCodes && !fetchResponse.ok) {
             data.value = initialData || null
             throw new Error(fetchResponse.statusText)
           }

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -322,7 +322,7 @@ export function useFetch<T>(url: MaybeRefOrGetter<string>, ...args: any[]): UseF
   const supportsAbort = typeof AbortController === 'function'
 
   let fetchOptions: RequestInit = {}
-  let options: UseFetchOptions = { immediate: true, refetch: false, timeout: 0 }
+  let options: UseFetchOptions = { immediate: true, refetch: false, timeout: 0, throwOnErrCodes: true }
   interface InternalConfig { method: HttpMethod; type: DataType; payload: unknown; payloadType?: string }
   const config: InternalConfig = {
     method: 'GET',


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Solves same problem as #3092 , but provides a non-breaking solution, since users do expect the non-standard behavior, as it's more intuitive. But there are cases, especially when integrating with APIs, where stock FetchAPI behavior is necessary.

This adds an option `throwOnErrCodes` that is true by default, but can be disabled; in which case, http error codes will be accepted as successful responses, and populate the `data` field instead of the `error` field.

This also has the benefit of allowing someone to disable `throwOnErrCodes` and implement their own custom error detection in `afterFetch` hooks, since throwing inside one results in falling back to the useFetch `error` being populated.

### Additional context

solves #2452
solves #526
solves #553
supersedes #572
related #2711

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2ae0871</samp>

This pull request enhances the `useFetch` function with a new option `throwOnErrCodes` that allows users to opt out of throwing errors on non-200 status codes. It also adds tests and documentation for this new feature.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2ae0871</samp>

*  Add `throwOnErrCodes` option to `useFetch` to disable error throwing for non-200 status codes ([link](https://github.com/vueuse/vueuse/pull/3126/files?diff=unified&w=0#diff-0db62ed388d474bc80cd69e2ff1593cd6c9719b8794d8f88459a1704e8da25b5R167-R174), [link](https://github.com/vueuse/vueuse/pull/3126/files?diff=unified&w=0#diff-0db62ed388d474bc80cd69e2ff1593cd6c9719b8794d8f88459a1704e8da25b5L214-R222), [link](https://github.com/vueuse/vueuse/pull/3126/files?diff=unified&w=0#diff-0db62ed388d474bc80cd69e2ff1593cd6c9719b8794d8f88459a1704e8da25b5L317-R325), [link](https://github.com/vueuse/vueuse/pull/3126/files?diff=unified&w=0#diff-0db62ed388d474bc80cd69e2ff1593cd6c9719b8794d8f88459a1704e8da25b5L447-R455))
*  Update `useFetch` documentation to explain how to use the new option and handle error codes like the native FetchAPI (`packages/core/useFetch/index.md`, [link](https://github.com/vueuse/vueuse/pull/3126/files?diff=unified&w=0#diff-8e2a59a63d7197173044c5bdc03f0c6b63a72b72f7231b855e3c3302d1300da5R131-R145))
*  Add test cases to verify the behavior of `useFetch` with and without the new option, and with a custom error thrown in the `afterFetch` hook (`packages/core/useFetch/index.test.ts`, [link](https://github.com/vueuse/vueuse/pull/3126/files?diff=unified&w=0#diff-cfa32f32f2a1245f1809ab44fa2bfc07a3b5ea7ea2e40cf4893a60ad410c7f2eR95-R103), [link](https://github.com/vueuse/vueuse/pull/3126/files?diff=unified&w=0#diff-cfa32f32f2a1245f1809ab44fa2bfc07a3b5ea7ea2e40cf4893a60ad410c7f2eR581-R596))
