### PR TITLE
fix(toRefs): don't trigger unwanted watchEffects

### DIFF
--- a/packages/shared/toRefs/index.test.ts
+++ b/packages/shared/toRefs/index.test.ts
@@ -1,4 +1,4 @@
-import { computed, isVue3, reactive, ref } from 'vue-demi'
+import { computed, isVue3, reactive, ref, watchSyncEffect } from 'vue-demi'
 import { describe, expect, it, vi } from 'vitest'
 import { toRefs } from '.'
 
@@ -96,6 +96,44 @@ describe('toRefs', () => {
 
     refs[1].value = 1
     expect(spy).toHaveBeenLastCalledWith(['a', 1])
+  })
+
+  it('should trigger unwanted effects with replaceRef = false', () => {
+    const spy = vi.fn()
+    const obj = ref({
+      a: 'a',
+      b: 0,
+    })
+
+    const { a, b } = toRefs(obj, { replaceRef: true })
+    expect(a.value).toBe('a')
+    expect(b.value).toBe(0)
+
+    watchSyncEffect(() => spy(a.value))
+
+    expect(spy).toHaveBeenCalledTimes(1)
+
+    b.value = 1
+    expect(spy).toHaveBeenCalledTimes(2)
+  })
+
+  it('should not trigger unwanted effects with replaceRef = false', () => {
+    const spy = vi.fn()
+    const obj = ref({
+      a: 'a',
+      b: 0,
+    })
+
+    const { a, b } = toRefs(obj, { replaceRef: false })
+    expect(a.value).toBe('a')
+    expect(b.value).toBe(0)
+
+    watchSyncEffect(() => spy(a.value))
+
+    expect(spy).toHaveBeenCalledTimes(1)
+
+    b.value = 1
+    expect(spy).toHaveBeenCalledTimes(1)
   })
 
   it('should save instance of class', () => {

--- a/packages/shared/toRefs/index.ts
+++ b/packages/shared/toRefs/index.ts
@@ -1,6 +1,7 @@
 import type { ToRefs } from 'vue-demi'
 import { toRefs as _toRefs, customRef, isRef } from 'vue-demi'
-import type { MaybeRef } from '../utils'
+import { toValue } from '../toValue'
+import type { MaybeRef, MaybeRefOrGetter } from '../utils'
 
 export interface ToRefsOptions {
   /**
@@ -8,7 +9,7 @@ export interface ToRefsOptions {
    *
    * @default true
    */
-  replaceRef?: boolean
+  replaceRef?: MaybeRefOrGetter<boolean>
 }
 
 /**
@@ -28,14 +29,14 @@ export function toRefs<T extends object>(
     ? new Array(objectRef.value.length)
     : {}
 
-  const { replaceRef = true } = options
-
   for (const key in objectRef.value) {
     result[key] = customRef<T[typeof key]>(() => ({
       get() {
         return objectRef.value[key]
       },
       set(v) {
+        const replaceRef = toValue(options.replaceRef) ?? true
+
         if (replaceRef) {
           if (Array.isArray(objectRef.value)) {
             const copy: any = [...objectRef.value]


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

This one is hard to tackle because of #885. The functionality here is kind of exclusive with the bug that this PR aims to fix. 

This PR introduces `ToRefsOptions` property with a `replaceRef` boolean flag. By default, the flag is set to `true` to prevent breaking changes. If `replaceRef` is true, and one of the returned `toRefs` ref is changed, the original ref object is replaced by a copy. If the flag is set to false, only a key of the original ref is updated.

fixes #3258

### Additional context

I couldn't come up with a better name. Maybe `deep` would better resemble that.

Another solution that I thought of would be to check if `objectRef.constructor.name === 'RefImpl'` and if so, update only the key. Vue has no system (that I know of) of distinguishing between `Ref`, `ComputedRef` and `CustomRef`, so that solution seems a bit hacky and is prone to changes of Vue internals. Also it makes `toRefs` kind of unpredictable when used with other composables.

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 59632ac</samp>

Added a new feature to the `toRefs` function to optionally replace the original ref with a copy on property update. This can help avoid unwanted side effects when using `toRefs` with reactive objects. Updated the tests and the documentation accordingly.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 59632ac</samp>

*  Add `ToRefsOptions` interface to define the type of the optional parameter for the `toRefs` function ([link](https://github.com/vueuse/vueuse/pull/3260/files?diff=unified&w=0#diff-4446d4d66581192297cb43e319d6def3c9223a58a4b074d5d01b3ba0c111a8c7R5-R13))
*  Modify `toRefs` function signature to accept an `options` parameter with a default value of an empty object ([link](https://github.com/vueuse/vueuse/pull/3260/files?diff=unified&w=0#diff-4446d4d66581192297cb43e319d6def3c9223a58a4b074d5d01b3ba0c111a8c7R22))
*  Destructure the `options` parameter and assign a default value of true to the `replaceRef` variable ([link](https://github.com/vueuse/vueuse/pull/3260/files?diff=unified&w=0#diff-4446d4d66581192297cb43e319d6def3c9223a58a4b074d5d01b3ba0c111a8c7R31-R32))
*  Change the `set` function of the computed property to check the value of the `replaceRef` variable and either replace the original ref with a copy or mutate it directly on property update ([link](https://github.com/vueuse/vueuse/pull/3260/files?diff=unified&w=0#diff-4446d4d66581192297cb43e319d6def3c9223a58a4b074d5d01b3ba0c111a8c7L27-R55))
*  Import `watchSyncEffect` function from `vue-demi` in `toRefs/index.test.ts` ([link](https://github.com/vueuse/vueuse/pull/3260/files?diff=unified&w=0#diff-40081f482b42715e9129ca9ca969e7da8027111cd763498f4f4587a48ae57e95L1-R1))
*  Add two new tests to check the behavior of the `toRefs` function with different values of the `replaceRef` option ([link](https://github.com/vueuse/vueuse/pull/3260/files?diff=unified&w=0#diff-40081f482b42715e9129ca9ca969e7da8027111cd763498f4f4587a48ae57e95R101-R138))
