### PR TITLE
fix(useStorage): not reactive with multiple apps at the same tab

### DIFF
--- a/packages/core/useStorage/index.ts
+++ b/packages/core/useStorage/index.ts
@@ -125,7 +125,7 @@ export function useStorage<T = unknown>(key: string, defaults: MaybeRefOrGetter<
  *
  * @see https://vueuse.org/useStorage
  */
-export function useStorage<T extends(string | number | boolean | object | null)>(
+export function useStorage<T extends (string | number | boolean | object | null)>(
   key: string,
   defaults: MaybeRefOrGetter<T>,
   storage: StorageLike | undefined,
@@ -171,6 +171,8 @@ export function useStorage<T extends(string | number | boolean | object | null)>
 
   if (window && listenToStorageChanges) {
     useEventListener(window, 'storage', update)
+    // issue #3168
+    window.dispatchEvent(new Event('storage'))
     useEventListener(window, customStorageEventName, updateFromCustomEvent)
   }
 

--- a/packages/core/useStorage/index.ts
+++ b/packages/core/useStorage/index.ts
@@ -171,8 +171,6 @@ export function useStorage<T extends (string | number | boolean | object | null)
 
   if (window && listenToStorageChanges) {
     useEventListener(window, 'storage', update)
-    // issue #3186
-    window.dispatchEvent(new Event('storage'))
     useEventListener(window, customStorageEventName, updateFromCustomEvent)
   }
 
@@ -191,10 +189,12 @@ export function useStorage<T extends (string | number | boolean | object | null)
         if (oldValue !== serialized) {
           storage!.setItem(key, serialized)
 
-          // send custom event to communicate within same page
-          // importantly this should _not_ be a StorageEvent since those cannot
-          // be constructed with a non-built-in storage area
           if (window) {
+            // issue #3186
+            window.dispatchEvent(new Event('storage'))
+            // send custom event to communicate within same page
+            // importantly this should _not_ be a StorageEvent since those cannot
+            // be constructed with a non-built-in storage area
             window.dispatchEvent(new CustomEvent<StorageEventLike>(customStorageEventName, {
               detail: {
                 key,

--- a/packages/core/useStorage/index.ts
+++ b/packages/core/useStorage/index.ts
@@ -171,7 +171,7 @@ export function useStorage<T extends (string | number | boolean | object | null)
 
   if (window && listenToStorageChanges) {
     useEventListener(window, 'storage', update)
-    // issue #3168
+    // issue #3186
     window.dispatchEvent(new Event('storage'))
     useEventListener(window, customStorageEventName, updateFromCustomEvent)
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

closes #3186

See: https://codepen.io/alexzhang1030/pen/JjaqRPW

related: https://stackoverflow.com/questions/35865481/storage-event-not-firing

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a9a2f50</samp>

Fixed `useStorage` hook to sync with storage changes from other sources and improved code readability in `packages/core/useStorage/index.ts`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a9a2f50</samp>

* Fix a bug where `useStorage` hook would not react to changes made by other tabs or windows in the same origin by dispatching a `storage` event on the `window` object after setting or removing an item from the local storage ([link](https://github.com/vueuse/vueuse/pull/3187/files?diff=unified&w=0#diff-015d17be17c2a02d87f6b40bc47f526a5e82a01ee334f2883d271c6d98543d21R174-R175))
* Add a space between `extends` and the type parameter `T` in the `StorageOptions` interface to improve readability and consistency with the TypeScript style guide ([link](https://github.com/vueuse/vueuse/pull/3187/files?diff=unified&w=0#diff-015d17be17c2a02d87f6b40bc47f526a5e82a01ee334f2883d271c6d98543d21L128-R128))
