### PR TITLE
fix:复用已用的工具函数 noop, 销毁时自动调用 stop,pageOffset 已被废弃,替换为 scroll,为 mousele…

### DIFF
--- a/packages/core/useMouseInElement/index.ts
+++ b/packages/core/useMouseInElement/index.ts
@@ -1,4 +1,5 @@
 import { ref, watch } from 'vue-demi'
+import { noop, tryOnScopeDispose } from '@vueuse/shared'
 import type { MaybeElementRef } from '../unrefElement'
 import { unrefElement } from '../unrefElement'
 import type { UseMouseOptions } from '../useMouse'
@@ -36,7 +37,7 @@ export function useMouseInElement(
   const elementWidth = ref(0)
   const isOutside = ref(true)
 
-  let stop = () => {}
+  let stop = noop
 
   if (window) {
     stop = watch(
@@ -53,8 +54,8 @@ export function useMouseInElement(
           height,
         } = el.getBoundingClientRect()
 
-        elementPositionX.value = left + window.pageXOffset
-        elementPositionY.value = top + window.pageYOffset
+        elementPositionX.value = left + window.scrollX
+        elementPositionY.value = top + window.scrollY
         elementHeight.value = height
         elementWidth.value = width
 
@@ -72,9 +73,9 @@ export function useMouseInElement(
       { immediate: true },
     )
 
-    useEventListener(document, 'mouseleave', () => {
-      isOutside.value = true
-    })
+    useEventListener(document, 'mouseleave', () => { isOutside.value = true }, { passive: true })
+
+    tryOnScopeDispose(stop)
   }
 
   return {


### PR DESCRIPTION
…ave 事件增加 passive 参数

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

fix:
1. 复用已用的工具函数 noop
2. 在 tryOnScopeDispose 中清除副作用
3. pageOffsetX/pageOffsetY 已被废弃,替换为 scrollX/scrollY
4. 为 mouseleave 事件增加 passive 参数

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8619422</samp>

Refactor `useMouseInElement` function to use shared utilities and optimize event handling. This improves the core package's code quality and efficiency.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8619422</samp>

* Import utility functions `noop` and `tryOnScopeDispose` from the shared package to simplify the code and handle scope disposal ([link](https://github.com/vueuse/vueuse/pull/3301/files?diff=unified&w=0#diff-dd6454c86efc47eb57288a861fc6f5ca5bdd0629608a24eac2c9fddfbe69bb1eR2))
* Use `window.scrollX` and `window.scrollY` instead of `window.pageXOffset` and `window.pageYOffset` for shorter and more consistent variable names ([link](https://github.com/vueuse/vueuse/pull/3301/files?diff=unified&w=0#diff-dd6454c86efc47eb57288a861fc6f5ca5bdd0629608a24eac2c9fddfbe69bb1eL56-R58))
* Add `passive` option to the `mouseleave` event listener to improve scrolling performance and prevent default behavior ([link](https://github.com/vueuse/vueuse/pull/3301/files?diff=unified&w=0#diff-dd6454c86efc47eb57288a861fc6f5ca5bdd0629608a24eac2c9fddfbe69bb1eL75-R78))
* Call `tryOnScopeDispose(stop)` at the end of the function to remove event listeners when the scope is disposed and prevent memory leaks and errors ([link](https://github.com/vueuse/vueuse/pull/3301/files?diff=unified&w=0#diff-dd6454c86efc47eb57288a861fc6f5ca5bdd0629608a24eac2c9fddfbe69bb1eL75-R78))
* Assign `noop` to the `stop` variable by default to avoid creating an empty function object ([link](https://github.com/vueuse/vueuse/pull/3301/files?diff=unified&w=0#diff-dd6454c86efc47eb57288a861fc6f5ca5bdd0629608a24eac2c9fddfbe69bb1eL39-R40))
