### PR TITLE
fix(useRouteParams): Deconstruct the route parameter to separate the path

### DIFF
--- a/packages/router/useRouteParams/index.test.ts
+++ b/packages/router/useRouteParams/index.test.ts
@@ -143,4 +143,14 @@ describe('useRouteParams', () => {
     expect(page.value).toBeNull()
     expect(lang.value).toBeNull()
   })
+  it('should url parameters will be encoded', async () => {
+    let route = getRoute()
+    const router = { replace: (r: any) => route = r } as any
+    const path: Ref<any> = useRouteParams('path', null, { route, router })
+    path.value = 'bar/b'
+
+    await nextTick()
+    console.log('path: ', route.params)
+    expect(path.value).toBe('bar/b')
+  })
 })

--- a/packages/router/useRouteParams/index.ts
+++ b/packages/router/useRouteParams/index.ts
@@ -1,6 +1,6 @@
 import type { Ref } from 'vue-demi'
 import { customRef, nextTick } from 'vue-demi'
-import type { RouteParamValueRaw } from 'vue-router'
+import type { RouteLocationRaw, RouteParamValueRaw } from 'vue-router'
 import { useRoute, useRouter } from 'vue-router'
 import { toValue, tryOnScopeDispose } from '@vueuse/shared'
 import type { ReactiveRouteOptionsWithTransform } from '../_types'
@@ -57,9 +57,10 @@ export function useRouteParams<
       _params.set(name, (v === defaultValue || v === null) ? undefined : v)
 
       trigger()
-
       nextTick(() => {
-        router[toValue(mode)]({ ...route, params: { ...route.params, ...Object.fromEntries(_params.entries()) } })
+        const { name: pathName, path, ...otherRouteParams } = route
+        const routeParams = { name: pathName, ...otherRouteParams }
+        router[toValue(mode)]({ ...routeParams, params: { ...route.params, ...Object.fromEntries(_params.entries()) } } as RouteLocationRaw)
       })
     },
   }))


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

fixed #[3164](https://github.com/vueuse/vueuse/issues/3164) 

According to the official documentation of [vue router](https://router.vuejs.org/guide/essentials/navigation.html), when path and params are used at the same time, params will become invalid. So if we pass a string with `/` in params, the route will jump to an undefined page. The url should be encoded, not directly displayed on the url

### Additional context

```javascript
<script lang="ts" setup>
import { useRouteParams } from '@vueuse/router';
import { useRoute, useRouter, RouteLocationRaw } from 'vue-router';
const route = useRoute();
const router = useRouter();

const id = useRouteParams('id');
// eg: the route path is /far
/** At this time the url is http://localhost:5173/far/bar/a **/
const change = () => {
  id.value = 'bar/a';
};
/** At this time the url is http://localhost:5173/far/bar%2Fc **/
const change2 = () => {
  const { name, path, ...otherRouteParams } = route;
  let routeParams = { name, ...otherRouteParams };
  console.log('change2: ', { ...routeParams, params: { ...route.params, id: 'bar/c' } });
  router.replace({ ...routeParams, params: { ...route.params, id: 'bar/c' } } as RouteLocationRaw);
};
</script>
<template>
  <div>{{ JSON.stringify(id) }}</div>
  <button @click="change">click1</button>
  <button @click="change2">click2</button>
</template>
```
If you refresh the page at this time change1 will cause your page to go to the wrong params
---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 338f2cc</samp>

This pull request enhances the `useRouteParams` function from the `router` package by using a more accurate type and fixing a url encoding bug. It also adds a new test case to verify the bug fix.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 338f2cc</samp>

* Fix a bug in `useRouteParams` that caused router methods to fail with routes that had a `path` property ([link](https://github.com/vueuse/vueuse/pull/3182/files?diff=unified&w=0#diff-f657fa605a6d4b2a9769faa5835fde4154c39c4a01a09cf8ae63e9dac446fcd8L60-R63))
* Import the `RouteLocationRaw` type from `vue-router` in `useRouteParams` to type the argument of the router methods ([link](https://github.com/vueuse/vueuse/pull/3182/files?diff=unified&w=0#diff-f657fa605a6d4b2a9769faa5835fde4154c39c4a01a09cf8ae63e9dac446fcd8L3-R3))
* Add a test case for `useRouteParams` that checks the url parameters are encoded properly ([link](https://github.com/vueuse/vueuse/pull/3182/files?diff=unified&w=0#diff-a57f86ebcafcb55d44126c69a48bd1f5c88e513a80fddd3241ecd3ae34ba76ddR146-R155))
