### PR TITLE
fix(useScroll): support configurable window

### DIFF
--- a/packages/core/useScroll/index.ts
+++ b/packages/core/useScroll/index.ts
@@ -122,7 +122,7 @@ export function useScroll(
   function scrollTo(_x: number | undefined, _y: number | undefined) {
     const _element = toValue(element)
 
-    if (!_element)
+    if (typeof document === 'undefined' || !_element)
       return
 
     (_element instanceof Document ? document.body : _element)?.scrollTo({
@@ -255,7 +255,7 @@ export function useScroll(
     measure() {
       const _element = toValue(element)
 
-      if (_element)
+      if (typeof document !== 'undefined' && _element)
         setArrivedState(_element)
     },
   }

--- a/packages/core/useScroll/index.ts
+++ b/packages/core/useScroll/index.ts
@@ -2,8 +2,10 @@ import { computed, reactive, ref } from 'vue-demi'
 import type { MaybeRefOrGetter } from '@vueuse/shared'
 import { noop, toValue, useDebounceFn, useThrottleFn } from '@vueuse/shared'
 import { useEventListener } from '../useEventListener'
+import type { ConfigurableWindow } from '../_configurable'
+import { defaultWindow } from '../_configurable'
 
-export interface UseScrollOptions {
+export interface UseScrollOptions extends ConfigurableWindow {
   /**
    * Throttle time for scroll event, it’s disabled by default.
    *
@@ -94,6 +96,7 @@ export function useScroll(
       passive: true,
     },
     behavior = 'auto',
+    window = defaultWindow,
   } = options
 
   const internalX = ref(0)
@@ -120,12 +123,14 @@ export function useScroll(
   })
 
   function scrollTo(_x: number | undefined, _y: number | undefined) {
-    const _element = toValue(element)
-
-    if (typeof document === 'undefined' || !_element)
+    if (!window)
       return
 
-    (_element instanceof Document ? document.body : _element)?.scrollTo({
+    const _element = toValue(element)
+    if (!_element)
+      return
+
+    (_element instanceof Document ? window.document.body : _element)?.scrollTo({
       top: toValue(_y) ?? y.value,
       left: toValue(_x) ?? x.value,
       behavior: toValue(behavior),
@@ -161,10 +166,13 @@ export function useScroll(
   const onScrollEndDebounced = useDebounceFn(onScrollEnd, throttle + idle)
 
   const setArrivedState = (target: HTMLElement | SVGElement | Window | Document | null | undefined) => {
+    if (!window)
+      return
+
     const el = (
       target === window
         ? (target as Window).document.documentElement
-        : target === document ? (target as Document).documentElement : target
+        : target === window.document ? (target as Document).documentElement : target
     ) as HTMLElement
 
     const { display, flexDirection } = getComputedStyle(el)
@@ -193,8 +201,8 @@ export function useScroll(
     let scrollTop = el.scrollTop
 
     // patch for mobile compatible
-    if (target === document && !scrollTop)
-      scrollTop = document.body.scrollTop
+    if (target === window.document && !scrollTop)
+      scrollTop = window.document.body.scrollTop
 
     directions.top = scrollTop < internalY.value
     directions.bottom = scrollTop > internalY.value
@@ -221,8 +229,11 @@ export function useScroll(
   }
 
   const onScrollHandler = (e: Event) => {
+    if (!window)
+      return
+
     const eventTarget = (
-      e.target === document ? (e.target as Document).documentElement : e.target
+      e.target === window.document ? (e.target as Document).documentElement : e.target
     ) as HTMLElement
 
     setArrivedState(eventTarget)
@@ -255,7 +266,7 @@ export function useScroll(
     measure() {
       const _element = toValue(element)
 
-      if (typeof document !== 'undefined' && _element)
+      if (window && _element)
         setArrivedState(_element)
     },
   }


### PR DESCRIPTION
Don't access `document` if the environment was torn down in tests

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

The problem actually happens with `useInfiniteScroll` because it calls `.measure` in `nextTick`.

It is possible to have the element in the DOM and have no `document` in Vitest if `useInfiniteScroll` callback is async, since the environment is torn down sooner than this code runs, but the component itself didn't unmount yet.

If we don't have this check, `setArrivedState` fails with the error:

> ReferenceError: document is not defined

I also added a check to `scrollTo` just in case someone calls `y.value = someValue` outside when document is not available (also possible in SSR).

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 63ce941</samp>

Fix `useScroll` bug in SSR environments. Add `document` checks to prevent errors when accessing `_element` in `packages/core/useScroll/index.ts`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 63ce941</samp>

*  Prevent errors in SSR environments by checking for `document` object before accessing or using `_element` variable ([link](https://github.com/vueuse/vueuse/pull/3229/files?diff=unified&w=0#diff-6854b45663451a9e8c15d7b4e0bd17a681777359676d0a6c6d8dc32539bdcea6L125-R125), [link](https://github.com/vueuse/vueuse/pull/3229/files?diff=unified&w=0#diff-6854b45663451a9e8c15d7b4e0bd17a681777359676d0a6c6d8dc32539bdcea6L258-R258))
