### PR TITLE
fix(useClipboard): "Read" mode is not working on Firefox and some other changes 

### DIFF
--- a/packages/core/useClipboard/demo.vue
+++ b/packages/core/useClipboard/demo.vue
@@ -4,27 +4,32 @@ import { useClipboard, usePermission } from '@vueuse/core'
 
 const input = ref('')
 
-const { text, isClipboardApiSupported, isClipboardReadSupported, copy } = useClipboard()
+const { text, isSupported, isClipboardApiSupported, isClipboardReadSupported, copy } = useClipboard()
 const permissionRead = usePermission('clipboard-read')
 const permissionWrite = usePermission('clipboard-write')
 </script>
 
 <template>
-  <note>
-    <p>Clipboard Permission: read <b>{{ permissionRead }}</b> | write <b>{{ permissionWrite }}</b></p>
-    <p v-if="!isClipboardApiSupported">
-      Your browser does not support Clipboard API. <code>document.execCommand("copy")</code> will be used if legacy mode is enabled.
-    </p>
-    <p v-if="!isClipboardReadSupported">
-      Your browser does not support <code>navigator.clipboard.readText()</code>. Legacy method will be used if both read & legacy mode is enabled.
-    </p>
-  </note>
-
-  <div class="example">
-    <p>Current copied: <code>{{ text || 'none' }}</code></p>
-    <input v-model="input" type="text">
-    <button @click="copy(input)">
-      Copy
-    </button>
+  <div v-if="isSupported">
+    <note>
+      <p>Clipboard Permission: read <b>{{ permissionRead }}</b> | write <b>{{ permissionWrite }}</b></p>
+      <p v-if="!isClipboardApiSupported">
+        Your browser does not support Clipboard API. <code>document.execCommand("copy")</code> will be used if legacy mode is enabled.
+      </p>
+      <p v-if="!isClipboardReadSupported">
+        Your browser does not support <code>navigator.clipboard.readText()</code>. Legacy method will be used if both read & legacy mode is enabled.
+      </p>
+    </note>
+    <div class="example">
+      <p>Current copied: <code>{{ text || 'none' }}</code></p>
+      <input v-model="input" type="text">
+      <button @click="copy(input)">
+        Copy
+      </button>
+    </div>
   </div>
+
+  <p v-else>
+    Your browser does not support Clipboard API
+  </p>
 </template>

--- a/packages/core/useClipboard/demo.vue
+++ b/packages/core/useClipboard/demo.vue
@@ -4,26 +4,27 @@ import { useClipboard, usePermission } from '@vueuse/core'
 
 const input = ref('')
 
-const { text, isSupported, copy } = useClipboard()
+const { text, isClipboardApiSupported, isClipboardReadSupported, copy } = useClipboard({ read: true, legacy: true })
 const permissionRead = usePermission('clipboard-read')
 const permissionWrite = usePermission('clipboard-write')
 </script>
 
 <template>
-  <div v-if="isSupported">
-    <note>
-      Clipboard Permission: read <b>{{ permissionRead }}</b> | write
-      <b>{{ permissionWrite }}</b>
-    </note>
-    <p>
-      Current copied: <code>{{ text || 'none' }}</code>
+  <note>
+    <p>Clipboard Permission: read <b>{{ permissionRead }}</b> | write <b>{{ permissionWrite }}</b></p>
+    <p v-if="!isClipboardApiSupported">
+      Your browser does not support Clipboard API. <code>document.execCommand("copy")</code> will be used.
     </p>
+    <p v-if="!isClipboardReadSupported">
+      Your browser does not support <code>navigator.clipboard.readText()</code>. Legacy method will be used.
+    </p>
+  </note>
+
+  <div class="example">
+    <p>Current copied: <code>{{ text || 'none' }}</code></p>
     <input v-model="input" type="text">
     <button @click="copy(input)">
       Copy
     </button>
   </div>
-  <p v-else>
-    Your browser does not support Clipboard API
-  </p>
 </template>

--- a/packages/core/useClipboard/demo.vue
+++ b/packages/core/useClipboard/demo.vue
@@ -4,7 +4,7 @@ import { useClipboard, usePermission } from '@vueuse/core'
 
 const input = ref('')
 
-const { text, isClipboardApiSupported, isClipboardReadSupported, copy } = useClipboard({ read: true, legacy: true })
+const { text, isClipboardApiSupported, isClipboardReadSupported, copy } = useClipboard()
 const permissionRead = usePermission('clipboard-read')
 const permissionWrite = usePermission('clipboard-write')
 </script>
@@ -13,10 +13,10 @@ const permissionWrite = usePermission('clipboard-write')
   <note>
     <p>Clipboard Permission: read <b>{{ permissionRead }}</b> | write <b>{{ permissionWrite }}</b></p>
     <p v-if="!isClipboardApiSupported">
-      Your browser does not support Clipboard API. <code>document.execCommand("copy")</code> will be used.
+      Your browser does not support Clipboard API. <code>document.execCommand("copy")</code> will be used if legacy mode is enabled.
     </p>
     <p v-if="!isClipboardReadSupported">
-      Your browser does not support <code>navigator.clipboard.readText()</code>. Legacy method will be used.
+      Your browser does not support <code>navigator.clipboard.readText()</code>. Legacy method will be used if both read & legacy mode is enabled.
     </p>
   </note>
 

--- a/packages/core/useClipboard/index.md
+++ b/packages/core/useClipboard/index.md
@@ -14,7 +14,7 @@ Reactive [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipbo
 import { useClipboard } from '@vueuse/core'
 
 const source = ref('Hello')
-const { text, copy, copied, isSupported } = useClipboard({ source })
+const { text, copy, copied, isSupported, isClipboardApiSupported, isClipboardReadSupported } = useClipboard({ source })
 ```
 
 ```html

--- a/packages/core/useClipboard/index.md
+++ b/packages/core/useClipboard/index.md
@@ -34,3 +34,5 @@ const { text, copy, copied, isSupported, isClipboardApiSupported, isClipboardRea
 ```
 
 Set `legacy: true` to keep the ability to copy if [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API) is not available. It will handle copy with [execCommand](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand) as fallback.
+
+Set `read: true` to also automatically update `text` when user copy / cut text (i.e. [copy / cut events](https://developer.mozilla.org/en-US/docs/Web/API/ClipboardEvent) triggered)

--- a/packages/core/useClipboard/index.ts
+++ b/packages/core/useClipboard/index.ts
@@ -93,7 +93,7 @@ export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<strin
 
   const isClipboardApiSupported = useSupported(() => (navigator && 'clipboard' in navigator))
   const isClipboardReadSupported = useSupported(() => (navigator && 'clipboard' in navigator) && navigator.clipboard.readText)
-  const isSupported = computed(() => (isClipboardApiSupported.value && isClipboardReadSupported.value) || legacy)
+  const isSupported = computed(() => isClipboardApiSupported.value || legacy)
   const text = ref('')
   const copied = ref(false)
   const timeout = useTimeoutFn(() => copied.value = false, copiedDuring)
@@ -104,7 +104,7 @@ export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<strin
         text.value = value
       })
     }
-    else {
+    else if (legacy) {
       text.value = legacyRead()
     }
   }

--- a/packages/core/useClipboard/index.ts
+++ b/packages/core/useClipboard/index.ts
@@ -38,6 +38,8 @@ export interface UseClipboardOptions<Source> extends ConfigurableNavigator {
 }
 
 export interface UseClipboardReturn<Optional> {
+  isClipboardApiSupported: ComputedRef<boolean>
+  isClipboardReadSupported: ComputedRef<boolean>
   isSupported: ComputedRef<boolean>
   text: Ref<string>
   copied: Ref<boolean>
@@ -110,6 +112,8 @@ export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<strin
   }
 
   return {
+    isClipboardApiSupported,
+    isClipboardReadSupported,
     isSupported,
     text: text as ComputedRef<string>,
     copied: copied as ComputedRef<boolean>,

--- a/packages/core/useClipboard/index.ts
+++ b/packages/core/useClipboard/index.ts
@@ -132,7 +132,9 @@ export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<strin
     ta.style.opacity = '0'
     document.body.appendChild(ta)
     ta.select()
-    document.execCommand('copy')
+    const copyResult = document.execCommand('copy')
+    if (!copyResult)
+      throw new Error('[useClipboard] Fail to copy with legacy method')
     ta.remove()
   }
 

--- a/packages/core/useClipboard/index.ts
+++ b/packages/core/useClipboard/index.ts
@@ -99,7 +99,7 @@ export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<strin
   const timeout = useTimeoutFn(() => copied.value = false, copiedDuring)
 
   function updateText() {
-    if (isClipboardApiSupported.value) {
+    if (isClipboardReadSupported.value) {
       navigator!.clipboard.readText().then((value) => {
         text.value = value
       })

--- a/packages/core/useClipboard/index.ts
+++ b/packages/core/useClipboard/index.ts
@@ -38,11 +38,39 @@ export interface UseClipboardOptions<Source> extends ConfigurableNavigator {
 }
 
 export interface UseClipboardReturn<Optional> {
+  /**
+   * Whether Clipboard API is supported or not
+   */
   isClipboardApiSupported: ComputedRef<boolean>
+
+  /**
+   * Firefox does support Clipboard API, but only writing
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/readText#browser_compatibility
+   */
   isClipboardReadSupported: ComputedRef<boolean>
+
+  /**
+   * Whether it is possible to copy text via JS or not
+   */
   isSupported: ComputedRef<boolean>
+
+  /**
+   * The current text inside the clipboard
+   */
   text: Ref<string>
+
+  /**
+   * Status where the target text is copied
+   */
   copied: Ref<boolean>
+
+  /**
+   * The function for Copying the text
+   *
+   * @param {string} text to be copied
+   * @returns {Promise<void>}
+   */
   copy: Optional extends true ? (text?: string) => Promise<void> : (text: string) => Promise<void>
 }
 
@@ -64,7 +92,8 @@ export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<strin
   } = options
 
   const isClipboardApiSupported = useSupported(() => (navigator && 'clipboard' in navigator))
-  const isSupported = computed(() => isClipboardApiSupported.value || legacy)
+  const isClipboardReadSupported = useSupported(() => (navigator && 'clipboard' in navigator) && navigator.clipboard.readText)
+  const isSupported = computed(() => (isClipboardApiSupported.value && isClipboardReadSupported.value) || legacy)
   const text = ref('')
   const copied = ref(false)
   const timeout = useTimeoutFn(() => copied.value = false, copiedDuring)

--- a/packages/core/useClipboard/index.ts
+++ b/packages/core/useClipboard/index.ts
@@ -38,9 +38,9 @@ export interface UseClipboardOptions<Source> extends ConfigurableNavigator {
 }
 
 export interface UseClipboardReturn<Optional> {
-  isSupported: Ref<boolean>
-  text: ComputedRef<string>
-  copied: ComputedRef<boolean>
+  isSupported: ComputedRef<boolean>
+  text: Ref<string>
+  copied: Ref<boolean>
   copy: Optional extends true ? (text?: string) => Promise<void> : (text: string) => Promise<void>
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

6 things are done in this PR

#### (1) Read mode support on Firefox

According to [MDN Clipboard API Docs](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/readText#browser_compatibility), Firefox is only able to write text into the clipboard, but not read from it. So that legacy method should be used for reading the clipboard in Firefox.

To do so, I tried to check if `navigator.clipboard.readText()` is available, where Firefox does support Clipboard API but not `read()` & `readText()`. If not and `legacy` is set to be `true`, legacy reading method would be used.

#### (2) Wrong type is using for the returns variable

Previously:
```ts
isSupported: Ref<boolean>
text: ComputedRef<string>
copied: ComputedRef<boolean>
```

Which should be:
```ts
isSupported: ComputedRef<boolean>
text: Ref<string>
copied: Ref<boolean>
```

#### (3) Exporting 2 more variables

While we are facing some different behavior about Clipboard API compatibility between browsers, for example:

|  | Clipboard API | Write | Read |
| -------- | :------: | :------: | :------: |
| Chrome     | ✅     | ✅     | ✅     |
| Firefox     | ✅     | ✅     | 🚫     |
| IE     | 🚫     | 🚫     | 🚫     |

I think it is good to export some more flag for users to check the compatibility, so that apart from `isSupported`, I also want to export `isClipboardApiSupported` and `isClipboardReadSupported` (Newly added) for detail checking purpose.


#### (4) Throw error on fail copy with legacy copy

I tried to check for the return value of `document.execCommand("copy")` and throw an error if it returns `false`.

#### (5) JSDoc for the returning variables

I tried to write some JSDoc for them.

#### (6) Update for the use Clipboard document

I wrote a sentence about the use of `read` mode and also include new checking in the demo.

### Additional context

I am not so sure if (4) would be working or not, while according to [MDN execCommand Document](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand#return_value), `false` means unsupported or disabled, but not meaning fail.

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 800ec42</samp>

Added `read` option and browser compatibility checks to `useClipboard` function. The function can now read the clipboard text using the Clipboard API or the legacy method, and exposes two refs to indicate the support level. The demo and the documentation were updated accordingly.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 800ec42</samp>

*  Add two new computed refs to `useClipboard` to indicate browser support for Clipboard API and `navigator.clipboard.readText()` ([link](https://github.com/vueuse/vueuse/pull/3298/files?diff=unified&w=0#diff-104a20ea8a35b01c36721b36a81d3138312e27a997280d66290ce7e8a9bc466aL41-R73),[link](https://github.com/vueuse/vueuse/pull/3298/files?diff=unified&w=0#diff-104a20ea8a35b01c36721b36a81d3138312e27a997280d66290ce7e8a9bc466aR95),[link](https://github.com/vueuse/vueuse/pull/3298/files?diff=unified&w=0#diff-104a20ea8a35b01c36721b36a81d3138312e27a997280d66290ce7e8a9bc466aL71-R107),[link](https://github.com/vueuse/vueuse/pull/3298/files?diff=unified&w=0#diff-104a20ea8a35b01c36721b36a81d3138312e27a997280d66290ce7e8a9bc466aR146-R147),[link](https://github.com/vueuse/vueuse/pull/3298/files?diff=unified&w=0#diff-f6f0edcfde360bae35a2945d8afe122f29bcb8ea4f5d3fa60283b33d91c3b245L7-R7),[link](https://github.com/vueuse/vueuse/pull/3298/files?diff=unified&w=0#diff-01b6125e1ab05d5dc5311c2a032284dbd17cd32e724eba71e6bbd4b1c512af98L17-R17))
*  Update the demo and the documentation to show the new return values and explain the `read` option ([link](https://github.com/vueuse/vueuse/pull/3298/files?diff=unified&w=0#diff-f6f0edcfde360bae35a2945d8afe122f29bcb8ea4f5d3fa60283b33d91c3b245L15-R31),[link](https://github.com/vueuse/vueuse/pull/3298/files?diff=unified&w=0#diff-01b6125e1ab05d5dc5311c2a032284dbd17cd32e724eba71e6bbd4b1c512af98R37-R38))
*  Improve error handling and feedback for the legacy copy method by throwing an error if `document.execCommand('copy')` fails ([link](https://github.com/vueuse/vueuse/pull/3298/files?diff=unified&w=0#diff-104a20ea8a35b01c36721b36a81d3138312e27a997280d66290ce7e8a9bc466aL104-R137))
*  Add a condition to check the `legacy` option before using the legacy read method ([link](https://github.com/vueuse/vueuse/pull/3298/files?diff=unified&w=0#diff-104a20ea8a35b01c36721b36a81d3138312e27a997280d66290ce7e8a9bc466aL71-R107))
