### PR TITLE
docs(useWebWorker): escape table divider

### DIFF
--- a/packages/core/useWebWorker/index.md
+++ b/packages/core/useWebWorker/index.md
@@ -20,7 +20,7 @@ const { data, post, terminate, worker } = useWebWorker('/path/to/worker.js')
 | data   | `Ref<any>`                        | Reference to the latest data received via the worker, can be watched to respond to incoming messages |
 | worker | `ShallowRef<Worker \| undefined>` | Reference to the instance of the WebWorker                                                           |
 
-| Method    | Signature                                                                                                                                   | Description
-| --------- | ------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
-| post      | `(message: any, transfer: Transferable[]): void`<br>`(message: any, options?: StructuredSerializeOptions \| undefined): void`                | Sends data to the worker thread. |
-| terminate | `() => void`                                                                                             | Stops and terminates the worker. |
+| Method    | Signature                                                                                                                     | Description                      |
+| --------- | ----------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
+| post      | `(message: any, transfer: Transferable[]): void`<br>`(message: any, options?: StructuredSerializeOptions \| undefined): void` | Sends data to the worker thread. |
+| terminate | `() => void`                                                                                                                  | Stops and terminates the worker. |

--- a/packages/core/useWebWorker/index.md
+++ b/packages/core/useWebWorker/index.md
@@ -22,5 +22,5 @@ const { data, post, terminate, worker } = useWebWorker('/path/to/worker.js')
 
 | Method    | Signature                                                                                                                                   | Description
 | --------- | ------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
-| post      | `(message: any, transfer: Transferable[]): void`<br>`(message: any, options?: StructuredSerializeOptions | undefined): void`                | Sends data to the worker thread. |
+| post      | `(message: any, transfer: Transferable[]): void`<br>`(message: any, options?: StructuredSerializeOptions \| undefined): void`                | Sends data to the worker thread. |
 | terminate | `() => void`                                                                                             | Stops and terminates the worker. |

--- a/packages/core/useWebWorker/index.md
+++ b/packages/core/useWebWorker/index.md
@@ -20,7 +20,7 @@ const { data, post, terminate, worker } = useWebWorker('/path/to/worker.js')
 | data   | `Ref<any>`                        | Reference to the latest data received via the worker, can be watched to respond to incoming messages |
 | worker | `ShallowRef<Worker \| undefined>` | Reference to the instance of the WebWorker                                                           |
 
-| Method    | Signature                                                                                                | Description                      |
-| --------- | -------------------------------------------------------------------------------------------------------- | -------------------------------- | -------------------------------- |
+| Method    | Signature                                                                                                                                   | Description
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
 | post      | `(message: any, transfer: Transferable[]): void`<br>`(message: any, options?: StructuredSerializeOptions | undefined): void`                | Sends data to the worker thread. |
 | terminate | `() => void`                                                                                             | Stops and terminates the worker. |


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

There was a minor error in the markdown table resulting it not being rendered as a table. 

The contents has not been changed, just formatting of documentation.


### Additional context

[Link to the formatting problem on vueuse](https://vueuse.org/core/useWebWorker/#usage)
