### PR TITLE
types: fix type error with Vue #9556

### DIFF
--- a/packages/core/createReusableTemplate/index.ts
+++ b/packages/core/createReusableTemplate/index.ts
@@ -68,7 +68,7 @@ export function createReusableTemplate<
         render.value = slots.default
       }
     },
-  }) as DefineTemplateComponent<Bindings, Slots>
+  }) as unknown as DefineTemplateComponent<Bindings, Slots>
 
   const reuse = defineComponent({
     inheritAttrs,
@@ -80,7 +80,7 @@ export function createReusableTemplate<
         return (inheritAttrs && vnode?.length === 1) ? vnode[0] : vnode
       }
     },
-  }) as ReuseTemplateComponent<Bindings, Slots>
+  }) as unknown as ReuseTemplateComponent<Bindings, Slots>
 
   return makeDestructurable(
     { define, reuse },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Working on this PR https://github.com/vuejs/core/pull/9556 to introduce some type utilities and improve `defineComponent` type.

That causes the `defineComponent` to be more strict on types.

This PR has compatibility with the correct Vue version, only an issue when that PR is merged.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
A more elegant approach would use the introduced `DeclareComponent` helper to patch `$slots` :

```ts
export type DefineTemplateComponent<
  Bindings extends object,
  Slots extends Record<string, Slot | undefined>,
> = DeclareComponetn<{
  new(): { $slots: { default(_: Bindings & { $slots: Slots }): any } }
}>
```
But that not compatible with 3.3.
