### PR TITLE
feat(useMutationObserver): add `takeRecords` function

### DIFF
--- a/packages/core/useMutationObserver/index.test.ts
+++ b/packages/core/useMutationObserver/index.test.ts
@@ -166,4 +166,25 @@ describe('useMutationObserver', () => {
     await promiseTimeout(10)
     expect(cb).toHaveBeenCalledTimes(1)
   })
+
+  it('should work with takeRecords', async () => {
+    const target = document.createElement('div')
+    const cb = vi.fn()
+
+    const { takeRecords } = useMutationObserver(target, cb, {
+      attributes: true,
+    })
+
+    target.setAttribute('id', 'footer')
+    await promiseTimeout(10)
+    expect(cb).toHaveBeenCalledTimes(1)
+
+    target.setAttribute('id', 'header')
+    const records = takeRecords()
+
+    await promiseTimeout(10)
+    expect(records).toHaveLength(1)
+    expect(records![0].target).toBe(target)
+    expect(cb).toHaveBeenCalledTimes(1)
+  })
 })

--- a/packages/core/useMutationObserver/index.ts
+++ b/packages/core/useMutationObserver/index.ts
@@ -46,6 +46,10 @@ export function useMutationObserver(
     { immediate: true },
   )
 
+  const takeRecords = () => {
+    return observer?.takeRecords()
+  }
+
   const stop = () => {
     cleanup()
     stopWatch()
@@ -56,6 +60,7 @@ export function useMutationObserver(
   return {
     isSupported,
     stop,
+    takeRecords,
   }
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a4d76ea</samp>

This pull request adds a `takeRecords` function to the `useMutationObserver` hook, which lets users access the mutation records without affecting the observer. It also adds a test case for this feature in `index.test.ts`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a4d76ea</samp>

*  Implement and expose `takeRecords` function for `useMutationObserver` hook ([link](https://github.com/vueuse/vueuse/pull/3480/files?diff=unified&w=0#diff-da50736ee00ff6293e6541e95e2518436421b4ddc33730c401b602f349be86b0R49-R52),[link](https://github.com/vueuse/vueuse/pull/3480/files?diff=unified&w=0#diff-da50736ee00ff6293e6541e95e2518436421b4ddc33730c401b602f349be86b0R63))
* Add test case for `takeRecords` function in `index.test.ts` ([link](https://github.com/vueuse/vueuse/pull/3480/files?diff=unified&w=0#diff-8d4441a9e8238cd8a892b795951468494603938a4469271654ef9d93c63bc2eaR169-R189))
