### PR TITLE
fix(onClickOutside): adjust shouldListen handling timing

### DIFF
--- a/packages/core/onClickOutside/index.ts
+++ b/packages/core/onClickOutside/index.ts
@@ -90,8 +90,7 @@ export function onClickOutside<T extends OnClickOutsideOptions>(
     useEventListener(window, 'click', listener, { passive: true, capture }),
     useEventListener(window, 'pointerdown', (e) => {
       const el = unrefElement(target)
-      if (el)
-        shouldListen = !e.composedPath().includes(el) && !shouldIgnore(e)
+      shouldListen = !shouldIgnore(e) && !!(el && !e.composedPath().includes(el))
     }, { passive: true }),
     detectIframe && useEventListener(window, 'blur', (event) => {
       setTimeout(() => {


### PR DESCRIPTION
even if the target is falsy, we should care about the ignore options

fix #3465

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description
* Fix #3465  *
* Function: onClickOutside *

In current logic, if the target is falsy when the event trigger, it won't care about the ignore options which make no sense.
This PR change the logic to judge if should ignore at first before any other judgements related with e
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 018e21c</samp>

Refactor and optimize the `onClickOutside` function in `packages/core/onClickOutside/index.ts` by simplifying and reordering the logic for setting the `shouldListen` variable.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 018e21c</samp>

*  Simplify and optimize the logic for setting `shouldListen` ([link](https://github.com/vueuse/vueuse/pull/3503/files?diff=unified&w=0#diff-8b308f45dba561e732d94afb100d76cc2aee8b7d265690c72e6fdf1e9dc59925L93-R93))
