### PR TITLE
feat(useBreakpoints): add breakpoints for PrimeFlex

### DIFF
--- a/packages/core/useBreakpoints/breakpoints.ts
+++ b/packages/core/useBreakpoints/breakpoints.ts
@@ -92,3 +92,15 @@ export const breakpointsMasterCss = {
   '3xl': 1920,
   '4xl': 2560,
 }
+
+/**
+ * Breakpoints from PrimeFlex
+ *
+ * @see https://www.primefaces.org/primeflex/setup
+ */
+export const breakpointsPrimeFlex = {
+  sm: 576,
+  md: 768,
+  lg: 992,
+  xl: 1200
+}

--- a/packages/core/useBreakpoints/breakpoints.ts
+++ b/packages/core/useBreakpoints/breakpoints.ts
@@ -102,5 +102,5 @@ export const breakpointsPrimeFlex = {
   sm: 576,
   md: 768,
   lg: 992,
-  xl: 1200
+  xl: 1200,
 }


### PR DESCRIPTION
### Description

This PR adds the default breakpoints for [PrimeFlex](https://www.primefaces.org/primeflex/) that many PrimeVue themes are based on. Breakpoints derived from the [setup](https://www.primefaces.org/primeflex/setup) page, variables chapter, and the [code](https://github.com/primefaces/primeflex/blob/master/styles/lib/core/_variables.scss).

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2c44749</samp>

Added `breakpointsPrimeFlex` object to `breakpoints.ts` to support PrimeFlex CSS utility library. This allows users to choose between Tailwind CSS and PrimeFlex breakpoints for the `useBreakpoints` function.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2c44749</samp>

* Add `breakpointsPrimeFlex` object to define PrimeFlex breakpoints ([link](https://github.com/vueuse/vueuse/pull/3317/files?diff=unified&w=0#diff-68e970b5e6fd64669abf5ac2cc6a82e378b89224d9971aa943e36927e82135e5R95-R106))
