### PR TITLE
fix(syncRef): syncRef typing issue for boolean

### DIFF
--- a/packages/shared/syncRef/index.test.ts
+++ b/packages/shared/syncRef/index.test.ts
@@ -249,5 +249,9 @@ describe('syncRef', () => {
     syncRef(refNumBoolean, ref0, {
       direction: 'rtl',
     })
+
+    const bool0 = ref(false)
+    const bool1 = ref(false)
+    syncRef(bool0, bool1)
   })
 })

--- a/packages/shared/syncRef/index.ts
+++ b/packages/shared/syncRef/index.ts
@@ -8,7 +8,7 @@ type SpecificFieldPartial<T, K extends keyof T> = Partial<Pick<T, K>> & Omit<T, 
 /**
  * A = B
  */
-type Equal<A, B> = A extends B ? (B extends A ? true : false) : false
+type Equal<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false
 
 /**
  * A ∩ B ≠ ∅


### PR DESCRIPTION
useSyncRef with two boolean needed a transform.
Updated Equal type to properly compare boolean.

Used implementation from: https://github.com/microsoft/TypeScript/issues/27024#issuecomment-420227672

Before:
```ts
type Equal<A, B> = A extends B ? (B extends A ? true : false) : false

type Test = Equal<boolean, boolean>
//     ^? boolean
```

After:
```ts
type Equal<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false

type Test = Equal<boolean, boolean>
//     ^? true
```

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7a1af39</samp>

This pull request adds a test for `syncRef` and fixes a type error in `Equal`. These changes improve the reliability and correctness of the shared utilities.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7a1af39</samp>

* Fix type error in `Equal` type by wrapping types in tuples ([link](https://github.com/vueuse/vueuse/pull/3553/files?diff=unified&w=0#diff-4d06ccb8d3aefeb967955e826b907fb164dcc8e10889f6e48b03792ae45c3d1eL11-R11))
* Add test case for `syncRef` function using two boolean refs ([link](https://github.com/vueuse/vueuse/pull/3553/files?diff=unified&w=0#diff-00f6d1bad81095b21247b8aeef7ed3fef414bd55869280b7a144a87b5613cc4fR252-R255))
