### PR TITLE
feat(useCounter): initialValue support ref

### DIFF
--- a/packages/shared/useCounter/index.test.ts
+++ b/packages/shared/useCounter/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { ref } from 'vue-demi'
 import { useCounter } from '.'
 
 describe('useCounter', () => {
@@ -34,6 +35,47 @@ describe('useCounter', () => {
     expect(get()).toBe(25)
     reset()
     expect(count.value).toBe(25)
+    expect(get()).toBe(25)
+  })
+
+  it('should be update initial & counter', () => {
+    const initial = ref(0)
+    const { count, inc, dec, get, set, reset } = useCounter(initial)
+
+    expect(count.value).toBe(0)
+    expect(initial.value).toBe(0)
+    expect(get()).toBe(0)
+    inc()
+    expect(initial.value).toBe(1)
+    expect(count.value).toBe(1)
+    expect(get()).toBe(1)
+    inc(2)
+    expect(count.value).toBe(3)
+    expect(initial.value).toBe(3)
+    expect(get()).toBe(3)
+    dec()
+    expect(count.value).toBe(2)
+    expect(initial.value).toBe(2)
+    expect(get()).toBe(2)
+    dec(5)
+    expect(count.value).toBe(-3)
+    expect(initial.value).toBe(-3)
+    expect(get()).toBe(-3)
+    set(100)
+    expect(count.value).toBe(100)
+    expect(initial.value).toBe(100)
+    expect(get()).toBe(100)
+    reset()
+    expect(count.value).toBe(0)
+    expect(initial.value).toBe(0)
+    expect(get()).toBe(0)
+    reset(25)
+    expect(count.value).toBe(25)
+    expect(initial.value).toBe(25)
+    expect(get()).toBe(25)
+    reset()
+    expect(count.value).toBe(25)
+    expect(initial.value).toBe(25)
     expect(get()).toBe(25)
   })
 

--- a/packages/shared/useCounter/index.ts
+++ b/packages/shared/useCounter/index.ts
@@ -1,6 +1,7 @@
-import { toRef, toValue } from '../index'
+import { toRef } from '../toRef'
+import { toValue } from '../toValue'
 
-import type { MaybeRef } from '../index'
+import type { MaybeRef } from '../utils/types'
 
 export interface UseCounterOptions {
   min?: number

--- a/packages/shared/useCounter/index.ts
+++ b/packages/shared/useCounter/index.ts
@@ -1,4 +1,6 @@
-import { ref } from 'vue-demi'
+import { toRef, toValue } from '../index'
+
+import type { MaybeRef } from '../index'
 
 export interface UseCounterOptions {
   min?: number
@@ -12,8 +14,9 @@ export interface UseCounterOptions {
  * @param [initialValue=0]
  * @param {Object} options
  */
-export function useCounter(initialValue = 0, options: UseCounterOptions = {}) {
-  const count = ref(initialValue)
+export function useCounter(initialValue: MaybeRef<number> = 0, options: UseCounterOptions = {}) {
+  let _initialValue = toValue(initialValue)
+  const count = toRef(initialValue)
 
   const {
     max = Number.POSITIVE_INFINITY,
@@ -24,8 +27,8 @@ export function useCounter(initialValue = 0, options: UseCounterOptions = {}) {
   const dec = (delta = 1) => count.value = Math.max(min, count.value - delta)
   const get = () => count.value
   const set = (val: number) => (count.value = Math.max(min, Math.min(max, val)))
-  const reset = (val = initialValue) => {
-    initialValue = val
+  const reset = (val = _initialValue) => {
+    _initialValue = val
     return set(val)
   }
 

--- a/packages/shared/useCounter/index.ts
+++ b/packages/shared/useCounter/index.ts
@@ -1,7 +1,7 @@
-import { toRef } from '../toRef'
-import { toValue } from '../toValue'
+// eslint-disable-next-line no-restricted-imports
+import { ref, unref } from 'vue-demi'
 
-import type { MaybeRef } from '../utils/types'
+import type { MaybeRef } from 'vue-demi'
 
 export interface UseCounterOptions {
   min?: number
@@ -16,8 +16,8 @@ export interface UseCounterOptions {
  * @param {Object} options
  */
 export function useCounter(initialValue: MaybeRef<number> = 0, options: UseCounterOptions = {}) {
-  let _initialValue = toValue(initialValue)
-  const count = toRef(initialValue)
+  let _initialValue = unref(initialValue)
+  const count = ref(initialValue)
 
   const {
     max = Number.POSITIVE_INFINITY,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

make `useCounter` initialValue support ref.

```ts
const initial = ref(10)
const { count, inc, get } = useCounter(initial)

inc()
initial.value // 11
count.value // 11
get() // 11
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e7f79e5</samp>

This pull request enhances the `useCounter` function to support reactive initial values and state, and updates the test file accordingly. It also fixes a bug in the `reset` function.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e7f79e5</samp>

*  Add support for reactive references as initial values for `useCounter` ([link](https://github.com/vueuse/vueuse/pull/3266/files?diff=unified&w=0#diff-7a5e48e83f17ab2e7965e9d46041fa573414ecda49db8f9f8383a30e8f14c38fL1-R4), [link](https://github.com/vueuse/vueuse/pull/3266/files?diff=unified&w=0#diff-7a5e48e83f17ab2e7965e9d46041fa573414ecda49db8f9f8383a30e8f14c38fL15-R19), [link](https://github.com/vueuse/vueuse/pull/3266/files?diff=unified&w=0#diff-7a5e48e83f17ab2e7965e9d46041fa573414ecda49db8f9f8383a30e8f14c38fL27-R31))
  - Import `toRef`, `toValue`, and `MaybeRef` from `shared/index` in `useCounter/index.ts` ([link](https://github.com/vueuse/vueuse/pull/3266/files?diff=unified&w=0#diff-7a5e48e83f17ab2e7965e9d46041fa573414ecda49db8f9f8383a30e8f14c38fL1-R4))
  - Use `toValue` to get the actual value of `initialValue` and store it in `_initialValue` ([link](https://github.com/vueuse/vueuse/pull/3266/files?diff=unified&w=0#diff-7a5e48e83f17ab2e7965e9d46041fa573414ecda49db8f9f8383a30e8f14c38fL15-R19))
  - Use `toRef` to create a reactive reference for `count` ([link](https://github.com/vueuse/vueuse/pull/3266/files?diff=unified&w=0#diff-7a5e48e83f17ab2e7965e9d46041fa573414ecda49db8f9f8383a30e8f14c38fL15-R19))
  - Use `_initialValue` as the default value for `reset` ([link](https://github.com/vueuse/vueuse/pull/3266/files?diff=unified&w=0#diff-7a5e48e83f17ab2e7965e9d46041fa573414ecda49db8f9f8383a30e8f14c38fL27-R31))
* Add test case for `useCounter` with reactive reference as initial value in `useCounter/index.test.ts` ([link](https://github.com/vueuse/vueuse/pull/3266/files?diff=unified&w=0#diff-bb78c23602f3c51f74b158b2eef10277c8c20fcba504122892879e985e9dc90eR2), [link](https://github.com/vueuse/vueuse/pull/3266/files?diff=unified&w=0#diff-bb78c23602f3c51f74b158b2eef10277c8c20fcba504122892879e985e9dc90eR41-R81))
  - Import `ref` from `vue-demi` to create reactive references ([link](https://github.com/vueuse/vueuse/pull/3266/files?diff=unified&w=0#diff-bb78c23602f3c51f74b158b2eef10277c8c20fcba504122892879e985e9dc90eR2))
  - Test the counter methods with a reactive reference as `initialValue` ([link](https://github.com/vueuse/vueuse/pull/3266/files?diff=unified&w=0#diff-bb78c23602f3c51f74b158b2eef10277c8c20fcba504122892879e985e9dc90eR41-R81))
