### PR TITLE
fix(useGamepad): explicitly ensure gamepad index is available

### DIFF
--- a/packages/core/useGamepad/index.ts
+++ b/packages/core/useGamepad/index.ts
@@ -85,6 +85,7 @@ export function useGamepad(options: UseGamepadOptions = {}) {
       hapticActuators,
       axes: gamepad.axes.map(axes => axes),
       buttons: gamepad.buttons.map(button => ({ pressed: button.pressed, touched: button.touched, value: button.value })),
+      index: gamepad.index,
     } as Gamepad
   }
 


### PR DESCRIPTION
### Description

Ensures useGamepad explicitly exposes gamepads indexes.

### Additional context

Fixes #3652
