### PR TITLE
feat(onLongPress): return stop func to let users can stop listeners

### DIFF
--- a/packages/core/onLongPress/index.ts
+++ b/packages/core/onLongPress/index.ts
@@ -1,4 +1,5 @@
 import { computed } from 'vue-demi'
+import type { Fn } from '@vueuse/shared'
 import type { MaybeElementRef } from '../unrefElement'
 import { unrefElement } from '../unrefElement'
 import { useEventListener } from '../useEventListener'
@@ -63,6 +64,12 @@ export function onLongPress(
     once: options?.modifiers?.once,
   }
 
-  useEventListener(elementRef, 'pointerdown', onDown, listenerOptions)
-  useEventListener(elementRef, ['pointerup', 'pointerleave'], clear, listenerOptions)
+  const cleanup = [
+    useEventListener(elementRef, 'pointerdown', onDown, listenerOptions),
+    useEventListener(elementRef, ['pointerup', 'pointerleave'], clear, listenerOptions),
+  ].filter(Boolean) as Fn[]
+
+  const stop = () => cleanup.forEach(fn => fn())
+
+  return stop
 }


### PR DESCRIPTION
fix #3505

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

feat(onLongPress): return stop func to let users can stop listeners
fix #3505 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a14e3ee</samp>

Added a way to stop `onLongPress` and improved type annotations. The core function `onLongPress` now returns a `stop` function that can be used to detach the event listeners. The `Fn` type from `packages/shared/index.ts` was imported to annotate the callback and `stop` functions.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a14e3ee</samp>

* Import `Fn` type from `@vueuse/shared` to use for `onLongPress` return value and `cleanup` array elements ([link](https://github.com/vueuse/vueuse/pull/3526/files?diff=unified&w=0#diff-0899c8523002afb4767e781076341d09cbb32d9bb4a874bbe4c3c6928e12707eR2))
* Modify `onLongPress` to return a `stop` function that removes the event listeners from the element ([link](https://github.com/vueuse/vueuse/pull/3526/files?diff=unified&w=0#diff-0899c8523002afb4767e781076341d09cbb32d9bb4a874bbe4c3c6928e12707eL66-R74))
