### PR TITLE
fix(useScroll): reset values when component goes into a deactivated state

### DIFF
--- a/packages/core/useScroll/index.ts
+++ b/packages/core/useScroll/index.ts
@@ -1,4 +1,4 @@
-import { computed, onDeactivated, reactive, ref } from 'vue-demi'
+import { computed, getCurrentInstance, onDeactivated, reactive, ref } from 'vue-demi'
 import type { MaybeRefOrGetter } from '@vueuse/shared'
 import { noop, toValue, useDebounceFn, useThrottleFn } from '@vueuse/shared'
 import { useEventListener } from '../useEventListener'
@@ -151,12 +151,14 @@ export function useScroll(
     bottom: false,
   })
 
-  onDeactivated(() => {
-    internalX.value = internalY.value = 0
+  if (getCurrentInstance()) {
+    onDeactivated(() => {
+      internalX.value = internalY.value = 0
 
-    arrivedState.left = arrivedState.top = true
-    arrivedState.right = arrivedState.bottom = false
-  })
+      arrivedState.left = arrivedState.top = true
+      arrivedState.right = arrivedState.bottom = false
+    })
+  }
 
   const onScrollEnd = (e: Event) => {
     // dedupe if support native scrollend event

--- a/packages/core/useScroll/index.ts
+++ b/packages/core/useScroll/index.ts
@@ -1,4 +1,4 @@
-import { computed, reactive, ref } from 'vue-demi'
+import { computed, onDeactivated, reactive, ref } from 'vue-demi'
 import type { MaybeRefOrGetter } from '@vueuse/shared'
 import { noop, toValue, useDebounceFn, useThrottleFn } from '@vueuse/shared'
 import { useEventListener } from '../useEventListener'
@@ -149,6 +149,13 @@ export function useScroll(
     right: false,
     top: false,
     bottom: false,
+  })
+
+  onDeactivated(() => {
+    internalX.value = internalY.value = 0
+
+    arrivedState.left = arrivedState.top = true
+    arrivedState.right = arrivedState.bottom = false
   })
 
   const onScrollEnd = (e: Event) => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

when a component instance is inserted into the DOM as part of a cached tree (keep-alive) the element scroll value equals 0 by default

### Additional context


---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c964dfe</samp>

Improved `useScroll` hook to handle component deactivation. Added `onDeactivated` dependency to `packages/core/useScroll/index.ts`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c964dfe</samp>

* Import and use `onDeactivated` function from `vue-demi` to reset scroll state when component is deactivated ([link](https://github.com/vueuse/vueuse/pull/3408/files?diff=unified&w=0#diff-6854b45663451a9e8c15d7b4e0bd17a681777359676d0a6c6d8dc32539bdcea6L1-R1), [link](https://github.com/vueuse/vueuse/pull/3408/files?diff=unified&w=0#diff-6854b45663451a9e8c15d7b4e0bd17a681777359676d0a6c6d8dc32539bdcea6R154-R160))
