### PR TITLE
fix(build): Fix compatibility with rollup

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -30,7 +30,7 @@
   "module": "./index.mjs",
   "unpkg": "./index.iife.min.js",
   "jsdelivr": "./index.iife.min.js",
-  "types": "./index.d.cts",
+  "types": "./index.d.ts",
   "dependencies": {
     "@vueuse/core": "workspace:*",
     "@vueuse/shared": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,7 +35,7 @@
   "module": "./index.mjs",
   "unpkg": "./index.iife.min.js",
   "jsdelivr": "./index.iife.min.js",
-  "types": "./index.d.cts",
+  "types": "./index.d.ts",
   "dependencies": {
     "@types/web-bluetooth": "^0.0.20",
     "@vueuse/metadata": "workspace:*",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -31,7 +31,7 @@
   },
   "main": "./index.cjs",
   "module": "./index.mjs",
-  "types": "./index.d.cts",
+  "types": "./index.d.ts",
   "peerDependencies": {
     "electron": ">=9.0.0"
   },

--- a/packages/firebase/package.json
+++ b/packages/firebase/package.json
@@ -45,7 +45,7 @@
   "module": "./index.mjs",
   "unpkg": "./index.iife.min.js",
   "jsdelivr": "./index.iife.min.js",
-  "types": "./index.d.cts",
+  "types": "./index.d.ts",
   "peerDependencies": {
     "firebase": ">=9.0.0"
   },

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -91,7 +91,7 @@
   "module": "./index.mjs",
   "unpkg": "./index.iife.min.js",
   "jsdelivr": "./index.iife.min.js",
-  "types": "./index.d.cts",
+  "types": "./index.d.ts",
   "peerDependencies": {
     "async-validator": "*",
     "axios": "*",

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -32,7 +32,7 @@
   "module": "./index.mjs",
   "unpkg": "./index.iife.min.js",
   "jsdelivr": "./index.iife.min.js",
-  "types": "./index.d.cts",
+  "types": "./index.d.ts",
   "dependencies": {
     "@vueuse/shared": "workspace:*",
     "vue-demi": ">=0.14.6"

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -29,7 +29,7 @@
   },
   "main": "./index.cjs",
   "module": "./index.mjs",
-  "types": "./index.d.cts",
+  "types": "./index.d.ts",
   "files": [
     "index.*"
   ],

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -31,7 +31,7 @@
   },
   "main": "./index.cjs",
   "module": "./index.mjs",
-  "types": "./index.d.cts",
+  "types": "./index.d.ts",
   "peerDependencies": {
     "nuxt": "^3.0.0"
   },

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -32,7 +32,7 @@
   "module": "./index.mjs",
   "unpkg": "./index.iife.min.js",
   "jsdelivr": "./index.iife.min.js",
-  "types": "./index.d.cts",
+  "types": "./index.d.ts",
   "peerDependencies": {
     "vue-router": ">=4.0.0-rc.1"
   },

--- a/packages/rxjs/package.json
+++ b/packages/rxjs/package.json
@@ -33,7 +33,7 @@
   "module": "./index.mjs",
   "unpkg": "./index.iife.min.js",
   "jsdelivr": "./index.iife.min.js",
-  "types": "./index.d.cts",
+  "types": "./index.d.ts",
   "peerDependencies": {
     "rxjs": ">=6.0.0"
   },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -30,7 +30,7 @@
   "module": "./index.mjs",
   "unpkg": "./index.iife.min.js",
   "jsdelivr": "./index.iife.min.js",
-  "types": "./index.d.cts",
+  "types": "./index.d.ts",
   "dependencies": {
     "vue-demi": ">=0.14.6"
   }

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -133,7 +133,6 @@ for (const { globals, name, external, submodules, iife, build, cjs, mjs, dts, ta
         input,
         output: [
           { file: `packages/${name}/dist/${fn}.d.cts` },
-          { file: `packages/${name}/dist/${fn}.d.mts` },
           { file: `packages/${name}/dist/${fn}.d.ts` }, // for node10 compatibility
         ],
         plugins: [
@@ -173,7 +172,6 @@ for (const { globals, name, external, submodules, iife, build, cjs, mjs, dts, ta
         input: `packages/${name}/${fn}/component.ts`,
         output: [
           { file: `packages/${name}/dist/${fn}/component.d.cts` },
-          { file: `packages/${name}/dist/${fn}/component.d.mts` },
           { file: `packages/${name}/dist/${fn}/component.d.ts` }, // for node10 compatibility
         ],
         plugins: [

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -248,7 +248,7 @@ export async function updatePackageJSON(indexes: PackageIndexes) {
       directory: `packages/${name}`,
     }
     packageJSON.main = './index.cjs'
-    packageJSON.types = './index.d.cts'
+    packageJSON.types = './index.d.ts'
     packageJSON.module = './index.mjs'
     if (iife !== false) {
       packageJSON.unpkg = './index.iife.min.js'


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This pull request is to solve the problem with compatibility with rollup. When I package with rollup, I found the Error " RollupError: "useFetch" is not exported by "node_modules/.pnpm/registry.npmmirror.com+@vueuse+core@10.7.0_vue@3.3.9/node_modules/@vueuse/core/index.d.cts", imported by XXX". Change the default type .d.cts to .d.ts will solve this problem.  Associate Issue #3591


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
