### PR TITLE
fix: vitepress style

### DIFF
--- a/packages/.vitepress/theme/styles/demo.css
+++ b/packages/.vitepress/theme/styles/demo.css
@@ -48,8 +48,8 @@
     outline: none;
     color: white;
     margin: 0.5rem 0;
-    border-bottom: 2px solid var(--vp-c-brand-dark);
-    text-shadow: 1px 1px 1px var(--vp-c-brand-dark);
+    border-bottom: 2px solid var(--vp-c-brand-2);
+    text-shadow: 1px 1px 1px var(--vp-c-brand-2);
     border-radius: 4px;
     font-size: 1rem;
     box-sizing: border-box;
@@ -73,12 +73,12 @@
   }
 
   button:hover {
-    background-color: var(--vp-c-brand-dark);
+    background-color: var(--vp-c-brand-2);
   }
 
   button:active {
     border-bottom: 0;
-    border-top: 2px solid var(--vp-c-brand-dark);
+    border-top: 2px solid var(--vp-c-brand-2);
   }
   button ~ button {
     margin-left: 0.5rem;

--- a/packages/.vitepress/theme/styles/vars.css
+++ b/packages/.vitepress/theme/styles/vars.css
@@ -57,13 +57,13 @@
  * -------------------------------------------------------------------------- */
 
 :root {
-  --vp-button-brand-border: var(--vp-c-brand-light);
+  --vp-button-brand-border: var(--vp-c-brand-soft);
   --vp-button-brand-text: var(--vp-c-text-dark-1);
-  --vp-button-brand-bg: var(--vp-c-brand);
-  --vp-button-brand-hover-border: var(--vp-c-brand-light);
+  --vp-button-brand-bg: var(--vp-c-brand-1);
+  --vp-button-brand-hover-border: var(--vp-c-brand-soft);
   --vp-button-brand-hover-text: var(--vp-c-text-dark-1);
-  --vp-button-brand-hover-bg: var(--vp-c-brand-light);
-  --vp-button-brand-active-border: var(--vp-c-brand-light);
+  --vp-button-brand-hover-bg: var(--vp-c-brand-soft);
+  --vp-button-brand-active-border: var(--vp-c-brand-soft);
   --vp-button-brand-active-text: var(--vp-c-text-dark-1);
   --vp-button-brand-active-bg: var(--vp-button-brand-bg);
 }


### PR DESCRIPTION
### Description
The previous commit modified some CSS variables, causing the button's background to become transparent on hover. This commit applies appropriate CSS variables.

