### PR TITLE
feat(useRafFn): option fpsLimit

### DIFF
--- a/packages/core/useRafFn/index.ts
+++ b/packages/core/useRafFn/index.ts
@@ -14,7 +14,6 @@ export interface UseRafFnCallbackArguments {
    * Time elapsed since the creation of the web page. See {@link https://developer.mozilla.org/en-US/docs/Web/API/DOMHighResTimeStamp#the_time_origin Time origin}.
    */
   timestamp: DOMHighResTimeStamp
-
 }
 
 export interface UseRafFnOptions extends ConfigurableWindow {

--- a/packages/core/useRafFn/index.ts
+++ b/packages/core/useRafFn/index.ts
@@ -24,7 +24,8 @@ export interface UseRafFnOptions extends ConfigurableWindow {
    */
   immediate?: boolean
   /**
-   * The maximum delta value in milliseconds for a frame to be considered valid.
+   * The maximum frame per second to execute the function.
+   * Set to `undefined` to disable the limit.
    *
    * @default undefined
    */
@@ -46,7 +47,7 @@ export function useRafFn(fn: (args: UseRafFnCallbackArguments) => void, options:
   } = options
 
   const isActive = ref(false)
-  const interval: null | number = fpsLimit ? 1000 / fpsLimit : null
+  const intervalLimit = fpsLimit ? 1000 / fpsLimit : null
   let previousFrameTimestamp = 0
   let rafId: null | number = null
 
@@ -56,7 +57,7 @@ export function useRafFn(fn: (args: UseRafFnCallbackArguments) => void, options:
 
     const delta = timestamp - (previousFrameTimestamp || timestamp)
 
-    if (interval && delta < interval) {
+    if (intervalLimit && delta < intervalLimit) {
       rafId = window.requestAnimationFrame(loop)
       return
     }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Modern mobile devices have seen significant improvements in screen refresh rates, some even supporting dynamic FPS.If developers use requestAnimationFrame for animations, it can result in inconsistent animation speed.

While developers can enhance this on their own, proactively providing this option would be more DX-friendly.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 76a0296</samp>

Added an option to limit the FPS of `useRafFn` and improved its performance. This allows users to fine-tune the animation or rendering effects created by the function.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 76a0296</samp>

*  Add `fpsLimit` option to `useRafFn` hook to limit the maximum frames per second ([link](https://github.com/vueuse/vueuse/pull/3459/files?diff=unified&w=0#diff-80fba29722597fce2f73a9b693b85a627c4c4192a581f0af7cd3f3ce0e68ebdeR26-R31), [link](https://github.com/vueuse/vueuse/pull/3459/files?diff=unified&w=0#diff-80fba29722597fce2f73a9b693b85a627c4c4192a581f0af7cd3f3ce0e68ebdeL38-R49), [link](https://github.com/vueuse/vueuse/pull/3459/files?diff=unified&w=0#diff-80fba29722597fce2f73a9b693b85a627c4c4192a581f0af7cd3f3ce0e68ebdeR59-R63))
  * Destructure `fpsLimit` from `options` parameter and calculate `interval` based on it ([link](https://github.com/vueuse/vueuse/pull/3459/files?diff=unified&w=0#diff-80fba29722597fce2f73a9b693b85a627c4c4192a581f0af7cd3f3ce0e68ebdeL38-R49))
  * Check `interval` against `delta` to determine if current frame is valid or not ([link](https://github.com/vueuse/vueuse/pull/3459/files?diff=unified&w=0#diff-80fba29722597fce2f73a9b693b85a627c4c4192a581f0af7cd3f3ce0e68ebdeR59-R63))
  * Return early and request another animation frame if `delta` is too small ([link](https://github.com/vueuse/vueuse/pull/3459/files?diff=unified&w=0#diff-80fba29722597fce2f73a9b693b85a627c4c4192a581f0af7cd3f3ce0e68ebdeR59-R63))
