### PR TITLE
fix(useScroll): Cannot read properties of null (reading document)

### DIFF
--- a/packages/core/useScroll/index.ts
+++ b/packages/core/useScroll/index.ts
@@ -251,7 +251,7 @@ export function useScroll(
   )
 
   tryOnMounted(() => {
-    setArrivedState(toValue(element))
+    toValue(element) && setArrivedState(toValue(element))
   })
 
   useEventListener(

--- a/packages/core/useScroll/index.ts
+++ b/packages/core/useScroll/index.ts
@@ -251,7 +251,11 @@ export function useScroll(
   )
 
   tryOnMounted(() => {
-    toValue(element) && setArrivedState(toValue(element))
+    const _element = toValue(element)
+    if (!_element)
+      return
+
+    setArrivedState(_element)
   })
 
   useEventListener(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

fixes #3543

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

In the PR #3384, triggered once `setArrivedState` when the component is first mounted.
When `element` is `null`, `setArrivedState` will still be triggered once.
This PR adds a judgment to avoid this problem.

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 45bd3f0</samp>

Fix a bug in `useScroll` hook that caused state updates and errors when the element was null or undefined. Add a truthy check for `toValue(element)` before calling `setArrivedState` in `packages/core/useScroll/index.ts`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 45bd3f0</samp>

* Fix a bug related to the `useScroll` hook that caused unnecessary state updates and potential errors when the element is null or undefined ([link](https://github.com/vueuse/vueuse/pull/3544/files?diff=unified&w=0#diff-6854b45663451a9e8c15d7b4e0bd17a681777359676d0a6c6d8dc32539bdcea6L254-R254))
