### PR TITLE
refactor(onKeyStroke): change handler return type to any

### DIFF
--- a/packages/core/onKeyStroke/index.ts
+++ b/packages/core/onKeyStroke/index.ts
@@ -36,11 +36,11 @@ function createKeyPredicate(keyFilter: KeyFilter): KeyPredicate {
  *
  * @see https://vueuse.org/onKeyStroke
  */
-export function onKeyStroke(key: KeyFilter, handler: (event: KeyboardEvent) => void, options?: OnKeyStrokeOptions): () => void
-export function onKeyStroke(handler: (event: KeyboardEvent) => void, options?: OnKeyStrokeOptions): () => void
+export function onKeyStroke(key: KeyFilter, handler: (event: KeyboardEvent) => any, options?: OnKeyStrokeOptions): () => void
+export function onKeyStroke(handler: (event: KeyboardEvent) => any, options?: OnKeyStrokeOptions): () => void
 export function onKeyStroke(...args: any[]) {
   let key: KeyFilter
-  let handler: (event: KeyboardEvent) => void
+  let handler: (event: KeyboardEvent) => any
   let options: OnKeyStrokeOptions = {}
 
   if (args.length === 3) {
@@ -90,7 +90,7 @@ export function onKeyStroke(...args: any[]) {
  * @param handler
  * @param options
  */
-export function onKeyDown(key: KeyFilter, handler: (event: KeyboardEvent) => void, options: Omit<OnKeyStrokeOptions, 'eventName'> = {}) {
+export function onKeyDown(key: KeyFilter, handler: (event: KeyboardEvent) => any, options: Omit<OnKeyStrokeOptions, 'eventName'> = {}) {
   return onKeyStroke(key, handler, { ...options, eventName: 'keydown' })
 }
 
@@ -102,7 +102,7 @@ export function onKeyDown(key: KeyFilter, handler: (event: KeyboardEvent) => voi
  * @param handler
  * @param options
  */
-export function onKeyPressed(key: KeyFilter, handler: (event: KeyboardEvent) => void, options: Omit<OnKeyStrokeOptions, 'eventName'> = {}) {
+export function onKeyPressed(key: KeyFilter, handler: (event: KeyboardEvent) => any, options: Omit<OnKeyStrokeOptions, 'eventName'> = {}) {
   return onKeyStroke(key, handler, { ...options, eventName: 'keypress' })
 }
 
@@ -114,6 +114,6 @@ export function onKeyPressed(key: KeyFilter, handler: (event: KeyboardEvent) => 
  * @param handler
  * @param options
  */
-export function onKeyUp(key: KeyFilter, handler: (event: KeyboardEvent) => void, options: Omit<OnKeyStrokeOptions, 'eventName'> = {}) {
+export function onKeyUp(key: KeyFilter, handler: (event: KeyboardEvent) => any, options: Omit<OnKeyStrokeOptions, 'eventName'> = {}) {
   return onKeyStroke(key, handler, { ...options, eventName: 'keyup' })
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

I've faced this issue when wanting to use `onKeyDown` function where I've passed an async function as a `handler` argument - the eslint was throwing `@typescript-eslint/no-misused-promises` error/warning. However it does not throw this when using `useEventListener`, as in typing of `useEventListener` is return type of handler argument `any`, instead of `void`.

Since `onKeyDown`, `onKeyStroke`, `onKeyUp` and `onKeyPress` are using `useEventListener` inside, I think it's better to keep the typing restrictions of `handler` argument the same between those and prevent the eslint error/warning to be thrown.