### PR TITLE
fix(useFetch): generated payloadType on execute

### DIFF
--- a/packages/core/useFetch/index.test.ts
+++ b/packages/core/useFetch/index.test.ts
@@ -696,4 +696,28 @@ describe.skipIf(isBelowNode18)('useFetch', () => {
       expect(onFetchResponseSpy).toBeCalledTimes(1)
     })
   })
+
+  it('should be generated payloadType on execute', async () => {
+    const form = ref()
+    const { execute } = useFetch('https://example.com').post(form)
+
+    form.value = { x: 1 }
+    await execute()
+
+    await retry(() => {
+      expect(fetchSpyHeaders()['Content-Type']).toBe('application/json')
+    })
+  })
+
+  it('should be generated payloadType on execute', async () => {
+    const form = ref<any>({ x: 1 })
+    const { execute } = useFetch('https://example.com').post(form)
+
+    form.value = new FormData()
+    await execute()
+
+    await retry(() => {
+      expect(fetchSpyHeaders()['Content-Type']).toBe(undefined)
+    })
+  })
 })

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -393,10 +393,15 @@ export function useFetch<T>(url: MaybeRefOrGetter<string>, ...args: any[]): UseF
 
     if (config.payload) {
       const headers = headersToObject(defaultFetchOptions.headers) as Record<string, string>
+      const payload = toValue(config.payload)
+      // Set the payload to json type only if it's not provided and a literal object is provided and the object is not `formData`
+      // The only case we can deduce the content type and `fetch` can't
+      if (!config.payloadType && payload && Object.getPrototypeOf(payload) === Object.prototype && !(payload instanceof FormData))
+        config.payloadType = 'json'
+
       if (config.payloadType)
         headers['Content-Type'] = payloadMapping[config.payloadType] ?? config.payloadType
 
-      const payload = toValue(config.payload)
       defaultFetchOptions.body = config.payloadType === 'json'
         ? JSON.stringify(payload)
         : payload as BodyInit
@@ -537,12 +542,6 @@ export function useFetch<T>(url: MaybeRefOrGetter<string>, ...args: any[]): UseF
             { deep: true },
           )
         }
-
-        const rawPayload = toValue(config.payload)
-        // Set the payload to json type only if it's not provided and a literal object is provided and the object is not `formData`
-        // The only case we can deduce the content type and `fetch` can't
-        if (!payloadType && rawPayload && Object.getPrototypeOf(rawPayload) === Object.prototype && !(rawPayload instanceof FormData))
-          config.payloadType = 'json'
 
         return {
           ...shell,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

close #3250

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f85bdf3</samp>

Improved the handling of different payload types and headers in `useFetch` and added tests to verify the functionality. Refactored the code to avoid duplication and ensure consistency.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f85bdf3</samp>

* Move the logic for setting the payload type and the Content-Type header to the main `useFetch` function, to ensure consistency and avoid duplication ([link](https://github.com/vueuse/vueuse/pull/3251/files?diff=unified&w=0#diff-0db62ed388d474bc80cd69e2ff1593cd6c9719b8794d8f88459a1704e8da25b5L396-R404), [link](https://github.com/vueuse/vueuse/pull/3251/files?diff=unified&w=0#diff-0db62ed388d474bc80cd69e2ff1593cd6c9719b8794d8f88459a1704e8da25b5L541-L546))
* Modify the condition for setting the payload type to `json` to exclude `FormData` instances, since they are handled by `fetch` without specifying the header ([link](https://github.com/vueuse/vueuse/pull/3251/files?diff=unified&w=0#diff-0db62ed388d474bc80cd69e2ff1593cd6c9719b8794d8f88459a1704e8da25b5L396-R404))
* Add two test cases to check the behavior of `useFetch` with different types of payloads (JSON and FormData) and how the Content-Type header is set accordingly ([link](https://github.com/vueuse/vueuse/pull/3251/files?diff=unified&w=0#diff-cfa32f32f2a1245f1809ab44fa2bfc07a3b5ea7ea2e40cf4893a60ad410c7f2eR699-R722))
* Use the `ref` function from Vue to create reactive values for the payload and the `retry` function from the test utils to wait for the fetch call to complete and assert the expected header value in the test cases ([link](https://github.com/vueuse/vueuse/pull/3251/files?diff=unified&w=0#diff-cfa32f32f2a1245f1809ab44fa2bfc07a3b5ea7ea2e40cf4893a60ad410c7f2eR699-R722))
