### PR TITLE
fix(useObjectUrl): improve parameter type

### DIFF
--- a/packages/core/useObjectUrl/index.ts
+++ b/packages/core/useObjectUrl/index.ts
@@ -1,6 +1,6 @@
 import { readonly, ref, watch } from 'vue-demi'
 import { toValue, tryOnScopeDispose } from '@vueuse/shared'
-import type { MaybeRef } from '@vueuse/shared'
+import type { MaybeRefOrGetter } from '@vueuse/shared'
 
 /**
  * Reactive URL representing an object.
@@ -8,7 +8,7 @@ import type { MaybeRef } from '@vueuse/shared'
  * @see https://vueuse.org/useObjectUrl
  * @param object
  */
-export function useObjectUrl(object: MaybeRef<Blob | MediaSource | undefined>) {
+export function useObjectUrl(object: MaybeRefOrGetter<Blob | MediaSource | null | undefined>) {
   const url = ref<string | undefined>()
 
   const release = () => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

---

### Description

Allow `object` parameter type to have `null` as value. Also, changes `MaybeRef` type to `MaybeRefOrGetter`.

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6831346</samp>

Improved the `useObjectUrl` hook to support dynamic blob or media source creation. Added a function argument to the hook that can return a blob, a media source, or null.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6831346</samp>

*  Replace `MaybeRef` with `MaybeRefOrGetter` to support dynamic blob or media source creation ([link](https://github.com/vueuse/vueuse/pull/3239/files?diff=unified&w=0#diff-83d387268ef5aa57cf8502061448e64109f05c26e816e5217872df6e999c181fL3-R3), [link](https://github.com/vueuse/vueuse/pull/3239/files?diff=unified&w=0#diff-83d387268ef5aa57cf8502061448e64109f05c26e816e5217872df6e999c181fL11-R11))
*  Allow passing null as a possible value for the source object ([link](https://github.com/vueuse/vueuse/pull/3239/files?diff=unified&w=0#diff-83d387268ef5aa57cf8502061448e64109f05c26e816e5217872df6e999c181fL11-R11))
