### PR TITLE
fix(createEventHook): `trigger` should not ignore falsy values

### DIFF
--- a/packages/shared/createEventHook/index.test.ts
+++ b/packages/shared/createEventHook/index.test.ts
@@ -39,6 +39,25 @@ describe('createEventHook', () => {
     expect(timesFired).toBe(2)
   })
 
+  it('should trigger event and pass falsy values', () => {
+    let timesFired = 0
+
+    type Falsy = false | 0 | '' | null | undefined
+    const { on: onResult, trigger } = createEventHook<Falsy>()
+
+    const values: Falsy[] = [false, 0, '', null, undefined]
+    const results: Falsy[] = []
+    onResult((value: Falsy) => {
+      timesFired++
+      results.push(value)
+    })
+    for (const value of values)
+      trigger(value)
+
+    expect(timesFired).toBe(values.length)
+    expect(results).toMatchObject(values)
+  })
+
   it('should add and remove event listener', () => {
     const listener = vi.fn()
     const { on, off, trigger } = createEventHook<string>()

--- a/packages/shared/createEventHook/index.ts
+++ b/packages/shared/createEventHook/index.ts
@@ -38,8 +38,8 @@ export function createEventHook<T = any>(): EventHook<T> {
     }
   }
 
-  const trigger: EventHookTrigger<T> = (param?: T) => {
-    return Promise.all(Array.from(fns).map(fn => param !== undefined ? fn(param) : (fn as Callback<void>)()))
+  const trigger: EventHookTrigger<T> = (...args) => {
+    return Promise.all(Array.from(fns).map(fn => fn(...(args as [T]))))
   }
 
   return {

--- a/packages/shared/createEventHook/index.ts
+++ b/packages/shared/createEventHook/index.ts
@@ -39,7 +39,7 @@ export function createEventHook<T = any>(): EventHook<T> {
   }
 
   const trigger: EventHookTrigger<T> = (param?: T) => {
-    return Promise.all(Array.from(fns).map(fn => param ? fn(param) : (fn as Callback<void>)()))
+    return Promise.all(Array.from(fns).map(fn => param !== undefined ? fn(param) : (fn as Callback<void>)()))
   }
 
   return {


### PR DESCRIPTION

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description
Fixes #3560.

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d80046c</samp>

This pull request fixes a bug and adds a test case for the `createEventHook` function. It allows passing falsy values to the event hook callbacks and checks the expected results in the test file `packages/shared/createEventHook/index.test.ts`.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d80046c</samp>

* Fix a bug and improve the flexibility of the `trigger` function in `createEventHook` ([link](https://github.com/vueuse/vueuse/pull/3561/files?diff=unified&w=0#diff-e7f6c2121aa36ff115952572f25b671a5cc7549c37f2fab6dda05029cd65dbe2L42-R42))
* Add a new test case for the `createEventHook` function to check the behavior of the `trigger` function with falsy values ([link](https://github.com/vueuse/vueuse/pull/3561/files?diff=unified&w=0#diff-25029db94c761070c7346023ff0f43b38cf34bbfe14be3c81bbf17c751ecbac3R42-R60))
