### PR TITLE
feat(onLongPress): add `distanceThreshold` option

### DIFF
--- a/packages/core/onLongPress/index.test.ts
+++ b/packages/core/onLongPress/index.test.ts
@@ -110,6 +110,38 @@ describe('onLongPress', () => {
     expect(onLongPressCallback).toHaveBeenCalledTimes(0)
   }
 
+  async function triggerCallbackWithThreshold(isRef: boolean) {
+    const onLongPressCallback = vi.fn()
+    pointerdownEvent = new PointerEvent('pointerdown', { cancelable: true, bubbles: true, clientX: 20, clientY: 20 })
+    const moveWithinThresholdEvent = new PointerEvent('pointermove', { cancelable: true, bubbles: true, clientX: 17, clientY: 25 })
+    const moveOutsideThresholdEvent = new PointerEvent('pointermove', { cancelable: true, bubbles: true, clientX: 4, clientY: 30 })
+    onLongPress(isRef ? element : element.value, onLongPressCallback, { threshold: 15, delay: 1000 })
+    // first pointer down
+    element.value.dispatchEvent(pointerdownEvent)
+
+    // pointer move outside threshold
+    await promiseTimeout(500)
+    element.value.dispatchEvent(moveOutsideThresholdEvent)
+    await promiseTimeout(500)
+    expect(onLongPressCallback).toHaveBeenCalledTimes(0)
+
+    // pointer up to cancel callback
+    element.value.dispatchEvent(pointerUpEvent)
+
+    // wait for 500ms after pointer up
+    await promiseTimeout(500)
+    expect(onLongPressCallback).toHaveBeenCalledTimes(0)
+
+    // another pointer down
+    element.value.dispatchEvent(pointerdownEvent)
+
+    // pointer move within threshold
+    await promiseTimeout(500)
+    element.value.dispatchEvent(moveWithinThresholdEvent)
+    await promiseTimeout(500)
+    expect(onLongPressCallback).toHaveBeenCalledTimes(1)
+  }
+
   function suites(isRef: boolean) {
     describe('given no options', () => {
       it('should trigger longpress after 500ms', () => triggerCallback(isRef))
@@ -121,6 +153,7 @@ describe('onLongPress', () => {
       it('should work with once and prevent modifiers', () => workOnceAndPreventModifiers(isRef))
       it('should stop propagation', () => stopPropagation(isRef))
       it('should remove event listeners after being stopped', () => stopEventListeners(isRef))
+      it('should trigger longpress if pointer is moved', () => triggerCallbackWithThreshold(isRef))
     })
   }
 

--- a/packages/core/onLongPress/index.test.ts
+++ b/packages/core/onLongPress/index.test.ts
@@ -115,7 +115,7 @@ describe('onLongPress', () => {
     pointerdownEvent = new PointerEvent('pointerdown', { cancelable: true, bubbles: true, clientX: 20, clientY: 20 })
     const moveWithinThresholdEvent = new PointerEvent('pointermove', { cancelable: true, bubbles: true, clientX: 17, clientY: 25 })
     const moveOutsideThresholdEvent = new PointerEvent('pointermove', { cancelable: true, bubbles: true, clientX: 4, clientY: 30 })
-    onLongPress(isRef ? element : element.value, onLongPressCallback, { threshold: 15, delay: 1000 })
+    onLongPress(isRef ? element : element.value, onLongPressCallback, { distanceThreshold: 15, delay: 1000 })
     // first pointer down
     element.value.dispatchEvent(pointerdownEvent)
 
@@ -149,7 +149,7 @@ describe('onLongPress', () => {
 
     describe('given options', () => {
       it('should trigger longpress after options.delay ms', () => triggerCallbackWithDelay(isRef))
-      it('should not tirgger longpress when child element on longpress', () => notTriggerCallbackOnChildLongPress(isRef))
+      it('should not trigger longpress when child element on longpress', () => notTriggerCallbackOnChildLongPress(isRef))
       it('should work with once and prevent modifiers', () => workOnceAndPreventModifiers(isRef))
       it('should stop propagation', () => stopPropagation(isRef))
       it('should remove event listeners after being stopped', () => stopEventListeners(isRef))

--- a/packages/core/onLongPress/index.ts
+++ b/packages/core/onLongPress/index.ts
@@ -3,8 +3,10 @@ import { computed } from 'vue-demi'
 import type { MaybeElementRef } from '../unrefElement'
 import { unrefElement } from '../unrefElement'
 import { useEventListener } from '../useEventListener'
+import type { Position } from '../types'
 
 const DEFAULT_DELAY = 500
+const DEFAULT_THRESHOLD = 10
 
 export interface OnLongPressOptions {
   /**
@@ -15,6 +17,13 @@ export interface OnLongPressOptions {
   delay?: number
 
   modifiers?: OnLongPressModifiers
+
+  /**
+   * Distance in pixels
+   *
+   * @default 10
+   */
+  threshold?: number
 }
 
 export interface OnLongPressModifiers {
@@ -33,12 +42,14 @@ export function onLongPress(
   const elementRef = computed(() => unrefElement(target))
 
   let timeout: ReturnType<typeof setTimeout> | undefined
+  let posStart: Position | undefined
 
   function clear() {
     if (timeout) {
       clearTimeout(timeout)
       timeout = undefined
     }
+    posStart = undefined
   }
 
   function onDown(ev: PointerEvent) {
@@ -53,10 +64,34 @@ export function onLongPress(
     if (options?.modifiers?.stop)
       ev.stopPropagation()
 
+    posStart = {
+      x: ev.x,
+      y: ev.y,
+    }
     timeout = setTimeout(
       () => handler(ev),
       options?.delay ?? DEFAULT_DELAY,
     )
+  }
+
+  function onMove(ev: PointerEvent) {
+    if (options?.modifiers?.self && ev.target !== elementRef.value)
+      return
+
+    if (!posStart)
+      return
+
+    if (options?.modifiers?.prevent)
+      ev.preventDefault()
+
+    if (options?.modifiers?.stop)
+      ev.stopPropagation()
+
+    const dx = ev.x - posStart.x
+    const dy = ev.y - posStart.y
+    const distance = Math.sqrt(dx * dx + dy * dy)
+    if (distance >= (options?.threshold ?? DEFAULT_THRESHOLD))
+      clear()
   }
 
   const listenerOptions: AddEventListenerOptions = {
@@ -66,6 +101,7 @@ export function onLongPress(
 
   const cleanup = [
     useEventListener(elementRef, 'pointerdown', onDown, listenerOptions),
+    useEventListener(elementRef, 'pointermove', onMove, listenerOptions),
     useEventListener(elementRef, ['pointerup', 'pointerleave'], clear, listenerOptions),
   ].filter(Boolean) as Fn[]
 

--- a/packages/core/onLongPress/index.ts
+++ b/packages/core/onLongPress/index.ts
@@ -18,11 +18,11 @@ export interface OnLongPressOptions {
   modifiers?: OnLongPressModifiers
 
   /**
-   * Distance in pixels
-   *
+   * Allowance of moving distance in pixels,
+   * The action will get canceled When moving too far from the pointerdown position.
    * @default 10
    */
-  threshold?: number
+  distanceThreshold?: number | false
 }
 
 export interface OnLongPressModifiers {
@@ -77,7 +77,7 @@ export function onLongPress(
     if (options?.modifiers?.self && ev.target !== elementRef.value)
       return
 
-    if (!posStart)
+    if (!posStart || options?.distanceThreshold === false)
       return
 
     if (options?.modifiers?.prevent)
@@ -89,7 +89,7 @@ export function onLongPress(
     const dx = ev.x - posStart.x
     const dy = ev.y - posStart.y
     const distance = Math.sqrt(dx * dx + dy * dy)
-    if (distance >= (options?.threshold ?? DEFAULT_THRESHOLD))
+    if (distance >= (options?.distanceThreshold ?? DEFAULT_THRESHOLD))
       clear()
   }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Avoid long presses that are still triggered by moving after a press.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
