### PR TITLE
feat(useHasSlot): add useHasSlot function

### DIFF
--- a/packages/core/useHasSlot/demo.vue
+++ b/packages/core/useHasSlot/demo.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import { useHasSlot } from '@vueuse/core'
+
+const hasSlot = useHasSlot()
+const hasFooSlot = hasSlot('foo')
+</script>
+
+<template>
+  <div>
+    <div>Foo Slot is {{ hasFooSlot ? 'Exist' : 'Not Exist' }}</div>
+    <slot name="foo" />
+  </div>
+</template>

--- a/packages/core/useHasSlot/index.md
+++ b/packages/core/useHasSlot/index.md
@@ -1,0 +1,12 @@
+# useHasSlot
+
+Checks named slots exist in a component template
+
+## Usage
+
+```ts
+import { useHasSlot } from '@vueuse/core'
+
+const hasSlot = useHasSlot()
+const hasFooSlot = hasSlot('foo')
+```

--- a/packages/core/useHasSlot/index.test.ts
+++ b/packages/core/useHasSlot/index.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { useHasSlot } from '.'
+
+describe('useHasSlot', () => {
+  it('should be defined', () => {
+    expect(useHasSlot).toBeDefined()
+  })
+
+  it('should return true when the slot exists', () => {
+    const Component = {
+      template: '<div><slot name="foo" /></div>',
+      setup() {
+        const hasSlot = useHasSlot()
+        return { hasSlot }
+      },
+    }
+
+    const wrapper = mount(Component, {
+      slots: {
+        foo: '<span>bar</span>',
+      },
+    })
+
+    expect(!!wrapper.vm.$slots.foo).toBe(true)
+  })
+
+  it('should return false when the slot does not exist', () => {
+    const Component = {
+      template: '<div><slot name="foo" /></div>',
+      setup() {
+        const hasSlot = useHasSlot()
+        return { hasSlot }
+      },
+    }
+
+    const wrapper = mount(Component)
+
+    expect(!!wrapper.vm.$slots.foo).toBe(false)
+  })
+})

--- a/packages/core/useHasSlot/index.ts
+++ b/packages/core/useHasSlot/index.ts
@@ -1,0 +1,10 @@
+import { useSlots } from 'vue-demi'
+
+export function useHasSlot() {
+  function hasSlot(name: string) {
+    const slot = useSlots()
+    return !!slot[name]
+  }
+
+  return hasSlot
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #3221 `).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

This code defines a Vue 3 composable `useHasSlot` that checks if a named slot exists in a component's template. It uses the `useSlots` composition API to retrieve the named slot and returns true if it exists, false otherwise. The composable returns the `hasSlot` function for use in the component. This PR solves the #3221 Issue.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2be830c</samp>

This pull request adds a new function `useHasSlot` to the core package, which allows checking the existence of a named slot in a Vue component. It also adds a demo, a documentation, and a test file for the function.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2be830c</samp>

*  Implement `useHasSlot` function to check the existence of a slot in a Vue component ([link](https://github.com/vueuse/vueuse/pull/3227/files?diff=unified&w=0#diff-53f35458b869c68e68239a8c9f116693735721a8455a4e5a3783ed4753b47e24R1-R10))
*  Document `useHasSlot` function with a usage example in `index.md` ([link](https://github.com/vueuse/vueuse/pull/3227/files?diff=unified&w=0#diff-78a39fdcd66413c864b4ff5bf50d99a19f4cd4440a023010d931f965710512f4R1-R12))
*  Test `useHasSlot` function with three test cases in `index.test.ts` using vitest and vue-test-utils ([link](https://github.com/vueuse/vueuse/pull/3227/files?diff=unified&w=0#diff-1656b3611dc80b2896c20f46ac93ca591c6bf6758099aefbbeeece17cc349411R1-R41))
*  Add a demo component in `demo.vue` to show how to use `useHasSlot` function with reactive variables and conditional rendering ([link](https://github.com/vueuse/vueuse/pull/3227/files?diff=unified&w=0#diff-faf716afc90497cd8365b14c0a1d8f8906129690d5a9fd34618b088db9d4ddc9R1-R13))
