### PR TITLE
docs(useMouse): remove duplicate text on composable documentation

### DIFF
--- a/packages/core/useMouse/index.md
+++ b/packages/core/useMouse/index.md
@@ -39,13 +39,6 @@ const extractor: UseMouseEventExtractor = event => (
 const { x, y, sourceType } = useMouse({ target: parentEl, type: extractor })
 ```
 
-Touch is enabled by default. To only detect mouse changes, set `touch` to `false`.
-The `dragover` event is used to track mouse position while dragging.
-
-```js
-const { x, y } = useMouse({ touch: false })
-```
-
 ## Component Usage
 
 ```html


### PR DESCRIPTION
Remove duplicate text and code block in useMouse compsable documentation page. 
The following is displayed twice: 

"Touch is enabled by default. To only detect mouse changes, set touch to false. The dragover event is used to track mouse position while dragging."

"const { x, y } = useMouse({ touch: false })"


