### PR TITLE
fix(useWebsocket): pongTimeout auto-reconnect no work

### DIFF
--- a/packages/core/useWebSocket/index.ts
+++ b/packages/core/useWebSocket/index.ts
@@ -275,6 +275,7 @@ export function useWebSocket<Data = any>(
         pongTimeoutWait = setTimeout(() => {
           // auto-reconnect will be trigger with ws.onclose()
           close()
+          explicitlyClosed = false;
         }, pongTimeout)
       },
       interval,

--- a/packages/core/useWebSocket/index.ts
+++ b/packages/core/useWebSocket/index.ts
@@ -275,7 +275,7 @@ export function useWebSocket<Data = any>(
         pongTimeoutWait = setTimeout(() => {
           // auto-reconnect will be trigger with ws.onclose()
           close()
-          explicitlyClosed = false;
+          explicitlyClosed = false
         }, pongTimeout)
       },
       interval,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
When I attempted to use the useWebsocket hook from VueUse in my project, I noticed during testing that it doesn't automatically reconnect when a heartbeat pong times out.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ac3fb07</samp>

Fix a bug in `useWebSocket` that prevented automatic reconnection after an error. Reset the `explicitlyClosed` flag when the connection is opened.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ac3fb07</samp>

* Fix a bug where the WebSocket connection would not be reopened automatically after an error if the user had previously closed it manually ([link](https://github.com/vueuse/vueuse/pull/3321/files?diff=unified&w=0#diff-9b23df18f0f5236a301bc5926a49b4e0ea571aa84752304cc34a2f44047fa0f1R278))
