### PR TITLE
feat(refAutoReset): support maybe-ref as value

### DIFF
--- a/packages/shared/refAutoReset/index.test.ts
+++ b/packages/shared/refAutoReset/index.test.ts
@@ -30,6 +30,14 @@ describe('refAutoReset', () => {
     expect(val.value).toBe('default')
   })
 
+  it('should be reset with maybeRef', async () => {
+    const val = refAutoReset(() => [123], () => 10)
+    val.value = [999]
+    expect(val.value).toEqual([999])
+    await new Promise(resolve => setTimeout(resolve, 11))
+    expect(val.value).toEqual([123])
+  })
+
   it('should change afterMs', async () => {
     const afterMs = ref(150)
     const val = refAutoReset('default', afterMs)

--- a/packages/shared/refAutoReset/index.ts
+++ b/packages/shared/refAutoReset/index.ts
@@ -11,14 +11,14 @@ import { tryOnScopeDispose } from '../tryOnScopeDispose'
  * @param defaultValue The value which will be set.
  * @param afterMs      A zero-or-greater delay in milliseconds.
  */
-export function refAutoReset<T>(defaultValue: T, afterMs: MaybeRefOrGetter<number> = 10000): Ref<T> {
+export function refAutoReset<T>(defaultValue: MaybeRefOrGetter<T>, afterMs: MaybeRefOrGetter<number> = 10000): Ref<T> {
   return customRef<T>((track, trigger) => {
-    let value: T = defaultValue
+    let value: T = toValue(defaultValue)
     let timer: any
 
     const resetAfter = () =>
       setTimeout(() => {
-        value = defaultValue
+        value = toValue(defaultValue)
         trigger()
       }, toValue(afterMs))
 


### PR DESCRIPTION
Now you can use MaybeRefOrGetter as the reset-to value.

```js
refAutoReset(() => 'default', 1000)
```