### PR TITLE
feat(useEventSource)!: reactive url params, new options

### DIFF
--- a/packages/core/useEventSource/demo.vue
+++ b/packages/core/useEventSource/demo.vue
@@ -1,0 +1,29 @@
+<script lang="ts" setup>
+import { ref } from 'vue-demi'
+import { useEventSource } from '.'
+
+const url = ref('https://sse.dev/test')
+const messages = ref<string[]>([])
+const res = useEventSource(url, {
+  onMessage(es, e) {
+    messages.value.push(e.data)
+  },
+})
+</script>
+
+<template>
+  <div>
+    <input v-model="url" type="text">
+    status: {{ res.status.value }}
+    <button :disabled="res.status.value !== 'CLOSED'" @click="res.open">
+      open
+    </button>
+    <button :disabled="res.status.value !== 'OPEN'" @click="res.close">
+      close
+    </button>
+    <pre>data: {{ res.data.value }}</pre>
+    <pre>onMessages: {{ messages }}</pre>
+  </div>
+</template>
+
+<style lang="scss"></style>

--- a/packages/core/useEventSource/index.ts
+++ b/packages/core/useEventSource/index.ts
@@ -1,9 +1,30 @@
 import type { Ref } from 'vue-demi'
 import { ref, shallowRef } from 'vue-demi'
-import { tryOnScopeDispose } from '@vueuse/shared'
-import { useEventListener } from '../useEventListener'
+import type { MaybeRefOrGetter } from '@vueuse/shared'
+import { toValue, tryOnScopeDispose, watchWithFilter } from '@vueuse/shared'
 
-export type UseEventSourceOptions = EventSourceInit
+export type UseEventSourceOptions = EventSourceInit & {
+  /**
+   * Connect eventsource immediate after calling this function.
+   *
+   * @default true
+   */
+  immediate?: boolean
+
+  onConnected?: (es: Event) => void
+  onError?: (es: EventSource, event: Event) => void
+  onMessage?: (es: EventSource, event: MessageEvent) => void
+}
+
+export interface UseEventSourceReturn {
+  data: Ref<string | null>
+  status: Ref<'OPEN' | 'CONNECTING' | 'CLOSED'>
+  eventSource: Ref<EventSource | null>
+  error: Ref<Event | null>
+
+  open: () => void
+  close: () => void
+}
 
 /**
  * Reactive wrapper for EventSource.
@@ -11,66 +32,75 @@ export type UseEventSourceOptions = EventSourceInit
  * @see https://vueuse.org/useEventSource
  * @see https://developer.mozilla.org/en-US/docs/Web/API/EventSource/EventSource EventSource
  * @param url
- * @param events
  * @param options
  */
-export function useEventSource(url: string | URL, events: Array<string> = [], options: UseEventSourceOptions = {}) {
-  const event: Ref<string | null> = ref(null)
+export function useEventSource(url: MaybeRefOrGetter<string>, options: UseEventSourceOptions = {}): UseEventSourceReturn {
   const data: Ref<string | null> = ref(null)
-  const status = ref('CONNECTING') as Ref<'OPEN' | 'CONNECTING' | 'CLOSED'>
+  const status = ref('CLOSED') as Ref<'OPEN' | 'CONNECTING' | 'CLOSED'>
   const eventSource = ref(null) as Ref<EventSource | null>
   const error = shallowRef(null) as Ref<Event | null>
 
   const {
+    onConnected = () => {},
+    onMessage = () => {},
+    onError = () => {},
+    immediate = true,
     withCredentials = false,
   } = options
 
+  const updateStatus = () => {
+    status.value = eventSource.value?.readyState === EventSource.OPEN
+      ? 'OPEN'
+      : eventSource.value?.readyState === EventSource.CONNECTING
+        ? 'CONNECTING'
+        : 'CLOSED'
+  }
+
   const close = () => {
     if (eventSource.value) {
+      data.value = null
       eventSource.value.close()
       eventSource.value = null
-      status.value = 'CLOSED'
+      updateStatus()
     }
   }
 
-  const es = new EventSource(url, { withCredentials })
-
-  eventSource.value = es
-
-  es.onopen = () => {
-    status.value = 'OPEN'
-    error.value = null
-  }
-
-  es.onerror = (e) => {
-    status.value = 'CLOSED'
-    error.value = e
-  }
-
-  es.onmessage = (e: MessageEvent) => {
-    event.value = null
-    data.value = e.data
-  }
-
-  for (const event_name of events) {
-    useEventListener(es, event_name, (e: Event & { data?: string }) => {
-      event.value = event_name
-      data.value = e.data || null
-    })
-  }
-
-  tryOnScopeDispose(() => {
+  const open = () => {
     close()
+    eventSource.value = new EventSource(toValue(url), { withCredentials })
+    updateStatus()
+
+    eventSource.value.onopen = (e) => {
+      updateStatus()
+      error.value = null
+      onConnected(e)
+    }
+
+    eventSource.value.onerror = (e) => {
+      updateStatus()
+      error.value = e
+      onError(eventSource.value!, e)
+    }
+
+    eventSource.value.onmessage = (e: MessageEvent) => {
+      data.value = e.data
+      onMessage(eventSource.value!, e)
+    }
+  }
+
+  watchWithFilter(() => toValue(url), () => open(), {
+    immediate,
+    eventFilter: invoke => immediate && invoke(),
   })
+
+  tryOnScopeDispose(close)
 
   return {
     eventSource,
-    event,
     data,
     status,
     error,
+    open,
     close,
   }
 }
-
-export type UseEventSourceReturn = ReturnType<typeof useEventSource>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

1. when message is same data string can't track the data.value changed. add some callback function to resolve this.
2. url change will close the old EventSource and start a new EventSoure.
3. add a immediate options.
4. remove events params(I don't know why we need this) if we need this i can rollback this feature.

closes: #3353

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
#3353
---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d640220</samp>

This pull request adds a new feature to the `useEventSource` function that allows it to accept dynamic and reactive urls and more options for the event source connection and events. It also adds a `demo.vue` file that demonstrates how to use the function in a Vue component.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d640220</samp>

*  Add a `useEventSource` function to create and manage an event source connection and data ([link](https://github.com/vueuse/vueuse/pull/3354/files?diff=unified&w=0#diff-b72fd2901e38163c28e638d63e4b29be022f1057e48b42758c080fcbc560fcadL14-R106))
  - Accept a url parameter that can be a ref, a getter function, or a plain value ([link](https://github.com/vueuse/vueuse/pull/3354/files?diff=unified&w=0#diff-b72fd2901e38163c28e638d63e4b29be022f1057e48b42758c080fcbc560fcadL3-R28))
  - Use `watchWithFilter` to react to url changes and call `open` to create a new event source instance ([link](https://github.com/vueuse/vueuse/pull/3354/files?diff=unified&w=0#diff-b72fd2901e38163c28e638d63e4b29be022f1057e48b42758c080fcbc560fcadL14-R106))
  - Attach event listeners for `onConnected`, `onMessage`, and `onError` callbacks from the options ([link](https://github.com/vueuse/vueuse/pull/3354/files?diff=unified&w=0#diff-b72fd2901e38163c28e638d63e4b29be022f1057e48b42758c080fcbc560fcadL14-R106))
  - Set `data` to null when closing the connection ([link](https://github.com/vueuse/vueuse/pull/3354/files?diff=unified&w=0#diff-b72fd2901e38163c28e638d63e4b29be022f1057e48b42758c080fcbc560fcadL14-R106))
  - Update `status` based on the event source `readyState` ([link](https://github.com/vueuse/vueuse/pull/3354/files?diff=unified&w=0#diff-b72fd2901e38163c28e638d63e4b29be022f1057e48b42758c080fcbc560fcadL14-R106))
  - Return an object with `data`, `status`, `close`, and `open` properties ([link](https://github.com/vueuse/vueuse/pull/3354/files?diff=unified&w=0#diff-b72fd2901e38163c28e638d63e4b29be022f1057e48b42758c080fcbc560fcadL14-R106))
* Add a `demo.vue` file to show how to use the `useEventSource` function in a Vue component ([link](https://github.com/vueuse/vueuse/pull/3354/files?diff=unified&w=0#diff-72b109cf8ecab30ebf57bbb3e9f558ae7560cf85aa6026d0323e8a3f026c850bR1-R29))
  - Import the function from `index.ts` ([link](https://github.com/vueuse/vueuse/pull/3354/files?diff=unified&w=0#diff-72b109cf8ecab30ebf57bbb3e9f558ae7560cf85aa6026d0323e8a3f026c850bR1-R29))
  - Create reactive refs for the url, messages, and the return value of `useEventSource` ([link](https://github.com/vueuse/vueuse/pull/3354/files?diff=unified&w=0#diff-72b109cf8ecab30ebf57bbb3e9f558ae7560cf85aa6026d0323e8a3f026c850bR1-R29))
  - Use the options to handle the `onMessage` event and append the data to the messages array ([link](https://github.com/vueuse/vueuse/pull/3354/files?diff=unified&w=0#diff-72b109cf8ecab30ebf57bbb3e9f558ae7560cf85aa6026d0323e8a3f026c850bR1-R29))
  - Render UI elements to display and control the event source connection and data ([link](https://github.com/vueuse/vueuse/pull/3354/files?diff=unified&w=0#diff-72b109cf8ecab30ebf57bbb3e9f558ae7560cf85aa6026d0323e8a3f026c850bR1-R29))
* Add some imports from the `@vueuse/shared` package, such as `toValue`, `watchWithFilter`, and `MaybeRefOrGetter` types ([link](https://github.com/vueuse/vueuse/pull/3354/files?diff=unified&w=0#diff-b72fd2901e38163c28e638d63e4b29be022f1057e48b42758c080fcbc560fcadL3-R28))
* Add some additional properties to the `UseEventSourceOptions` type, such as `immediate`, `onConnected`, `onError`, and `onMessage`, to allow more customization and callbacks for the event source connection and events ([link](https://github.com/vueuse/vueuse/pull/3354/files?diff=unified&w=0#diff-b72fd2901e38163c28e638d63e4b29be022f1057e48b42758c080fcbc560fcadL3-R28))
