### PR TITLE
feat(useAxios): allow parameters to be refs fixes #3051

### DIFF
--- a/packages/integrations/useAxios/demo.vue
+++ b/packages/integrations/useAxios/demo.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
+import { computed, ref } from 'vue'
 import { stringify } from '@vueuse/docs-utils'
 import { useAxios } from '.'
 
+const id = ref(1)
+
 const { data, isLoading, isFinished, execute } = useAxios(
-  'https://jsonplaceholder.typicode.com/todos/1',
+  computed(() => `https://jsonplaceholder.typicode.com/todos/${id.value}`),
 )
 const text = stringify(data)
 </script>
@@ -11,6 +14,9 @@ const text = stringify(data)
 <template>
   <button @click="execute()">
     Execute
+  </button>
+  <button @click="id = id + 1">
+    Change ID
   </button>
   <note>Loading: {{ isLoading.toString() }}</note>
   <note>Finished: {{ isFinished.toString() }}</note>

--- a/packages/integrations/useAxios/index.ts
+++ b/packages/integrations/useAxios/index.ts
@@ -1,6 +1,9 @@
 import type { Ref, ShallowRef } from 'vue-demi'
-import { ref, shallowRef } from 'vue-demi'
+
+// eslint-disable-next-line no-restricted-imports
+import { computed, ref, shallowRef, unref, watch } from 'vue-demi'
 import { noop, until } from '@vueuse/shared'
+import type { MaybeRef } from '@vueuse/shared'
 import type { AxiosInstance, AxiosRequestConfig, AxiosResponse, CancelTokenSource } from 'axios'
 import axios, { AxiosError } from 'axios'
 
@@ -103,12 +106,14 @@ export interface UseAxiosOptions<T = any> {
 }
 type OverallUseAxiosReturn<T, R, D> = StrictUseAxiosReturn<T, R, D> | EasyUseAxiosReturn<T, R, D>
 
-export function useAxios<T = any, R = AxiosResponse<T>, D = any>(url: string, config?: AxiosRequestConfig<D>, options?: UseAxiosOptions): StrictUseAxiosReturn<T, R, D> & Promise<StrictUseAxiosReturn<T, R, D>>
-export function useAxios<T = any, R = AxiosResponse<T>, D = any>(url: string, instance?: AxiosInstance, options?: UseAxiosOptions): StrictUseAxiosReturn<T, R, D> & Promise<StrictUseAxiosReturn<T, R, D>>
-export function useAxios<T = any, R = AxiosResponse<T>, D = any>(url: string, config: AxiosRequestConfig<D>, instance: AxiosInstance, options?: UseAxiosOptions): StrictUseAxiosReturn<T, R, D> & Promise<StrictUseAxiosReturn<T, R, D>>
-export function useAxios<T = any, R = AxiosResponse<T>, D = any>(config?: AxiosRequestConfig<D>): EasyUseAxiosReturn<T, R, D> & Promise<EasyUseAxiosReturn<T, R, D>>
-export function useAxios<T = any, R = AxiosResponse<T>, D = any>(instance?: AxiosInstance): EasyUseAxiosReturn<T, R, D> & Promise<EasyUseAxiosReturn<T, R, D>>
-export function useAxios<T = any, R = AxiosResponse<T>, D = any>(config?: AxiosRequestConfig<D>, instance?: AxiosInstance): EasyUseAxiosReturn<T, R, D> & Promise<EasyUseAxiosReturn<T, R, D>>
+// Since AxiosInstance can be a function, MaybeRefOrGetter can't be used, since Vue will assume its a getter function and call it with toValue/toRef
+// But we also can't assume that an overload parameter isn't a function, so MaybeRefOrGetter<string> subsequently can't be used
+export function useAxios<T = any, R = AxiosResponse<T>, D = any>(url: MaybeRef<string>, config?: MaybeRef<AxiosRequestConfig<D>>, options?: MaybeRef<UseAxiosOptions>): StrictUseAxiosReturn<T, R, D> & Promise<StrictUseAxiosReturn<T, R, D>>
+export function useAxios<T = any, R = AxiosResponse<T>, D = any>(url: MaybeRef<string>, instance?: MaybeRef<AxiosInstance>, options?: MaybeRef<UseAxiosOptions>): StrictUseAxiosReturn<T, R, D> & Promise<StrictUseAxiosReturn<T, R, D>>
+export function useAxios<T = any, R = AxiosResponse<T>, D = any>(url: MaybeRef<string>, config: MaybeRef<AxiosRequestConfig<D>>, instance: MaybeRef<AxiosInstance>, options?: MaybeRef<UseAxiosOptions>): StrictUseAxiosReturn<T, R, D> & Promise<StrictUseAxiosReturn<T, R, D>>
+export function useAxios<T = any, R = AxiosResponse<T>, D = any>(config?: MaybeRef<AxiosRequestConfig<D>>): EasyUseAxiosReturn<T, R, D> & Promise<EasyUseAxiosReturn<T, R, D>>
+export function useAxios<T = any, R = AxiosResponse<T>, D = any>(instance?: MaybeRef<AxiosInstance>): EasyUseAxiosReturn<T, R, D> & Promise<EasyUseAxiosReturn<T, R, D>>
+export function useAxios<T = any, R = AxiosResponse<T>, D = any>(config?: MaybeRef<AxiosRequestConfig<D>>, instance?: MaybeRef<AxiosInstance>): EasyUseAxiosReturn<T, R, D> & Promise<EasyUseAxiosReturn<T, R, D>>
 
 /**
  * Wrapper for axios.
@@ -116,50 +121,58 @@ export function useAxios<T = any, R = AxiosResponse<T>, D = any>(config?: AxiosR
  * @see https://vueuse.org/useAxios
  */
 export function useAxios<T = any, R = AxiosResponse<T>, D = any>(...args: any[]): OverallUseAxiosReturn<T, R, D> & Promise<OverallUseAxiosReturn<T, R, D>> {
-  const url: string | undefined = typeof args[0] === 'string' ? args[0] : undefined
-  const argsPlaceholder = typeof url === 'string' ? 1 : 0
-  let defaultConfig: AxiosRequestConfig<D> = {}
-  let instance: AxiosInstance = axios
-  let options: UseAxiosOptions<T> = {
-    immediate: !!argsPlaceholder,
-    shallow: true,
-  }
+  const url = computed(() => {
+    const val = unref(args[0])
+    return typeof val === 'string' ? val : undefined
+  })
 
-  const isAxiosInstance = (val: any) => !!val?.request
+  const resolvedArgs = computed(() => {
+    const isAxiosInstance = (val: unknown): val is AxiosInstance => {
+      return (typeof val === 'object' || typeof val === 'function') && val !== null && 'request' in val
+    }
 
-  if (args.length > 0 + argsPlaceholder) {
-    /**
-     * Unable to use `instanceof` here because of (https://github.com/axios/axios/issues/737)
-     * so instead we are checking if there is a `request` on the object to see if it is an
-     * axios instance
-     */
-    if (isAxiosInstance(args[0 + argsPlaceholder]))
-      instance = args[0 + argsPlaceholder]
-    else
-      defaultConfig = args[0 + argsPlaceholder]
-  }
+    const argsPlaceholder = unref(typeof url.value === 'string' ? 1 : 0)
+    const firstValue = unref(args[0 + argsPlaceholder])
+    const secondValue = unref(args[1 + argsPlaceholder])
 
-  if (args.length > 1 + argsPlaceholder) {
-    if (isAxiosInstance(args[1 + argsPlaceholder]))
-      instance = args[1 + argsPlaceholder]
-  }
-  if (
-    (args.length === 2 + argsPlaceholder && !isAxiosInstance(args[1 + argsPlaceholder]))
+    let defaultConfig: AxiosRequestConfig<D> = {}
+    let instance: AxiosInstance = axios
+    let options: UseAxiosOptions<T> = {
+      immediate: !!argsPlaceholder,
+      shallow: true,
+    }
+
+    if (args.length > 0 + argsPlaceholder) {
+      if (isAxiosInstance(firstValue))
+        instance = firstValue
+      else
+        defaultConfig = firstValue
+    }
+
+    if (args.length > 1 + argsPlaceholder) {
+      if (isAxiosInstance(secondValue))
+        instance = secondValue
+    }
+    if (
+      (args.length === 2 + argsPlaceholder && !isAxiosInstance(secondValue))
     || args.length === 3 + argsPlaceholder
-  )
-    options = args[args.length - 1]
+    )
+      options = unref(args[args.length - 1])
 
-  const {
-    initialData,
-    shallow,
-    onSuccess = noop,
-    onError = noop,
-    immediate,
-    resetOnExecute = false,
-  } = options
+    return {
+      defaultConfig,
+      instance,
+      options: {
+        ...options,
+        onSuccess: options.onSuccess ?? noop,
+        onError: options.onError ?? noop,
+        resetOnExecute: options.resetOnExecute ?? false,
+      },
+    }
+  })
 
   const response = shallowRef<AxiosResponse<T>>()
-  const data = (shallow ? shallowRef : ref)<T>(initialData!) as Ref<T>
+  const data = (resolvedArgs.value.options.shallow ? shallowRef : ref)<T>(resolvedArgs.value.options.initialData!) as Ref<T>
   const isFinished = ref(false)
   const isLoading = ref(false)
   const isAborted = ref(false)
@@ -188,8 +201,8 @@ export function useAxios<T = any, R = AxiosResponse<T>, D = any>(...args: any[])
    * Reset data to initialData
    */
   const resetData = () => {
-    if (resetOnExecute)
-      data.value = initialData!
+    if (resolvedArgs.value.options.resetOnExecute)
+      data.value = resolvedArgs.value.options.initialData!
   }
 
   const waitUntilFinished = () =>
@@ -205,11 +218,11 @@ export function useAxios<T = any, R = AxiosResponse<T>, D = any>(...args: any[])
   } as Promise<OverallUseAxiosReturn<T, R, D>>
 
   let executeCounter = 0
-  const execute: OverallUseAxiosReturn<T, R, D>['execute'] = (executeUrl: string | AxiosRequestConfig<D> | undefined = url, config: AxiosRequestConfig<D> = {}) => {
+  const execute: OverallUseAxiosReturn<T, R, D>['execute'] = (executeUrl: string | AxiosRequestConfig<D> | undefined = url.value, config: AxiosRequestConfig<D> = {}) => {
     error.value = undefined
     const _url = typeof executeUrl === 'string'
       ? executeUrl
-      : url ?? config.url
+      : url.value ?? config.url
 
     if (_url === undefined) {
       error.value = new AxiosError(AxiosError.ERR_INVALID_URL)
@@ -223,29 +236,31 @@ export function useAxios<T = any, R = AxiosResponse<T>, D = any>(...args: any[])
     executeCounter += 1
     const currentExecuteCounter = executeCounter
 
-    instance(_url, { ...defaultConfig, ...typeof executeUrl === 'object' ? executeUrl : config, cancelToken: cancelToken.token })
+    resolvedArgs.value.instance(_url, { ...resolvedArgs.value.defaultConfig, ...typeof executeUrl === 'object' ? executeUrl : config, cancelToken: cancelToken.token })
       .then((r: any) => {
         if (isAborted.value)
           return
         response.value = r
         const result = r.data
         data.value = result
-        onSuccess(result)
+        resolvedArgs.value.options.onSuccess(result)
       })
       .catch((e: any) => {
         error.value = e
-        onError(e)
+        resolvedArgs.value.options.onError(e)
       })
       .finally(() => {
-        options.onFinish?.()
+        resolvedArgs.value.options.onFinish?.()
         if (currentExecuteCounter === executeCounter)
           loading(false)
       })
     return promise
   }
 
-  if (immediate && url)
-    (execute as StrictUseAxiosReturn<T, R, D>['execute'])()
+  watch(url, (newValue) => {
+    if (resolvedArgs.value.options.immediate && newValue)
+      (execute as StrictUseAxiosReturn<T, R, D>['execute'])()
+  }, { immediate: true })
 
   const result = {
     response,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

fixes #3051

useAxios composable not accepting reactive data. Leading to situations where the "composable" behaves more like a util

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

`const data = (resolvedArgs.value.options.shallow ? shallowRef : ref)<T>(resolvedArgs.value.options.initialData!) as Ref<T>` has an issue where we only decide whether it is a shallow ref or a ref on initialization. This was sufficient before the options was reactive, but now that it is reactive, it only decides its state on initialization. If you were to change this option, the ref wouldn't be made a shallowRef and vice versa. I decided to leave it this way because the alternative would be `let data = ...` which has its own downsides

There's also the noted use of unref, which it would be best to toValue/toRef with MaybeRefOrGetter, but if you look at the note, you'll see why. Perhaps there's some way to sidestep this issue and allow getters, but I don't know of any way to allow getters in this context. Correctly me if I'm wrong