### PR TITLE
refactor(useEventListener): refactor the usage of `useEventListener`

### DIFF
--- a/packages/core/onLongPress/index.ts
+++ b/packages/core/onLongPress/index.ts
@@ -64,6 +64,5 @@ export function onLongPress(
   }
 
   useEventListener(elementRef, 'pointerdown', onDown, listenerOptions)
-  useEventListener(elementRef, 'pointerup', clear, listenerOptions)
-  useEventListener(elementRef, 'pointerleave', clear, listenerOptions)
+  useEventListener(elementRef, ['pointerup', 'pointerleave'], clear, listenerOptions)
 }

--- a/packages/core/useAnimate/index.ts
+++ b/packages/core/useAnimate/index.ts
@@ -265,9 +265,7 @@ export function useAnimate(
     onReady?.(animate.value)
   }
 
-  useEventListener(animate, 'cancel', syncPause)
-  useEventListener(animate, 'finish', syncPause)
-  useEventListener(animate, 'remove', syncPause)
+  useEventListener(animate, ['cancel', 'finish', 'remove'], syncPause)
 
   const { resume: resumeRef, pause: pauseRef } = useRafFn(() => {
     if (!animate.value)

--- a/packages/core/useBattery/index.ts
+++ b/packages/core/useBattery/index.ts
@@ -24,7 +24,7 @@ type NavigatorWithBattery = Navigator & {
  * @param options
  */
 export function useBattery({ navigator = defaultNavigator }: ConfigurableNavigator = {}) {
-  const events = ['chargingchange', 'chargingtimechange', 'dischargingtimechange', 'levelchange'] as const
+  const events = ['chargingchange', 'chargingtimechange', 'dischargingtimechange', 'levelchange']
 
   const isSupported = useSupported(() => navigator && 'getBattery' in navigator)
 

--- a/packages/core/useBattery/index.ts
+++ b/packages/core/useBattery/index.ts
@@ -24,7 +24,7 @@ type NavigatorWithBattery = Navigator & {
  * @param options
  */
 export function useBattery({ navigator = defaultNavigator }: ConfigurableNavigator = {}) {
-  const events = ['chargingchange', 'chargingtimechange', 'dischargingtimechange', 'levelchange']
+  const events = ['chargingchange', 'chargingtimechange', 'dischargingtimechange', 'levelchange'] as const
 
   const isSupported = useSupported(() => navigator && 'getBattery' in navigator)
 
@@ -48,8 +48,7 @@ export function useBattery({ navigator = defaultNavigator }: ConfigurableNavigat
       .then((_battery) => {
         battery = _battery
         updateBatteryInfo.call(battery)
-        for (const event of events)
-          useEventListener(battery, event, updateBatteryInfo, { passive: true })
+        useEventListener(battery, events, updateBatteryInfo, { passive: true })
       })
   }
 

--- a/packages/core/useClipboard/index.ts
+++ b/packages/core/useClipboard/index.ts
@@ -4,7 +4,6 @@ import type { MaybeRefOrGetter } from '@vueuse/shared'
 import { toValue, useTimeoutFn } from '@vueuse/shared'
 import type { ComputedRef, Ref } from 'vue-demi'
 import { computed, ref } from 'vue-demi'
-import type { WindowEventName } from '../useEventListener'
 import { useEventListener } from '../useEventListener'
 import { useSupported } from '../useSupported'
 import type { ConfigurableNavigator } from '../_configurable'
@@ -62,7 +61,6 @@ export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<strin
     legacy = false,
   } = options
 
-  const events = ['copy', 'cut']
   const isClipboardApiSupported = useSupported(() => (navigator && 'clipboard' in navigator))
   const isSupported = computed(() => isClipboardApiSupported.value || legacy)
   const text = ref('')
@@ -80,10 +78,8 @@ export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<strin
     }
   }
 
-  if (isSupported.value && read) {
-    for (const event of events)
-      useEventListener(event as WindowEventName, updateText)
-  }
+  if (isSupported.value && read)
+    useEventListener(['copy', 'cut'], updateText)
 
   async function copy(value = toValue(source)) {
     if (isSupported.value && value != null) {

--- a/packages/core/useEventListener/index.ts
+++ b/packages/core/useEventListener/index.ts
@@ -80,10 +80,10 @@ export function useEventListener<E extends keyof DocumentEventMap>(
  * @param listener
  * @param options
  */
-export function useEventListener<K extends keyof HTMLElementEventMap>(
+export function useEventListener<E extends keyof HTMLElementEventMap>(
   target: MaybeRefOrGetter<HTMLElement | null | undefined>,
-  event: K,
-  listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any,
+  event: Arrayable<E>,
+  listener: (this: HTMLElement, ev: HTMLElementEventMap[E]) => any,
   options?: boolean | AddEventListenerOptions
 ): () => void
 

--- a/packages/core/useMouse/index.ts
+++ b/packages/core/useMouse/index.ts
@@ -113,13 +113,12 @@ export function useMouse(options: UseMouseOptions = {}) {
     : (event: TouchEvent) => touchHandler(event)
 
   if (target) {
-    useEventListener(target, 'mousemove', mouseHandlerWrapper, { passive: true })
-    useEventListener(target, 'dragover', mouseHandlerWrapper, { passive: true })
+    const listenerOptions = { passive: true }
+    useEventListener(target, ['mousemove', 'dragover'], mouseHandlerWrapper, listenerOptions)
     if (touch && type !== 'movement') {
-      useEventListener(target, 'touchstart', touchHandlerWrapper, { passive: true })
-      useEventListener(target, 'touchmove', touchHandlerWrapper, { passive: true })
+      useEventListener(target, ['touchstart', 'touchmove'], touchHandlerWrapper, listenerOptions)
       if (resetOnTouchEnds)
-        useEventListener(target, 'touchend', reset, { passive: true })
+        useEventListener(target, 'touchend', reset, listenerOptions)
     }
   }
 

--- a/packages/core/usePointer/index.ts
+++ b/packages/core/usePointer/index.ts
@@ -75,9 +75,9 @@ export function usePointer(options: UsePointerOptions = {}) {
   }
 
   if (target) {
-    useEventListener(target, 'pointerdown', handler, { passive: true })
-    useEventListener(target, 'pointermove', handler, { passive: true })
-    useEventListener(target, 'pointerleave', () => isInside.value = false, { passive: true })
+    const listenerOptions = { passive: true }
+    useEventListener(target, ['pointerdown', 'pointermove'], handler, listenerOptions)
+    useEventListener(target, 'pointerleave', () => isInside.value = false, listenerOptions)
   }
 
   return {

--- a/packages/core/useSwipe/index.ts
+++ b/packages/core/useSwipe/index.ts
@@ -147,8 +147,7 @@ export function useSwipe(
         onSwipe?.(e)
     }, listenerOptions),
 
-    useEventListener(target, 'touchend', onTouchEnd, listenerOptions),
-    useEventListener(target, 'touchcancel', onTouchEnd, listenerOptions),
+    useEventListener(target, ['touchend', 'touchcancel'], onTouchEnd, listenerOptions),
   ]
 
   const stop = () => stops.forEach(s => s())


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Combine the same listeners for different events into one.

```ts
  useEventListener(elementRef, 'pointerup', clear, listenerOptions)
  useEventListener(elementRef, 'pointerleave', clear, listenerOptions)
```

to:

```ts
  useEventListener(elementRef, ['pointerup', 'pointerleave'], clear, listenerOptions)
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3038d2d</samp>

Refactor several functions that use the `useEventListener` hook to accept an array of event names instead of a single one. This improves the type safety and readability of the code and reduces the number of hook calls. The affected functions are `useBattery`, `useClipboard`, `useAnimate`, `useMouse`, `usePointer`, and `useSwipe`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3038d2d</samp>

*  Refactor `useEventListener` hook to accept an array of event names as the second argument ([link](https://github.com/vueuse/vueuse/pull/3247/files?diff=unified&w=0#diff-0899c8523002afb4767e781076341d09cbb32d9bb4a874bbe4c3c6928e12707eL67-R67), [link](https://github.com/vueuse/vueuse/pull/3247/files?diff=unified&w=0#diff-6a8cff024156607dd1073495d422f775b01a9a2d561a3fb4affe796b4f6a9777L268-R268), [link](https://github.com/vueuse/vueuse/pull/3247/files?diff=unified&w=0#diff-691701c505359a19edbc1413c0e12ff5adf965b28da31eefbc658799e9960c87L51-R51), [link](https://github.com/vueuse/vueuse/pull/3247/files?diff=unified&w=0#diff-104a20ea8a35b01c36721b36a81d3138312e27a997280d66290ce7e8a9bc466aL83-R82), [link](https://github.com/vueuse/vueuse/pull/3247/files?diff=unified&w=0#diff-acac08f31319ce15064e72bec03f921b9731164f2022b1a17ed4c09ba2864540L116-R121), [link](https://github.com/vueuse/vueuse/pull/3247/files?diff=unified&w=0#diff-e620bb2c333b104a6968b5abc36bd7448702296b8984c13acdd2f12de40a6b4aL78-R80), [link](https://github.com/vueuse/vueuse/pull/3247/files?diff=unified&w=0#diff-5ffb9b0e11c97044d56e5be2cae9a3149b7c7031d244a804f82e2788a2cfa07eL150-R150))
  * Annotate the `events` array in `useBattery` with `as const` to improve type inference and safety ([link](https://github.com/vueuse/vueuse/pull/3247/files?diff=unified&w=0#diff-691701c505359a19edbc1413c0e12ff5adf965b28da31eefbc658799e9960c87L27-R27))
  * Remove the `WindowEventName` type and the `events` array from `useClipboard` as they are no longer needed ([link](https://github.com/vueuse/vueuse/pull/3247/files?diff=unified&w=0#diff-104a20ea8a35b01c36721b36a81d3138312e27a997280d66290ce7e8a9bc466aL7), [link](https://github.com/vueuse/vueuse/pull/3247/files?diff=unified&w=0#diff-104a20ea8a35b01c36721b36a81d3138312e27a997280d66290ce7e8a9bc466aL65))
  * Extract the `listenerOptions` object to a variable in `useMouse` and `usePointer` to avoid repetition ([link](https://github.com/vueuse/vueuse/pull/3247/files?diff=unified&w=0#diff-acac08f31319ce15064e72bec03f921b9731164f2022b1a17ed4c09ba2864540L116-R121), [link](https://github.com/vueuse/vueuse/pull/3247/files?diff=unified&w=0#diff-e620bb2c333b104a6968b5abc36bd7448702296b8984c13acdd2f12de40a6b4aL78-R80))
