### PR TITLE
feat(createEventHook): allow trigger to optionally have no parameters

### DIFF
--- a/packages/shared/createEventHook/index.test.ts
+++ b/packages/shared/createEventHook/index.test.ts
@@ -27,6 +27,18 @@ describe('createEventHook', () => {
     expect(message).toBe('Hello World')
   })
 
+  it('should trigger event with no params', () => {
+    let timesFired = 0
+
+    const { on: onResult, trigger } = createEventHook()
+
+    onResult(() => timesFired++)
+    trigger()
+    trigger()
+
+    expect(timesFired).toBe(2)
+  })
+
   it('should add and remove event listener', () => {
     const listener = vi.fn()
     const { on, off, trigger } = createEventHook<string>()


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

---

### Description

Previously, `createEventHook()`'s `trigger()` would always require at least one parameter:

```ts
const { trigger } = createEventHook();

trigger();
//      ^
// TypeScript error: Expected 1 arguments, but got 0
```

Now, parameters are optional. This allows a use case where there is no other information to send when triggering an event, and simply knowing that an event was triggered is all that is needed:

```ts
const { on, trigger } = createEventHook();

// This is now possible:
trigger(/* having no arguments is now allowed */);

// Elsewhere, we can listen for the event:
on((/* no arguments */) => {})
```

### Additional context

I ran into a need for this when I was using `createEventHook()` for some kind of simple event where I had no other information to provide on `trigger()`, and I only cared about the fact that an event was triggered.

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 251b985</samp>

This pull request enhances the `createEventHook` function and its interface to support events without parameters. It also adds a new test case and refactors the type definitions for the event hook callbacks.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 251b985</samp>

*  Simplify type signatures of event hook functions by introducing a new type alias `Callback<T>` that can handle both parameterized and parameterless callbacks ([link](https://github.com/vueuse/vueuse/pull/3507/files?diff=unified&w=0#diff-e7f6c2121aa36ff115952572f25b671a5cc7549c37f2fab6dda05029cd65dbe2L7-R10),[link](https://github.com/vueuse/vueuse/pull/3507/files?diff=unified&w=0#diff-e7f6c2121aa36ff115952572f25b671a5cc7549c37f2fab6dda05029cd65dbe2L23-R30))
*  Allow event hook to trigger events with or without parameters by making the `trigger` function accept an optional parameter of type `T` and invoking the callbacks accordingly ([link](https://github.com/vueuse/vueuse/pull/3507/files?diff=unified&w=0#diff-e7f6c2121aa36ff115952572f25b671a5cc7549c37f2fab6dda05029cd65dbe2L40-R42))
*  Add a new test case in `createEventHook/index.test.ts` to verify that the event hook can be triggered without any parameters and that the registered callbacks are fired ([link](https://github.com/vueuse/vueuse/pull/3507/files?diff=unified&w=0#diff-25029db94c761070c7346023ff0f43b38cf34bbfe14be3c81bbf17c751ecbac3R30-R41))