### PR TITLE
fix(utils): update `isClient` to check `document` too

### DIFF
--- a/packages/shared/utils/is.ts
+++ b/packages/shared/utils/is.ts
@@ -1,5 +1,5 @@
 /* eslint-disable antfu/top-level-function */
-export const isClient = typeof window !== 'undefined' && !!window.document
+export const isClient = typeof window !== 'undefined' && typeof document !== 'undefined'
 export const isDef = <T = any>(val?: T): val is T => typeof val !== 'undefined'
 export const notNullish = <T = any>(val?: T | null | undefined): val is T => val != null
 export const assert = (condition: boolean, ...infos: any[]) => {

--- a/packages/shared/utils/is.ts
+++ b/packages/shared/utils/is.ts
@@ -1,5 +1,5 @@
 /* eslint-disable antfu/top-level-function */
-export const isClient = typeof document !== 'undefined'
+export const isClient = typeof window !== 'undefined' && !!window.document
 export const isDef = <T = any>(val?: T): val is T => typeof val !== 'undefined'
 export const notNullish = <T = any>(val?: T | null | undefined): val is T => val != null
 export const assert = (condition: boolean, ...infos: any[]) => {

--- a/packages/shared/utils/is.ts
+++ b/packages/shared/utils/is.ts
@@ -1,5 +1,5 @@
 /* eslint-disable antfu/top-level-function */
-export const isClient = typeof window !== 'undefined'
+export const isClient = typeof document !== 'undefined'
 export const isDef = <T = any>(val?: T): val is T => typeof val !== 'undefined'
 export const notNullish = <T = any>(val?: T | null | undefined): val is T => val != null
 export const assert = (condition: boolean, ...infos: any[]) => {


### PR DESCRIPTION
### Description

The current `isClient` implementation checks whether `window` is defined or not. This breaks things when using SSR with Deno as `window` is defined there (https://deno.land/api@v1.36.1?s=Window)

### Additional context

- users can override stuff like this: https://github.com/vuejs/vitepress/commit/e8edd0a05f43491656c00db36630f391caf64461, but its not feasible to pass that to every function
- x-ref: https://github.com/denoland/deno/issues/13367

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0c222fe</samp>

Fixed a bug in `isClient` function that incorrectly detected browser environments. Changed the function to use `document` instead of `window` in `packages/shared/utils/is.ts`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0c222fe</samp>

* Fix bug where `isClient` returns true in non-browser environments ([link](https://github.com/vueuse/vueuse/pull/3329/files?diff=unified&w=0#diff-16e06395b506fea663904348dd85973415701966b7a4ef2c464d991d7c833c25L2-R2))
