### PR TITLE
feat(useCancellableAsyncState): add `useCancellableAsyncState`

### DIFF
--- a/packages/core/useCancellableAsyncState/demo.vue
+++ b/packages/core/useCancellableAsyncState/demo.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import axios from 'axios'
+import YAML from 'js-yaml'
+import { useCancellableAsyncState } from '@vueuse/core'
+
+const { isLoading, state, isReady, execute } = useCancellableAsyncState(
+  (onCancel, args: unknown) => {
+    const abortController = new AbortController()
+    onCancel(() => abortController.abort())
+    const id = args?.id || 1
+    return axios.get(
+      `https://jsonplaceholder.typicode.com/todos/${id}`,
+      { signal: abortController.signal },
+    ).then(t => t.data)
+  },
+  {},
+  {
+    resetOnExecute: false,
+  },
+)
+</script>
+
+<template>
+  <div>
+    <note>Ready: {{ isReady.toString() }}</note>
+    <note>Loading: {{ isLoading.toString() }}</note>
+    <pre lang="json" class="ml-2">{{ YAML.dump(state) }}</pre>
+    <button @click="execute(0, { id: 2 })">
+      Execute
+    </button>
+  </div>
+</template>

--- a/packages/core/useCancellableAsyncState/index.md
+++ b/packages/core/useCancellableAsyncState/index.md
@@ -1,0 +1,29 @@
+---
+category: State
+---
+
+# useCancellableAsyncState
+
+Cancellable version of `useAsyncState`
+
+## Usage
+
+```ts
+import axios from 'axios'
+import { useCancellableAsyncState } from '@vueuse/core'
+
+const { state, isReady, isLoading } = useCancellableAsyncState(
+  (onCancel) => {
+    const abortController = new AbortController()
+
+    onCancel(() => abortController.abort())
+
+    const id = args?.id || 1
+    return axios.get(
+      `https://jsonplaceholder.typicode.com/todos/${id}`,
+      { signal: abortController.signal },
+    )
+  },
+  {},
+)
+```

--- a/packages/core/useCancellableAsyncState/index.test.ts
+++ b/packages/core/useCancellableAsyncState/index.test.ts
@@ -1,0 +1,113 @@
+import { promiseTimeout } from '@vueuse/shared'
+import { describe, expect, it, vi } from 'vitest'
+import type { CancellableAsyncStateOnCancel } from '.'
+import { useCancellableAsyncState } from '.'
+
+describe('useCancellableAsyncState', () => {
+  it('should be defined', () => {
+    expect(useCancellableAsyncState).toBeDefined()
+  })
+
+  const p1 = (_: CancellableAsyncStateOnCancel, num = 1) => {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve(num)
+      }, 50)
+    })
+  }
+  const p2 = async (_: CancellableAsyncStateOnCancel, id?: string) => {
+    if (!id)
+      throw new Error('error')
+    return id
+  }
+
+  it('should work', async () => {
+    const { execute, state } = useCancellableAsyncState(p1, 0)
+    expect(state.value).toBe(0)
+    await execute(0, 2)
+    expect(state.value).toBe(2)
+  })
+
+  it('should work with await', async () => {
+    const asyncState = useCancellableAsyncState(p1, 0, { immediate: true })
+    expect(asyncState.isLoading.value).toBeTruthy()
+    await asyncState
+    expect(asyncState.isLoading.value).toBeFalsy()
+  })
+
+  it('should work with isLoading', () => {
+    const { execute, isLoading } = useCancellableAsyncState(p1, 0, { immediate: false })
+    expect(isLoading.value).toBeFalsy()
+    execute(1)
+    expect(isLoading.value).toBeTruthy()
+  })
+
+  it('should work with isReady', async () => {
+    const { execute, isReady } = useCancellableAsyncState(p1, 0, { immediate: false })
+    expect(isReady.value).toBeFalsy()
+    await execute(1)
+    expect(isReady.value).toBeTruthy()
+  })
+
+  it('should work with error', async () => {
+    const { execute, error } = useCancellableAsyncState(p2, '0', { immediate: false })
+    expect(error.value).toBeUndefined()
+    await execute()
+    expect(error.value).toBeInstanceOf(Error)
+  })
+
+  it('should work with delay', async () => {
+    const { execute, state } = useCancellableAsyncState(p1, 0, { delay: 100 })
+    await promiseTimeout(50)
+    expect(state.value).toBe(0)
+    await execute(0, 2)
+    expect(state.value).toBe(2)
+  })
+
+  it('should work with onSuccess', async () => {
+    const onSuccess = vi.fn()
+    const { execute } = useCancellableAsyncState(p1, 0, { onSuccess })
+    await execute(0, 2)
+    expect(onSuccess).toHaveBeenCalled()
+    expect(onSuccess).toHaveBeenCalledWith(2)
+  })
+
+  it('should work with onError', async () => {
+    const onError = vi.fn()
+    const { execute } = useCancellableAsyncState(p2, '0', { onError, immediate: false })
+    await execute()
+    expect(onError).toHaveBeenCalled()
+    expect(onError).toHaveBeenCalledWith(new Error('error'))
+  })
+
+  it('should work with throwError', async () => {
+    const { execute } = useCancellableAsyncState(p2, '0', { throwError: true, immediate: false })
+    await expect(execute()).rejects.toThrowError('error')
+  })
+
+  it('cancel is called', async () => {
+    const onCancel = vi.fn()
+    const p = (cancel: CancellableAsyncStateOnCancel, num = 1) => {
+      cancel(() => onCancel())
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          resolve(num)
+        }, 10)
+      })
+    }
+
+    const { execute, state } = useCancellableAsyncState(p, 0)
+    await promiseTimeout(5)
+    execute(0, 1)
+    expect(state.value).toBe(0)
+    expect(onCancel).toBeCalledTimes(1)
+
+    await promiseTimeout(5)
+    execute(0, 2)
+    expect(state.value).toBe(0)
+    expect(onCancel).toBeCalledTimes(2)
+
+    await promiseTimeout(10)
+    expect(state.value).toBe(2)
+  })
+})

--- a/packages/core/useCancellableAsyncState/index.ts
+++ b/packages/core/useCancellableAsyncState/index.ts
@@ -1,0 +1,128 @@
+import type { Fn } from '@vueuse/shared'
+import { noop, promiseTimeout, until } from '@vueuse/shared'
+import type { Ref, UnwrapRef } from 'vue-demi'
+import { ref, shallowRef } from 'vue-demi'
+import type { UseAsyncStateOptions, UseAsyncStateReturn, UseAsyncStateReturnBase } from '../useAsyncState'
+
+/**
+ * Handle overlapping executions.
+ *
+ * @param cancelCallback The provided callback is invoked when a re-invocation of the execute function is triggered before the previous one finished
+ */
+export type CancellableAsyncStateOnCancel = (cancelCallback: Fn) => void
+
+/**
+ * Cancellable version of `useAsyncState`.
+ *
+ * @see https://vueuse.org/useCancellableAsyncState
+ * @param promise         The cancellable promise / async function to be resolved
+ * @param initialState    The initial state, used until the first evaluation finishes
+ * @param options
+ */
+export function useCancellableAsyncState<Data, Params extends any[] = [], Shallow extends boolean = true >(
+  promise: Promise<Data> | ((onCancel: CancellableAsyncStateOnCancel, ...args: Params) => Promise<Data>),
+  initialState: Data,
+  options?: UseAsyncStateOptions<Shallow, Data>,
+): UseAsyncStateReturn<Data, Params, Shallow> {
+  const {
+    immediate = true,
+    delay = 0,
+    onError = noop,
+    onSuccess = noop,
+    resetOnExecute = true,
+    shallow = true,
+    throwError,
+  } = options ?? {}
+  const state = shallow ? shallowRef(initialState) : ref(initialState)
+  const isReady = ref(false)
+  const isLoading = ref(false)
+  const error = shallowRef<unknown | undefined>(undefined)
+
+  let counter = 0
+  let cleanup: Fn | undefined
+  const onCancel = (fn: Fn) => {
+    cleanup = () => {
+      fn()
+      cleanup = void 0
+    }
+  }
+
+  async function execute(delay = 0, ...args: any[]) {
+    counter++
+    if (cleanup)
+      cleanup()
+
+    const counterAtBeginning = counter
+    let hasFinished = false
+
+    if (resetOnExecute)
+      state.value = initialState
+    error.value = undefined
+    isReady.value = false
+    isLoading.value = true
+
+    if (delay > 0)
+      await promiseTimeout(delay)
+
+    const _promise = typeof promise === 'function'
+      ? promise(((cancelCallback) => {
+        onCancel(() => {
+          isLoading.value = false
+
+          if (!hasFinished)
+            cancelCallback()
+        })
+      }) as CancellableAsyncStateOnCancel, ...args as Params)
+      : promise
+
+    try {
+      const data = await _promise
+      if (counterAtBeginning === counter) {
+        state.value = data
+        isReady.value = true
+        onSuccess(data)
+      }
+    }
+    catch (e) {
+      error.value = e
+      onError(e)
+      if (throwError)
+        throw e
+    }
+    finally {
+      if (counterAtBeginning === counter)
+        isLoading.value = false
+
+      hasFinished = true
+    }
+
+    return state.value as Data
+  }
+
+  if (immediate)
+    execute(delay)
+
+  const shell: UseAsyncStateReturnBase<Data, Params, Shallow> = {
+    state: state as Shallow extends true ? Ref<Data> : Ref<UnwrapRef<Data>>,
+    isReady,
+    isLoading,
+    error,
+    execute,
+  }
+
+  function waitUntilIsLoaded() {
+    return new Promise<UseAsyncStateReturnBase<Data, Params, Shallow>>((resolve, reject) => {
+      until(isLoading).toBe(false)
+        .then(() => resolve(shell))
+        .catch(reject)
+    })
+  }
+
+  return {
+    ...shell,
+    then(onFulfilled, onRejected) {
+      return waitUntilIsLoaded()
+        .then(onFulfilled, onRejected)
+    },
+  }
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Add a cancellable version of `useAsyncState` that does not directly modify `useAsyncState` and maintains the same style as `useAsyncState`

- ref: #3328
<br>
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Known potential issue: When the `options.delay` is greater than the time interval between two consecutive calls to `execute`, the `onCancel` has not been invoked yet to register the callback