### PR TITLE
feat(useRTDB): add errorHandler option

### DIFF
--- a/packages/firebase/useRTDB/index.ts
+++ b/packages/firebase/useRTDB/index.ts
@@ -5,6 +5,7 @@ import { ref } from 'vue-demi'
 import { tryOnScopeDispose } from '@vueuse/shared'
 
 export interface UseRTDBOptions {
+  errorHandler?: (err: Error) => void
   autoDispose?: boolean
 }
 
@@ -18,6 +19,7 @@ export function useRTDB<T = any>(
   options: UseRTDBOptions = {},
 ) {
   const {
+    errorHandler = (err: Error) => console.error(err),
     autoDispose = true,
   } = options
   const data = ref(undefined) as Ref<T | undefined>
@@ -26,7 +28,7 @@ export function useRTDB<T = any>(
     data.value = snapshot.val()
   }
 
-  const off = onValue(docRef, update)
+  const off = onValue(docRef, update, errorHandler)
 
   if (autoDispose)
     tryOnScopeDispose(() => off())


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
---

### Description

Similar to [useFirestore](https://github.com/vueuse/vueuse/blob/main/packages/firebase/useFirestore/index.ts#L9), add an option to manually handle errors via the `errorHandler` option.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 30373b2</samp>

Added a new option to `useRTDB` hook for Firebase Realtime Database integration. This option lets users provide a custom function to handle errors from database operations.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 30373b2</samp>

*  Add `errorHandler` parameter to `useRTDBOptions` interface and `useRTDB` function to allow custom error handling for Firebase Realtime Database operations ([link](https://github.com/vueuse/vueuse/pull/3232/files?diff=unified&w=0#diff-8e555f63ae4995f626cf9e9578b90906be527cc86277ce5fb875ed9893446794R8), [link](https://github.com/vueuse/vueuse/pull/3232/files?diff=unified&w=0#diff-8e555f63ae4995f626cf9e9578b90906be527cc86277ce5fb875ed9893446794R22))
*  Pass `errorHandler` parameter to `onValue` function call in `useRTDB` function to handle errors during database read or write ([link](https://github.com/vueuse/vueuse/pull/3232/files?diff=unified&w=0#diff-8e555f63ae4995f626cf9e9578b90906be527cc86277ce5fb875ed9893446794L29-R31))
