### PR TITLE
fix(createReusableTemplate): camelize all props

### DIFF
--- a/packages/core/createReusableTemplate/index.test.ts
+++ b/packages/core/createReusableTemplate/index.test.ts
@@ -73,6 +73,8 @@ describe.skipIf(isVue2)('createReusableTemplate', () => {
           h(DefineFoo, ({ $slots, ...args }: any) => h('pre', JSON.stringify(args))),
 
           h(ReuseFoo, { myMsg: 'Foo' }),
+
+          // @ts-expect-error Vue automatically converts hyphenized props to camelCase
           h(ReuseFoo, { 'my-msg': 'Bar' }),
         ])
       },

--- a/packages/core/createReusableTemplate/index.test.ts
+++ b/packages/core/createReusableTemplate/index.test.ts
@@ -64,6 +64,23 @@ describe.skipIf(isVue2)('createReusableTemplate', () => {
     expect(wrapper.text()).toBe('{"msg":"Foo"}{"msg":"Bar"}')
   })
 
+  it('hyphen props', () => {
+    const [DefineFoo, ReuseFoo] = createReusableTemplate<{ myMsg: string }>()
+
+    const wrapper = mount({
+      render() {
+        return h(Fragment, null, [
+          h(DefineFoo, ({ $slots, ...args }: any) => h('pre', JSON.stringify(args))),
+
+          h(ReuseFoo, { myMsg: 'Foo' }),
+          h(ReuseFoo, { 'my-msg': 'Bar' }),
+        ])
+      },
+    })
+
+    expect(wrapper.text()).toBe('{"myMsg":"Foo"}{"myMsg":"Bar"}')
+  })
+
   it('slots', () => {
     const [DefineFoo, ReuseFoo] = createReusableTemplate<{ msg: string }, { default: Slot }>()
 

--- a/packages/core/createReusableTemplate/index.ts
+++ b/packages/core/createReusableTemplate/index.ts
@@ -65,7 +65,7 @@ export function createReusableTemplate<
         const camelizedAttrs = Object.entries(attrs).reduce((acc, [key, value]) => {
           acc[camelize(key)] = value
           return acc
-        }, {})
+        }, {} as Record<string, any>)
 
         return render.value?.({ ...camelizedAttrs, $slots: slots })
       }

--- a/packages/core/createReusableTemplate/index.ts
+++ b/packages/core/createReusableTemplate/index.ts
@@ -1,5 +1,5 @@
 import type { DefineComponent, Slot } from 'vue-demi'
-import { defineComponent, isVue3, shallowRef, version } from 'vue-demi'
+import { camelize, defineComponent, isVue3, shallowRef, version } from 'vue-demi'
 import { makeDestructurable } from '@vueuse/shared'
 
 export type DefineTemplateComponent<
@@ -61,7 +61,13 @@ export function createReusableTemplate<
       return () => {
         if (!render.value && process.env.NODE_ENV !== 'production')
           throw new Error('[VueUse] Failed to find the definition of reusable template')
-        return render.value?.({ ...attrs, $slots: slots })
+
+        const camelizedAttrs = Object.entries(attrs).reduce((acc, [key, value]) => {
+          acc[camelize(key)] = value
+          return acc
+        }, {})
+
+        return render.value?.({ ...camelizedAttrs, $slots: slots })
       }
     },
   }) as ReuseTemplateComponent<Bindings, Slots>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description
All attributes are now camelized using vue's `camelize` function

fixes #3261

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 84fc9da</samp>

Improved `createReusableTemplate` to handle hyphenated props and added a test case for it. This allows creating reusable templates with consistent prop naming and ensures their correct rendering.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 84fc9da</samp>

* Import `camelize` function from `vue-demi` to normalize props passed to reusable template ([link](https://github.com/vueuse/vueuse/pull/3262/files?diff=unified&w=0#diff-2ab8a265afffefa3f7f94474668e63c4eb38974e01686c2c439ffb672275b2ebL2-R2))
* Apply `camelize` function to `attrs` object before passing it to `render` function in `createReusableTemplate` ([link](https://github.com/vueuse/vueuse/pull/3262/files?diff=unified&w=0#diff-2ab8a265afffefa3f7f94474668e63c4eb38974e01686c2c439ffb672275b2ebL64-R70))
* Add test case for `createReusableTemplate` with hyphenated props in `index.test.ts` ([link](https://github.com/vueuse/vueuse/pull/3262/files?diff=unified&w=0#diff-7f9567af94fe374d14656d6371a348ce6366d7196387dd39cf9979b4809391e9R67-R83))
