### PR TITLE
fix(useDark): In Vue 2.6 mode.system is undefined

### DIFF
--- a/packages/core/useDark/index.ts
+++ b/packages/core/useDark/index.ts
@@ -1,4 +1,6 @@
 import { computed } from 'vue-demi'
+import { defaultWindow } from '../_configurable'
+import { usePreferredDark } from '../usePreferredDark'
 import { useColorMode } from '../useColorMode'
 import type { BasicColorSchema, UseColorModeOptions } from '../useColorMode'
 
@@ -36,6 +38,7 @@ export function useDark(options: UseDarkOptions = {}) {
   const {
     valueDark = 'dark',
     valueLight = '',
+    window = defaultWindow,
   } = options
 
   const mode = useColorMode({
@@ -52,13 +55,24 @@ export function useDark(options: UseDarkOptions = {}) {
     },
   })
 
+  const system = computed(() => {
+    if (mode.system) {
+      return mode.system.value
+    }
+    else {
+      // In Vue 2.6, ref not be extensible, mode.system is undefined
+      const preferredDark = usePreferredDark({ window })
+      return preferredDark.value ? 'dark' : 'light'
+    }
+  })
+
   const isDark = computed<boolean>({
     get() {
       return mode.value === 'dark'
     },
     set(v) {
       const modeVal = v ? 'dark' : 'light'
-      if (mode.system.value === modeVal)
+      if (system.value === modeVal)
         mode.value = 'auto'
       else
         mode.value = modeVal


### PR DESCRIPTION
<!-- Thank you for contributing! -->
The returned value of useColorMode does not have the "system" property, causing an error in the set function of useDark with mode.system.value

Before:
```javascript
const isDark = computed<boolean>({
    get() {
      return mode.value === 'dark'
    },
    set(v) {
      const modeVal = v ? 'dark' : 'light'
      if (mode.system.value === modeVal)
        mode.value = 'auto'
      else
        mode.value = modeVal
    },
 })
```

after: 
```javascript
const system = computed(() => {
    if (mode.system) {
      return mode.system.value
    }
    else {
      // In Vue 2.6, ref not be extensible, mode.system is undefined
      const preferredDark = usePreferredDark({ window })
      return preferredDark.value ? 'dark' : 'light'
    }
  })

 const isDark = computed<boolean>({
    get() {
      return mode.value === 'dark'
    },
    set(v) {
      const modeVal = v ? 'dark' : 'light'
      if (system.value === modeVal)
        mode.value = 'auto'
      else
        mode.value = modeVal
    },
})
```


### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7a70213</samp>

Add `window` and `system` options to `useDark` for better cross-environment support.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7a70213</samp>

* Add a new parameter `window` to the `useDark` function to allow custom window object for media query and `localStorage` access ([link](https://github.com/vueuse/vueuse/pull/3562/files?diff=unified&w=0#diff-4f71efeaa35b7e8cfa292beb8f7c8c77e4716106d9fe3601a43edf8362edfbaeR41))
* Import `defaultWindow` from `_configurable` module and use it as the default value for `window` parameter ([link](https://github.com/vueuse/vueuse/pull/3562/files?diff=unified&w=0#diff-4f71efeaa35b7e8cfa292beb8f7c8c77e4716106d9fe3601a43edf8362edfbaeR2-R3), [link](https://github.com/vueuse/vueuse/pull/3562/files?diff=unified&w=0#diff-4f71efeaa35b7e8cfa292beb8f7c8c77e4716106d9fe3601a43edf8362edfbaeR41))
* Import `usePreferredDark` from `usePreferredDark` module and use it to provide a reactive value for the user's preferred color scheme ([link](https://github.com/vueuse/vueuse/pull/3562/files?diff=unified&w=0#diff-4f71efeaa35b7e8cfa292beb8f7c8c77e4716106d9fe3601a43edf8362edfbaeR2-R3))
* Add a new computed property `system` to the `useDark` function that returns the current system color scheme based on `mode.system` or `usePreferredDark` ([link](https://github.com/vueuse/vueuse/pull/3562/files?diff=unified&w=0#diff-4f71efeaa35b7e8cfa292beb8f7c8c77e4716106d9fe3601a43edf8362edfbaeR58-R68))
* Replace `mode.system.value` with `system.value` in the setter of the `isDark` computed property to ensure correct system color scheme ([link](https://github.com/vueuse/vueuse/pull/3562/files?diff=unified&w=0#diff-4f71efeaa35b7e8cfa292beb8f7c8c77e4716106d9fe3601a43edf8362edfbaeL61-R75))
