### PR TITLE
feat(watchOnce): return function for manual watcher stopping

### DIFF
--- a/packages/shared/watchOnce/index.ts
+++ b/packages/shared/watchOnce/index.ts
@@ -1,21 +1,23 @@
-import type { WatchCallback, WatchOptions, WatchSource } from 'vue-demi'
+import type { WatchCallback, WatchOptions, WatchSource, WatchStopHandle } from 'vue-demi'
 import { nextTick, watch } from 'vue-demi'
 import type { MapOldSources, MapSources } from '../utils'
 
 // overloads
-export function watchOnce<T extends Readonly<WatchSource<unknown>[]>, Immediate extends Readonly<boolean> = false>(source: [...T], cb: WatchCallback<MapSources<T>, MapOldSources<T, Immediate>>, options?: WatchOptions<Immediate>): void
+export function watchOnce<T extends Readonly<WatchSource<unknown>[]>, Immediate extends Readonly<boolean> = false>(source: [...T], cb: WatchCallback<MapSources<T>, MapOldSources<T, Immediate>>, options?: WatchOptions<Immediate>): WatchStopHandle
 
-export function watchOnce<T, Immediate extends Readonly<boolean> = false>(sources: WatchSource<T>, cb: WatchCallback<T, Immediate extends true ? T | undefined : T>, options?: WatchOptions<Immediate>): void
+export function watchOnce<T, Immediate extends Readonly<boolean> = false>(sources: WatchSource<T>, cb: WatchCallback<T, Immediate extends true ? T | undefined : T>, options?: WatchOptions<Immediate>): WatchStopHandle
 
 // implementation
 export function watchOnce<Immediate extends Readonly<boolean> = false>(
   source: any,
   cb: any,
   options?: WatchOptions<Immediate>,
-): void {
+): WatchStopHandle {
   const stop = watch(source, (...args) => {
     nextTick(() => stop())
 
     return cb(...args)
   }, options)
+
+  return stop
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

All watchers are expected to return `WatchStopHandle` functions, which allow to stop these watchers manually. `watchOnce` was the only watcher, that could not be stopped manually. Now it can.

### Additional context

Although the case, when `watchOnce` should be stopped manually before it'll be triggered, is rare, it is better to be consistent and provide the ability to perform cleanup.

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bf72035</samp>

Return `WatchStopHandle` from `watchOnce` function. This allows users to stop the watcher manually and aligns the function with other `watch` utilities in `vueuse`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bf72035</samp>

*  Return `WatchStopHandle` from `watchOnce` function to allow manual stopping and align with `watch` signature ([link](https://github.com/vueuse/vueuse/pull/3475/files?diff=unified&w=0#diff-6c70097073ea196a62e8d55026d0ca646ea34000a6d165007699a38d048710e0L1-R8), [link](https://github.com/vueuse/vueuse/pull/3475/files?diff=unified&w=0#diff-6c70097073ea196a62e8d55026d0ca646ea34000a6d165007699a38d048710e0L15-R15), [link](https://github.com/vueuse/vueuse/pull/3475/files?diff=unified&w=0#diff-6c70097073ea196a62e8d55026d0ca646ea34000a6d165007699a38d048710e0R21-R22))
