### PR TITLE
fix(useMousePressed): change type of element parameter to MaybeComputedElementRef

### DIFF
--- a/packages/core/useMousePressed/index.ts
+++ b/packages/core/useMousePressed/index.ts
@@ -1,5 +1,5 @@
 import { computed, ref } from 'vue-demi'
-import type { MaybeElementRef } from '../unrefElement'
+import type { MaybeComputedElementRef } from '../unrefElement'
 import { unrefElement } from '../unrefElement'
 import { useEventListener } from '../useEventListener'
 import type { UseMouseSourceType } from '../useMouse'
@@ -39,7 +39,7 @@ export interface MousePressedOptions extends ConfigurableWindow {
   /**
    * Element target to be capture the click
    */
-  target?: MaybeElementRef
+  target?: MaybeComputedElementRef
 }
 
 /**


### PR DESCRIPTION

### Description


This aligns `useMousePressed` with many other composables to use `MaybeComputedElementRef`. It only fixes the type as `useMousePressed` is using `unrefElement` already, which accepts `MaybeComputedElementRef`.

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4316c06</samp>

Improved `useMousePressed` hook to accept computed refs of elements as targets. Refactored some types for clarity and consistency.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4316c06</samp>

* Rename `MaybeElementRef` to `MaybeComputedElementRef` to support computed element refs ([link](https://github.com/vueuse/vueuse/pull/3566/files?diff=unified&w=0#diff-ee257ef23e7179575b10826475e362b4b1ba68bfadae08f82365f3172964896bL2-R2))
* Update `target` option of `MousePressedOptions` to use `MaybeComputedElementRef` ([link](https://github.com/vueuse/vueuse/pull/3566/files?diff=unified&w=0#diff-ee257ef23e7179575b10826475e362b4b1ba68bfadae08f82365f3172964896bL42-R42))
