### PR TITLE
feat(syncRef): enhance syncRef type restrict

### DIFF
--- a/packages/shared/syncRef/index.test.ts
+++ b/packages/shared/syncRef/index.test.ts
@@ -97,4 +97,149 @@ describe('syncRef', () => {
     expect(right.value).toBe(10)
     expect(left.value).toBe(5)
   })
+
+  it('ts works', () => {
+    const ref0 = ref(0)
+    const ref1 = ref(1)
+    const refString = ref('1')
+    const refNumString = ref<number | string>(1)
+    const refNumBoolean = ref<number | boolean>(1)
+    // L = A && direction === 'both'
+    syncRef(ref0, ref1)()
+    syncRef(ref0, ref1, {
+      direction: 'both',
+    })()
+    syncRef(ref0, ref1, {
+      direction: 'both',
+      transform: {},
+    })()
+    syncRef(ref0, ref1, {
+      direction: 'both',
+      transform: {
+        ltr: v => v,
+      },
+    })()
+    syncRef(ref0, ref1, {
+      direction: 'both',
+      transform: {
+        rtl: v => v,
+      },
+    })()
+    syncRef(ref0, ref1, {
+      direction: 'both',
+      transform: {
+        ltr: v => v,
+        rtl: v => v,
+      },
+    })()
+    syncRef(ref0, ref1, {
+      direction: 'both',
+      transform: {
+        // @ts-expect-error wrong type, should be (left: L) => R
+        ltr: v => v.toString(),
+        rtl: v => v,
+      },
+    })()
+    // L = A && direction === 'ltr'
+    syncRef(ref0, ref1, {
+      direction: 'ltr',
+    })()
+    syncRef(ref0, ref1, {
+      direction: 'ltr',
+      transform: {},
+    })()
+    syncRef(ref0, ref1, {
+      direction: 'ltr',
+      transform: {
+        ltr: v => v,
+      },
+    })()
+    syncRef(ref0, ref1, {
+      direction: 'ltr',
+      transform: {
+      // @ts-expect-error wrong transform type, should be ltr
+        rtl: v => v,
+      },
+    })()
+    // L = A && direction === 'rtl'
+    syncRef(ref0, ref1, {
+      direction: 'rtl',
+    })()
+    syncRef(ref0, ref1, {
+      direction: 'rtl',
+      transform: {},
+    })()
+    syncRef(ref0, ref1, {
+      direction: 'rtl',
+      transform: {
+        rtl: v => v,
+      },
+    })()
+    // L ⊆ R && direction === 'both'
+    // @ts-expect-error wrong type, should provide transform
+    syncRef(ref0, refNumString, {
+      direction: 'both',
+    })()
+    syncRef(ref0, refNumString, {
+      direction: 'both',
+      transform: {
+        ltr: v => v.toString(),
+        rtl: v => Number(v),
+      },
+    })()
+    // L ⊆ R && direction === 'ltr'
+    syncRef(ref0, refNumString, {
+      direction: 'ltr',
+      transform: {
+        ltr: v => v.toString(),
+      },
+    })()
+    // L ⊆ R && direction === 'rtl'
+    syncRef(ref0, refNumString, {
+      direction: 'ltr',
+      transform: {
+        ltr: v => Number(v),
+      },
+    })()
+    // L ∩ R = ∅ && direction === 'both'
+    syncRef(ref0, refString, {
+      direction: 'both',
+      transform: {
+        ltr: v => v.toString(),
+        rtl: v => Number(v),
+      },
+    })()
+    // L ∩ R = ∅ && direction === 'ltr'
+    syncRef(ref0, refString, {
+      direction: 'ltr',
+      transform: {
+        ltr: v => v.toString(),
+      },
+    })()
+    // L ∩ R = ∅ && direction === 'rtl'
+    syncRef(ref0, refString, {
+      direction: 'rtl',
+      transform: {
+        rtl: v => Number(v),
+      },
+    })()
+    // L ∩ R = ∅ && direction === 'both'
+    syncRef(ref0, refString, {
+      direction: 'both',
+      // @ts-expect-error wrong type, should provide ltr
+      transform: {
+        rtl: v => Number(v),
+      },
+    })()
+    // L ∩ R ≠ ∅
+    syncRef(refNumString, refNumBoolean, {
+      transform: {
+        ltr: v => Number(v),
+        rtl: v => Number(v),
+      },
+    })
+
+    // @ts-expect-error lack of options
+    syncRef(ref0, refString)()
+  })
 })

--- a/packages/shared/syncRef/index.test.ts
+++ b/packages/shared/syncRef/index.test.ts
@@ -241,5 +241,13 @@ describe('syncRef', () => {
 
     // @ts-expect-error lack of options
     syncRef(ref0, refString)()
+
+    syncRef(ref0, refNumBoolean, {
+      direction: 'ltr',
+    })()
+
+    syncRef(refNumBoolean, ref0, {
+      direction: 'rtl',
+    })
   })
 })

--- a/packages/shared/syncRef/index.ts
+++ b/packages/shared/syncRef/index.ts
@@ -94,7 +94,7 @@ export type SyncRefOptions<L, R, D extends Direction> = ConfigurableFlushSync & 
       }
     : IncludeButNotEqual<L, R> extends true
       ? {
-          transform: SpecificFieldPartial<Pick<Transform<L, R>, 'ltr'>, 'ltr'>
+          transform?: SpecificFieldPartial<Pick<Transform<L, R>, 'ltr'>, 'ltr'>
         }
       : IncludeButNotEqual<R, L> extends true
         ? {
@@ -119,7 +119,7 @@ export type SyncRefOptions<L, R, D extends Direction> = ConfigurableFlushSync & 
         }
       : IncludeButNotEqual<R, L> extends true
         ? {
-            transform: SpecificFieldPartial<Pick<Transform<L, R>, 'rtl'>, 'rtl'>
+            transform?: SpecificFieldPartial<Pick<Transform<L, R>, 'rtl'>, 'rtl'>
           }
         : IntersectButNotEqual<L, R> extends true
           ? {
@@ -144,7 +144,7 @@ export type SyncRefOptions<L, R, D extends Direction> = ConfigurableFlushSync & 
  * @param right
  * @param [options?]
  */
-export function syncRef<L, R, D extends Direction = 'both'>(
+export function syncRef<L, R, D extends Direction>(
   left: Ref<L>,
   right: Ref<R>,
   ...[options]: Equal<L, R> extends true

--- a/packages/shared/syncRef/index.ts
+++ b/packages/shared/syncRef/index.ts
@@ -142,14 +142,14 @@ export type SyncRefOptions<L, R, D extends Direction> = ConfigurableFlushSync & 
  * 4. A ∩ B = ∅
  * @param left
  * @param right
- * @param args
+ * @param [options?]
  */
 export function syncRef<L, R, D extends Direction = 'both'>(
   left: Ref<L>,
   right: Ref<R>,
-  ...args: Equal<L, R> extends true
-    ? [SyncRefOptions<L, R, D>?]
-    : [SyncRefOptions<L, R, D>]
+  ...[options]: Equal<L, R> extends true
+    ? [options?: SyncRefOptions<L, R, D>]
+    : [options: SyncRefOptions<L, R, D>]
 ) {
   const {
     flush = 'sync',
@@ -157,7 +157,7 @@ export function syncRef<L, R, D extends Direction = 'both'>(
     immediate = true,
     direction = 'both',
     transform = {},
-  } = args[0] || {}
+  } = options || {}
 
   const watchers: WatchPausableReturn[] = []
 

--- a/packages/shared/syncRef/index.ts
+++ b/packages/shared/syncRef/index.ts
@@ -4,7 +4,7 @@ import type { WatchPausableReturn } from '../watchPausable'
 import { pausableWatch } from '../watchPausable'
 
 type Direction = 'ltr' | 'rtl' | 'both'
-type SpecificFieldPartial<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
+type SpecificFieldPartial<T, K extends keyof T> = Partial<Pick<T, K>> & Omit<T, K>
 /**
  * A = B
  */
@@ -37,10 +37,67 @@ type NotIntersect<A, B> = Equal<A, B> extends true
     ? true
     : false
 
+// L = R
+interface EqualType<
+  D extends Direction,
+  L,
+  R,
+  O extends keyof Transform<L, R> = D extends 'both' ? 'ltr' | 'rtl' : D,
+> {
+  transform?: SpecificFieldPartial<Pick<Transform<L, R>, O>, O>
+}
+
+type StrictIncludeMap<IncludeType extends 'LR' | 'RL', D extends Exclude<Direction, 'both'>, L, R> = (Equal<[IncludeType, D], ['LR', 'ltr']>
+& Equal<[IncludeType, D], ['RL', 'rtl']>) extends true
+  ? {
+      transform?: SpecificFieldPartial<Pick<Transform<L, R>, D>, D>
+    } : {
+      transform: Pick<Transform<L, R>, D>
+    }
+
+// L ⊆ R
+type StrictIncludeType<IncludeType extends 'LR' | 'RL', D extends Direction, L, R> = D extends 'both'
+  ? {
+      transform: SpecificFieldPartial<Transform<L, R>, IncludeType extends 'LR' ? 'ltr' : 'rtl'>
+    }
+  : D extends Exclude<Direction, 'both'>
+    ? StrictIncludeMap<IncludeType, D, L, R>
+    : never
+
+// L ∩ R ≠ ∅
+type IntersectButNotEqualType<D extends Direction, L, R> = D extends 'both'
+  ? {
+      transform: Transform<L, R>
+    }
+  : D extends Exclude<Direction, 'both'>
+    ? {
+        transform: Pick<Transform<L, R>, D>
+      }
+    : never
+
+// L ∩ R = ∅
+type NotIntersectType<D extends Direction, L, R> = IntersectButNotEqualType<D, L, R>
 interface Transform<L, R> {
   ltr: (left: L) => R
   rtl: (right: R) => L
 }
+
+type TransformType<D extends Direction, L, R> = Equal<L, R> extends true
+  // L = R
+  ? EqualType<D, L, R>
+  : IncludeButNotEqual<L, R> extends true
+    // L ⊆ R
+    ? StrictIncludeType<'LR', D, L, R>
+    : IncludeButNotEqual<R, L> extends true
+      // R ⊆ L
+      ? StrictIncludeType<'RL', D, L, R>
+      : IntersectButNotEqual<L, R> extends true
+        // L ∩ R ≠ ∅
+        ? IntersectButNotEqualType<D, L, R>
+        : NotIntersect<L, R> extends true
+          // L ∩ R = ∅
+          ? NotIntersectType<D, L, R>
+          : never
 
 export type SyncRefOptions<L, R, D extends Direction> = ConfigurableFlushSync & {
   /**
@@ -63,83 +120,16 @@ export type SyncRefOptions<L, R, D extends Direction> = ConfigurableFlushSync & 
    */
   direction?: D
 
-} & {
-  /**
-   * Custom transform function
-   */
-  both: Equal<L, R> extends true
-    ? {
-        transform?: SpecificFieldPartial<Transform<L, R>, 'ltr' | 'rtl'>
-      }
-    : IncludeButNotEqual<L, R> extends true
-      ? {
-          transform: SpecificFieldPartial<Transform<L, R>, 'ltr'>
-        }
-      : IncludeButNotEqual<R, L> extends true
-        ? {
-            transform: SpecificFieldPartial<Transform<L, R>, 'rtl'>
-          }
-        : IntersectButNotEqual<L, R> extends true
-          ? {
-              transform: Transform<L, R>
-            }
-          : NotIntersect<L, R> extends true
-            ? {
-                transform: Transform<L, R>
-              }
-            : never
-  ltr: Equal<L, R> extends true
-    ? {
-        transform?: SpecificFieldPartial<Pick<Transform<L, R>, 'ltr'>, 'ltr'>
-      }
-    : IncludeButNotEqual<L, R> extends true
-      ? {
-          transform?: SpecificFieldPartial<Pick<Transform<L, R>, 'ltr'>, 'ltr'>
-        }
-      : IncludeButNotEqual<R, L> extends true
-        ? {
-            transform: Pick<Transform<L, R>, 'ltr'>
-          }
-        : IntersectButNotEqual<L, R> extends true
-          ? {
-              transform: Pick<Transform<L, R>, 'ltr'>
-            }
-          : NotIntersect<L, R> extends true
-            ? {
-                transform: Pick<Transform<L, R>, 'ltr'>
-              }
-            : never
-  rtl: Equal<L, R> extends true
-    ? {
-        transform?: SpecificFieldPartial<Pick<Transform<L, R>, 'rtl'>, 'rtl'>
-      }
-    : IncludeButNotEqual<L, R> extends true
-      ? {
-          transform: Pick<Transform<L, R>, 'rtl'>
-        }
-      : IncludeButNotEqual<R, L> extends true
-        ? {
-            transform?: SpecificFieldPartial<Pick<Transform<L, R>, 'rtl'>, 'rtl'>
-          }
-        : IntersectButNotEqual<L, R> extends true
-          ? {
-              transform: Pick<Transform<L, R>, 'rtl'>
-            }
-          : NotIntersect<L, R> extends true
-            ? {
-                transform: Pick<Transform<L, R>, 'rtl'>
-              }
-            : never
-}[D]
+} & TransformType<D, L, R>
 
 /**
  * Two-way refs synchronization.
  * From the set theory perspective to restrict the option's type
  * Check in the following order:
- * 1. A = B
- * 2. A ∩ B ≠ ∅
- * 3. A ⊆ B
- * 4. A ∩ B = ∅
+ * 1. L = R
+ * 2. L ∩ R ≠ ∅
+ * 3. L ⊆ R
+ * 4. L ∩ R = ∅
  * @param left
  * @param right
  * @param [options?]

--- a/packages/shared/syncRef/index.ts
+++ b/packages/shared/syncRef/index.ts
@@ -1,9 +1,48 @@
-import type { Ref } from 'vue-demi'
+import { type Ref } from 'vue-demi'
 import type { ConfigurableFlushSync } from '../utils'
 import type { WatchPausableReturn } from '../watchPausable'
 import { pausableWatch } from '../watchPausable'
 
-export interface SyncRefOptions<L, R = L> extends ConfigurableFlushSync {
+type Direction = 'ltr' | 'rtl' | 'both'
+type SpecificFieldPartial<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
+/**
+ * A = B
+ */
+type Equal<A, B> = A extends B ? (B extends A ? true : false) : false
+
+/**
+ * A ∩ B ≠ ∅
+ */
+type IntersectButNotEqual<A, B> = Equal<A, B> extends true
+  ? false
+  : A & B extends never
+    ? false
+    : true
+
+/**
+ * A ⊆ B
+ */
+type IncludeButNotEqual<A, B> = Equal<A, B> extends true
+  ? false
+  : A extends B
+    ? true
+    : false
+
+/**
+ * A ∩ B = ∅
+ */
+type NotIntersect<A, B> = Equal<A, B> extends true
+  ? false
+  : A & B extends never
+    ? true
+    : false
+
+interface Transform<L, R> {
+  ltr: (left: L) => R
+  rtl: (right: R) => L
+}
+
+export type SyncRefOptions<L, R, D extends Direction> = ConfigurableFlushSync & {
   /**
    * Watch deeply
    *
@@ -22,36 +61,108 @@ export interface SyncRefOptions<L, R = L> extends ConfigurableFlushSync {
    *
    * @default 'both'
    */
-  direction?: 'ltr' | 'rtl' | 'both'
+  direction?: D
 
+} & {
   /**
    * Custom transform function
    */
-  transform?: {
-    ltr?: (left: L) => R
-    rtl?: (right: R) => L
-  }
-}
+  both: Equal<L, R> extends true
+    ? {
+        transform?: SpecificFieldPartial<Transform<L, R>, 'ltr' | 'rtl'>
+      }
+    : IncludeButNotEqual<L, R> extends true
+      ? {
+          transform: SpecificFieldPartial<Transform<L, R>, 'ltr'>
+        }
+      : IncludeButNotEqual<R, L> extends true
+        ? {
+            transform: SpecificFieldPartial<Transform<L, R>, 'rtl'>
+          }
+        : IntersectButNotEqual<L, R> extends true
+          ? {
+              transform: Transform<L, R>
+            }
+          : NotIntersect<L, R> extends true
+            ? {
+                transform: Transform<L, R>
+              }
+            : never
+  ltr: Equal<L, R> extends true
+    ? {
+        transform?: SpecificFieldPartial<Pick<Transform<L, R>, 'ltr'>, 'ltr'>
+      }
+    : IncludeButNotEqual<L, R> extends true
+      ? {
+          transform: SpecificFieldPartial<Pick<Transform<L, R>, 'ltr'>, 'ltr'>
+        }
+      : IncludeButNotEqual<R, L> extends true
+        ? {
+            transform: Pick<Transform<L, R>, 'ltr'>
+          }
+        : IntersectButNotEqual<L, R> extends true
+          ? {
+              transform: Pick<Transform<L, R>, 'ltr'>
+            }
+          : NotIntersect<L, R> extends true
+            ? {
+                transform: Pick<Transform<L, R>, 'ltr'>
+              }
+            : never
+  rtl: Equal<L, R> extends true
+    ? {
+        transform?: SpecificFieldPartial<Pick<Transform<L, R>, 'rtl'>, 'rtl'>
+      }
+    : IncludeButNotEqual<L, R> extends true
+      ? {
+          transform: Pick<Transform<L, R>, 'rtl'>
+        }
+      : IncludeButNotEqual<R, L> extends true
+        ? {
+            transform: SpecificFieldPartial<Pick<Transform<L, R>, 'rtl'>, 'rtl'>
+          }
+        : IntersectButNotEqual<L, R> extends true
+          ? {
+              transform: Pick<Transform<L, R>, 'rtl'>
+            }
+          : NotIntersect<L, R> extends true
+            ? {
+                transform: Pick<Transform<L, R>, 'rtl'>
+              }
+            : never
+}[D]
 
 /**
  * Two-way refs synchronization.
- *
+ * From the set theory perspective to restrict the option's type
+ * Check in the following order:
+ * 1. A = B
+ * 2. A ∩ B ≠ ∅
+ * 3. A ⊆ B
+ * 4. A ∩ B = ∅
  * @param left
  * @param right
+ * @param args
  */
-export function syncRef<L, R = L>(left: Ref<L>, right: Ref<R>, options: SyncRefOptions<L, R> = {}) {
+export function syncRef<L, R, D extends Direction = 'both'>(
+  left: Ref<L>,
+  right: Ref<R>,
+  ...args: Equal<L, R> extends true
+    ? [SyncRefOptions<L, R, D>?]
+    : [SyncRefOptions<L, R, D>]
+) {
   const {
     flush = 'sync',
     deep = false,
     immediate = true,
     direction = 'both',
     transform = {},
-  } = options
+  } = args[0] || {}
 
   const watchers: WatchPausableReturn[] = []
 
-  const transformLTR = transform.ltr ?? (v => v)
-  const transformRTL = transform.rtl ?? (v => v)
+  const transformLTR = ('ltr' in transform && transform.ltr) || (v => v)
+  const transformRTL = ('rtl' in transform && transform.rtl) || (v => v)
 
   if (direction === 'both' || direction === 'ltr') {
     watchers.push(pausableWatch(


### PR DESCRIPTION
fix#3511

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

fix #3511 
From the set theory perspective to restrict the option's type

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8495e56</samp>

This pull request improves the `syncRef` function and its TypeScript support. It adds more type checks and constraints for the function options and arguments, and it covers various use cases with a new test file.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8495e56</samp>

*  Restrict and infer the types of the `syncRef` function options based on the direction and the ref types ([link](https://github.com/vueuse/vueuse/pull/3515/files?diff=unified&w=0#diff-4d06ccb8d3aefeb967955e826b907fb164dcc8e10889f6e48b03792ae45c3d1eL1-R45), [link](https://github.com/vueuse/vueuse/pull/3515/files?diff=unified&w=0#diff-4d06ccb8d3aefeb967955e826b907fb164dcc8e10889f6e48b03792ae45c3d1eL25-R153))
* Simplify the `syncRef` function implementation and handle the optional options parameter ([link](https://github.com/vueuse/vueuse/pull/3515/files?diff=unified&w=0#diff-4d06ccb8d3aefeb967955e826b907fb164dcc8e10889f6e48b03792ae45c3d1eL49-R165))
* Add a test case for the `syncRef` function in `packages/shared/syncRef/index.test.ts` ([link](https://github.com/vueuse/vueuse/pull/3515/files?diff=unified&w=0#diff-00f6d1bad81095b21247b8aeef7ed3fef414bd55869280b7a144a87b5613cc4fR100-R244))
