### PR TITLE
fix(useCloned): check for getter function to watch

### DIFF
--- a/packages/core/useCloned/index.test.ts
+++ b/packages/core/useCloned/index.test.ts
@@ -29,6 +29,18 @@ describe('useCloned', () => {
     expect(cloned.value).toEqual(data.value)
   })
 
+  it('works with getter function', async () => {
+    const data = ref({ test: 'test' })
+
+    const { cloned } = useCloned(() => data.value)
+
+    data.value.test = 'success'
+
+    await nextTick()
+
+    expect(cloned.value).toEqual(data.value)
+  })
+
   it('works with refs and manual sync', async () => {
     const data = ref({ test: 'test' })
 

--- a/packages/core/useCloned/index.ts
+++ b/packages/core/useCloned/index.ts
@@ -53,7 +53,7 @@ export function useCloned<T>(
     cloned.value = clone(toValue(source))
   }
 
-  if (!manual && isRef(source)) {
+  if (!manual && (isRef(source) || typeof source === 'function')) {
     watch(source, sync, {
       ...options,
       deep,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

The types in the docs says it would work with getter function. But actually, the getter function didn't get passed to `watch`.

This PR checks for getter function for watching.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 29d917c</samp>

Added support for getter functions as source arguments to `useCloned` function and added a test case for it. This change enables `useCloned` to clone values from reactive objects or computed properties.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 29d917c</samp>

*  Add support for getter functions as source argument in `useCloned` ([link](https://github.com/vueuse/vueuse/pull/3142/files?diff=unified&w=0#diff-28a0ffed5f59d3aa2a568fe9705b3c5741e7fa38880af03e2a56dd49a4da5e06L56-R56))
*  Add test case for `useCloned` with getter function as source ([link](https://github.com/vueuse/vueuse/pull/3142/files?diff=unified&w=0#diff-c26566400d12bf879e1641184b43a4c612f552d309244545bf1e81232318dcd8R32-R43))
