### PR TITLE
fix(useWebSocket): webworker support

### DIFF
--- a/packages/core/useWebSocket/index.ts
+++ b/packages/core/useWebSocket/index.ts
@@ -287,7 +287,7 @@ export function useWebSocket<Data = any>(
     heartbeatResume = resume
   }
 
-  if (autoClose) {
+  if (autoClose && isClient) {
     useEventListener('beforeunload', () => close())
     tryOnScopeDispose(close)
   }

--- a/packages/core/useWebSocket/index.ts
+++ b/packages/core/useWebSocket/index.ts
@@ -1,7 +1,7 @@
 import type { Ref } from 'vue-demi'
 import { ref, watch } from 'vue-demi'
 import type { Fn, MaybeRefOrGetter } from '@vueuse/shared'
-import { isClient, toRef, tryOnScopeDispose, useIntervalFn } from '@vueuse/shared'
+import { isClient, isWorker, toRef, tryOnScopeDispose, useIntervalFn } from '@vueuse/shared'
 import { useEventListener } from '../useEventListener'
 
 export type WebSocketStatus = 'OPEN' | 'CONNECTING' | 'CLOSED'
@@ -293,7 +293,7 @@ export function useWebSocket<Data = any>(
   }
 
   const open = () => {
-    if (!isClient)
+    if (!isClient || !isWorker)
       return
     close()
     explicitlyClosed = false

--- a/packages/core/useWebSocket/index.ts
+++ b/packages/core/useWebSocket/index.ts
@@ -293,7 +293,7 @@ export function useWebSocket<Data = any>(
   }
 
   const open = () => {
-    if (!isClient || !isWorker)
+    if (!isClient && !isWorker)
       return
     close()
     explicitlyClosed = false

--- a/packages/core/useWebSocket/index.ts
+++ b/packages/core/useWebSocket/index.ts
@@ -287,8 +287,9 @@ export function useWebSocket<Data = any>(
     heartbeatResume = resume
   }
 
-  if (autoClose && isClient) {
-    useEventListener('beforeunload', () => close())
+  if (autoClose) {
+    if (isClient)
+      useEventListener('beforeunload', () => close())
     tryOnScopeDispose(close)
   }
 

--- a/packages/shared/utils/is.ts
+++ b/packages/shared/utils/is.ts
@@ -1,5 +1,6 @@
 /* eslint-disable antfu/top-level-function */
 export const isClient = typeof window !== 'undefined' && typeof document !== 'undefined'
+export const isWorker = typeof WorkerGlobalScope !== 'undefined' && globalThis instanceof WorkerGlobalScope
 export const isDef = <T = any>(val?: T): val is T => typeof val !== 'undefined'
 export const notNullish = <T = any>(val?: T | null | undefined): val is T => val != null
 export const assert = (condition: boolean, ...infos: any[]) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es2020",
     "jsx": "preserve",
-    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "lib": ["ESNext", "DOM", "DOM.Iterable", "webworker"],
     "baseUrl": ".",
     "rootDir": ".",
     "module": "esnext",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [ x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x ] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

This PR solves the issue when useWebsocket is used in a webworker. 

### Additional context
The bug was introduced with PR fix(useWebSocket): ssr support
#3370 

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e648dd4</samp>

Added `isWorker` utility function to check for web worker environment and used it to improve `useWebSocket` compatibility with web workers.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e648dd4</samp>

*  Add `isWorker` function to `@vueuse/shared/utils/is.ts` to check if the current environment is a web worker ([link](https://github.com/vueuse/vueuse/pull/3469/files?diff=unified&w=0#diff-16e06395b506fea663904348dd85973415701966b7a4ef2c464d991d7c833c25R3))
*  Import `isWorker` function in `useWebSocket` and use it to return early from `open` function if the environment is a web worker, since web workers cannot use the `window.WebSocket` constructor ([link](https://github.com/vueuse/vueuse/pull/3469/files?diff=unified&w=0#diff-9b23df18f0f5236a301bc5926a49b4e0ea571aa84752304cc34a2f44047fa0f1L4-R4), [link](https://github.com/vueuse/vueuse/pull/3469/files?diff=unified&w=0#diff-9b23df18f0f5236a301bc5926a49b4e0ea571aa84752304cc34a2f44047fa0f1L296-R296))
