### PR TITLE
fix(useBreakpoints): add missing breakpoint for the bootstrap

### DIFF
--- a/packages/core/useBreakpoints/breakpoints.ts
+++ b/packages/core/useBreakpoints/breakpoints.ts
@@ -17,6 +17,7 @@ export const breakpointsTailwind = {
  * @see https://getbootstrap.com/docs/5.0/layout/breakpoints
  */
 export const breakpointsBootstrapV5 = {
+  xs: 0,
   sm: 576,
   md: 768,
   lg: 992,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.

---

### Description

Added missing `xs` breakpoint for the bootstrap. Ref - https://getbootstrap.com/docs/5.0/layout/breakpoints/#available-breakpoints

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2d85e32</samp>

Added the `xs` breakpoint to the `breakpointsTailwind` object in `packages/core/useBreakpoints/breakpoints.ts`. This allows users of the `useBreakpoints` function to access the smallest screen size defined by the Tailwind CSS framework.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2d85e32</samp>

*  Add `xs` breakpoint to `breakpointsTailwind` object ([link](https://github.com/vueuse/vueuse/pull/3413/files?diff=unified&w=0#diff-68e970b5e6fd64669abf5ac2cc6a82e378b89224d9971aa943e36927e82135e5R20)) to align with Tailwind CSS breakpoints and enable users to access the smallest screen size
