### PR TITLE
refactor: use different url for avatar images in contributors section.

### DIFF
--- a/packages/contributors.ts
+++ b/packages/contributors.ts
@@ -19,7 +19,7 @@ export interface CoreTeam {
 const contributorsAvatars: Record<string, string> = {}
 
 function getAvatarUrl(name: string) {
-  return `https://github.com/${name}.png`
+  return `https://avatars.githubusercontent.com/${name}?v=4`
 }
 
 const contributorList = (contributors as string[]).reduce((acc, name) => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This might be a dumb PR but I have notice that the avatar images in "Contributors" section are not showing as the request is returning a 403 error.

![image](https://github.com/vueuse/vueuse/assets/38622893/a2977427-bdb7-4c61-91a1-0ea60bd79728)

But if I change the url to `avatars.githubusercontent.com` it does not fail.


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

No
