### PR TITLE
feat(useSorted): accept getter function as source

### DIFF
--- a/packages/core/useSorted/index.ts
+++ b/packages/core/useSorted/index.ts
@@ -1,5 +1,5 @@
 import type { Ref } from 'vue-demi'
-import type { MaybeRef } from '@vueuse/shared'
+import type { MaybeRefOrGetter } from '@vueuse/shared'
 import { toValue } from '@vueuse/shared'
 import { computed, isRef, watchEffect } from 'vue-demi'
 
@@ -26,9 +26,9 @@ export interface UseSortedOptions<T = any> {
 const defaultSortFn: UseSortedFn = <T>(source: T[], compareFn: UseSortedCompareFn<T>): T[] => source.sort(compareFn)
 const defaultCompare: UseSortedCompareFn<number> = (a, b) => a - b
 
-export function useSorted<T = any>(source: MaybeRef<T[]>, compareFn?: UseSortedCompareFn<T>): Ref<T[]>
-export function useSorted<T = any>(source: MaybeRef<T[]>, options?: UseSortedOptions<T>): Ref<T[]>
-export function useSorted<T = any>(source: MaybeRef<T[]>, compareFn?: UseSortedCompareFn<T>, options?: Omit<UseSortedOptions<T>, 'compareFn'>): Ref<T[]>
+export function useSorted<T = any>(source: MaybeRefOrGetter<T[]>, compareFn?: UseSortedCompareFn<T>): Ref<T[]>
+export function useSorted<T = any>(source: MaybeRefOrGetter<T[]>, options?: UseSortedOptions<T>): Ref<T[]>
+export function useSorted<T = any>(source: MaybeRefOrGetter<T[]>, compareFn?: UseSortedCompareFn<T>, options?: Omit<UseSortedOptions<T>, 'compareFn'>): Ref<T[]>
 /**
  * reactive sort array
  *


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Enables users to use a getter function for `useSorted` source. 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1a12c68</samp>

Added support for getter functions as `source` parameter for `useSorted` function. Updated type definitions and documentation for `packages/core/useSorted/index.ts`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1a12c68</samp>

*  Change the type of the `source` parameter of the `useSorted` function to accept a getter function that returns an array, in addition to a ref or a plain value, to improve flexibility and consistency ([link](https://github.com/vueuse/vueuse/pull/3249/files?diff=unified&w=0#diff-86a4c5423538533003fda2458cf0363352e5f39ffe48d697da8448e4aa3e6883L2-R2), [link](https://github.com/vueuse/vueuse/pull/3249/files?diff=unified&w=0#diff-86a4c5423538533003fda2458cf0363352e5f39ffe48d697da8448e4aa3e6883L29-R31))
* Update the type definitions of the `useSorted` function in the file `packages/core/useSorted/index.ts` to match the change in the `source` parameter type ([link](https://github.com/vueuse/vueuse/pull/3249/files?diff=unified&w=0#diff-86a4c5423538533003fda2458cf0363352e5f39ffe48d697da8448e4aa3e6883L29-R31))
