### PR TITLE
docs(best-practice): cleanup language and examples

### DIFF
--- a/packages/guide/best-practice.md
+++ b/packages/guide/best-practice.md
@@ -17,7 +17,7 @@ const mouse = useMouse()
 console.log(mouse.x.value)
 ```
 
-If you prefer to use them as object properties style, you can unwrap the refs by using `reactive()`. For example:
+If you prefer to use them as object properties, you can unwrap the refs by using `reactive()`. For example:
 
 ```ts
 import { reactive } from 'vue'
@@ -33,7 +33,7 @@ console.log(mouse.x)
 
 Similar to Vue's `watch` and `computed` that will be disposed when the component is unmounted, VueUse's functions also clean up the side-effects automatically.
 
-For example, `useEventListener` will call `removeEventListener` when the component is unmounted so you don't need to worry about it.
+For example, `useEventListener` will call `removeEventListener` when the component is unmounted.
 
 ```ts
 // will cleanup automatically
@@ -42,7 +42,7 @@ useEventListener('mousemove', () => {})
 
 All VueUse functions follow this convention.
 
-To manually dispose the side-effects, some function returns a stop handler just like the `watch` function. For example:
+To manually dispose the side-effects, some functions return a stop handler just like the `watch` function. For example:
 
 ```ts
 const stop = useEventListener('mousemove', () => {})
@@ -53,7 +53,7 @@ const stop = useEventListener('mousemove', () => {})
 stop()
 ```
 
-While not all function return the handler, a more general solution is to use the [`effectScope` API](https://vuejs.org/api/reactivity-advanced.html#effectscope) from Vue.
+Not all functions return a `stop` handler so a more general solution is to use the [`effectScope` API](https://vuejs.org/api/reactivity-advanced.html#effectscope) from Vue.
 
 ```ts
 import { effectScope } from 'vue'
@@ -72,30 +72,32 @@ scope.run(() => {
 scope.stop()
 ```
 
-You can learn more about effect scope in [this RFC](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0041-reactivity-effect-scope.md).
+You can learn more about `effectScope` in [this RFC](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0041-reactivity-effect-scope.md).
 
-### Passing Ref as Argument
+### Reactive Arguments
 
-In Vue, we use the `setup()` function to construct the "connections" between the data and logics. To make it flexible, most of the VueUse function also accepts ref version of the arguments.
+In Vue, we use the `setup()` function to construct the "connections" between data and logic. To make it flexible, most of the VueUse functions also accept refs for the arguments because refs are reactive.
 
-Taking `useTitle` as an example:
+Take `useTitle` as an example:
 
-###### Normal usage
+###### Non-reactive Argument
 
-Normally `useTitle` return a ref that reflects to the page's title. When you assign new value to the ref, it automatically updates the title.
+The `useTitle` composable helps you get and set the current page's `document.title` property.
 
 ```ts
 const isDark = useDark()
-const title = useTitle('Set title')
+const title = useTitle('Hello')
+
+console.log(document.title) // "Hello"
 
 watch(isDark, () => {
   title.value = isDark.value ? '🌙 Good evening!' : '☀️ Good morning!'
 })
 ```
 
-###### Connection usage
+###### Ref Argument
 
-If you think in "connection", you can instead passing a ref that make it bind to the page's title.
+You can pass a ref into `useTitle` instead of using the returned ref.
 
 ```ts
 const isDark = useDark()
@@ -104,9 +106,9 @@ const title = computed(() => isDark.value ? '🌙 Good evening!' : '☀️ Good 
 useTitle(title)
 ```
 
-###### Reactive Getter
+###### Reactive Getter Argument
 
-Since VueUse 9.0, we introduce a new convention for passing "Reactive Getter" as the argument. Which works great with reactive object and [Reactivity Transform](https://vuejs.org/guide/extras/reactivity-transform.html#reactivity-transform).
+Since VueUse 9.0, we introduced a new convention for passing a "Reactive Getter" as the argument, which works great with reactive objects and [Reactivity Transform](https://vuejs.org/guide/extras/reactivity-transform.html#reactivity-transform).
 
 ```ts
 const isDark = useDark()


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

As I was reading the [Best Practice](https://vueuse.org/guide/best-practice.html) document, I was distracted by some grammar mistakes and a vague and/or confusing example; so this PR provides fixes to eliminate said distractions.

Thank you for providing a "Best Practice" document! My aim in opening this PR is only to make it even more helpful than it already is.

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c3754b1</samp>

This pull request enhances the quality and relevance of the `best-practice.md` guide for VueUse users. It revises the language, format, and content of the guide, especially the part on reactive arguments. It also corrects some mistakes and outdated references.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c3754b1</samp>

*  Restructure and update the section "Reactive Arguments" to demonstrate the different ways of using refs and reactive getters as arguments for VueUse functions ([link](https://github.com/vueuse/vueuse/pull/3309/files?diff=unified&w=0#diff-ed316126b8d7ebedd026d337bf4da84e5265d5ffcfafbf147c5246110be25a0aL75-R92), [link](https://github.com/vueuse/vueuse/pull/3309/files?diff=unified&w=0#diff-ed316126b8d7ebedd026d337bf4da84e5265d5ffcfafbf147c5246110be25a0aL96-R100), [link](https://github.com/vueuse/vueuse/pull/3309/files?diff=unified&w=0#diff-ed316126b8d7ebedd026d337bf4da84e5265d5ffcfafbf147c5246110be25a0aL107-R116))
*  Fix grammatical and pluralization errors in the sentences "If you prefer to use them as object properties style" and "To manually dispose the side-effects, some function returns a stop handler just like the `watch` function" ([link](https://github.com/vueuse/vueuse/pull/3309/files?diff=unified&w=0#diff-ed316126b8d7ebedd026d337bf4da84e5265d5ffcfafbf147c5246110be25a0aL20-R20), [link](https://github.com/vueuse/vueuse/pull/3309/files?diff=unified&w=0#diff-ed316126b8d7ebedd026d337bf4da84e5265d5ffcfafbf147c5246110be25a0aL45-R45))
*  Simplify the sentence "The `useEventListener` function will automatically handle the event listener removal when the component is unmounted, so you don't need to worry about it" by removing the redundant phrase "so you don't need to worry about it" ([link](https://github.com/vueuse/vueuse/pull/3309/files?diff=unified&w=0#diff-ed316126b8d7ebedd026d337bf4da84e5265d5ffcfafbf147c5246110be25a0aL36-R36))
*  Improve the clarity and accuracy of the sentence "To manually dispose the side-effects, not all function return the handler, you can use the `effectScope` API for a more general solution" by changing it to "Not all functions return a `stop` handler to manually dispose the side-effects. You can use the `effectScope` API for a more general solution" and updating the link text ([link](https://github.com/vueuse/vueuse/pull/3309/files?diff=unified&w=0#diff-ed316126b8d7ebedd026d337bf4da84e5265d5ffcfafbf147c5246110be25a0aL56-R56))
