### PR TITLE
chore(useCssVar): Improved parameter type

### DIFF
--- a/packages/core/useCssVar/index.ts
+++ b/packages/core/useCssVar/index.ts
@@ -24,8 +24,8 @@ export interface UseCssVarOptions extends ConfigurableWindow {
  * @param target
  * @param options
  */
-export function useCssVar(
-  prop: MaybeRefOrGetter<string>,
+export function useCssVar<T extends `--${string}`>(
+  prop: MaybeRefOrGetter<T>,
   target?: MaybeElementRef,
   options: UseCssVarOptions = {},
 ) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Restrict CSS variables to strings starting with "--".


<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4c61cd9</samp>

Improved type safety and inference for `useCssVar` function. The function now accepts and returns generic types that are constrained by valid CSS custom property names.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4c61cd9</samp>

*  Restrict the `prop` argument of `useCssVar` to valid CSS custom property names and infer the return type from it using a generic type parameter `T` ([link](https://github.com/vueuse/vueuse/pull/3241/files?diff=unified&w=0#diff-5e960804c77e62ab6819930b95f3b1fea61aae2bc0866d3e8ca999c5d09ff9ffL27-R28))
