### PR TITLE
fix(useTextareaAutosize): incorrect behavior when resizing vertically…

### DIFF
--- a/packages/core/useTextareaAutosize/demo.vue
+++ b/packages/core/useTextareaAutosize/demo.vue
@@ -10,7 +10,7 @@ const { textarea, input } = useTextareaAutosize()
     <textarea
       ref="textarea"
       v-model="input"
-      class="resize-none"
+      class="resize-y"
       placeholder="What's on your mind?"
     />
   </div>

--- a/packages/core/useTextareaAutosize/index.ts
+++ b/packages/core/useTextareaAutosize/index.ts
@@ -28,7 +28,6 @@ export function useTextareaAutosize(options?: UseTextareaAutosizeOptions) {
 
     let height = ''
 
-    textarea.value!.style.height = '1px'
     textareaScrollHeight.value = textarea.value?.scrollHeight
 
     // If style target is provided update its height
@@ -38,7 +37,9 @@ export function useTextareaAutosize(options?: UseTextareaAutosizeOptions) {
     else
       height = `${textareaScrollHeight.value}px`
 
-    textarea.value!.style.height = height
+    // If the text's height is greater than the target's height, adapt the target's height to the text's height
+    if (textarea.value?.scrollHeight > textarea.value?.clientHeight)
+      textarea.value!.style.height = height
 
     options?.onResize?.()
   }


### PR DESCRIPTION
… (#3372)

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

it seems like it has some issues with resizing when using Y axis or using both axes. Though only X axis works just fine.

See more information [here(#3372)](https://github.com/vueuse/vueuse/issues/3372).

relevant tests here: https://play.vueuse.org/#N4IgDghgxg1hDmBTAziAXAbVAOwgW0XRADcBXRAWgBNE8BLEAGhGQHtSAnKQtEU7MDHhMQNZFA50wAFzqtsRAGrkABABFadFQAoAFhAA2AMxV1sKgGIdE2KLoCUp5CogqaxRAdZgz8FaVkDOmkATxcDLwB3ZxD2FWlWFUjJaUQVAFVsOg8OZEMVZTSAGToAIw4ISRQVI1YOAtUAJhUAMhUAZhFOAyJdaWkwZDQAemH+QXgAOihWPGGyShp6YaDS4bMaAA9JvAArVABfRhx8HhAAAQXSZERh5H1rKhE2Tm4icaERMQkpWXkiADKD0QVAaiHSN38gWCdBQky6HB6vD6AyGow+Uxmc0u5Gut3ulRB5wAjAAGSbEyak9bYLY7fYgI4nAhEHGIPHDGbWZ7sLhnDFfFA-GRyBS8ADCrAiiCgf3MrBMKBu2Fk+UKKkleDArGQMPkGWhshQCKRIBRgxGYwEQmms2GbI5XMQJPJlOpG0Q2z2hwAuswjHQDMa0KAAIJgMCTBboUCpLUGCCpIgAHio2QAfAAdcwqXPJ1KbaSEiDZ3NllTWIwAXkzIALResJZApfLKmIFDwrBoBhrIDMYACtZb5agCeQyF71l1AC9KCEhzny2AE9xdFKaBxewB1fTSADkzn1sU4KnotIA-Avy8Msznk8M08R089hdIiHQtXVpCpgP4bgAVT0G0QCBQwCHU6FnFQDhqDhZhUPcHRuTk6kQPcAG5s2zGZsGQb9f3rYtGFMAQAmglQqz-RBAMLYswISGdEG0ex0MZZhJTqNNcFSKNyBjOtaGXRMzlTbIW1qFVe07bBWCvFRSngXsgngPoKAAVlJUk3EqGA0CoHT1M0uSjCDTZewAPxUGYDDk+te24FVEA4OSwF7Ro5NKTinMndhaRBBdbzzZBIHMOzawAFk2GyQHTYBf2IQxVAOA572CiBsEClRkzS0KgN7ZA8G0jhdOU1SAE5NKK3TvGgYIQkM2tT17aQKHcmKAFl2EhOKVATUpPGglK7hC2970fZ9mHESQZCIGgA2wRAAAU4MGbRgBbPrPDQFQAWkSRsHgRgWwSgxyG2gA5Ug8H6jgjuwA57EZZKgA

I solved this problem by dynamically modifying the textarea's height. When the height of the textarea is higher than the height of the text, keep the height of the textarea unchanged; when the height of the text is higher than the height of the textarea, dynamically modify the height of the textarea.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b075f16</samp>

Fixed and improved `useTextareaAutosize` core function and demo component. The function now handles empty and long texts better and the component allows user-controlled vertical resizing.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b075f16</samp>

* Fix bug that caused textarea to shrink to 1px when input was empty or cleared ([link](https://github.com/vueuse/vueuse/pull/3373/files?diff=unified&w=0#diff-45baa8ff0be8f6ff97e364c8e01fad9b7ff6f0a0a8924765a239c8a47c5f02e4L31))
* Prevent textarea from expanding unnecessarily when text fits within initial height ([link](https://github.com/vueuse/vueuse/pull/3373/files?diff=unified&w=0#diff-45baa8ff0be8f6ff97e364c8e01fad9b7ff6f0a0a8924765a239c8a47c5f02e4L41-R42))
* Allow vertical resizing of textarea by user for better accessibility and user experience ([link](https://github.com/vueuse/vueuse/pull/3373/files?diff=unified&w=0#diff-3de13492210f05bb530affa5933fd9f0452da7136c175c2eb4575e57859c5984L13-R13))
* Update `demo.vue` to reflect changes in `useTextareaAutosize` ([link](https://github.com/vueuse/vueuse/pull/3373/files?diff=unified&w=0#diff-3de13492210f05bb530affa5933fd9f0452da7136c175c2eb4575e57859c5984L13-R13))
