### PR TITLE
feat(useFileDialog): add directory parameters

### DIFF
--- a/packages/core/useFileDialog/index.md
+++ b/packages/core/useFileDialog/index.md
@@ -13,6 +13,7 @@ import { useFileDialog } from '@vueuse/core'
 
 const { files, open, reset, onChange } = useFileDialog({
   accept: 'image/*', // Set to accept only image files
+  directory: true, // Select directories instead of files if set true
 })
 
 onChange((files) => {

--- a/packages/core/useFileDialog/index.ts
+++ b/packages/core/useFileDialog/index.ts
@@ -23,12 +23,19 @@ export interface UseFileDialogOptions extends ConfigurableDocument {
    * @default false
    */
   reset?: boolean
+  /**
+   * Select directories instead of files.
+   * @see [HTMLInputElement webkitdirectory](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/webkitdirectory)
+   * @default false
+   */
+  directory?: boolean
 }
 
 const DEFAULT_OPTIONS: UseFileDialogOptions = {
   multiple: true,
   accept: '*',
   reset: false,
+  directory: false,
 }
 
 export interface UseFileDialogReturn {
@@ -79,6 +86,8 @@ export function useFileDialog(options: UseFileDialogOptions = {}): UseFileDialog
     }
     input.multiple = _options.multiple!
     input.accept = _options.accept!
+    // webkitdirectory key is not stabled, maybe replaced in the future.
+    input.webkitdirectory = _options.directory!
     if (hasOwn(_options, 'capture'))
       input.capture = _options.capture!
     if (_options.reset)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
- add `directory` parameter to select a whole directory
- adapt to #3441 
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 262a1aa</samp>

This pull request adds a new feature to the `useFileDialog` hook that enables directory selection in some browsers. It also updates the documentation with an example of using this feature.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 262a1aa</samp>

*  Add `directory` option to `useFileDialog` hook to enable selecting directories in the file dialog ([link](https://github.com/vueuse/vueuse/pull/3513/files?diff=unified&w=0#diff-312e918931fbf29ae14be2138936f5c7e89090050c98823cdb84ae0616f04486R26-R31), [link](https://github.com/vueuse/vueuse/pull/3513/files?diff=unified&w=0#diff-312e918931fbf29ae14be2138936f5c7e89090050c98823cdb84ae0616f04486R38), [link](https://github.com/vueuse/vueuse/pull/3513/files?diff=unified&w=0#diff-312e918931fbf29ae14be2138936f5c7e89090050c98823cdb84ae0616f04486R89-R90), [link](https://github.com/vueuse/vueuse/pull/3513/files?diff=unified&w=0#diff-d5ae99cf9b6d776e10189d7470e706f7b2eb652137847bf9e50f27e009fca38eR16))
  * Update the `UseFileDialogOptions` interface and the `DEFAULT_OPTIONS` constant to include the `directory` option, which is a boolean that defaults to false ([link](https://github.com/vueuse/vueuse/pull/3513/files?diff=unified&w=0#diff-312e918931fbf29ae14be2138936f5c7e89090050c98823cdb84ae0616f04486R26-R31), [link](https://github.com/vueuse/vueuse/pull/3513/files?diff=unified&w=0#diff-312e918931fbf29ae14be2138936f5c7e89090050c98823cdb84ae0616f04486R38))
  * Set the `webkitdirectory` attribute of the input element to the value of the `directory` option, using a non-standard feature that works in some browsers ([link](https://github.com/vueuse/vueuse/pull/3513/files?diff=unified&w=0#diff-312e918931fbf29ae14be2138936f5c7e89090050c98823cdb84ae0616f04486R89-R90))
  * Add an example of using the `directory` option in the documentation file `index.md` ([link](https://github.com/vueuse/vueuse/pull/3513/files?diff=unified&w=0#diff-d5ae99cf9b6d776e10189d7470e706f7b2eb652137847bf9e50f27e009fca38eR16))
