### PR TITLE
fix(useEventListener): improved `useEventListener` overload

### DIFF
--- a/packages/core/useEventListener/index.ts
+++ b/packages/core/useEventListener/index.ts
@@ -72,7 +72,25 @@ export function useEventListener<E extends keyof DocumentEventMap>(
 /**
  * Register using addEventListener on mounted, and removeEventListener automatically on unmounted.
  *
- * Overload 4: Custom event target with event type infer
+ * Overload 4: Explicitly HTMLElement target
+ *
+ * @see https://vueuse.org/useEventListener
+ * @param target
+ * @param event
+ * @param listener
+ * @param options
+ */
+export function useEventListener<K extends keyof HTMLElementEventMap>(
+  target: MaybeRefOrGetter<HTMLElement | null | undefined>,
+  event: K,
+  listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any,
+  options?: boolean | AddEventListenerOptions
+): () => void
+
+/**
+ * Register using addEventListener on mounted, and removeEventListener automatically on unmounted.
+ *
+ * Overload 5: Custom event target with event type infer
  *
  * @see https://vueuse.org/useEventListener
  * @param target
@@ -90,7 +108,7 @@ export function useEventListener<Names extends string, EventType = Event>(
 /**
  * Register using addEventListener on mounted, and removeEventListener automatically on unmounted.
  *
- * Overload 5: Custom event target fallback
+ * Overload 6: Custom event target fallback
  *
  * @see https://vueuse.org/useEventListener
  * @param target


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

When listening to events on an `HTMLElement`, the type of the event object should be the corresponding event object type in `HTMLElementEventMap`, rather than `Event`.

Before improved:

```ts
const el = ref<HTMLElement>()

useEventListener(el, 'click', (e) => {
  console.log(e.clientX) // error
  // `e` should be of type `MouseEvent`, but is `Event`
})
```

After improved:

```ts
const el = ref<HTMLElement>()

useEventListener(el, 'click', (e) => {
  console.log(e.clientX) // success
})
```
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 763280f</samp>

Improved `useEventListener` function to handle custom event targets and added more documentation.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 763280f</samp>

*  Add a new overload for `useEventListener` that accepts a custom event target and infers the event type ([link](https://github.com/vueuse/vueuse/pull/3246/files?diff=unified&w=0#diff-830e350c5d6d8c12673ac43e7736d6171361e43f9a9a9cef443b5715b6d84745R83-R100))
*  Update the comment for the previous overload of `useEventListener` to specify that the target is an HTMLElement ([link](https://github.com/vueuse/vueuse/pull/3246/files?diff=unified&w=0#diff-830e350c5d6d8c12673ac43e7736d6171361e43f9a9a9cef443b5715b6d84745L75-R75))
*  Update the comment for the next overload of `useEventListener` to reflect the new overload order ([link](https://github.com/vueuse/vueuse/pull/3246/files?diff=unified&w=0#diff-830e350c5d6d8c12673ac43e7736d6171361e43f9a9a9cef443b5715b6d84745L93-R111))
