### PR TITLE
feat(useClamp): useCustomRef as value

### DIFF
--- a/packages/math/useClamp/index.test.ts
+++ b/packages/math/useClamp/index.test.ts
@@ -1,4 +1,4 @@
-import { computed, isReadonly, ref } from 'vue-demi'
+import { computed, customRef, isReadonly, ref } from 'vue-demi'
 import { describe, expect, it } from 'vitest'
 import { useClamp } from '.'
 
@@ -54,6 +54,34 @@ describe('useClamp', () => {
   it('should work with computed', () => {
     const baseRef = ref(10)
     const value = computed(() => baseRef.value)
+    const min = ref(0)
+    const max = ref(100)
+
+    const v = useClamp(value, min, max)
+
+    expect(v.value).toBe(10)
+
+    baseRef.value = -10
+    expect(v.value).toBe(0)
+
+    baseRef.value = 110
+    expect(v.value).toBe(100)
+
+    expect(isReadonly(v)).toBeTruthy()
+  })
+
+  it('should work with customRef', () => {
+    const baseRef = ref(10)
+    const value = customRef((track, trigger) => ({
+      get: () => {
+        track()
+        return baseRef.value
+      },
+      set: (v: number) => {
+        baseRef.value = v
+        trigger()
+      },
+    }))
     const min = ref(0)
     const max = ref(100)
 

--- a/packages/math/useClamp/index.ts
+++ b/packages/math/useClamp/index.ts
@@ -3,6 +3,10 @@ import { computed, isReadonly, isRef, ref } from 'vue-demi'
 import type { MaybeRefOrGetter, ReadonlyRefOrGetter } from '@vueuse/shared'
 import { clamp, toValue } from '@vueuse/shared'
 
+function isCustomRef(value: MaybeRefOrGetter<number>) {
+  return isRef(value) && '_get' in value && '_set' in value
+}
+
 export function useClamp(
   value: ReadonlyRefOrGetter<number>,
   min: MaybeRefOrGetter<number>,
@@ -24,7 +28,7 @@ export function useClamp(
  * @param max
  */
 export function useClamp(value: MaybeRefOrGetter<number>, min: MaybeRefOrGetter<number>, max: MaybeRefOrGetter<number>) {
-  if (typeof value === 'function' || isReadonly(value) || isRef(value))
+  if (typeof value === 'function' || isReadonly(value) || isCustomRef(value))
     return computed(() => clamp(toValue(value), toValue(min), toValue(max)))
 
   const _value = ref(value)

--- a/packages/math/useClamp/index.ts
+++ b/packages/math/useClamp/index.ts
@@ -1,9 +1,15 @@
 import type { ComputedRef, Ref } from 'vue-demi'
-import { computed, isReadonly, isRef, ref } from 'vue-demi'
+import { computed, isReadonly, isRef, isVue2, ref } from 'vue-demi'
 import type { MaybeRefOrGetter, ReadonlyRefOrGetter } from '@vueuse/shared'
 import { clamp, toValue } from '@vueuse/shared'
 
 function isCustomRef(value: MaybeRefOrGetter<number>) {
+  if (isVue2 && isRef(value)) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, 'value')
+
+    return descriptor?.get?.name !== 'reactiveGetter' && descriptor?.set?.name !== 'reactiveSetter'
+  }
+
   return isRef(value) && '_get' in value && '_set' in value
 }
 

--- a/packages/math/useClamp/index.ts
+++ b/packages/math/useClamp/index.ts
@@ -1,5 +1,5 @@
 import type { ComputedRef, Ref } from 'vue-demi'
-import { computed, isReadonly, ref } from 'vue-demi'
+import { computed, isReadonly, isRef, ref } from 'vue-demi'
 import type { MaybeRefOrGetter, ReadonlyRefOrGetter } from '@vueuse/shared'
 import { clamp, toValue } from '@vueuse/shared'
 
@@ -24,7 +24,7 @@ export function useClamp(
  * @param max
  */
 export function useClamp(value: MaybeRefOrGetter<number>, min: MaybeRefOrGetter<number>, max: MaybeRefOrGetter<number>) {
-  if (typeof value === 'function' || isReadonly(value))
+  if (typeof value === 'function' || isReadonly(value) || isRef(value))
     return computed(() => clamp(toValue(value), toValue(min), toValue(max)))
 
   const _value = ref(value)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

fixes #3347

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f20b6c7</samp>

Enhanced `useClamp` to handle custom refs and added a test case for it. Used `vue-demi` for cross-compatibility with Vue 2 and 3.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f20b6c7</samp>

*  Add support for custom refs in `useClamp` ([link](https://github.com/vueuse/vueuse/pull/3363/files?diff=unified&w=0#diff-29e28e6c01397e5e9c4c12a8afc303dc4e19014b33171f59da1af6c83a3f0478L2-R9), [link](https://github.com/vueuse/vueuse/pull/3363/files?diff=unified&w=0#diff-29e28e6c01397e5e9c4c12a8afc303dc4e19014b33171f59da1af6c83a3f0478L27-R31))
  - Import `isRef` from `vue-demi` and define `isCustomRef` helper function ([link](https://github.com/vueuse/vueuse/pull/3363/files?diff=unified&w=0#diff-29e28e6c01397e5e9c4c12a8afc303dc4e19014b33171f59da1af6c83a3f0478L2-R9))
  - Modify the condition for returning a computed ref to include custom refs ([link](https://github.com/vueuse/vueuse/pull/3363/files?diff=unified&w=0#diff-29e28e6c01397e5e9c4c12a8afc303dc4e19014b33171f59da1af6c83a3f0478L27-R31))
*  Add test case for `useClamp` with a custom ref ([link](https://github.com/vueuse/vueuse/pull/3363/files?diff=unified&w=0#diff-aeb9dd1428b259f53e957185d8764847f951ac5df043c3dbce11ffefb98e01cfL1-R1), [link](https://github.com/vueuse/vueuse/pull/3363/files?diff=unified&w=0#diff-aeb9dd1428b259f53e957185d8764847f951ac5df043c3dbce11ffefb98e01cfR73-R100))
  - Import `customRef` from `vue-demi` and use it to create a custom ref that wraps another ref ([link](https://github.com/vueuse/vueuse/pull/3363/files?diff=unified&w=0#diff-aeb9dd1428b259f53e957185d8764847f951ac5df043c3dbce11ffefb98e01cfL1-R1))
  - Assert that the value is clamped and the returned ref is readonly ([link](https://github.com/vueuse/vueuse/pull/3363/files?diff=unified&w=0#diff-aeb9dd1428b259f53e957185d8764847f951ac5df043c3dbce11ffefb98e01cfR73-R100))
