### PR TITLE
fix(useRouteQuery) Set undefined when null, undefined or default value

### DIFF
--- a/packages/router/useRouteParams/index.test.ts
+++ b/packages/router/useRouteParams/index.test.ts
@@ -202,7 +202,7 @@ describe('useRouteParams', () => {
     await nextTick()
 
     expect(page.value).toBe(1)
-    expect(route.params.page).toBe(1)
+    expect(route.params.page).toBeUndefined()
     expect(onUpdate).not.toHaveBeenCalled()
   })
 

--- a/packages/router/useRouteParams/index.ts
+++ b/packages/router/useRouteParams/index.ts
@@ -63,7 +63,7 @@ export function useRouteParams<
           return
 
         param = v
-        _paramsQueue.set(name, v)
+        _paramsQueue.set(name, (v === defaultValue || v === null) ? undefined : v)
 
         trigger()
 

--- a/packages/router/useRouteQuery/index.test.ts
+++ b/packages/router/useRouteQuery/index.test.ts
@@ -222,7 +222,7 @@ describe('useRouteQuery', () => {
     await nextTick()
 
     expect(page.value).toBe(1)
-    expect(route.query.page).toBe(1)
+    expect(route.query.page).toBeUndefined()
     expect(onUpdate).not.toHaveBeenCalled()
   })
 
@@ -262,5 +262,23 @@ describe('useRouteQuery', () => {
 
     expect(page.value).toBe(2)
     expect(lang.value).toBe('en-US')
+  })
+
+  it.each([{ value: 'default' }, { value: null }, { value: undefined }])('should reset value when $value value', async ({ value }) => {
+    let route = getRoute({
+      search: 'vue3',
+    })
+    const router = { replace: (r: any) => route = r } as any
+
+    const search: Ref<any> = useRouteQuery('search', 'default', { route, router })
+
+    expect(search.value).toBe('vue3')
+    expect(route.query.search).toBe('vue3')
+
+    search.value = value
+
+    await nextTick()
+
+    expect(route.query.search).toBeUndefined()
   })
 })

--- a/packages/router/useRouteQuery/index.ts
+++ b/packages/router/useRouteQuery/index.ts
@@ -63,7 +63,7 @@ export function useRouteQuery<
           return
 
         query = v
-        _queriesQueue.set(name, v)
+        _queriesQueue.set(name, (v === defaultValue || v === null) ? undefined : v)
 
         trigger()
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

fix #3290 

### Additional context

Also tried to resolve the same issue for useRouteParams

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2473669</samp>

This pull request fixes bugs and improves the behavior of `useRouteQuery` and `useRouteParams` functions, which sync refs with route query and param values. It makes them remove the query or param from the route when the ref value is the default, null, or undefined.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2473669</samp>

*  Remove param or query from route when it matches default value or is null ([link](https://github.com/vueuse/vueuse/pull/3291/files?diff=unified&w=0#diff-f657fa605a6d4b2a9769faa5835fde4154c39c4a01a09cf8ae63e9dac446fcd8L67-R67), [link](https://github.com/vueuse/vueuse/pull/3291/files?diff=unified&w=0#diff-3a643af876b64ca6e9d5db979bfc2cfb0af8d46845a7cd6bfe4b1e41e5a369b5L66-R66))
* Fix tests for `useRouteParams` and `useRouteQuery` to expect undefined instead of 1 when ref is set to default value ([link](https://github.com/vueuse/vueuse/pull/3291/files?diff=unified&w=0#diff-a57f86ebcafcb55d44126c69a48bd1f5c88e513a80fddd3241ecd3ae34ba76ddL174-R174), [link](https://github.com/vueuse/vueuse/pull/3291/files?diff=unified&w=0#diff-faa7aba85ff895209572d55a507c772d3fbc8ff9530641d792cd69d5eeb0101aL195-R195))
* Add test for `useRouteQuery` to check that it resets the value when it is set to default value, null, or undefined ([link](https://github.com/vueuse/vueuse/pull/3291/files?diff=unified&w=0#diff-faa7aba85ff895209572d55a507c772d3fbc8ff9530641d792cd69d5eeb0101aR236-R253))
