### PR TITLE
fix(useInfiniteScroll): improve visibility check

### DIFF
--- a/packages/core/useInfiniteScroll/index.test.ts
+++ b/packages/core/useInfiniteScroll/index.test.ts
@@ -6,7 +6,6 @@ import { useInfiniteScroll } from '.'
 
 vi.mock('../useElementVisibility')
 describe('useInfiniteScroll', () => {
-  const scrollEvent = new Event('scroll')
   it('should be defined', () => {
     expect(useInfiniteScroll).toBeDefined()
   })
@@ -41,25 +40,29 @@ describe('useInfiniteScroll', () => {
   })
 
   it('should call the loadMore handler, when user scrolls', async () => {
-    vi.useFakeTimers({
-      toFake: ['setTimeout'],
-    })
+    const mockElementScrollHeight = 100
     const mockHandler = vi.fn()
-    const mockElement = givenMockElement()
+    const mockElement = givenMockElement({
+      scrollHeight: mockElementScrollHeight,
+    })
     givenElementVisibilityRefMock(true)
 
     useInfiniteScroll(mockElement, mockHandler)
-    expect(mockHandler).toHaveBeenCalledTimes(1)
-
-    await vi.advanceTimersToNextTimer()
+    mockElement.scrollTop = mockElementScrollHeight
+    mockElement.dispatchEvent(new Event('scroll'))
     await flushPromises()
-    mockElement.dispatchEvent(scrollEvent)
 
-    expect(mockHandler).toHaveBeenCalledTimes(2)
+    expect(mockHandler).toHaveBeenCalledTimes(1)
   })
 
-  function givenMockElement() {
-    return document.createElement('div')
+  function givenMockElement({
+    scrollHeight = 0,
+  } = {}): HTMLDivElement {
+    const mockElement = document.createElement('div')
+    Object.defineProperty(mockElement, 'scrollHeight', {
+      value: scrollHeight,
+    })
+    return mockElement
   }
 
   function givenElementVisibilityRefMock(defaultValue: boolean) {

--- a/packages/core/useInfiniteScroll/index.test.ts
+++ b/packages/core/useInfiniteScroll/index.test.ts
@@ -1,0 +1,70 @@
+import { flushPromises } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue-demi'
+import { useElementVisibility } from '../useElementVisibility'
+import { useInfiniteScroll } from '.'
+
+vi.mock('../useElementVisibility')
+describe('useInfiniteScroll', () => {
+  const scrollEvent = new Event('scroll')
+  it('should be defined', () => {
+    expect(useInfiniteScroll).toBeDefined()
+  })
+
+  it.each([
+    [ref(givenMockElement())],
+    [givenMockElement()],
+    [document],
+    [window],
+  ])('should calls the loadMore handler, when element is visible', (target) => {
+    const mockHandler = vi.fn()
+    givenElementVisibilityRefMock(true)
+
+    useInfiniteScroll(target, mockHandler)
+
+    expect(mockHandler).toHaveBeenCalledTimes(1)
+  })
+
+  it('should calls the loadMore handler, when element visibility state form hidden to visible', async () => {
+    const mockHandler = vi.fn()
+    const mockElement = givenMockElement()
+    const visibilityRefMock = givenElementVisibilityRefMock(false)
+
+    useInfiniteScroll(mockElement, mockHandler)
+
+    expect(mockHandler).not.toHaveBeenCalled()
+
+    visibilityRefMock.value = true
+    await flushPromises()
+
+    expect(mockHandler).toHaveBeenCalledTimes(1)
+  })
+
+  it('should call the loadMore handler, when user scrolls', async () => {
+    vi.useFakeTimers({
+      toFake: ['setTimeout'],
+    })
+    const mockHandler = vi.fn()
+    const mockElement = givenMockElement()
+    givenElementVisibilityRefMock(true)
+
+    useInfiniteScroll(mockElement, mockHandler)
+    expect(mockHandler).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersToNextTimer()
+    await flushPromises()
+    mockElement.dispatchEvent(scrollEvent)
+
+    expect(mockHandler).toHaveBeenCalledTimes(2)
+  })
+
+  function givenMockElement() {
+    return document.createElement('div')
+  }
+
+  function givenElementVisibilityRefMock(defaultValue: boolean) {
+    const mockVisibilityRef = ref(defaultValue)
+    vi.mocked(useElementVisibility).mockReturnValue(mockVisibilityRef)
+    return mockVisibilityRef
+  }
+})

--- a/packages/core/useInfiniteScroll/index.ts
+++ b/packages/core/useInfiniteScroll/index.ts
@@ -61,7 +61,7 @@ export function useInfiniteScroll(
     state.measure()
 
     const el = toValue(element) as HTMLElement
-    if (!el || !el.offsetParent)
+    if (!el || el.offsetParent === null)
       return
 
     const isNarrower = (direction === 'bottom' || direction === 'top')

--- a/packages/core/useInfiniteScroll/index.ts
+++ b/packages/core/useInfiniteScroll/index.ts
@@ -96,9 +96,7 @@ export function useInfiniteScroll(
 
   watch(
     () => [state.arrivedState[direction], isElementVisible.value],
-    (newState) => {
-      checkAndLoad()
-    },
+    checkAndLoad,
     { immediate: true },
   )
 

--- a/packages/core/useInfiniteScroll/index.ts
+++ b/packages/core/useInfiniteScroll/index.ts
@@ -58,7 +58,7 @@ export function useInfiniteScroll(
   const promise = ref<any>()
   const isLoading = computed(() => !!promise.value)
   // Document and Window cannot be observed by IntersectionObserver
-  const observerElement = computed(() => {
+  const observedElement = computed<HTMLElement | SVGElement | null | undefined>(() => {
     const el = toValue(element)
     if (el instanceof Window)
       return window.document.documentElement
@@ -68,17 +68,18 @@ export function useInfiniteScroll(
 
     return el
   })
-  const isElementVisible = useElementVisibility(observerElement)
+  const isElementVisible = useElementVisibility(observedElement)
 
   function checkAndLoad() {
     state.measure()
 
-    if (!observerElement.value || !isElementVisible.value)
+    if (!observedElement.value || !isElementVisible.value)
       return
 
+    const { scrollHeight, clientHeight, scrollWidth, clientWidth } = observedElement.value as HTMLElement
     const isNarrower = (direction === 'bottom' || direction === 'top')
-      ? observerElement.value.scrollHeight <= observerElement.value.clientHeight
-      : observerElement.value.scrollWidth <= observerElement.value.clientWidth
+      ? scrollHeight <= clientHeight
+      : scrollWidth <= clientWidth
 
     if (state.arrivedState[direction] || isNarrower) {
       if (!promise.value) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

adjust element offsetParent check to fix useInfiniteScroll broken on v10.2.1 #3201 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0181645</samp>

Fixed a bug in `useInfiniteScroll` that caused excessive data loading for some elements. Changed the hidden element detection logic to use `el.offsetParent === null` instead of `!el.offsetParent`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0181645</samp>

* Fix the condition for checking if the element is hidden to use `el.offsetParent === null` instead of `!el.offsetParent` ([link](https://github.com/vueuse/vueuse/pull/3212/files?diff=unified&w=0#diff-f1e18d7fa553054c65bf5b7e4fe4daf0fbfb98fe7224964f3f46661a3770d6a1L64-R64)). This prevents unnecessary loading of data when the element is not hidden but has a falsy `offsetParent`, such as when the element is fixed or the offset parent is the root element. This change affects the file `packages/core/useInfiniteScroll/index.ts`.
