### PR TITLE
fix(useScroll): evade edge case when window or document is Proxy

### DIFF
--- a/packages/core/useScroll/index.ts
+++ b/packages/core/useScroll/index.ts
@@ -170,9 +170,9 @@ export function useScroll(
       return
 
     const el = (
-      target === window
+      (target as Window).document
         ? (target as Window).document.documentElement
-        : target === window.document ? (target as Document).documentElement : target
+        : (target as Document).documentElement ?? target
     ) as HTMLElement
 
     const { display, flexDirection } = getComputedStyle(el)
@@ -233,7 +233,7 @@ export function useScroll(
       return
 
     const eventTarget = (
-      e.target === window.document ? (e.target as Document).documentElement : e.target
+      (e.target as Document).documentElement ?? e.target
     ) as HTMLElement
 
     setArrivedState(eventTarget)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

fix https://github.com/vueuse/vueuse/issues/3136

the e.target/target will never be equal to window.document/window when it is a Proxy.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ab6806a</samp>

Refactor `useScroll` to use optional chaining and remove redundant checks. Improve readability and performance of getting scroll element and event target.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ab6806a</samp>

*  Simplify the logic for getting the scroll element and the event target by using the optional chaining operator (??) ([link](https://github.com/vueuse/vueuse/pull/3280/files?diff=unified&w=0#diff-6854b45663451a9e8c15d7b4e0bd17a681777359676d0a6c6d8dc32539bdcea6L173-R175), [link](https://github.com/vueuse/vueuse/pull/3280/files?diff=unified&w=0#diff-6854b45663451a9e8c15d7b4e0bd17a681777359676d0a6c6d8dc32539bdcea6L236-R236))
