### PR TITLE
fix(useInfiniteScroll): prevent infinite load when v-show set false

### DIFF
--- a/packages/core/useInfiniteScroll/index.ts
+++ b/packages/core/useInfiniteScroll/index.ts
@@ -61,7 +61,7 @@ export function useInfiniteScroll(
     state.measure()
 
     const el = toValue(element) as HTMLElement
-    if (!el)
+    if (!el || !el.offsetParent)
       return
 
     const isNarrower = (direction === 'bottom' || direction === 'top')


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
When we use v-show to control the scroll component，I found it would be infinite trigger load method of setting v-show false.
To close https://github.com/vueuse/vueuse/issues/3098 in a different way.
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a79de66</samp>

Fixed a bug in `useInfiniteScroll` hook that caused loading when the element was hidden or detached. Added a check for the element's offset parent in `checkAndLoad` function in `packages/core/useInfiniteScroll/index.ts`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a79de66</samp>

*  Prevent loading when element is hidden or detached by checking offset parent in `checkAndLoad` ([link](https://github.com/vueuse/vueuse/pull/3143/files?diff=unified&w=0#diff-f1e18d7fa553054c65bf5b7e4fe4daf0fbfb98fe7224964f3f46661a3770d6a1L64-R64))
