### PR TITLE
fix(useWebsocket): reset pongTimeout on close

### DIFF
--- a/packages/core/useWebSocket/index.ts
+++ b/packages/core/useWebSocket/index.ts
@@ -176,6 +176,7 @@ export function useWebSocket<Data = any>(
     if (!wsRef.value)
       return
     explicitlyClosed = true
+    resetHeartbeat()
     heartbeatPause?.()
     wsRef.value.close(code, reason)
   }

--- a/packages/core/useWebSocket/index.ts
+++ b/packages/core/useWebSocket/index.ts
@@ -171,16 +171,6 @@ export function useWebSocket<Data = any>(
 
   let pongTimeoutWait: ReturnType<typeof setTimeout> | undefined
 
-  // Status code 1000 -> Normal Closure https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent/code
-  const close: WebSocket['close'] = (code = 1000, reason) => {
-    if (!wsRef.value)
-      return
-    explicitlyClosed = true
-    resetHeartbeat()
-    heartbeatPause?.()
-    wsRef.value.close(code, reason)
-  }
-
   const _sendBuffer = () => {
     if (bufferedData.length && wsRef.value && status.value === 'OPEN') {
       for (const buffer of bufferedData)
@@ -192,6 +182,16 @@ export function useWebSocket<Data = any>(
   const resetHeartbeat = () => {
     clearTimeout(pongTimeoutWait)
     pongTimeoutWait = undefined
+  }
+
+  // Status code 1000 -> Normal Closure https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent/code
+  const close: WebSocket['close'] = (code = 1000, reason) => {
+    if (!wsRef.value)
+      return
+    explicitlyClosed = true
+    resetHeartbeat()
+    heartbeatPause?.()
+    wsRef.value.close(code, reason)
   }
 
   const send = (data: string | ArrayBuffer | Blob, useBuffer = true) => {


### PR DESCRIPTION
reset pong timeout

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 85f7e07</samp>

Fix heartbeat bug in `useWebSocket` function. Clear the heartbeat interval when the WebSocket connection is closed by calling `resetHeartbeat` in `packages/core/useWebSocket/index.ts`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 85f7e07</samp>

* Fix heartbeat bug for WebSocket connection ([link](https://github.com/vueuse/vueuse/pull/3324/files?diff=unified&w=0#diff-9b23df18f0f5236a301bc5926a49b4e0ea571aa84752304cc34a2f44047fa0f1R179))
