### PR TITLE
fix(onClickOutside): fix outside click on html element in ios

### DIFF
--- a/packages/core/onClickOutside/index.ts
+++ b/packages/core/onClickOutside/index.ts
@@ -51,6 +51,7 @@ export function onClickOutside<T extends OnClickOutsideOptions>(
     _iOSWorkaround = true
     Array.from(window.document.body.children)
       .forEach(el => el.addEventListener('click', noop))
+    window.document.documentElement.addEventListener('click', noop)
   }
 
   let shouldListen = true


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description
In iOS if `body` has `pointer-events: none`, click events will happen on the `html` element but will not bubble up to the Window element. This fixes it.
### Additional context

https://github.com/radix-vue/radix-vue/issues/217

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b86ce87</samp>

Fix `onClickOutside` bug on Safari by adding a dummy event listener. This prevents Safari from firing a click event on the first touch after a touchend event.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b86ce87</samp>

*  Work around Safari bug that triggers click event on first touch after touchend ([link](https://github.com/vueuse/vueuse/pull/3252/files?diff=unified&w=0#diff-8b308f45dba561e732d94afb100d76cc2aee8b7d265690c72e6fdf1e9dc59925R54))
