### PR TITLE
docs(useScriptTag): Made some gotchas of `useScriptTag()` more obvious.

### DIFF
--- a/packages/core/useScriptTag/index.md
+++ b/packages/core/useScriptTag/index.md
@@ -4,7 +4,9 @@ category: Browser
 
 # useScriptTag
 
-Script tag injecting.
+Creates a script tag, with support for automaticly unloading (deleting) the script tag on unmount.
+
+If a script tag already exists for the given URL, `useScriptTag()` will not create another script tag, but keep in mind that, depending on how you use it, `useScriptTag()` it might have already loaded then unloaded that particular JS file from a previous call of `useScriptTag()`.
 
 ## Usage
 


### PR DESCRIPTION
<details>
<summary>Boilerplate</summary>

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>
</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
The first five or so times I looked up the documentation for `useScriptTag()` I didn't catch that this had Vue-specific behavior such as automatically unloading on unmount. Also, I had to look at the source code myself to see if it would load the same remote JS script twice, if `useScriptTag()` was called twice.

I made these changes to help make those details more obvious.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

If `useScriptTag()` says the same, then I think this PR is good, but...

I actually hope that this PR is not accepted and that instead `useScriptTag()` is changed.** `useScriptTag()` is in violation of y'all's own guideline https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md#asynchronous-composables . I think I should be able to write
```
await useScriptTag(scriptUrl);
somethingThatDependsOnThatScriptHavingAlreadyFinishedRunning();
```

Also, I don't understand why `useScriptTag()` would ever unload the script, except in the case that there is an error that prevents the script from loading. With that exception, it doesn't sound desirable. Yes, theoretically the script tag might take up some memory sitting on the DOM, but surely that is nothing compared to the risk of accidentally running the same script twice.

Also, wouldn't unloading the script tag on unmount possibly cause race condition problems? Let's say that the user uses it like `useScriptTag(scriptUrl)` in a vue component called `FooComponent`. Let's also say that an instance of `FooComponent` was mounted then quickly unmounted. As the code currently is, it will create then quickly delete the script tag. What if the browser is such that it will not run the script at all if it takes a while to download the script and the script tag for that script is deleted before the downloading finished?! That sounds like a nasty race condition to me. And maybe it might make different behaviors based on different web browsers (I didn't research that particular detail very much. Not sure). 

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ce57029</samp>

Improved the documentation of `useScriptTag` function in `packages/core/useScriptTag/index.md` by adding more details and examples. This change enhances the usability and understanding of the function for the vueuse/vueuse users.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ce57029</samp>

* Add `useScriptTag` function to load and unload external scripts dynamically ([link](https://github.com/vueuse/vueuse/pull/3135/files?diff=unified&w=0#diff-d41413b9c7a70a252fd1d6bfee65fd0a8c49fd811701c91fa0d880eb67878108L7-R10),F
