### PR TITLE
fix(useMediaQuery): only add/remove event listeners on query change

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:redirects": "esno scripts/redirects.ts",
     "build:rollup": "NODE_OPTIONS=\"--max-old-space-size=6144\" rollup -c",
     "build:types": "tsc --emitDeclarationOnly && nr types:fix",
-    "clean": "rimraf dist types \"packages/*/dist\"",
+    "clean": "rimraf --glob dist types \"packages/*/dist\"",
     "dev": "nr update && nr docs",
     "docs": "vue-demi-switch 3 && vitepress dev packages --open",
     "docs:build": "nr update:full && vitepress build packages && nr build:redirects && esno scripts/post-docs.ts",

--- a/packages/core/useMediaQuery/index.ts
+++ b/packages/core/useMediaQuery/index.ts
@@ -42,16 +42,14 @@ export function useMediaQuery(query: MaybeRefOrGetter<string>, options: Configur
     cleanup()
 
     mediaQuery = window!.matchMedia(toValue(query))
-    matches.value = !!mediaQuery?.matches
-
-    if (!mediaQuery)
-      return
 
     if ('addEventListener' in mediaQuery)
       mediaQuery.addEventListener('change', handler)
     else
       // @ts-expect-error deprecated API
       mediaQuery.addListener(handler)
+
+    matches.value = mediaQuery.matches
   })
 
   tryOnScopeDispose(() => {

--- a/packages/core/useWindowSize/index.test.ts
+++ b/packages/core/useWindowSize/index.test.ts
@@ -4,10 +4,20 @@ import { useWindowSize } from '.'
 
 describe('useWindowSize', () => {
   const addEventListenerSpy = vi.spyOn(window, 'addEventListener')
-  const matchMediaSpy = vi.spyOn(window, 'matchMedia')
+  const matchMediaSpy = vi.spyOn(window, 'matchMedia').mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }))
+
   beforeEach(() => {
-    addEventListenerSpy.mockReset()
-    matchMediaSpy.mockReset()
+    addEventListenerSpy.mockClear()
+    matchMediaSpy.mockClear()
   })
 
   afterAll(() => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

This pull request changes `useMediaQuery` to only register event listeners when it is first created or when the reactive value for the passed in `query` changes in order to avoid re-creating the event listeners on every `change` event. This will avoid any excess overhead in the event handler itself.

Fixes #3235 

### Additional context

In the process, `toRef(query).value` was changed `toValue(query)`. I am not sure nor haven't tried yet whether this preserves the reactivity inside `watchEffect`. If this works as intended, it should be a slight improvement in bundled code size. Update: Reactivity seems to be working fine.

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4cf721b</samp>

Enhance `useMediaQuery` to support getter functions and fix a bug. Refactor the code for better performance and readability.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4cf721b</samp>

*  Replace `toRef` with `toValue` to support `MaybeRefOrGetter` type for `query` argument of `useMediaQuery` ([link](https://github.com/vueuse/vueuse/pull/3236/files?diff=unified&w=0#diff-d9533c610c4da5a1c5a0e03fc40091a2a8834c552c81ffc974287a7d4f7d53f1L5-R5), [link](https://github.com/vueuse/vueuse/pull/3236/files?diff=unified&w=0#diff-d9533c610c4da5a1c5a0e03fc40091a2a8834c552c81ffc974287a7d4f7d53f1L42-R45))
*  Move and modify `update` and `cleanup` functions to improve performance, readability, and bug fix ([link](https://github.com/vueuse/vueuse/pull/3236/files?diff=unified&w=0#diff-d9533c610c4da5a1c5a0e03fc40091a2a8834c552c81ffc974287a7d4f7d53f1L24-R39), [link](https://github.com/vueuse/vueuse/pull/3236/files?diff=unified&w=0#diff-d9533c610c4da5a1c5a0e03fc40091a2a8834c552c81ffc974287a7d4f7d53f1L53-R61))
*  Move `watchEffect` call inside `stopWatch` variable and pass it to `tryOnScopeDispose` to avoid unnecessary effects and ensure proper cleanup ([link](https://github.com/vueuse/vueuse/pull/3236/files?diff=unified&w=0#diff-d9533c610c4da5a1c5a0e03fc40091a2a8834c552c81ffc974287a7d4f7d53f1L53-R61))
