### PR TITLE
fix: vue 2 support for provideLocal and injectLocal

### DIFF
--- a/packages/shared/createInjectionState/index.test.ts
+++ b/packages/shared/createInjectionState/index.test.ts
@@ -1,19 +1,20 @@
-import { type InjectionKey, type Ref, defineComponent, h, inject, ref } from 'vue-demi'
-import { createInjectionState } from '@vueuse/shared'
+import { type InjectionKey, type Ref, defineComponent, h, inject, nextTick, ref } from 'vue-demi'
+import { createInjectionState, injectLocal } from '@vueuse/shared'
 import { describe, expect, it } from 'vitest'
-import { mount } from '../../.test'
+import { mount, useSetup } from '../../.test'
 
 describe('createInjectionState', () => {
-  it('should work 1', () => {
+  it('should work for simple nested component', async () => {
     const [useProvideCountState, useCountState] = createInjectionState((initialValue: number) => {
       const count = ref(initialValue)
       return count
     })
 
+    let count: Ref<number> | undefined
+
     const ChildComponent = defineComponent({
       setup() {
-        const count = useCountState()
-        expect(count?.value).toBe(0)
+        count = useCountState()
 
         return () => h('div')
       },
@@ -21,16 +22,20 @@ describe('createInjectionState', () => {
 
     const RootComponent = defineComponent({
       setup() {
-        useProvideCountState(0)
+        useProvideCountState(114514)
 
         return () => h(ChildComponent)
       },
     })
 
-    mount(RootComponent)
+    const vm = mount(RootComponent)
+    await nextTick()
+
+    expect(count?.value).toBe(114514)
+    vm.unmount()
   })
 
-  it('should work (custom key)', () => {
+  it('should work for custom key', async () => {
     const KEY: InjectionKey<Ref<number>> = Symbol('count-state')
 
     const [useProvideCountState, useCountState] = createInjectionState((initialValue: number) => {
@@ -38,12 +43,12 @@ describe('createInjectionState', () => {
       return count
     }, { injectionKey: KEY })
 
+    let count: Ref<number> | undefined
+    let count2: Ref<number> | undefined
     const ChildComponent = defineComponent({
       setup() {
-        const count = useCountState()
-        expect(count?.value).toBe(0)
-        const count2 = inject(KEY)
-        expect(count2?.value).toBe(0)
+        count = useCountState()
+        count2 = inject(KEY)
 
         return () => h('div')
       },
@@ -57,25 +62,43 @@ describe('createInjectionState', () => {
       },
     })
 
-    mount(RootComponent)
+    const vm = mount(RootComponent)
+    await nextTick()
+    expect(count?.value).toBe(0)
+    expect(count2?.value).toBe(0)
+    vm.unmount()
   })
 
-  it('allow call provideLocal and injectLocal in same component', () => {
+  it('allow call useProvidingState and useInjectedState in same component', async () => {
     const [useProvideCountState, useCountState] = createInjectionState((initialValue: number) => {
       const count = ref(initialValue)
       return count
     })
+    const vm = useSetup(() => {
+      useProvideCountState(114514)
+      const count = useCountState()!
 
-    const CanProvidingStateAndInjectedStateInSameComponent = defineComponent({
-      setup() {
-        useProvideCountState(114514)
-        const count = useCountState()!
-        expect(count.value).toBe(114514)
-
-        return () => h('div')
-      },
+      return { count }
     })
+    await nextTick()
+    expect(vm.count).toBe(114514)
+    vm.unmount()
+  })
 
-    mount(CanProvidingStateAndInjectedStateInSameComponent)
+  it('allow call useProvidingState and injectLocal in same component', async () => {
+    const KEY: InjectionKey<Ref<number>> | string = Symbol('count-state')
+    const [useProvideCountState] = createInjectionState((initialValue: number) => {
+      const count = ref(initialValue)
+      return count
+    }, { injectionKey: KEY })
+    const vm = useSetup(() => {
+      useProvideCountState(114514)
+      const count = injectLocal(KEY)!
+
+      return { count }
+    })
+    await nextTick()
+    expect(vm.count).toBe(114514)
+    vm.unmount()
   })
 })

--- a/packages/shared/injectLocal/index.test.ts
+++ b/packages/shared/injectLocal/index.test.ts
@@ -1,0 +1,61 @@
+import { type InjectionKey, defineComponent, getCurrentInstance, h, nextTick } from 'vue-demi'
+import { injectLocal, provideLocal } from '@vueuse/shared'
+import { describe, expect, it } from 'vitest'
+import { mount, useSetup } from '../../.test'
+
+describe('provideLocal injectLocal deps', () => {
+  it('depends on getCurrentInstance().proxy === getCurrentInstance().proxy', async () => {
+    const vm = useSetup(() => {
+      const instance1 = getCurrentInstance()
+      const instance2 = getCurrentInstance()
+      const instanceProxyStable = instance1?.proxy === instance2?.proxy
+      return { instance1, instance2, instanceProxyStable }
+    })
+    await nextTick()
+    expect(vm.instance1).not.toBeNull()
+    expect(vm.instance2).not.toBeNull()
+    expect(vm.instance1).toBeTypeOf('object')
+    expect(vm.instance2).toBeTypeOf('object')
+    expect(vm.instanceProxyStable).toBe(true)
+    vm.unmount()
+  })
+})
+
+describe('provideLocal injectLocal', () => {
+  it('should work for nested component', async () => {
+    const CountKey: InjectionKey<number> | string = Symbol('count')
+    let count: number | undefined
+    const ChildComponent = defineComponent({
+      setup() {
+        count = injectLocal(CountKey)
+
+        return () => h('div')
+      },
+    })
+
+    const RootComponent = defineComponent({
+      setup() {
+        provideLocal(CountKey, 2333)
+
+        return () => h(ChildComponent)
+      },
+    })
+    const vm = mount(RootComponent)
+    await nextTick()
+
+    expect(count).toBe(2333)
+    vm.unmount()
+  })
+
+  it('should work for same component', async () => {
+    const CountKey: InjectionKey<number> | string = Symbol('count')
+    const vm = useSetup(() => {
+      provideLocal(CountKey, 2333)
+      const count = injectLocal(CountKey)!
+      return { count }
+    })
+    await nextTick()
+    expect(vm.count).toBe(2333)
+    vm.unmount()
+  })
+})

--- a/packages/shared/injectLocal/index.ts
+++ b/packages/shared/injectLocal/index.ts
@@ -13,9 +13,9 @@ import { localProvidedStateMap } from '../provideLocal/map'
 // @ts-expect-error overloads are not compatible
 export const injectLocal: typeof inject = (...args) => {
   const key = args[0] as string | symbol
-  const instance = getCurrentInstance()
+  const instance = getCurrentInstance()?.proxy
   if (instance == null)
-    throw new Error('injectEnhancedAllowanceOfCallsFromTheSameComponent must be called in setup')
+    throw new Error('injectLocal must be called in setup')
 
   if (localProvidedStateMap.has(instance) && key in localProvidedStateMap.get(instance)!)
     return localProvidedStateMap.get(instance)![key]

--- a/packages/shared/provideLocal/index.ts
+++ b/packages/shared/provideLocal/index.ts
@@ -11,7 +11,7 @@ import { localProvidedStateMap } from './map'
  * ```
  */
 export const provideLocal: typeof provide = (key, value) => {
-  const instance = getCurrentInstance()
+  const instance = getCurrentInstance()?.proxy
   if (instance == null)
     throw new Error('provideLocal must be called in setup')
 

--- a/packages/shared/provideLocal/map.ts
+++ b/packages/shared/provideLocal/map.ts
@@ -1,3 +1,3 @@
 import type { getCurrentInstance } from 'vue-demi'
 
-export const localProvidedStateMap = new WeakMap<NonNullable<ReturnType<typeof getCurrentInstance>>, Record<string | symbol, any>>()
+export const localProvidedStateMap = new WeakMap<NonNullable<NonNullable<ReturnType<typeof getCurrentInstance>>['proxy']>, Record<string | symbol, any>>()


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

fix vue 2.7  support for provideLocal and injectLocal

See
https://github.com/vuejs/vue/blob/49b6bd4264c25ea41408f066a1835f38bf6fe9f1/src/v3/currentInstance.ts#L5-L14

Every time call getCurrentInstance in vue 2.7 will create a new Object，so we should use getCurrentInstance()?.proxy other than getCurrentInstance() as WeakMap key.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9bfc23c</samp>

This pull request fixes bugs and adds tests for the `provideLocal` and `injectLocal` functions, which enable local state management across components. It uses the `proxy` property of the component instance to access and set the local state in the `localProvidedStateMap` weak map.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9bfc23c</samp>

*  Fix bugs in `provideLocal` and `injectLocal` functions that use the wrong instance object to access and set the local state ([link](https://github.com/vueuse/vueuse/pull/3464/files?diff=unified&w=0#diff-ba81180701e963bbf6dcf1e15f6ef59f90f788179faa05cb16b6624494193925L16-R18), [link](https://github.com/vueuse/vueuse/pull/3464/files?diff=unified&w=0#diff-ebc0176920d2f721b2765598ee0d5f39d9b1eb81174861056ff465591b0d21b2L14-R14))
*  Update the type of the `localProvidedStateMap` variable to use the `proxy` property of the instance as the key ([link](https://github.com/vueuse/vueuse/pull/3464/files?diff=unified&w=0#diff-0aa9ceee4c7b48c3ad9c5bf0d5768e8e69ef2b87ee0e3524a43ff30bc676e8c0L3-R3))
*  Add test cases for `provideLocal` and `injectLocal` functions using `vitest` and `vue-demi` ([link](https://github.com/vueuse/vueuse/pull/3464/files?diff=unified&w=0#diff-7522ecb4b07e9cec47f5b8f739fc0ff0fa9413bcb936c757aa0e2349832f9955R1-R48))
