### PR TITLE
feat(useAsyncState): add `immediateExecuteParams` option

### DIFF
--- a/packages/core/useAsyncState/index.test.ts
+++ b/packages/core/useAsyncState/index.test.ts
@@ -19,6 +19,13 @@ describe('useAsyncState', () => {
       throw new Error('error')
     return id
   }
+  const p3 = (str: string, num: number) => {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve(str + num)
+      }, 50)
+    })
+  }
 
   it('should work', async () => {
     const { execute, state } = useAsyncState(p1, 0)
@@ -82,5 +89,11 @@ describe('useAsyncState', () => {
   it('should work with throwError', async () => {
     const { execute } = useAsyncState(p2, '0', { throwError: true, immediate: false })
     await expect(execute()).rejects.toThrowError('error')
+  })
+
+  it('should work with immediateExecuteParams', async () => {
+    const asyncState = useAsyncState(p3, undefined, { immediateExecuteParams: ['1', 1] })
+    await asyncState
+    expect(asyncState.state.value).toBe('11')
   })
 })

--- a/packages/core/useAsyncState/index.ts
+++ b/packages/core/useAsyncState/index.ts
@@ -14,7 +14,7 @@ export type UseAsyncStateReturn<Data, Params extends any[], Shallow extends bool
   UseAsyncStateReturnBase<Data, Params, Shallow>
   & PromiseLike<UseAsyncStateReturnBase<Data, Params, Shallow>>
 
-export interface UseAsyncStateOptions<Shallow extends boolean, D = any> {
+export interface UseAsyncStateOptions<Shallow extends boolean, D = any, Params extends any[] = any> {
   /**
    * Delay for executing the promise. In milliseconds.
    *
@@ -67,6 +67,13 @@ export interface UseAsyncStateOptions<Shallow extends boolean, D = any> {
    * @default false
    */
   throwError?: boolean
+  /**
+   *
+   * When immediate is true, the immediateExecuteParams is used as a parameter for the first executing the promise
+   *
+   * @default []
+   */
+  immediateExecuteParams?: Params
 }
 
 /**
@@ -81,7 +88,7 @@ export interface UseAsyncStateOptions<Shallow extends boolean, D = any> {
 export function useAsyncState<Data, Params extends any[] = [], Shallow extends boolean = true>(
   promise: Promise<Data> | ((...args: Params) => Promise<Data>),
   initialState: Data,
-  options?: UseAsyncStateOptions<Shallow, Data>,
+  options?: UseAsyncStateOptions<Shallow, Data, Params>,
 ): UseAsyncStateReturn<Data, Params, Shallow> {
   const {
     immediate = true,
@@ -91,6 +98,7 @@ export function useAsyncState<Data, Params extends any[] = [], Shallow extends b
     resetOnExecute = true,
     shallow = true,
     throwError,
+    immediateExecuteParams = [],
   } = options ?? {}
   const state = shallow ? shallowRef(initialState) : ref(initialState)
   const isReady = ref(false)
@@ -131,7 +139,7 @@ export function useAsyncState<Data, Params extends any[] = [], Shallow extends b
   }
 
   if (immediate)
-    execute(delay)
+    execute(delay, ...immediateExecuteParams)
 
   const shell: UseAsyncStateReturnBase<Data, Params, Shallow> = {
     state: state as Shallow extends true ? Ref<Data> : Ref<UnwrapRef<Data>>,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Add immediateExecuteParams option. When immediate is true, the immediateExecuteParams is used as a parameter for the first executing the promise

### Additional context
