### PR TITLE
docs(useAsyncState): state is shallowRef by default

### DIFF
--- a/packages/core/useAsyncState/index.md
+++ b/packages/core/useAsyncState/index.md
@@ -4,7 +4,7 @@ category: State
 
 # useAsyncState
 
-Reactive async state. Will not block your setup function and will trigger changes once the promise is ready.
+Reactive async state. Will not block your setup function and will trigger changes once the promise is ready. The state is a `shallowRef` by default.
 
 ## Usage
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Add a sentence to specify that the state is a `shallowRef` by default.

### Additional context

It's not clear that this is a `shallowRef` by default, you have to look at the types or the source code. 

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8f1fc9f</samp>

Update documentation of `useAsyncState` and other functions. Clarify the reactivity behavior and default options of `useAsyncState` in `packages/core/useAsyncState/index.md`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8f1fc9f</samp>

* Clarify that the state returned by `useAsyncState` is a `shallowRef` by default and explain how to use a custom ref factory ([link](https://github.com/vueuse/vueuse/pull/3401/files?diff=unified&w=0#diff-2d44ae5f575855b8e0604f2b85996c3f108d48ee4b1b11fed28332ebd7d3b262L7-R7))
