### PR TITLE
fix: useInfiniteScroll is called even when there is no manual scroll (#3489)

### DIFF
--- a/packages/core/useInfiniteScroll/index.test.ts
+++ b/packages/core/useInfiniteScroll/index.test.ts
@@ -10,20 +10,6 @@ describe('useInfiniteScroll', () => {
     expect(useInfiniteScroll).toBeDefined()
   })
 
-  it.each([
-    [ref(givenMockElement())],
-    [givenMockElement()],
-    [document],
-    [window],
-  ])('should calls the loadMore handler, when element is visible', (target) => {
-    const mockHandler = vi.fn()
-    givenElementVisibilityRefMock(true)
-
-    useInfiniteScroll(target, mockHandler)
-
-    expect(mockHandler).toHaveBeenCalledTimes(1)
-  })
-
   it('should calls the loadMore handler, when element visibility state form hidden to visible', async () => {
     const mockHandler = vi.fn()
     const mockElement = givenMockElement()

--- a/packages/core/useInfiniteScroll/index.ts
+++ b/packages/core/useInfiniteScroll/index.ts
@@ -28,6 +28,13 @@ export interface UseInfiniteScrollOptions extends UseScrollOptions {
    * @default 100
    */
   interval?: number
+
+  /**
+   * Whether to load more immediately when mounted.
+   *
+   * @default true
+   */
+  immediate?: boolean
 }
 
 /**
@@ -43,6 +50,7 @@ export function useInfiniteScroll(
   const {
     direction = 'bottom',
     interval = 100,
+    immediate = true,
   } = options
 
   const state = reactive(useScroll(
@@ -94,7 +102,7 @@ export function useInfiniteScroll(
   watch(
     () => [state.arrivedState[direction], isElementVisible.value],
     checkAndLoad,
-    { immediate: true },
+    { immediate },
   )
 
   return {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

fix: useInfiniteScroll is called even when there is no manual scroll  (#3489)

### Additional context

1. Add the `immediate` option to control to load more immediately when mounted.
2. Removed ‘should calls the loadMore handler, when element is visible’ test. (When the element is visible, there is no need to call the loadMore handler. loadMore is triggered when the child element scrolls to the specified position.)
---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d507a7d</samp>

Added a new option and improved the logic of the `useInfiniteScroll` hook. Removed a redundant test case.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d507a7d</samp>

*  Add `immediate` option to `useInfiniteScroll` hook to control initial loading behavior ([link](https://github.com/vueuse/vueuse/pull/3563/files?diff=unified&w=0#diff-f1e18d7fa553054c65bf5b7e4fe4daf0fbfb98fe7224964f3f46661a3770d6a1R31-R37), [link](https://github.com/vueuse/vueuse/pull/3563/files?diff=unified&w=0#diff-f1e18d7fa553054c65bf5b7e4fe4daf0fbfb98fe7224964f3f46661a3770d6a1R53), [link](https://github.com/vueuse/vueuse/pull/3563/files?diff=unified&w=0#diff-f1e18d7fa553054c65bf5b7e4fe4daf0fbfb98fe7224964f3f46661a3770d6a1L97-R113))
*  Simplify scroll direction checking by using computed property `isScrollY` ([link](https://github.com/vueuse/vueuse/pull/3563/files?diff=unified&w=0#diff-f1e18d7fa553054c65bf5b7e4fe4daf0fbfb98fe7224964f3f46661a3770d6a1R69), [link](https://github.com/vueuse/vueuse/pull/3563/files?diff=unified&w=0#diff-f1e18d7fa553054c65bf5b7e4fe4daf0fbfb98fe7224964f3f46661a3770d6a1L76-R85))
*  Handle edge case where loaded data does not change scroll size by recursively calling `checkAndLoad` function and warning user ([link](https://github.com/vueuse/vueuse/pull/3563/files?diff=unified&w=0#diff-f1e18d7fa553054c65bf5b7e4fe4daf0fbfb98fe7224964f3f46661a3770d6a1L88-R104))
*  Remove redundant test case for `useInfiniteScroll` hook in `index.test.ts` ([link](https://github.com/vueuse/vueuse/pull/3563/files?diff=unified&w=0#diff-7a065ed82f21fffa480334ad9074a18ca6b262e3a1afa1c27be96c8109898051L13-L26))
