### PR TITLE
feat(useDraggable): allowing calculations of bounds with fixed element

### DIFF
--- a/packages/core/useDraggable/index.ts
+++ b/packages/core/useDraggable/index.ts
@@ -42,6 +42,13 @@ export interface UseDraggableOptions {
   draggingElement?: MaybeRefOrGetter<HTMLElement | SVGElement | Window | Document | null | undefined>
 
   /**
+   * Element for calculating bounds (If not set, it will use the event's target).
+   *
+   * @default undefined
+   */
+  containerElement?: MaybeRefOrGetter<HTMLElement | SVGElement | null | undefined>
+
+  /**
    * Handle that triggers the drag event
    *
    * @default target
@@ -107,6 +114,7 @@ export function useDraggable(
     initialValue,
     axis = 'both',
     draggingElement = defaultWindow,
+    containerElement,
     handle: draggingHandle = target,
   } = options
 
@@ -134,7 +142,8 @@ export function useDraggable(
       return
     if (toValue(exact) && e.target !== toValue(target))
       return
-    const rect = toValue(target)!.getBoundingClientRect()
+    const container = toValue(containerElement) ?? toValue(target)
+    const rect = container!.getBoundingClientRect()
     const pos = {
       x: e.clientX - rect.left,
       y: e.clientY - rect.top,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.


---

### Description

The feature's idea is to be able to pass a fixed container for bounds calculations. This is especially useful when you have another calculation scale or when working with CSS Transforms (translation). This feature allows a calculation relative to the element you choose.

### Additional context

There is a similar initiative in this PR https://github.com/vueuse/vueuse/pull/3219.

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b1328a2</samp>

Add custom container option to `useDraggable`. This lets the user choose a different element than the document body as the reference for the draggable element's position and boundaries.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b1328a2</samp>

*  Add `containerElement` property to `UseDraggableOptions` interface to allow specifying a custom element for bounds calculation ([link](https://github.com/vueuse/vueuse/pull/3335/files?diff=unified&w=0#diff-f4ddcc2e5f178f71f5420d35c60a8b7a2df9d397154e21e85d5dcb1abf6c0ceeR45-R51))
*  Pass `containerElement` from options to `useDraggable` function ([link](https://github.com/vueuse/vueuse/pull/3335/files?diff=unified&w=0#diff-f4ddcc2e5f178f71f5420d35c60a8b7a2df9d397154e21e85d5dcb1abf6c0ceeR117))
*  Use `containerElement` or `target` to get the bounding rectangle of the container element in `useDraggable` function ([link](https://github.com/vueuse/vueuse/pull/3335/files?diff=unified&w=0#diff-f4ddcc2e5f178f71f5420d35c60a8b7a2df9d397154e21e85d5dcb1abf6c0ceeL137-R146))
*  Adjust `x` and `y` values of `pos` object based on the relative position of the mouse pointer inside the container element ([link](https://github.com/vueuse/vueuse/pull/3335/files?diff=unified&w=0#diff-f4ddcc2e5f178f71f5420d35c60a8b7a2df9d397154e21e85d5dcb1abf6c0ceeL137-R146))
