### PR TITLE
feat(onKeyStroke): ignore elements option.

### DIFF
--- a/packages/core/onKeyStroke/demo.vue
+++ b/packages/core/onKeyStroke/demo.vue
@@ -5,31 +5,35 @@ import { onKeyStroke } from '@vueuse/core'
 const translateX = ref(0)
 const translateY = ref(0)
 
+const options = { ignoreElements: ['input'] }
+
 onKeyStroke(['w', 'W', 'ArrowUp'], () => {
   translateY.value -= 10
-})
+}, options)
 
 onKeyStroke(['s', 'S', 'ArrowDown'], () => {
   translateY.value += 10
-})
+}, options)
 
 onKeyStroke(['a', 'A', 'ArrowLeft'], () => {
   translateX.value -= 10
-})
+}, options)
 
 onKeyStroke(['d', 'D', 'ArrowRight'], () => {
   translateX.value += 10
-}, { dedupe: true })
+}, { dedupe: true, ...options })
 </script>
 
 <template>
   <div>
+    <input type="text" placeholder="Ignored input" class="input">
     <div class="container border-base">
       <div class="ball" :style="{ transform: `translate(${translateX}px, ${translateY}px)` }" />
     </div>
     <div class="text-center mt-4">
       <p>Use the arrow keys or w a s d keys to control the movement of the ball.</p>
       <p>Repeated events are ignored on the key `d` or `->`.</p>
+      <p>Define tags, elements or custom handlers to ignore events.</p>
     </div>
   </div>
 </template>
@@ -46,6 +50,11 @@ onKeyStroke(['d', 'D', 'ArrowRight'], () => {
   overflow: hidden;
   border: 1px solid #a1a1a130;
   border-radius: 5px;
+}
+
+.input[type="text"] {
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .ball {

--- a/packages/core/onKeyStroke/index.md
+++ b/packages/core/onKeyStroke/index.md
@@ -90,6 +90,14 @@ Or
 onKeyUp('Shift', () => console.log('Shift key up'))
 ```
 
+### Ignore elements
+
+```js
+onKeyStroke(true, (e) => {
+  e.preventDefault()
+}, { ignoreElements: ['input', templateRef, event => true] })
+```
+
 
 ## Shorthands
 

--- a/packages/core/onKeyStroke/index.test.ts
+++ b/packages/core/onKeyStroke/index.test.ts
@@ -82,4 +82,70 @@ describe('onKeyStroke', () => {
     createKeyEvent('A', 'keydown', true)
     expect(callBackFn).toBeCalledTimes(1)
   })
+
+  it('should ignore with inline tags', () => {
+    onKeyStroke('A', callBackFn, { target: element, ignoreElements: ['div'] })
+    createKeyEvent('A', 'keydown')
+    expect(callBackFn).toBeCalledTimes(0)
+  })
+
+  it('should not ignore with not targeted inline tags', () => {
+    onKeyStroke('A', callBackFn, { target: element, ignoreElements: ['span', 'section', 'form'] })
+    createKeyEvent('A', 'keydown')
+    expect(callBackFn).toBeCalledTimes(1)
+  })
+
+  it('should ignore with ref inline tags', () => {
+    onKeyStroke('A', callBackFn, { target: element, ignoreElements: [ref('div')] })
+    createKeyEvent('A', 'keydown')
+    expect(callBackFn).toBeCalledTimes(0)
+  })
+
+  it('should ignore with function', () => {
+    onKeyStroke('A', callBackFn, { target: element, ignoreElements: [() => true] })
+    createKeyEvent('A', 'keydown')
+    createKeyEvent('A', 'keydown')
+
+    expect(callBackFn).toBeCalledTimes(0)
+  })
+
+  it('should not ignore with function returned false', () => {
+    onKeyStroke('A', callBackFn, { target: element, ignoreElements: [() => false] })
+    createKeyEvent('A', 'keydown')
+    expect(callBackFn).toBeCalledTimes(1)
+  })
+
+  it('should ignore with HTMLElement', () => {
+    onKeyStroke('A', callBackFn, { target: element, ignoreElements: [element.value] })
+    createKeyEvent('A', 'keydown')
+    expect(callBackFn).toBeCalledTimes(0)
+  })
+
+  it('should ignore with ref HTMLElement', () => {
+    onKeyStroke('A', callBackFn, { target: element, ignoreElements: [element] })
+    createKeyEvent('A', 'keydown')
+    expect(callBackFn).toBeCalledTimes(0)
+  })
+
+  it('should not ignore with not targeted HTMLElement', () => {
+    const anotherEl = ref(document.createElement('div'))
+
+    onKeyStroke('A', callBackFn, { target: element, ignoreElements: [anotherEl.value] })
+    createKeyEvent('A', 'keydown')
+    expect(callBackFn).toBeCalledTimes(1)
+  })
+
+  it('should work with several cases', () => {
+    const anotherEl = ref(document.createElement('div'))
+
+    onKeyStroke('A', callBackFn, {
+      target: element,
+      ignoreElements: [
+        anotherEl.value, 'input', () => false],
+    })
+
+    createKeyEvent('A', 'keydown')
+    createKeyEvent('A', 'keydown')
+    expect(callBackFn).toBeCalledTimes(2)
+  })
 })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

close #3282

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5e82929</samp>

Added a new option to `onKeyStroke` to ignore keyboard events based on custom conditions. Updated the demo, documentation, and test files to reflect this feature. Refactored the event listener logic to handle the new and existing options.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5e82929</samp>

*  Add `ignoreElements` option to `onKeyStroke` function to allow custom handlers to ignore events ([link](https://github.com/vueuse/vueuse/pull/3368/files?diff=unified&w=0#diff-2c7a2e69ae7edcc4ea997e3974ab9752ba58c5189039ddcc1395b5bb6c574f5cR9-R10), [link](https://github.com/vueuse/vueuse/pull/3368/files?diff=unified&w=0#diff-2c7a2e69ae7edcc4ea997e3974ab9752ba58c5189039ddcc1395b5bb6c574f5cR21), [link](https://github.com/vueuse/vueuse/pull/3368/files?diff=unified&w=0#diff-2c7a2e69ae7edcc4ea997e3974ab9752ba58c5189039ddcc1395b5bb6c574f5cL75-R100), [link](https://github.com/vueuse/vueuse/pull/3368/files?diff=unified&w=0#diff-c414cb588c07ed786479d0e273ad76dd031326d30bd1c711f8c04a1dcf065ebcL8-R29))
  * Define new type alias `IgnoreElementCase` for possible ignore cases ([link](https://github.com/vueuse/vueuse/pull/3368/files?diff=unified&w=0#diff-2c7a2e69ae7edcc4ea997e3974ab9752ba58c5189039ddcc1395b5bb6c574f5cR9-R10))
  * Update `OnKeyStrokeOptions` interface to include `ignoreElements` property ([link](https://github.com/vueuse/vueuse/pull/3368/files?diff=unified&w=0#diff-2c7a2e69ae7edcc4ea997e3974ab9752ba58c5189039ddcc1395b5bb6c574f5cR21))
  * Modify `onKeyStroke` function to check if event matches any ignore case and return early if so ([link](https://github.com/vueuse/vueuse/pull/3368/files?diff=unified&w=0#diff-2c7a2e69ae7edcc4ea997e3974ab9752ba58c5189039ddcc1395b5bb6c574f5cL75-R100))
  * Update `onKeyStroke` function calls in `demo.vue` to demonstrate `ignoreElements` feature ([link](https://github.com/vueuse/vueuse/pull/3368/files?diff=unified&w=0#diff-c414cb588c07ed786479d0e273ad76dd031326d30bd1c711f8c04a1dcf065ebcL8-R29))
* Update documentation and tests for `onKeyStroke` function to reflect new option ([link](https://github.com/vueuse/vueuse/pull/3368/files?diff=unified&w=0#diff-0b26cce0e1a3f7c6b7b5f267d37f20ce1aaeaf26eeeed42241c1a6528941fa36L93-R101), [link](https://github.com/vueuse/vueuse/pull/3368/files?diff=unified&w=0#diff-30d97ca9341e728239cfed122cce99c6e0a358155b248ed5a3bd7b9d6d05aebeR85-R150))
  * Add new subsection in `index.md` to show example of using `ignoreElements` with a function ([link](https://github.com/vueuse/vueuse/pull/3368/files?diff=unified&w=0#diff-0b26cce0e1a3f7c6b7b5f267d37f20ce1aaeaf26eeeed42241c1a6528941fa36L93-R101))
  * Add new test cases in `index.test.ts` to cover different scenarios of using `ignoreElements` with strings, refs, functions, and HTMLElements ([link](https://github.com/vueuse/vueuse/pull/3368/files?diff=unified&w=0#diff-30d97ca9341e728239cfed122cce99c6e0a358155b248ed5a3bd7b9d6d05aebeR85-R150))
* Improve UI of `demo.vue` to center input element and explain `ignoreElements` feature ([link](https://github.com/vueuse/vueuse/pull/3368/files?diff=unified&w=0#diff-c414cb588c07ed786479d0e273ad76dd031326d30bd1c711f8c04a1dcf065ebcR36), [link](https://github.com/vueuse/vueuse/pull/3368/files?diff=unified&w=0#diff-c414cb588c07ed786479d0e273ad76dd031326d30bd1c711f8c04a1dcf065ebcR55-R59))
  * Add paragraph element to describe the purpose and usage of `ignoreElements` option ([link](https://github.com/vueuse/vueuse/pull/3368/files?diff=unified&w=0#diff-c414cb588c07ed786479d0e273ad76dd031326d30bd1c711f8c04a1dcf065ebcR36))
  * Add CSS style to center input element ([link](https://github.com/vueuse/vueuse/pull/3368/files?diff=unified&w=0#diff-c414cb588c07ed786479d0e273ad76dd031326d30bd1c711f8c04a1dcf065ebcR55-R59))
