### PR TITLE
feat(useWebNotification): add `requestPermissions` option, return `permissionGranted` and `ensurePermissions`

### DIFF
--- a/packages/core/useWebNotification/index.md
+++ b/packages/core/useWebNotification/index.md
@@ -51,18 +51,3 @@ onClose((evt: Event) => {
   // Do something with the notification on:close event...
 })
 ```
-
-The web notification permissions API can also be called onMounted lifecycle hook as:
-
-const {
-  isSupported,
-  notification,
-  show,
-  close,
-  onClick,
-  onShow,
-  onError,
-  onClose,
-} = useWebNotification({
-  requestOnMounted: true
-})

--- a/packages/core/useWebNotification/index.md
+++ b/packages/core/useWebNotification/index.md
@@ -51,3 +51,18 @@ onClose((evt: Event) => {
   // Do something with the notification on:close event...
 })
 ```
+
+The web notification permissions API can also be called onMounted lifecycle hook as:
+
+const {
+  isSupported,
+  notification,
+  show,
+  close,
+  onClick,
+  onShow,
+  onError,
+  onClose,
+} = useWebNotification({
+  requestOnMounted: true
+})

--- a/packages/core/useWebNotification/index.ts
+++ b/packages/core/useWebNotification/index.ts
@@ -83,8 +83,9 @@ export interface WebNotificationOptions {
 
 export interface UseWebNotificationOptions extends ConfigurableWindow, WebNotificationOptions {
   /**
-   * Request for permissions immediately if it's not granted,
-   * otherwise label and deviceIds could be empty
+   * Request for permissions onMounted if it's not granted.
+   *
+   * Can be disabled and calling `ensurePermissions` to grant afterwords.
    *
    * @default true
    */


### PR DESCRIPTION
---

### Description

This MR addresses the usage concerns in #3314

This MR **_does not_** introduce breaking changes to the usage of the functional API, but introduces a change in the triggering of the notification request permission, i.e., it **will no longer** request permission `onMounted`.

---

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 093dd7a</samp>

This pull request enhances the `useWebNotification` hook with a new option and helper functions to request permission for web notifications more flexibly and conveniently. It also updates the documentation with an example of using the new option.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 093dd7a</samp>

*  Add `requestOnMounted` option to `useWebNotification` hook to control when permission is requested ([link](https://github.com/vueuse/vueuse/pull/3325/files?diff=unified&w=0#diff-941615d6e0fe6606acafbb3b72343a981ce06a4090861827cfdf1f7b329b8a28L84-R92),[link](https://github.com/vueuse/vueuse/pull/3325/files?diff=unified&w=0#diff-941615d6e0fe6606acafbb3b72343a981ce06a4090861827cfdf1f7b329b8a28L96-R119),[link](https://github.com/vueuse/vueuse/pull/3325/files?diff=unified&w=0#diff-941615d6e0fe6606acafbb3b72343a981ce06a4090861827cfdf1f7b329b8a28L145-R164),[link](https://github.com/vueuse/vueuse/pull/3325/files?diff=unified&w=0#diff-80106f8d8e5faad5e5d95114a4dd39a986bd2fe105733a2c7452f7607ce3ae1dR54-R68))
*  Simplify permission checking and requesting logic using `hasPermission` and `requestPermission` functions ([link](https://github.com/vueuse/vueuse/pull/3325/files?diff=unified&w=0#diff-941615d6e0fe6606acafbb3b72343a981ce06a4090861827cfdf1f7b329b8a28L110-R127),[link](https://github.com/vueuse/vueuse/pull/3325/files?diff=unified&w=0#diff-941615d6e0fe6606acafbb3b72343a981ce06a4090861827cfdf1f7b329b8a28L121-R144),[link](https://github.com/vueuse/vueuse/pull/3325/files?diff=unified&w=0#diff-941615d6e0fe6606acafbb3b72343a981ce06a4090861827cfdf1f7b329b8a28R189-R190))
*  Refactor `defaultOptions` to `defaultWebNotificationOptions` and destructure `window` option ([link](https://github.com/vueuse/vueuse/pull/3325/files?diff=unified&w=0#diff-941615d6e0fe6606acafbb3b72343a981ce06a4090861827cfdf1f7b329b8a28L96-R119),[link](https://github.com/vueuse/vueuse/pull/3325/files?diff=unified&w=0#diff-941615d6e0fe6606acafbb3b72343a981ce06a4090861827cfdf1f7b329b8a28L121-R144))
*  Update `useWebNotification/index.md` with new option and functions ([link](https://github.com/vueuse/vueuse/pull/3325/files?diff=unified&w=0#diff-80106f8d8e5faad5e5d95114a4dd39a986bd2fe105733a2c7452f7607ce3ae1dR54-R68))
