### PR TITLE
fix(reactiveComputed): unwrap reactive type

### DIFF
--- a/packages/shared/reactiveComputed/index.test.ts
+++ b/packages/shared/reactiveComputed/index.test.ts
@@ -1,5 +1,5 @@
 import { isVue2, nextTick, ref, watch, watchEffect } from 'vue-demi'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, expectTypeOf, it } from 'vitest'
 import { reactiveComputed } from '.'
 
 describe('reactiveComputed', () => {
@@ -8,9 +8,10 @@ describe('reactiveComputed', () => {
 
     const state = reactiveComputed(() => {
       return {
-        count: count.value,
+        count,
       }
     })
+    expectTypeOf(state).toEqualTypeOf<{ count: number }>()
 
     expect(state.count).toBe(0)
 

--- a/packages/shared/reactiveComputed/index.ts
+++ b/packages/shared/reactiveComputed/index.ts
@@ -1,9 +1,10 @@
+import type { UnwrapNestedRefs } from 'vue-demi'
 import { computed } from 'vue-demi'
 import { toReactive } from '../toReactive'
 
 /**
  * Computed reactive object.
  */
-export function reactiveComputed<T extends object>(fn: () => T): T {
+export function reactiveComputed<T extends object>(fn: () => T): UnwrapNestedRefs<T> {
   return toReactive(computed(fn))
 }

--- a/packages/shared/toReactive/index.ts
+++ b/packages/shared/toReactive/index.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-restricted-imports
-import { isRef, reactive, unref } from 'vue-demi'
+import { type UnwrapNestedRefs, isRef, reactive, unref } from 'vue-demi'
 import type { MaybeRef } from '../utils'
 
 /**
@@ -10,9 +10,9 @@ import type { MaybeRef } from '../utils'
  */
 export function toReactive<T extends object>(
   objectRef: MaybeRef<T>,
-): T {
+): UnwrapNestedRefs<T> {
   if (!isRef(objectRef))
-    return reactive(objectRef) as T
+    return reactive(objectRef)
 
   const proxy = new Proxy({}, {
     get(_, p, receiver) {
@@ -42,5 +42,5 @@ export function toReactive<T extends object>(
     },
   })
 
-  return reactive(proxy) as T
+  return reactive(proxy) as UnwrapNestedRefs<T>
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c33bd6e</samp>

Improved the type inference and handling of nested refs in the `toReactive` function and added type assertions to the `reactiveComputed` tests. Moved the `reactiveComputed` implementation to a separate file.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c33bd6e</samp>

* Refactor `reactiveComputed` function and add type assertion test ([link](https://github.com/vueuse/vueuse/pull/3215/files?diff=unified&w=0#diff-7f7b20f37904efcee6fa5eb343825e69577586eb6e71f69256d11d6e0e935002L2-R2),[link](https://github.com/vueuse/vueuse/pull/3215/files?diff=unified&w=0#diff-7f7b20f37904efcee6fa5eb343825e69577586eb6e71f69256d11d6e0e935002L11-R14),[link](https://github.com/vueuse/vueuse/pull/3215/files?diff=unified&w=0#diff-e05034030e955e272c77d1dd77f0514e7794798984edfab26132430f15f1bc2bL7-R7))
* Improve type inference and handling of nested refs in `toReactive` function ([link](https://github.com/vueuse/vueuse/pull/3215/files?diff=unified&w=0#diff-ef4a374b1be947d0fd1b84d419441dcc6a1889faacf195a76e7f4b17e0ab2a2fL1-R3),[link](https://github.com/vueuse/vueuse/pull/3215/files?diff=unified&w=0#diff-ef4a374b1be947d0fd1b84d419441dcc6a1889faacf195a76e7f4b17e0ab2a2fL13-R20),[link](https://github.com/vueuse/vueuse/pull/3215/files?diff=unified&w=0#diff-ef4a374b1be947d0fd1b84d419441dcc6a1889faacf195a76e7f4b17e0ab2a2fL45-R46))
