### PR TITLE
refactor(useStyleTag): remove deprecated 'type' property from HTMLStyleElement

### DIFF
--- a/packages/core/useStyleTag/index.md
+++ b/packages/core/useStyleTag/index.md
@@ -29,7 +29,7 @@ css.value = '.foo { margin-top: 64px; }'
 This code will be injected to `<head>`:
 
 ```html
-<style type="text/css" id="vueuse_styletag_1">
+<style id="vueuse_styletag_1">
 .foo { margin-top: 64px; }
 </style>
 ```
@@ -46,7 +46,7 @@ useStyleTag('.foo { margin-top: 32px; }', { id: 'custom-id' })
 
 ```html
 <!-- injected to <head> -->
-<style type="text/css" id="custom-id">
+<style id="custom-id">
 .foo { margin-top: 32px; }
 </style>
 ```
@@ -61,7 +61,7 @@ useStyleTag('.foo { margin-top: 32px; }', { media: 'print' })
 
 ```html
 <!-- injected to <head> -->
-<style type="text/css" id="vueuse_styletag_1" media="print">
+<style id="vueuse_styletag_1" media="print">
 .foo { margin-top: 32px; }
 </style>
 ```

--- a/packages/core/useStyleTag/index.ts
+++ b/packages/core/useStyleTag/index.ts
@@ -74,7 +74,6 @@ export function useStyleTag(
     const el = (document.getElementById(id) || document.createElement('style')) as HTMLStyleElement
 
     if (!el.isConnected) {
-      el.type = 'text/css'
       el.id = id
       if (options.media)
         el.media = options.media


### PR DESCRIPTION

### Description

see https://developer.mozilla.org/en-US/docs/Web/API/HTMLStyleElement/type

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 11e8df0</samp>

Removed the `type="text/css"` attribute from `<style>` tags in the `useStyleTag` function and documentation, to follow the HTML5 standard and simplify the code.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 11e8df0</samp>

*  Remove `type="text/css"` attribute from `<style>` tags in documentation and source code ([link](https://github.com/vueuse/vueuse/pull/3195/files?diff=unified&w=0#diff-246ab5a9f0fe9dc62304370d07dd879a7fe88cbe12708103399538b06f98c24bL32-R32), [link](https://github.com/vueuse/vueuse/pull/3195/files?diff=unified&w=0#diff-246ab5a9f0fe9dc62304370d07dd879a7fe88cbe12708103399538b06f98c24bL49-R49), [link](https://github.com/vueuse/vueuse/pull/3195/files?diff=unified&w=0#diff-246ab5a9f0fe9dc62304370d07dd879a7fe88cbe12708103399538b06f98c24bL64-R64), [link](https://github.com/vueuse/vueuse/pull/3195/files?diff=unified&w=0#diff-de7c411a2be00db77ad87b73a4a7cb9063d707fe95ebd9b8d7dad5bc7e6cdfa2L77))
