### PR TITLE
feat(useInfiniteScroll): add the `canLoadMore` option

### DIFF
--- a/packages/core/useInfiniteScroll/index.ts
+++ b/packages/core/useInfiniteScroll/index.ts
@@ -9,7 +9,7 @@ import { resolveElement } from '../_resolve-element'
 
 type InfiniteScrollElement = HTMLElement | SVGElement | Window | Document | null | undefined
 
-export interface UseInfiniteScrollOptions<T extends InfiniteScrollElement> extends UseScrollOptions {
+export interface UseInfiniteScrollOptions<T extends InfiniteScrollElement = InfiniteScrollElement> extends UseScrollOptions {
   /**
    * The minimum distance between the bottom of the element and the bottom of the viewport
    *

--- a/packages/core/useInfiniteScroll/index.ts
+++ b/packages/core/useInfiniteScroll/index.ts
@@ -7,7 +7,9 @@ import type { UseScrollOptions } from '../useScroll'
 import { useScroll } from '../useScroll'
 import { resolveElement } from '../_resolve-element'
 
-export interface UseInfiniteScrollOptions extends UseScrollOptions {
+type InfiniteScrollElement = HTMLElement | SVGElement | Window | Document | null | undefined
+
+export interface UseInfiniteScrollOptions<T extends InfiniteScrollElement> extends UseScrollOptions {
   /**
    * The minimum distance between the bottom of the element and the bottom of the viewport
    *
@@ -28,6 +30,13 @@ export interface UseInfiniteScrollOptions extends UseScrollOptions {
    * @default 100
    */
   interval?: number
+
+  /**
+   * A function that determines whether more content can be loaded for a specific element.
+   * Should return `true` if loading more content is allowed for the given element,
+   * and `false` otherwise.
+   */
+  canLoadMore?: (el: T) => boolean
 }
 
 /**
@@ -35,14 +44,15 @@ export interface UseInfiniteScrollOptions extends UseScrollOptions {
  *
  * @see https://vueuse.org/useInfiniteScroll
  */
-export function useInfiniteScroll(
-  element: MaybeRefOrGetter<HTMLElement | SVGElement | Window | Document | null | undefined>,
+export function useInfiniteScroll<T extends InfiniteScrollElement>(
+  element: MaybeRefOrGetter<T>,
   onLoadMore: (state: UnwrapNestedRefs<ReturnType<typeof useScroll>>) => Awaitable<void>,
-  options: UseInfiniteScrollOptions = {},
+  options: UseInfiniteScrollOptions<T> = {},
 ) {
   const {
     direction = 'bottom',
     interval = 100,
+    canLoadMore = () => true,
   } = options
 
   const state = reactive(useScroll(
@@ -69,7 +79,7 @@ export function useInfiniteScroll(
   function checkAndLoad() {
     state.measure()
 
-    if (!observedElement.value || !isElementVisible.value)
+    if (!observedElement.value || !isElementVisible.value || !canLoadMore(observedElement.value as T))
       return
 
     const { scrollHeight, clientHeight, scrollWidth, clientWidth } = observedElement.value as HTMLElement


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

fixed #3390 

When using `useInfiniteScroll`, there is a scenario where the element is not scrollable, leading to infinite triggering of `onLoadMore`. Due to potential issues related to element scrolling, this PR introduces the `canLoadMore` option. It is a function that returns a boolean type, allowing users to independently control whether more content can be loaded. With this option, users can make their own decisions on whether loading more content is feasible, addressing the issue of infinite triggering when the element is not scrollable.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

