### PR TITLE
feat(rxjs): add useExtractedObservable and watchExtractedObservable

### DIFF
--- a/packages/add-ons.md
+++ b/packages/add-ons.md
@@ -88,9 +88,11 @@ Integration wrappers for utility libraries
 Enables RxJS reactive functions in Vue
   - [`from`](https://vueuse.org/rxjs/from/) — / fromEvent
   - [`toObserver`](https://vueuse.org/rxjs/toObserver/) — sugar function to convert a `ref` into an RxJS [Observer](https://rxjs.dev/guide/observer)
+  - [`useExtractedObservable`](https://vueuse.org/rxjs/useExtractedObservable/) — use an RxJS [`Observable`](https://rxjs.dev/guide/observable) as extracted from one or more composables
   - [`useObservable`](https://vueuse.org/rxjs/useObservable/) — use an RxJS [`Observable`](https://rxjs.dev/guide/observable)
   - [`useSubject`](https://vueuse.org/rxjs/useSubject/) — bind an RxJS [`Subject`](https://rxjs.dev/guide/subject) to a `ref` and propagate value changes both ways
   - [`useSubscription`](https://vueuse.org/rxjs/useSubscription/) — use an RxJS [`Subscription`](https://rxjs.dev/guide/subscription) without worrying about unsubscribing from it or creating memory leaks
+  - [`watchExtractedObservable`](https://vueuse.org/rxjs/watchExtractedObservable/) — watch the values of an RxJS [`Observable`](https://rxjs.dev/guide/observable) as extracted from one or more composables
 
 
 ## Firebase - [`@vueuse/firebase`](https://vueuse.org/firebase/README.html)

--- a/packages/rxjs/README.md
+++ b/packages/rxjs/README.md
@@ -16,9 +16,11 @@ npm i <b>@vueuse/rxjs</b> rxjs
 <!--FUNCTIONS_LIST_STARTS-->
   - [`from`](https://vueuse.org/rxjs/from/) — / fromEvent
   - [`toObserver`](https://vueuse.org/rxjs/toObserver/) — sugar function to convert a `ref` into an RxJS [Observer](https://rxjs.dev/guide/observer)
+  - [`useExtractedObservable`](https://vueuse.org/rxjs/useExtractedObservable/) — use an RxJS [`Observable`](https://rxjs.dev/guide/observable) as extracted from one or more composables
   - [`useObservable`](https://vueuse.org/rxjs/useObservable/) — use an RxJS [`Observable`](https://rxjs.dev/guide/observable)
   - [`useSubject`](https://vueuse.org/rxjs/useSubject/) — bind an RxJS [`Subject`](https://rxjs.dev/guide/subject) to a `ref` and propagate value changes both ways
   - [`useSubscription`](https://vueuse.org/rxjs/useSubscription/) — use an RxJS [`Subscription`](https://rxjs.dev/guide/subscription) without worrying about unsubscribing from it or creating memory leaks
+  - [`watchExtractedObservable`](https://vueuse.org/rxjs/watchExtractedObservable/) — watch the values of an RxJS [`Observable`](https://rxjs.dev/guide/observable) as extracted from one or more composables
 
 
 <!--FUNCTIONS_LIST_ENDS-->

--- a/packages/rxjs/index.ts
+++ b/packages/rxjs/index.ts
@@ -1,5 +1,7 @@
 export * from './from'
 export * from './toObserver'
+export * from './useExtractedObservable'
 export * from './useObservable'
 export * from './useSubject'
 export * from './useSubscription'
+export * from './watchExtractedObservable'

--- a/packages/rxjs/useExtractedObservable/demo.vue
+++ b/packages/rxjs/useExtractedObservable/demo.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { ref } from 'vue-demi'
+import { interval } from 'rxjs'
+import { mapTo, scan, startWith } from 'rxjs/operators'
+import { useExtractedObservable } from '.'
+
+const start = ref(0)
+
+const count = useExtractedObservable(
+  start,
+  (start) => {
+    return interval(1000).pipe(
+      mapTo(1),
+      startWith(start),
+      scan((total, next) => next + total),
+    )
+  },
+)
+</script>
+
+<template>
+  <note>Update every 1s</note>
+  <label>
+    Start: <input v-model="start" type="number">
+  </label>
+  <p>Counter: {{ count }}</p>
+</template>

--- a/packages/rxjs/useExtractedObservable/index.md
+++ b/packages/rxjs/useExtractedObservable/index.md
@@ -1,0 +1,118 @@
+---
+category: '@RxJS'
+---
+
+# useExtractedObservable
+
+Use an RxJS [`Observable`](https://rxjs.dev/guide/observable) as extracted from one or more composables, return a `ref`,
+and automatically unsubscribe from it when the component is unmounted.
+
+Automatically unsubscribe on observable change, and automatically unsubscribe from it when the component is unmounted.
+
+Supports signatures that match all overloads
+of [`watch`](https://vuejs.org/guide/essentials/watchers.html#basic-example).
+
+## Usage
+
+```ts
+import { computed } from 'vue'
+import { useExtractedObservable } from '@vueuse/rxjs'
+import ObservableSocket from 'observable-socket'
+import { makeSocket, useUser } from '../some/lib/func'
+
+// setup()
+const user = useUser()
+const lastMessage = useExtractedObservable(user, u => ObservableSocket.create(makeSocket(u.id)).down)
+```
+
+If you want to add custom error handling to an `Observable` that might error, you can supply an optional `onError`
+configuration. Without this, RxJS will treat any error in the supplied `Observable` as an "unhandled error" and it will
+be thrown in a new call stack and reported to `window.onerror` (or `process.on('error')` if you happen to be in Node).
+
+```ts
+import { ref } from 'vue'
+import { useExtractedObservable } from '@vueuse/rxjs'
+import { interval } from 'rxjs'
+import { mapTo, scan, startWith, tap } from 'rxjs/operators'
+
+// setup()
+const start = ref(0)
+
+const count = useExtractedObservable(
+  start,
+  (start) => {
+    return interval(1000).pipe(
+      mapTo(1),
+      startWith(start),
+      scan((total, next) => next + total),
+      tap((n) => {
+        if (n === 10)
+          throw new Error('oops')
+      })
+    )
+  },
+  {
+    onError: (err) => {
+      console.log(err.message) // "oops"
+    },
+  }
+)
+```
+
+You can also supply an optional `onComplete` configuration if you need to attach special behavior when the watched
+observable completes.
+
+```ts
+import { ref } from 'vue'
+import { useExtractedObservable } from '@vueuse/rxjs'
+import { interval } from 'rxjs'
+import { mapTo, scan, startWith, takeWhile } from 'rxjs/operators'
+
+// setup()
+const start = ref(0)
+
+const count = useExtractedObservable(
+  start,
+  (start) => {
+    return interval(1000).pipe(
+      mapTo(1),
+      startWith(start),
+      scan((total, next) => next + total),
+      takeWhile(num => num < 10)
+    )
+  },
+  {
+    onComplete: () => {
+      console.log('Done!')
+    },
+  }
+)
+```
+
+If you want, you can also pass `watch` options as the last argument:
+
+```ts
+import { ref } from 'vue'
+import { useExtractedObservable } from '@vueuse/rxjs'
+import { interval } from 'rxjs'
+import { mapTo, scan, startWith, takeWhile } from 'rxjs/operators'
+
+// setup()
+const start = ref<number>()
+
+const count = useExtractedObservable(
+  start,
+  (start) => {
+    return interval(1000).pipe(
+      mapTo(1),
+      startWith(start),
+      scan((total, next) => next + total),
+      takeWhile(num => num < 10)
+    )
+  },
+  {},
+  {
+    immediate: false
+  }
+)
+```

--- a/packages/rxjs/useExtractedObservable/index.test.ts
+++ b/packages/rxjs/useExtractedObservable/index.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it, vi } from 'vitest'
+import { BehaviorSubject, Subject, of } from 'rxjs'
+import { nextTick, reactive, ref } from 'vue-demi'
+import { delay, endWith, tap } from 'rxjs/operators'
+import { useExtractedObservable } from './index'
+
+const waitFor = (delay: number) => new Promise(resolve => setTimeout(resolve, delay))
+
+describe('useExtractedObservable', () => {
+  describe('when no options are provided', () => {
+    it('should call the extractor immediately', () => {
+      const obs = new Subject<number>()
+
+      const last = ref(42)
+
+      const extractor = vi.fn((lastValue: number) => obs.pipe(endWith(lastValue)))
+
+      /* const refObs = */ useExtractedObservable(last, extractor)
+
+      expect(extractor).toHaveBeenCalledOnce()
+      expect(extractor.mock.lastCall![0]).toStrictEqual(last.value)
+    })
+  })
+
+  describe('when initialValue is not provided', () => {
+    it('should have undefined as a value until the observable emits a value', async () => {
+      expect.hasAssertions()
+      const obs = new Subject<number>()
+
+      const last = ref(42)
+
+      const refObs = useExtractedObservable(last, lastValue => obs.pipe(endWith(lastValue)))
+
+      expect(refObs.value).toBeUndefined()
+
+      obs.next(23)
+
+      await nextTick()
+
+      expect(refObs.value).toStrictEqual(23)
+    })
+  })
+
+  describe('when initialValue is provided', () => {
+    it('should have initialValue as a value until the observable emits a value', async () => {
+      expect.hasAssertions()
+      const obs = new Subject<number>()
+
+      const last = ref(42)
+
+      const refObs = useExtractedObservable(last, lastValue => obs.pipe(endWith(lastValue)), {
+        initialValue: 13,
+      })
+
+      expect(refObs.value).toStrictEqual(13)
+
+      obs.next(23)
+
+      await nextTick()
+
+      expect(refObs.value).toStrictEqual(23)
+    })
+
+    it('should hold the first emitted value if the observable emits values immediately on subscription', async () => {
+      expect.hasAssertions()
+      const obs = new BehaviorSubject(16)
+
+      const last = ref(42)
+
+      const refObs = useExtractedObservable(last, () => obs, {
+        initialValue: 13,
+      })
+
+      expect(refObs.value).toStrictEqual(16)
+    })
+  })
+
+  describe('when onError is provided', () => {
+    it('calls onError when an observable emits an error', async () => {
+      expect.hasAssertions()
+      const re = ref(0)
+      const error = new Error('Odd number')
+
+      const extractor = (num: number) => of(num).pipe(
+        tap((n: number) => {
+          if (n % 2 === 1)
+            throw error
+        }),
+      )
+      const onError = vi.fn()
+
+      const refObs = useExtractedObservable(re, extractor, {
+        onError,
+      })
+
+      expect(onError).not.toHaveBeenCalled()
+      expect(refObs.value).toStrictEqual(re.value)
+
+      re.value = 1
+
+      await nextTick()
+
+      expect(onError).toHaveBeenCalledOnce()
+      expect(onError).toHaveBeenCalledWith(error)
+    })
+
+    it('doesn\'t call onError when the observable doesn\'t emit an error', async () => {
+      expect.hasAssertions()
+
+      const re = ref([1, 2])
+      const onError = vi.fn()
+
+      /* const obsRef = */ useExtractedObservable(re, (arr: unknown[]) => of(...arr), {
+        onError,
+      })
+
+      expect(onError).not.toHaveBeenCalled()
+
+      re.value = [42]
+
+      await nextTick()
+
+      expect(onError).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when onComplete is provided', () => {
+    it('calls onComplete when an observable completes', async () => {
+      expect.hasAssertions()
+
+      const re = ref()
+      const extractor = (args: unknown[]) => of(...args)
+      const onComplete = vi.fn()
+
+      const obsRef = useExtractedObservable(re, extractor, {
+        onComplete,
+      }, {
+        immediate: false,
+      })
+
+      expect(onComplete).not.toHaveBeenCalled()
+
+      re.value = [19, 42]
+
+      await nextTick()
+      await nextTick()
+
+      expect(onComplete).toHaveBeenCalledOnce()
+      expect(obsRef.value).toStrictEqual(42)
+    })
+
+    it('doesn\'t call onComplete if the watched observable has changed before it could complete', async () => {
+      expect.hasAssertions()
+
+      const re = ref([13, 23, 420])
+      const extractor = (arr: unknown[]) => of(...arr).pipe(
+        delay(1000),
+      )
+      const onComplete = vi.fn()
+
+      const obsRef = useExtractedObservable(re, extractor, {
+        onComplete,
+      })
+
+      setTimeout(() => {
+        re.value = [42]
+      }, 500)
+
+      await waitFor(6000)
+
+      expect(onComplete).toHaveBeenCalledOnce()
+      expect(obsRef.value).toStrictEqual(42)
+    }, 9000)
+  })
+
+  it('properly uses an array of watch sources', async () => {
+    const obj = reactive({
+      xyz: 'abc',
+    })
+
+    const re = ref('def')
+
+    const extractor = ([abc, def]: [string, string]) => of(`${abc}${def}`)
+
+    const obsRef = useExtractedObservable([() => obj.xyz, re], extractor)
+
+    expect(obsRef.value).toStrictEqual('abcdef')
+
+    re.value = 'abc'
+
+    await nextTick()
+
+    expect(obsRef.value).toStrictEqual('abcabc')
+
+    obj.xyz = 'xyz'
+
+    await nextTick()
+
+    expect(obsRef.value).toStrictEqual('xyzabc')
+  })
+
+  it('properly uses an object of watch sources', async () => {
+    expect.hasAssertions()
+
+    const obj = reactive({
+      x: 0,
+      y: 0,
+      z: 0,
+    })
+
+    const extractor = (source: typeof obj) => of(`x: ${source.x}, y: ${source.y}, z: ${source.z}`)
+
+    const obsRef = useExtractedObservable(obj, extractor)
+
+    expect(obsRef.value).toStrictEqual('x: 0, y: 0, z: 0')
+
+    obj.x = 42
+
+    await nextTick()
+
+    expect(obsRef.value).toStrictEqual('x: 42, y: 0, z: 0')
+
+    obj.x = 0
+    obj.y = 1
+
+    await nextTick()
+
+    expect(obsRef.value).toStrictEqual('x: 0, y: 1, z: 0')
+
+    obj.x = 1
+    obj.y = 0
+    obj.z = 1
+
+    await nextTick()
+
+    expect(obsRef.value).toStrictEqual('x: 1, y: 0, z: 1')
+  })
+
+  it('properly uses a function as a watch source', async () => {
+    expect.hasAssertions()
+
+    const obj = reactive({
+      stuff: 'xyz',
+    })
+
+    const obsRef = useExtractedObservable(() => obj.stuff, val => of(`pre-${val}`))
+
+    expect(obsRef.value).toStrictEqual(`pre-${obj.stuff}`)
+
+    obj.stuff = 'test'
+
+    await nextTick()
+
+    expect(obsRef.value).toStrictEqual(`pre-${obj.stuff}`)
+  })
+})

--- a/packages/rxjs/useExtractedObservable/index.ts
+++ b/packages/rxjs/useExtractedObservable/index.ts
@@ -1,0 +1,124 @@
+import type { MapOldSources, MapSources, MultiWatchSources } from '@vueuse/shared'
+import { tryOnScopeDispose } from '@vueuse/shared'
+import type { Ref, WatchOptions, WatchSource } from 'vue-demi'
+import { readonly, shallowRef, watch } from 'vue-demi'
+import type { Subscription } from 'rxjs'
+import type { WatchExtractedObservableCallback } from '../watchExtractedObservable'
+import type { UseObservableOptions } from '../useObservable'
+
+export interface UseExtractedObservableOptions<E> extends UseObservableOptions<E> {
+  onComplete?: () => void
+}
+
+// overload: array of multiple sources + cb
+export function useExtractedObservable<
+  T extends MultiWatchSources,
+  E,
+  Immediate extends Readonly<boolean> = false,
+>(
+  sources: [...T],
+  extractor: WatchExtractedObservableCallback<
+    MapSources<T>,
+    MapOldSources<T, Immediate>,
+    E
+  >,
+  options?: UseExtractedObservableOptions<E>,
+  watchOptions?: WatchOptions<Immediate>,
+): Readonly<Ref<E>>
+
+// overload: multiple sources w/ `as const`
+// watch([foo, bar] as const, () => {})
+// somehow [...T] breaks when the type is readonly
+export function useExtractedObservable<
+  T extends Readonly<MultiWatchSources>,
+  E,
+  Immediate extends Readonly<boolean> = false,
+>(
+  sources: T,
+  extractor: WatchExtractedObservableCallback<
+    MapSources<T>,
+    MapOldSources<T, Immediate>,
+    E
+  >,
+  options?: UseExtractedObservableOptions<E>,
+  watchOptions?: WatchOptions<Immediate>,
+): Readonly<Ref<E>>
+
+// overload: single source + cb
+export function useExtractedObservable<
+  T,
+  E,
+  Immediate extends Readonly<boolean> = false,
+>(
+  sources: WatchSource<T>,
+  extractor: WatchExtractedObservableCallback<
+    T,
+    Immediate extends true ? T | undefined : T,
+    E
+  >,
+  options?: UseExtractedObservableOptions<E>,
+  watchOptions?: WatchOptions<Immediate>,
+): Readonly<Ref<E>>
+
+// overload: watching reactive object w/ cb
+export function useExtractedObservable<
+  T extends object,
+  E,
+  Immediate extends Readonly<boolean> = false,
+>(
+  sources: T,
+  extractor: WatchExtractedObservableCallback<
+    T,
+    Immediate extends true ? T | undefined : T,
+    E
+  >,
+  options?: UseExtractedObservableOptions<E>,
+  watchOptions?: WatchOptions<Immediate>,
+): Readonly<Ref<E>>
+
+// implementation
+export function useExtractedObservable<T = any, E = unknown, Immediate extends Readonly<boolean> = false>(
+  source: T | WatchSource<T>,
+  extractor: WatchExtractedObservableCallback<any, any, E>,
+  options?: UseExtractedObservableOptions<E>,
+  watchOptions?: WatchOptions<Immediate>,
+): Readonly<Ref<E>> {
+  let subscription: Subscription | undefined
+
+  tryOnScopeDispose(() => {
+    subscription?.unsubscribe()
+
+    // Set to undefined to avoid calling unsubscribe multiple times on a same subscription
+    subscription = undefined
+  })
+
+  // Construct it first so that the `watch` can override the value if the observable emits immediately
+  const obsRef = shallowRef<E | undefined>(options?.initialValue)
+
+  watch(source as any, (value, oldValue, onCleanup) => {
+    subscription?.unsubscribe()
+
+    if (typeof value !== 'undefined' && value !== null) {
+      const observable = extractor(value, oldValue, onCleanup)
+      subscription = observable.subscribe({
+        error: (err) => {
+          options?.onError?.(err)
+        },
+        complete: () => {
+          options?.onComplete?.()
+        },
+        next: (val) => {
+          obsRef.value = val
+        },
+      })
+    }
+    else {
+      subscription = undefined
+    }
+  }, {
+    immediate: true,
+    ...watchOptions,
+  })
+
+  return readonly(obsRef) as Readonly<Ref<E>>
+}

--- a/packages/rxjs/watchExtractedObservable/demo.vue
+++ b/packages/rxjs/watchExtractedObservable/demo.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+import type { Observable } from 'rxjs'
+import { fromEvent } from 'rxjs'
+import { map, skip, tap } from 'rxjs/operators'
+import { computed, reactive, ref } from 'vue-demi'
+import { watchExtractedObservable } from './index'
+
+class AudioPlayer {
+  public readonly reachEnd$: Observable<unknown>
+
+  /**
+   * Player progress as a number within [0;1]
+   */
+  public readonly progress$: Observable<number>
+
+  constructor(
+    public readonly audio: HTMLAudioElement,
+  ) {
+    let _magic = false
+    this.reachEnd$ = fromEvent(this.audio, 'ended')
+      .pipe(
+        tap(() => {
+          _magic = !_magic
+        }),
+        map(() => _magic),
+      )
+
+    this.progress$ = fromEvent(this.audio, 'timeupdate')
+      .pipe(
+        skip(1),
+        map(() => this.audio.currentTime / this.audio.duration),
+      )
+  }
+
+  async togglePlay() {
+    if (this.audio.paused)
+      return this.play()
+    else
+      return this.pause()
+  }
+
+  async play(): Promise<void> {
+    if (!this.audio.paused)
+      return
+
+    return this.audio.play()
+  }
+
+  async pause(): Promise<void> {
+    if (this.audio.paused)
+      return
+
+    return this.audio.pause()
+  }
+
+  /**
+   * @param percentage - A number in the range [0;1]
+   */
+  seek(percentage: number) {
+    this.audio.currentTime = percentage * this.audio.duration
+  }
+}
+
+const audio = ref<HTMLAudioElement>()
+const player = computed(() => audio.value ? new AudioPlayer(audio.value) : null)
+
+const state = reactive({
+  progress: 0,
+})
+
+watchExtractedObservable(player, p => p.progress$, (percentage: number) => {
+  state.progress = 100 * percentage
+})
+</script>
+
+<template>
+  <p>
+    Progress: {{ state.progress }}%
+  </p>
+  <audio ref="audio" src="https://upload.wikimedia.org/wikipedia/commons/f/f1/Sintel_movie_4K.webm" controls />
+</template>

--- a/packages/rxjs/watchExtractedObservable/index.md
+++ b/packages/rxjs/watchExtractedObservable/index.md
@@ -1,0 +1,86 @@
+---
+category: '@RxJS'
+---
+
+# watchExtractedObservable
+
+Watch the values of an RxJS [`Observable`](https://rxjs.dev/guide/observable) as extracted from one or more composables.
+
+Automatically unsubscribe on observable change, and automatically unsubscribe from it when the component is unmounted.
+
+Supports all overloads of [`watch`](https://vuejs.org/guide/essentials/watchers.html#basic-example).
+
+## Usage
+
+```ts
+import { computed, ref } from 'vue'
+import { watchExtractedObservable } from '@vueuse/rxjs'
+import { AudioPlayer } from '../my/libs/AudioPlayer'
+
+// setup()
+
+const audio = ref<HTMLAudioElement>()
+const player = computed(() => (audio.value ? new AudioPlayer(audio) : null))
+const state = reactive({
+  progress: 0,
+})
+
+watchExtractedObservable(player, p => p.progress$, (percentage) => {
+  state.progress = percentage * 100
+})
+```
+
+If you want to add custom error handling to an `Observable` that might error, you can supply an optional `onError` configuration. Without this, RxJS will treat any error in the supplied `Observable` as an "unhandled error" and it will be thrown in a new call stack and reported to `window.onerror` (or `process.on('error')` if you happen to be in Node).
+
+You can also supply an optional `onComplete` configuration if you need to attach special behavior when the watched observable completes.
+
+```ts
+import { computed, ref } from 'vue'
+import { watchExtractedObservable } from '@vueuse/rxjs'
+import { AudioPlayer } from '../my/libs/AudioPlayer'
+
+// setup()
+
+const audio = ref<HTMLAudioElement>()
+const player = computed(() => (audio.value ? new AudioPlayer(audio) : null))
+const state = reactive({
+  progress: 0,
+})
+
+watchExtractedObservable(player, p => p.progress$, (percentage) => {
+  state.progress = percentage * 100
+}, {
+  onError: (err: unknown) => {
+    console.error(err)
+  },
+  onComplete: () => {
+    state.progress = 100 // or 0, or whatever
+  },
+})
+```
+
+If you want, you can also pass `watch` options as the last argument:
+
+```ts
+import { computed, ref } from 'vue'
+import { watchExtractedObservable } from '@vueuse/rxjs'
+import { AudioPlayer } from '../my/libs/AudioPlayer'
+
+// setup()
+
+const audio = ref<HTMLAudioElement>()
+const player = computed(() => (audio.value ? new AudioPlayer(audio) : null))
+const state = reactive({
+  progress: 0,
+})
+
+watchExtractedObservable(player, p => p.progress$, (percentage) => {
+  state.progress = percentage * 100
+}, {
+  onError: (err: unknown) => {
+    console.error(err)
+  }
+}, {
+  immediate: true
+})
+```

--- a/packages/rxjs/watchExtractedObservable/index.test.ts
+++ b/packages/rxjs/watchExtractedObservable/index.test.ts
@@ -1,0 +1,282 @@
+import type { MockedFunction } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ComputedRef, Ref } from 'vue-demi'
+import type { Observable, Subject } from 'rxjs'
+import { BehaviorSubject, of } from 'rxjs'
+import { computed, nextTick, reactive, ref } from 'vue-demi'
+import { delay, map, tap } from 'rxjs/operators'
+import { watchExtractedObservable } from './index'
+
+class TestWrapper {
+  public readonly obs$: Subject<number>
+
+  constructor(private num: number) {
+    this.obs$ = new BehaviorSubject<number>(num)
+  }
+
+  incr() {
+    this.obs$.next(++this.num)
+  }
+}
+
+const waitFor = (delay: number) => new Promise(resolve => setTimeout(resolve, delay))
+
+describe('watchExtractedObservable', () => {
+  describe('when no options are provided', () => {
+    let numRef: Ref<number | undefined>
+    let obj: ComputedRef<TestWrapper | null>
+    let extractor: MockedFunction<(wrapper: TestWrapper) => Observable<number>>
+    let callback: MockedFunction<(num: number) => void>
+
+    beforeEach(() => {
+      numRef = ref<number>()
+      obj = computed(() => typeof numRef.value == 'number' ? new TestWrapper(numRef.value) : null)
+      extractor = vi.fn().mockImplementation((wrapper: TestWrapper) => wrapper.obs$)
+      callback = vi.fn().mockImplementation((num: number) => console.log(num))
+    })
+
+    it('calls neither the extractor nor the callback if the provided ref is nullish', () => {
+      const handle = watchExtractedObservable(obj, extractor, callback)
+
+      expect(extractor).not.toHaveBeenCalled()
+      expect(callback).not.toHaveBeenCalled()
+
+      handle()
+    })
+
+    it('calls the extractor and the callback after the ref has changed', async () => {
+      expect.hasAssertions()
+
+      const handle = watchExtractedObservable(obj, extractor, callback)
+
+      numRef.value = 0
+
+      await nextTick()
+
+      expect(extractor).toHaveBeenCalledOnce()
+
+      expect(callback).toHaveBeenCalledOnce()
+      expect(callback).toHaveBeenCalledWith(numRef.value)
+
+      handle()
+    })
+  })
+
+  describe('when onError is provided', () => {
+    it('calls onError when an observable emits an error', async () => {
+      expect.hasAssertions()
+
+      const re = ref(0)
+      const error = new Error('Odd number')
+
+      const extractor = (num: number) => of(num).pipe(
+        tap((n: number) => {
+          if (n % 2 === 1)
+            throw error
+        }),
+      )
+      const callback = vi.fn()
+      const onError = vi.fn()
+
+      const handle = watchExtractedObservable(re, extractor, callback, {
+        onError,
+      }, {
+        immediate: true,
+      })
+
+      expect(callback).toHaveBeenCalledOnce()
+      expect(callback).toHaveBeenCalledWith(re.value)
+      expect(onError).not.toHaveBeenCalled()
+
+      re.value = 1
+
+      await nextTick()
+
+      expect(onError).toHaveBeenCalledOnce()
+      expect(onError).toHaveBeenCalledWith(error)
+      expect(callback).toHaveBeenCalledOnce()
+
+      handle()
+    })
+
+    it('doesn\'t call onError when the observable doesn\'t emit an error', async () => {
+      expect.hasAssertions()
+
+      const re = ref([1, 2])
+      const callback = vi.fn()
+      const onError = vi.fn()
+
+      const handle = watchExtractedObservable(re, (arr: unknown[]) => of(...arr), callback, {
+        onError,
+      }, {
+        immediate: true,
+      })
+
+      expect(onError).not.toHaveBeenCalled()
+      expect(callback).toHaveBeenCalledTimes(2)
+      expect(callback).toHaveBeenCalledWith(1)
+      expect(callback).toHaveBeenLastCalledWith(2)
+
+      re.value = [42]
+
+      await nextTick()
+
+      expect(onError).not.toHaveBeenCalled()
+      expect(callback).toHaveBeenCalledTimes(3)
+      expect(callback).toHaveBeenLastCalledWith(42)
+
+      handle()
+    })
+  })
+
+  describe('when onComplete is provided', () => {
+    it('calls onComplete when an observable completes', async () => {
+      const re = ref([1, 2])
+      const extractor = (args: unknown[]) => of(...args)
+      const callback = vi.fn()
+      const onComplete = vi.fn()
+
+      const handle = watchExtractedObservable(re, extractor, callback, {
+        onComplete,
+      })
+
+      expect(callback).not.toHaveBeenCalled()
+      expect(onComplete).not.toHaveBeenCalled()
+
+      re.value = [1, 3, 6]
+
+      await nextTick()
+
+      expect(callback).toHaveBeenCalledTimes(3)
+      expect(onComplete).toHaveBeenCalledOnce()
+
+      re.value = [42]
+
+      await nextTick()
+
+      expect(callback).toHaveBeenCalledTimes(4)
+      expect(onComplete).toHaveBeenCalledTimes(2)
+
+      handle()
+    })
+
+    it('doesn\'t call onComplete if the watched observable has changed before it could complete', async () => {
+      expect.hasAssertions()
+
+      const re = ref([42, 23, 420])
+      const extractor = (arr: unknown[]) => of(...arr).pipe(
+        delay(1000),
+        map(() => 42),
+      )
+      const onComplete = vi.fn()
+
+      const handle = watchExtractedObservable(re, extractor, () => {}, {
+        onComplete,
+      }, {
+        immediate: true,
+      })
+
+      setTimeout(() => {
+        re.value = [42]
+      }, 500)
+
+      await waitFor(6000)
+
+      expect(onComplete).toHaveBeenCalledOnce()
+
+      handle()
+    }, 9000)
+  })
+
+  it('properly uses an array of watch sources', () => {
+    const obj = reactive({
+      xyz: 'abc',
+    })
+
+    const re = ref('def')
+
+    const extractor = ([abc, def]: [string, string]) => of([abc, def])
+    const callback = vi.fn(() => {})
+
+    const handle = watchExtractedObservable([() => obj.xyz, re], extractor, callback, {}, {
+      immediate: true,
+    })
+
+    expect(callback).toHaveBeenCalledOnce()
+    expect(callback).toHaveBeenCalledWith(['abc', 'def'])
+
+    handle()
+  })
+
+  it('properly uses an object of watch sources', async () => {
+    expect.hasAssertions()
+
+    const obj = reactive({
+      x: 0,
+      y: 0,
+      z: 0,
+    })
+
+    const extractor = (source: typeof obj) => of(`x: ${source.x}, y: ${source.y}, z: ${source.z}`)
+
+    const callback = vi.fn(() => {})
+
+    const handle = watchExtractedObservable(obj, extractor, callback, {}, {
+      immediate: true,
+    })
+
+    expect(callback).toHaveBeenLastCalledWith('x: 0, y: 0, z: 0')
+
+    obj.x = 42
+
+    await nextTick()
+
+    expect(callback).toHaveBeenLastCalledWith('x: 42, y: 0, z: 0')
+
+    obj.x = 0
+    obj.y = 1
+
+    await nextTick()
+
+    expect(callback).toHaveBeenLastCalledWith('x: 0, y: 1, z: 0')
+
+    obj.x = 1
+    obj.y = 0
+    obj.z = 1
+
+    await nextTick()
+
+    expect(callback).toHaveBeenLastCalledWith('x: 1, y: 0, z: 1')
+
+    expect(callback).toHaveBeenCalledTimes(4)
+
+    handle()
+  })
+
+  it('properly uses a function as a watch source', async () => {
+    expect.hasAssertions()
+
+    const obj = reactive({
+      stuff: 'xyz',
+    })
+
+    const callback = vi.fn(() => {})
+
+    const handle = watchExtractedObservable(() => obj.stuff, val => of(`pre-${val}`), callback)
+
+    expect(callback).not.toHaveBeenCalled()
+
+    await nextTick()
+
+    expect(callback).not.toHaveBeenCalled()
+
+    obj.stuff = 'test'
+
+    await nextTick()
+
+    expect(callback).toHaveBeenCalledOnce()
+    expect(callback).toHaveBeenCalledWith('pre-test')
+
+    handle()
+  })
+})

--- a/packages/rxjs/watchExtractedObservable/index.ts
+++ b/packages/rxjs/watchExtractedObservable/index.ts
@@ -1,0 +1,118 @@
+import type { WatchOptions, WatchSource, WatchStopHandle } from 'vue-demi'
+import { watch } from 'vue-demi'
+import type { Observable, Subscription } from 'rxjs'
+import type { MapOldSources, MapSources, MultiWatchSources } from '@vueuse/shared'
+import { tryOnScopeDispose } from '@vueuse/shared'
+
+export type OnCleanup = (cleanupFn: () => void) => void
+export type WatchExtractedObservableCallback<Value, OldValue, ObservableElement> = (value: NonNullable<Value>, oldValue: OldValue, onCleanup: OnCleanup) => Observable<ObservableElement>
+
+export interface WatchExtractedObservableOptions {
+  onError?: (err: unknown) => void
+  onComplete?: () => void
+}
+
+// overload: array of multiple sources + cb
+export function watchExtractedObservable<
+  T extends MultiWatchSources,
+  E,
+  Immediate extends Readonly<boolean> = false,
+>(
+  sources: [...T],
+  extractor: WatchExtractedObservableCallback<
+    MapSources<T>,
+    MapOldSources<T, Immediate>,
+    E
+  >,
+  callback: (snapshot: E) => void,
+  subscriptionOptions?: WatchExtractedObservableOptions,
+  watchOptions?: WatchOptions<Immediate>
+): WatchStopHandle
+
+// overload: multiple sources w/ `as const`
+// watch([foo, bar] as const, () => {})
+// somehow [...T] breaks when the type is readonly
+export function watchExtractedObservable<
+  T extends Readonly<MultiWatchSources>,
+  E,
+  Immediate extends Readonly<boolean> = false,
+>(
+  source: T,
+  extractor: WatchExtractedObservableCallback<
+    MapSources<T>,
+    MapOldSources<T, Immediate>,
+    E
+  >,
+  callback: (snapshot: E) => void,
+  subscriptionOptions?: WatchExtractedObservableOptions,
+  watchOptions?: WatchOptions<Immediate>
+): WatchStopHandle
+
+// overload: single source + cb
+export function watchExtractedObservable<
+  T,
+  E,
+  Immediate extends Readonly<boolean> = false,
+>(
+  source: WatchSource<T>,
+  extractor: WatchExtractedObservableCallback<
+    T,
+    Immediate extends true ? T | undefined : T,
+    E
+  >,
+  callback: (snapshot: E) => void,
+  subscriptionOptions?: WatchExtractedObservableOptions,
+  watchOptions?: WatchOptions<Immediate>
+): WatchStopHandle
+
+// overload: watching reactive object w/ cb
+export function watchExtractedObservable<
+  T extends object,
+  E,
+  Immediate extends Readonly<boolean> = false,
+>(
+  source: T,
+  extractor: WatchExtractedObservableCallback<
+    T,
+    Immediate extends true ? T | undefined : T,
+    E
+  >,
+  callback: (snapshot: E) => void,
+  subscriptionOptions?: WatchExtractedObservableOptions,
+  watchOptions?: WatchOptions<Immediate>
+): WatchStopHandle
+
+// implementation
+export function watchExtractedObservable<T = any, E = unknown, Immediate extends Readonly<boolean> = false>(
+  source: T | WatchSource<T>,
+  extractor: WatchExtractedObservableCallback<any, any, E>,
+  callback: (snapshot: E) => void,
+  subscriptionOptions?: WatchExtractedObservableOptions,
+  watchOptions?: WatchOptions<Immediate>,
+): WatchStopHandle {
+  let subscription: Subscription | undefined
+
+  tryOnScopeDispose(() => {
+    subscription?.unsubscribe()
+
+    // Set to undefined to avoid calling unsubscribe multiple times on a same subscription
+    subscription = undefined
+  })
+
+  return watch(source as any, (value, oldValue, onCleanup) => {
+    subscription?.unsubscribe()
+
+    if (typeof value !== 'undefined' && value !== null) {
+      const observable = extractor(value, oldValue, onCleanup)
+      subscription = observable.subscribe({
+        next: callback,
+        error: subscriptionOptions?.onError,
+        complete: subscriptionOptions?.onComplete,
+      })
+    }
+    else {
+      // Set to undefined to avoid calling unsubscribe multiple times on a same subscription
+      subscription = undefined
+    }
+  }, watchOptions)
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Introducing `useExtractedObservable` and `watchExtractedObservable` to play nicer with composables. These new composables also allow for better interoperability with libraries (and other kinds of existing code) that use and expose `Observable`s.

The concept is that you have (watch) sources that you observe (the composable way) and use to create an `Observable`. In one case you get the new values in a `shallowRef` à la `useObservable`, in the other you just react to new values à la `watch`.

One of the obvious use cases that comes to mind is how to interact with DOM refs and classes that take an `Element` as a constructor argument that would then expose one or more `Observable` instances. You have to created a `computed` to get an instance of you class. You can have a `computed` to get a reference to your observables, but then you can't just access the observable property to pass it to `useObservable`.

With `useExtractedObservable` and `watchExtractedObservable`, you can both keep sound reactivity and use RxJS as freely as you want.

```ts
// setup()
const audio = ref<HTMLAudioElement>();
const player = computed(() => audio.value ? new Player(audio.value) : null);
const progress = useExtractedObservable(player, p => p.progress$);
```

Observables and related subscriptions are disposed of properly (on end of an effect scope, on unmount, or on change of observable) so that DX remains friction free and UX stays coherent.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

One of the design choices I've kept from my self-rolled implementation was checking whether the new watched value is `undefined` or ` null`. It doesn't make sense to me to be able to extract an observable from either `undefined` or `null`, but that is obviously up to debate. This restriction only applies to non-array and non-object value types.

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7e8912f</samp>

This pull request adds two new functions to the RxJS add-on: `useExtractedObservable` and `watchExtractedObservable`. These functions allow creating and watching observables that depend on one or more composables, such as refs or other observables. The pull request also updates the documentation, demos, and tests for the new functions.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7e8912f</samp>

*  Add two new functions to the RxJS add-on: `useExtractedObservable` and `watchExtractedObservable` ([link](https://github.com/vueuse/vueuse/pull/3453/files?diff=unified&w=0#diff-3c96f38abeba0dbfc4e7cbae4edea29383a8e43115b3b394be2cfce33784d861L91-R95), [link](https://github.com/vueuse/vueuse/pull/3453/files?diff=unified&w=0#diff-359eebeea6a1f18b4e143f7b2557a9ed8beb99cb6715510793d6bfa710071963L19-R23), [link](https://github.com/vueuse/vueuse/pull/3453/files?diff=unified&w=0#diff-3a10d9a010c68a760a264432891d688110b303b19469004c496daee3e792f729L3-R7))
  * `useExtractedObservable` creates an observable that depends on one or more composables ([link](https://github.com/vueuse/vueuse/pull/3453/files?diff=unified&w=0#diff-73f2dff7fd6f00d2b68ab376d65e1766f52839afae7cb9f62baab1cb16427925R1-R124))
  * `watchExtractedObservable` subscribes to an observable extracted from one or more composables and invokes a callback on each emission ([link](https://github.com/vueuse/vueuse/pull/3453/files?diff=unified&w=0#diff-cefddbcab1a8f04168b68a7d72c461b8a4731e83ac582d62365da8027a042242R1-R118))
* Provide documentation, demo, and test files for the new functions ([link](https://github.com/vueuse/vueuse/pull/3453/files?diff=unified&w=0#diff-fecbcc17b97fbac9f8996ee3d3a8fb93fe4864e24d2c22a3044f53408d8230e3R1-R27), [link](https://github.com/vueuse/vueuse/pull/3453/files?diff=unified&w=0#diff-820277068d1dfbe64afed18e3205e170617403e93230e8f888d151ed38c500b9R1-R118), [link](https://github.com/vueuse/vueuse/pull/3453/files?diff=unified&w=0#diff-61fcdb80ecf89b0f1533599ada397297043fb8ac0167eb2030402cbfa7662e6dR1-R256), [link](https://github.com/vueuse/vueuse/pull/3453/files?diff=unified&w=0#diff-179ae406c4f3f68ca55887e3efb613a0b1637f34eed9744fcafe93688f63f71aR1-R81), [link](https://github.com/vueuse/vueuse/pull/3453/files?diff=unified&w=0#diff-05f5d1217bc50d4f709e67d6afaee2edf39b7c44fccea15075919597dfadbfbdR1-R86), [link](https://github.com/vueuse/vueuse/pull/3453/files?diff=unified&w=0#diff-f0ca65ba8ee752d29a8b8d60f6ea062f5619b7af922da1251ad08e1821022784R1-R282))
  * The documentation files explain the usage, parameters, options, and overloads of the functions, and provide code examples and links to the demo and source files ([link](https://github.com/vueuse/vueuse/pull/3453/files?diff=unified&w=0#diff-820277068d1dfbe64afed18e3205e170617403e93230e8f888d151ed38c500b9R1-R118), [link](https://github.com/vueuse/vueuse/pull/3453/files?diff=unified&w=0#diff-05f5d1217bc50d4f709e67d6afaee2edf39b7c44fccea15075919597dfadbfbdR1-R86))
  * The demo files show how to use the functions in a Vue component, and import the functions from the index file ([link](https://github.com/vueuse/vueuse/pull/3453/files?diff=unified&w=0#diff-fecbcc17b97fbac9f8996ee3d3a8fb93fe4864e24d2c22a3044f53408d8230e3R1-R27), [link](https://github.com/vueuse/vueuse/pull/3453/files?diff=unified&w=0#diff-179ae406c4f3f68ca55887e3efb613a0b1637f34eed9744fcafe93688f63f71aR1-R81))
  * The test files use vitest to test various scenarios and assertions, and import the functions from the index file and some other dependencies ([link](https://github.com/vueuse/vueuse/pull/3453/files?diff=unified&w=0#diff-61fcdb80ecf89b0f1533599ada397297043fb8ac0167eb2030402cbfa7662e6dR1-R256), [link](https://github.com/vueuse/vueuse/pull/3453/files?diff=unified&w=0#diff-f0ca65ba8ee752d29a8b8d60f6ea062f5619b7af922da1251ad08e1821022784R1-R282))
