### PR TITLE
feat(useWebWorkerFn): support local dependencies

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,6 +40,7 @@
     "@types/web-bluetooth": "^0.0.17",
     "@vueuse/metadata": "workspace:*",
     "@vueuse/shared": "workspace:*",
-    "vue-demi": ">=0.14.5"
+    "vue-demi": ">=0.14.5",
+    "isoworker": "^0.1.1"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,7 +40,7 @@
     "@types/web-bluetooth": "^0.0.17",
     "@vueuse/metadata": "workspace:*",
     "@vueuse/shared": "workspace:*",
-    "vue-demi": ">=0.14.5",
-    "isoworker": "^0.1.1"
+    "isoworker": "^0.1.1",
+    "vue-demi": ">=0.14.5"
   }
 }

--- a/packages/core/useWebWorkerFn/demo.vue
+++ b/packages/core/useWebWorkerFn/demo.vue
@@ -2,14 +2,16 @@
 import { computed, nextTick, ref } from 'vue'
 import { useDateFormat, useTimestamp, useWebWorkerFn } from '@vueuse/core'
 
+const pow = (value: number) => value * value
+const randomNumber = () => Math.trunc(Math.random() * 5_000_00)
+
 function heavyTask() {
-  const randomNumber = () => Math.trunc(Math.random() * 5_000_00)
-  const numbers: number[] = Array(5_000_000).fill(undefined).map(randomNumber)
+  const numbers: number[] = Array(5_000_000).fill(null).map(randomNumber)
   numbers.sort()
-  return numbers.slice(0, 5)
+  return numbers.slice(0, 5).map(pow)
 }
 
-const { workerFn, workerStatus, workerTerminate } = useWebWorkerFn(heavyTask)
+const { workerFn, workerStatus, workerTerminate } = useWebWorkerFn(heavyTask, { localDependencies: () => [pow, randomNumber] })
 const time = useTimestamp()
 const computedTime = useDateFormat(time, 'YYYY-MM-DD HH:mm:ss SSS')
 const running = computed(() => workerStatus.value === 'RUNNING')

--- a/packages/core/useWebWorkerFn/index.md
+++ b/packages/core/useWebWorkerFn/index.md
@@ -18,7 +18,7 @@ const { workerFn } = useWebWorkerFn(() => {
 })
 ```
 
-### With dependencies
+### With remote dependencies
 
 ```ts {7-9}
 import { useWebWorkerFn } from '@vueuse/core'
@@ -30,6 +30,22 @@ const { workerFn, workerStatus, workerTerminate } = useWebWorkerFn(
     dependencies: [
       'https://cdnjs.cloudflare.com/ajax/libs/date-fns/1.30.1/date_fns.js', // dateFns
     ],
+  },
+)
+```
+
+### With local dependencies
+
+```ts {9-9}
+import { useWebWorkerFn } from '@vueuse/core'
+
+const pow = (a: number) => a * a
+
+const { workerFn, workerStatus, workerTerminate } = useWebWorkerFn(
+  numbers => numbers.map(pow),
+  {
+    timeout: 50000,
+    localDeps: () => [pow]
   },
 )
 ```

--- a/packages/core/useWebWorkerFn/index.md
+++ b/packages/core/useWebWorkerFn/index.md
@@ -45,7 +45,7 @@ const { workerFn, workerStatus, workerTerminate } = useWebWorkerFn(
   numbers => numbers.map(pow),
   {
     timeout: 50000,
-    localDeps: () => [pow]
+    localDependencies: () => [pow]
   },
 )
 ```

--- a/packages/core/useWebWorkerFn/index.ts
+++ b/packages/core/useWebWorkerFn/index.ts
@@ -24,6 +24,7 @@ export interface UseWebWorkerOptions extends ConfigurableWindow {
    * An array that contains the external dependencies needed to run the worker
    */
   dependencies?: string[]
+  localDependencies?: () => unknown[]
 }
 
 /**
@@ -37,6 +38,7 @@ export function useWebWorkerFn<T extends (...fnArgs: any[]) => any>(fn: T,
   options: UseWebWorkerOptions = {}) {
   const {
     dependencies = [],
+    localDependencies = () => [],
     timeout,
     window = defaultWindow,
   } = options
@@ -62,7 +64,7 @@ export function useWebWorkerFn<T extends (...fnArgs: any[]) => any>(fn: T,
   tryOnScopeDispose(workerTerminate)
 
   const generateWorker = () => {
-    const blobUrl = createWorkerBlobUrl(fn, dependencies)
+    const blobUrl = createWorkerBlobUrl(fn, dependencies, localDependencies)
     const newWorker: Worker & { _url?: string } = new Worker(blobUrl)
     newWorker._url = blobUrl
 

--- a/packages/core/useWebWorkerFn/lib/createWorkerBlobUrl.ts
+++ b/packages/core/useWebWorkerFn/lib/createWorkerBlobUrl.ts
@@ -1,3 +1,4 @@
+import * as isoworker from 'isoworker'
 import jobRunner from './jobRunner'
 import depsParser from './depsParser'
 
@@ -6,17 +7,19 @@ import depsParser from './depsParser'
  *
  * @param {Function} fn the function to run with web worker
  * @param {Array.<String>} deps array of strings, imported into the worker through "importScripts"
+ * @param {Function} localDeps imported local functions
  *
  * @returns {String} a blob url, containing the code of "fn" as a string
  *
  * @example
- * createWorkerBlobUrl((a,b) => a+b, [])
+ * createWorkerBlobUrl((a,b) => a+b, [], () => [])
  * // return "onmessage=return Promise.resolve((a,b) => a + b)
  * .then(postMessage(['SUCCESS', result]))
  * .catch(postMessage(['ERROR', error])"
  */
-function createWorkerBlobUrl(fn: Function, deps: string[]) {
-  const blobCode = `${depsParser(deps)}; onmessage=(${jobRunner})(${fn})`
+function createWorkerBlobUrl(fn: Function, deps: string[], localDeps: () => unknown[]) {
+  const [context] = isoworker.createContext(localDeps)
+  const blobCode = `${depsParser(deps)}; ${context} onmessage=(${jobRunner})(${fn})`
   const blob = new Blob([blobCode], { type: 'text/javascript' })
   const url = URL.createObjectURL(blob)
   return url

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,6 +253,9 @@ importers:
       '@vueuse/shared':
         specifier: workspace:*
         version: link:../shared
+      isoworker:
+        specifier: ^0.1.1
+        version: 0.1.1
       vue-demi:
         specifier: 0.14.5
         version: 0.14.5(vue@3.3.4)
@@ -790,7 +793,7 @@ packages:
       '@babel/helper-plugin-utils': 7.21.5
       debug: 4.3.4
       lodash.debounce: 4.0.8
-      resolve: 1.22.2
+      resolve: 1.22.3
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
@@ -933,6 +936,7 @@ packages:
   /@babel/highlight@7.18.6:
     resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
     engines: {node: '>=6.9.0'}
+    requiresBuild: true
     dependencies:
       '@babel/helper-validator-identifier': 7.22.5
       chalk: 2.4.2
@@ -3331,7 +3335,7 @@ packages:
       builtin-modules: 3.3.0
       deepmerge: 4.3.1
       is-module: 1.0.0
-      resolve: 1.22.2
+      resolve: 1.22.3
       rollup: 2.79.1
     dev: true
 
@@ -3346,7 +3350,7 @@ packages:
       deepmerge: 4.3.1
       is-builtin-module: 3.2.1
       is-module: 1.0.0
-      resolve: 1.22.2
+      resolve: 1.22.3
       rollup: 2.79.1
     dev: true
 
@@ -3364,7 +3368,7 @@ packages:
       deepmerge: 4.3.1
       is-builtin-module: 3.2.1
       is-module: 1.0.0
-      resolve: 1.22.2
+      resolve: 1.22.3
       rollup: 3.26.3
     dev: false
 
@@ -6367,7 +6371,7 @@ packages:
     dependencies:
       debug: 3.2.7
       is-core-module: 2.12.1
-      resolve: 1.22.2
+      resolve: 1.22.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8070,6 +8074,10 @@ packages:
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  /isoworker@0.1.1:
+    resolution: {integrity: sha512-25hcgGZlLh3bxF6/YNS5aw/dw2H7cna/30EvKhq6Hwwsd7gzkML6oo9XrBTpExihBVJX/8RanSXR6M4Ox5dQWA==}
+    dev: false
+
   /istanbul-lib-coverage@3.2.0:
     resolution: {integrity: sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==}
     engines: {node: '>=8'}
@@ -9210,7 +9218,7 @@ packages:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
     dependencies:
       hosted-git-info: 2.8.9
-      resolve: 1.22.2
+      resolve: 1.22.3
       semver: 5.7.1
       validate-npm-package-license: 3.0.4
     dev: true
@@ -9942,7 +9950,7 @@ packages:
       postcss: 8.4.27
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
-      resolve: 1.22.2
+      resolve: 1.22.3
     dev: false
 
   /postcss-merge-longhand@6.0.0(postcss@8.4.27):
@@ -10614,6 +10622,7 @@ packages:
       is-core-module: 2.12.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+    dev: true
 
   /resolve@1.22.3:
     resolution: {integrity: sha512-P8ur/gp/AmbEzjr729bZnLjXK5Z+4P0zhIJgBgzqRih7hL7BOukHGtSTA3ACMY467GRFz3duQsi0bDZdR7DKdw==}
@@ -10622,7 +10631,6 @@ packages:
       is-core-module: 2.12.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
-    dev: true
 
   /responselike@1.0.2:
     resolution: {integrity: sha512-/Fpe5guzJk1gPqdJLJR5u7eG/gNY4nImjbRDaVWVMRhne55TCmj2i9Q+54PBRfatRC8v/rIiv9BN0pMd9OV5EQ==}


### PR DESCRIPTION
### Description

fixes #2005 

`useWebWorkerFn` used to support remote dependencies for the function passed but not local functions.
the library which this function is a port of (`useWorker` by Alessio Koci) have the support of local dependencies.

The addition is also very much a port of `useWorker` implementation.

### Additional context

In order to support this feature, I've added a new dependency on core package called `isoworker`. as the core package is very light with dependencies, im unsure if thats fine or it's enough for us to split it into integration package of its own. open for thoughts 



---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7e11dfb</samp>

This pull request adds a new feature to the `useWebWorkerFn` hook that allows users to pass local dependencies to the web worker. It uses the `isoworker` module to create a context for the dependencies and inject them into the worker blob URL. It also updates the documentation, the demo code, and the dependencies for the `@vueuse/core` package.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7e11dfb</samp>

*  Add `isoworker` dependency to `@vueuse/core` package to support local dependencies in `useWebWorkerFn` hook ([link](https://github.com/vueuse/vueuse/pull/3316/files?diff=unified&w=0#diff-0b810c38f3c138a3d5e44854edefd5eb966617ca84e62f06511f60acc40546c7L43-R44), [link](https://github.com/vueuse/vueuse/pull/3316/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR256-R258), [link](https://github.com/vueuse/vueuse/pull/3316/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR8077-R8080))
*  Add `localDependencies` option to `useWebWorkerFn` hook and pass it to `createWorkerBlobUrl` function ([link](https://github.com/vueuse/vueuse/pull/3316/files?diff=unified&w=0#diff-019ade442aba727662477223e75991d00540f3ddff53fc4ac8b7895419f5a800R27), [link](https://github.com/vueuse/vueuse/pull/3316/files?diff=unified&w=0#diff-019ade442aba727662477223e75991d00540f3ddff53fc4ac8b7895419f5a800R41), [link](https://github.com/vueuse/vueuse/pull/3316/files?diff=unified&w=0#diff-019ade442aba727662477223e75991d00540f3ddff53fc4ac8b7895419f5a800L65-R67), [link](https://github.com/vueuse/vueuse/pull/3316/files?diff=unified&w=0#diff-1810161e4c650178a8a214094ae2ef0e6fc28971d95b8f5252cbfc01bf244842L9-R22))
*  Use `isoworker` module to create a context for local dependencies and inject it into the web worker code in `createWorkerBlobUrl` function ([link](https://github.com/vueuse/vueuse/pull/3316/files?diff=unified&w=0#diff-1810161e4c650178a8a214094ae2ef0e6fc28971d95b8f5252cbfc01bf244842R1), [link](https://github.com/vueuse/vueuse/pull/3316/files?diff=unified&w=0#diff-1810161e4c650178a8a214094ae2ef0e6fc28971d95b8f5252cbfc01bf244842L9-R22))
*  Rename section title in `useWebWorkerFn` documentation from `With dependencies` to `With remote dependencies` and add a new section for `With local dependencies` with an example code snippet ([link](https://github.com/vueuse/vueuse/pull/3316/files?diff=unified&w=0#diff-66771610a5830f7eef4025ba521b44067aa4d55b53e75f9350f4d267cd2fd41aL21-R21), [link](https://github.com/vueuse/vueuse/pull/3316/files?diff=unified&w=0#diff-66771610a5830f7eef4025ba521b44067aa4d55b53e75f9350f4d267cd2fd41aR37-R52))
*  Modify demo code for `useWebWorkerFn` hook to use a different heavy task function that uses two local dependencies: `pow` and `randomNumber` ([link](https://github.com/vueuse/vueuse/pull/3316/files?diff=unified&w=0#diff-1cde97785b0db2a18416385df847978c499520e46ba4477654150c21db41c04eL5-R14))
*  Update version of `resolve` dependency from `1.22.2` to `1.22.3` in `pnpm-lock.yaml` file, affecting several packages that depend on it ([link](https://github.com/vueuse/vueuse/pull/3316/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL793-R796), [link](https://github.com/vueuse/vueuse/pull/3316/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3334-R3338), [link](https://github.com/vueuse/vueuse/pull/3316/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3349-R3353), [link](https://github.com/vueuse/vueuse/pull/3316/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3367-R3371), [link](https://github.com/vueuse/vueuse/pull/3316/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL6370-R6374), [link](https://github.com/vueuse/vueuse/pull/3316/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9213-R9221), [link](https://github.com/vueuse/vueuse/pull/3316/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9945-R9953))
*  Add `requiresBuild` property to `@vueuse/core` package in `pnpm-lock.yaml` file, indicating that the package needs to be built before being used ([link](https://github.com/vueuse/vueuse/pull/3316/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR939))
*  Correct a mistake in `pnpm-lock.yaml` file that marked `@vueuse/core` package as a dev dependency instead of a dependency ([link](https://github.com/vueuse/vueuse/pull/3316/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR10625), [link](https://github.com/vueuse/vueuse/pull/3316/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10625))
