### PR TITLE
docs(syncRefs): add example of multiple targets

### DIFF
--- a/packages/shared/syncRefs/index.md
+++ b/packages/shared/syncRefs/index.md
@@ -13,15 +13,24 @@ Keep target refs in sync with a source ref
 import { syncRefs } from '@vueuse/core'
 
 const source = ref('hello')
-const target = ref('target')
+const target1 = ref('target1')
+const target2 = ref('target2')
 
-const stop = syncRefs(source, target)
+const stop = syncRefs(source, [target1, target2])
 
-console.log(target.value) // hello
+console.log(target1.value) // hello
+console.log(target2.value) // hello
 
 source.value = 'foo'
 
-console.log(target.value) // foo
+console.log(target1.value) // foo
+console.log(target2.value) // foo
+```
+
+You can also pass a single ref.
+
+```ts
+const stop = syncRefs(source, target)
 ```
 
 ## Watch options

--- a/packages/shared/syncRefs/index.md
+++ b/packages/shared/syncRefs/index.md
@@ -13,6 +13,25 @@ Keep target refs in sync with a source ref
 import { syncRefs } from '@vueuse/core'
 
 const source = ref('hello')
+const target = ref('target')
+
+const stop = syncRefs(source, target)
+
+console.log(target.value) // hello
+
+source.value = 'foo'
+
+console.log(target.value) // foo
+```
+
+### Sync with multiple targets
+
+You can also pass an array of refs to sync.
+
+```ts
+import { syncRefs } from '@vueuse/core'
+
+const source = ref('hello')
 const target1 = ref('target1')
 const target2 = ref('target2')
 
@@ -25,12 +44,6 @@ source.value = 'foo'
 
 console.log(target1.value) // foo
 console.log(target2.value) // foo
-```
-
-You can also pass a single ref.
-
-```ts
-const stop = syncRefs(source, target)
 ```
 
 ## Watch options


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

No related issues.

While `syncRefs` accepts both single ref and multiple refs as an array, the documentation only describes the former case.

When I saw documentation of `syncRefs` for the first time, I thought `syncRefs` is another version of `syncRef` that accepts multiple refs (although it's not if I'm correct). But I can't find how to sync multiple refs because the documentation only describes how to pass a single ref.

This PR is to add description so that users can understand all usecases without seeing the code.

Another point is that, with this PR, the sample code comes to be aligned with the demo UI.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

This is my very first contribution to VueUse.
So, I might not be aware of the past decisions, although I read all guidelines.