### PR TITLE
docs(createReusableTemplate): add caveats

### DIFF
--- a/packages/core/createReusableTemplate/index.md
+++ b/packages/core/createReusableTemplate/index.md
@@ -183,6 +183,10 @@ const TemplateFoo = createReusableTemplate<{ msg: string }>()
 Dot notation is not supported in Vue 2.
 :::
 
+::: warning
+Passing boolean props without `v-bind` is not supported. See the [Caveats](#boolean-props) section for more details.
+:::
+
 ### Passing Slots
 
 It's also possible to pass slots back from `<ReuseTemplate>`. You can access the slots on `<DefineTemplate>` from `$slots`:
@@ -217,9 +221,37 @@ Passing slots does not work in Vue 2.
 
 ## Caveats
 
-- As opposed to Vue's built-in boolean prop transform, props defined as `boolean` that were passed without `v-bind` will be resolved into an empty string rather than `true`.
+### Boolean props
 
-- As opposed to Vue's built-in boolean prop transform, props defined as `boolean` that were not passed will be resolved into an `undefined` rather than `false`.
+As opposed to Vue's behavior, props defined as `boolean` that were passed without `v-bind` or absent will be resolved into an empty string or `undefined` respectively:
+
+```html
+<script setup lang="ts">
+import { createReusableTemplate } from '@vueuse/core'
+
+const [DefineTemplate, ReuseTemplate] = createReusableTemplate<{
+  value?: boolean
+}>()
+</script>
+
+<template>
+  <DefineTemplate v-slot="{ value }">
+    {{ typeof value }}: {{ value }}
+  </DefineTemplate>
+
+  <ReuseTemplate :value="true" />
+  <!-- boolean: true -->
+
+  <ReuseTemplate :value="false" />
+  <!-- boolean: false -->
+
+  <ReuseTemplate value />
+  <!-- string: -->
+
+  <ReuseTemplate />
+  <!-- undefined: -->
+</template>
+```
 
 ## References
 

--- a/packages/core/createReusableTemplate/index.md
+++ b/packages/core/createReusableTemplate/index.md
@@ -215,6 +215,12 @@ const [DefineTemplate, ReuseTemplate] = createReusableTemplate()
 Passing slots does not work in Vue 2.
 :::
 
+## Caveats
+
+- As opposed to Vue's built-in boolean prop transform, props defined as `boolean` that were passed without `v-bind` will be resolved into an empty string rather than `true`.
+
+- As opposed to Vue's built-in boolean prop transform, props defined as `boolean` that were not passed will be resolved into an `undefined` rather than `false`.
+
 ## References
 
 This function is migrated from [vue-reuse-template](https://github.com/antfu/vue-reuse-template).


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

We aren't able to check which type is expected at runtime (at least to my knowledge), so we cannot check if user expects
`boolean`, `string`, `undefined` or any union of it. That said, I've decided to add caveats section to `createReusableTemplate` that explains differences between it's prop resolution behavior and Vue's

closes #3277 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fc7e0d1</samp>

Added a `Caveats` section to the documentation of `createReusableTemplate` in `packages/core/createReusableTemplate/index.md`. The section explains how the function differs from Vue's boolean prop transform and how to avoid potential issues.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fc7e0d1</samp>

* Add a new section `Caveats` to the documentation of `createReusableTemplate` ([link](https://github.com/vueuse/vueuse/pull/3278/files?diff=unified&w=0#diff-9160b41d6960765dfafee8615e040275e9d0d67fa49258b1422b94a6751bf582R218-R223))
