### PR TITLE
feat: add `Promisify` type definition

### DIFF
--- a/packages/shared/utils/filters.ts
+++ b/packages/shared/utils/filters.ts
@@ -1,7 +1,7 @@
 import { readonly, ref } from 'vue-demi'
 import { toValue } from '../toValue'
 import { noop } from './is'
-import type { AnyFn, ArgumentsType, MaybeRefOrGetter, Pausable } from './types'
+import type { AnyFn, ArgumentsType, Awaited, MaybeRefOrGetter, Pausable, Promisify } from './types'
 
 export type FunctionArgs<Args extends any[] = any[], Return = void> = (...args: Args) => Return
 
@@ -14,7 +14,7 @@ export interface FunctionWrapperOptions<Args extends any[] = any[], This = any> 
 export type EventFilter<Args extends any[] = any[], This = any, Invoke extends AnyFn = AnyFn> = (
   invoke: Invoke,
   options: FunctionWrapperOptions<Args, This>
-) => ReturnType<Invoke> | Promise<ReturnType<Invoke>>
+) => ReturnType<Invoke> | Promisify<ReturnType<Invoke>>
 
 export interface ConfigurableEventFilter {
   /**
@@ -45,7 +45,7 @@ export interface DebounceFilterOptions {
  */
 export function createFilterWrapper<T extends AnyFn>(filter: EventFilter, fn: T) {
   function wrapper(this: any, ...args: ArgumentsType<T>) {
-    return new Promise<ReturnType<T>>((resolve, reject) => {
+    return new Promise<Awaited<ReturnType<T>>>((resolve, reject) => {
       // make sure it's a promise
       Promise.resolve(filter(() => fn.apply(this, args), { fn, thisArg: this, args }))
         .then(resolve)

--- a/packages/shared/utils/types.ts
+++ b/packages/shared/utils/types.ts
@@ -69,7 +69,20 @@ export type Awaitable<T> = Promise<T> | T
 
 export type ArgumentsType<T> = T extends (...args: infer U) => any ? U : never
 
-export type PromisifyFn<T extends AnyFn> = (...args: ArgumentsType<T>) => Promise<ReturnType<T>>
+/**
+ * Compatible with versions below TypeScript 4.5 Awaited
+ */
+export type Awaited<T> =
+  T extends null | undefined ? T : // special case for `null | undefined` when not in `--strictNullChecks` mode
+    T extends object & { then(onfulfilled: infer F, ...args: infer _): any } ? // `await` only unwraps object types with a callable `then`. Non-object types are not unwrapped
+      F extends ((value: infer V, ...args: infer _) => any) ? // if the argument to `then` is callable, extracts the first argument
+        Awaited<V> : // recursively unwrap the value
+        never : // the argument to `then` was not callable
+      T // non-object or non-thenable
+
+export type Promisify<T> = Promise<Awaited<T>>
+
+export type PromisifyFn<T extends AnyFn> = (...args: ArgumentsType<T>) => Promisify<ReturnType<T>>
 
 export interface Pausable {
   /**


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

fixed #3419

In PR #3419, when `PromisifyFn` received an async function, the return value was inferred as `Promise<Promise<T>>`, causing a type error. In this PR, we added the `Promisify` type to address this issue.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a4e30b9</samp>

Improved the type and value handling of async filters and functions in `createFilterWrapper` and `FunctionWrapper`. Added `Awaited` and `Promisify` types in `./types` for compatibility with older TypeScript versions.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a4e30b9</samp>

*  Import and define `Awaited` and `Promisify` types in `types.ts` to handle values that may be promises ([link](https://github.com/vueuse/vueuse/pull/3420/files?diff=unified&w=0#diff-22bf3f60b449d51004bd542887b4120f4b0abc5613be9ee9381e2e338f9cbccbL72-R86))
*  Use `Promisify` type in `FunctionWrapper` type in `filters.ts` to return the same type as the wrapped function ([link](https://github.com/vueuse/vueuse/pull/3420/files?diff=unified&w=0#diff-cdaaa527823b1185c9de2b274c26403a0b7268f5290f1d56f8af29941be6821dL17-R17))
*  Use `Awaited` type in `createFilterWrapper` function in `filters.ts` to resolve or reject the promise with the same value as the wrapped function ([link](https://github.com/vueuse/vueuse/pull/3420/files?diff=unified&w=0#diff-cdaaa527823b1185c9de2b274c26403a0b7268f5290f1d56f8af29941be6821dL48-R48))
*  Import `Awaited` and `Promisify` types from `types.ts` in `filters.ts` to use them in `FunctionWrapper` and `createFilterWrapper` ([link](https://github.com/vueuse/vueuse/pull/3420/files?diff=unified&w=0#diff-cdaaa527823b1185c9de2b274c26403a0b7268f5290f1d56f8af29941be6821dL4-R4))
