### PR TITLE
fix(useEventListener): immutable options on removal, close #2825

### DIFF
--- a/packages/core/useEventListener/index.ts
+++ b/packages/core/useEventListener/index.ts
@@ -164,7 +164,7 @@ export function useEventListener(...args: any[]) {
         return
 
       // create a clone of options, to avoid it being changed reactively on removal
-      const optionsClone = isObject(options) ? { ...options } : undefined
+      const optionsClone = isObject(options) ? { ...options } : options
       cleanups.push(
         ...(events as string[]).flatMap((event) => {
           return (listeners as Function[]).map(listener => register(el, event, listener, optionsClone))

--- a/packages/core/useEventListener/index.ts
+++ b/packages/core/useEventListener/index.ts
@@ -1,5 +1,5 @@
 import type { Arrayable, Fn, MaybeRefOrGetter } from '@vueuse/shared'
-import { noop, toValue, tryOnScopeDispose } from '@vueuse/shared'
+import { isObject, noop, toValue, tryOnScopeDispose } from '@vueuse/shared'
 import { watch } from 'vue-demi'
 import type { MaybeElementRef } from '../unrefElement'
 import { unrefElement } from '../unrefElement'
@@ -163,9 +163,11 @@ export function useEventListener(...args: any[]) {
       if (!el)
         return
 
+      // create a clone of options, to avoid it being changed reactively on removal
+      const optionsClone = isObject(options) ? { ...options } : undefined
       cleanups.push(
         ...(events as string[]).flatMap((event) => {
-          return (listeners as Function[]).map(listener => register(el, event, listener, options))
+          return (listeners as Function[]).map(listener => register(el, event, listener, optionsClone))
         }),
       )
     },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f9326b4</samp>

Fixed a bug in `useEventListener` and improved its type checking. The bug affected the `once` option, which now works as expected. The type checking function ensures that the `options` parameter is either a boolean or an object.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f9326b4</samp>

*  Import `isObject` function to check `options` parameter type ([link](https://github.com/vueuse/vueuse/pull/3346/files?diff=unified&w=0#diff-830e350c5d6d8c12673ac43e7736d6171361e43f9a9a9cef443b5715b6d84745L2-R2))
*  Clone `options` parameter to prevent reactive changes when removing listener ([link](https://github.com/vueuse/vueuse/pull/3346/files?diff=unified&w=0#diff-830e350c5d6d8c12673ac43e7736d6171361e43f9a9a9cef443b5715b6d84745L166-R170))
*  Fix bug where `once` option would not work properly for repeated listeners ([link](https://github.com/vueuse/vueuse/pull/3346/files?diff=unified&w=0#diff-830e350c5d6d8c12673ac43e7736d6171361e43f9a9a9cef443b5715b6d84745L166-R170))
