### PR TITLE
fix(fromEvent): torn down properly

### DIFF
--- a/packages/rxjs/from/index.ts
+++ b/packages/rxjs/from/index.ts
@@ -1,31 +1,28 @@
 import { Observable, fromEvent as fromEventRx, from as fromRxjs } from 'rxjs'
-import type { ObservableInput } from 'rxjs'
-import { filter, switchMap } from 'rxjs/operators'
+import type { ObservableInput, Subscription } from 'rxjs'
 import type { Ref, WatchOptions } from 'vue-demi'
 import type { MaybeRef } from '@vueuse/shared'
 import { isRef, watch } from 'vue-demi'
 
 export function from<T>(value: ObservableInput<T> | Ref<T>, watchOptions?: WatchOptions): Observable<T> {
-  if (isRef<T>(value)) {
-    return new Observable((subscriber) => {
-      const watchStopHandle = watch(value, val => subscriber.next(val), watchOptions)
+  if (isRef<T>(value))
+    return new Observable(subscriber => watch(value, val => subscriber.next(val), watchOptions))
 
-      return () => {
-        watchStopHandle()
-      }
-    })
-  }
-  else {
-    return fromRxjs(value)
-  }
+  return fromRxjs(value)
 }
 
 export function fromEvent<T extends HTMLElement>(value: MaybeRef<T>, event: string): Observable<Event> {
   if (isRef<T>(value)) {
-    return from(value, { immediate: true }).pipe(
-      filter(value => value instanceof HTMLElement),
-      switchMap(value => fromEventRx(value, event)),
-    )
+    return new Observable((subscriber) => {
+      let innerSub: Subscription | undefined
+      return watch(value, (element) => {
+        innerSub?.unsubscribe()
+        if (element instanceof HTMLElement) {
+          innerSub = fromEventRx(element, event).subscribe(subscriber)
+          subscriber.add(innerSub)
+        }
+      }, { immediate: true })
+    })
   }
   return fromEventRx(value, event)
 }

--- a/packages/rxjs/from/index.ts
+++ b/packages/rxjs/from/index.ts
@@ -1,6 +1,6 @@
 import { Observable, fromEvent as fromEventRx, from as fromRxjs } from 'rxjs'
 import type { ObservableInput } from 'rxjs'
-import { filter, mergeMap } from 'rxjs/operators'
+import { filter, switchMap } from 'rxjs/operators'
 import type { Ref, WatchOptions } from 'vue-demi'
 import type { MaybeRef } from '@vueuse/shared'
 import { isRef, watch } from 'vue-demi'
@@ -24,7 +24,7 @@ export function fromEvent<T extends HTMLElement>(value: MaybeRef<T>, event: stri
   if (isRef<T>(value)) {
     return from(value, { immediate: true }).pipe(
       filter(value => value instanceof HTMLElement),
-      mergeMap(value => fromEventRx(value, event)),
+      switchMap(value => fromEventRx(value, event)),
     )
   }
   return fromEventRx(value, event)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [?] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

This addresses issues with `fromEvent`, wherein if the ref is updated to a new HTMLElement or to anything really, the event listeners from the prevent elements are not torn down. This also improves the performance profile of the implementation a bit.

### Additional context

The only way I could figure out to test this was manually.

Pair programmed with @JessicaSachs .

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 64ba802</samp>

Improved `from` and `fromEvent` functions in `@vueuse/rxjs` package. Fixed a bug with ref elements in `fromEvent`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 64ba802</samp>

*  Refactor `fromEvent` function to avoid memory leaks and update event source when ref changes ([link](https://github.com/vueuse/vueuse/pull/3155/files?diff=unified&w=0#diff-a95ccd62875aef4730b643735d6b9bb747ea2be5ae57fe0fa49250d458182c79L2-R2),[link](https://github.com/vueuse/vueuse/pull/3155/files?diff=unified&w=0#diff-a95ccd62875aef4730b643735d6b9bb747ea2be5ae57fe0fa49250d458182c79L9-R25))
