### PR TITLE
feat(useCurrentElement): Allow get current element from a specific component

### DIFF
--- a/packages/core/useCurrentElement/index.md
+++ b/packages/core/useCurrentElement/index.md
@@ -45,6 +45,10 @@ export default {
 </template>
 ```
 
+::: warning
+Only works for Vue 3 because it uses [computedWithControl](https://vueuse.org/shared/computedWithControl/#manual-triggering) under the hood
+:::
+
 ## Caveats
 
 This functions uses [`$el` under the hood](https://vuejs.org/api/component-instance.html#el).

--- a/packages/core/useCurrentElement/index.md
+++ b/packages/core/useCurrentElement/index.md
@@ -14,6 +14,37 @@ import { useCurrentElement } from '@vueuse/core'
 const el = useCurrentElement() // ComputedRef<Element>
 ```
 
+Or pass a specific root vue component
+
+```vue
+<script>
+import { ref } from 'vue'
+import { useCurrentElement } from '@vueuse/core'
+
+export default {
+  setup() {
+    const rootComponentRef = ref()
+
+    const el = useCurrentElement(rootComponentRef) // ComputedRef<Element>
+    // use el any way you want
+
+    return {
+      rootComponentRef,
+      /* ... */
+    }
+  },
+}
+</script>
+
+<template>
+  <div>
+    <OtherVueComponent ref="rootComponentRef" />
+
+    <p>Hello world</p>
+  </div>
+</template>
+```
+
 ## Caveats
 
 This functions uses [`$el` under the hood](https://vuejs.org/api/component-instance.html#el).

--- a/packages/core/useCurrentElement/index.md
+++ b/packages/core/useCurrentElement/index.md
@@ -14,7 +14,7 @@ import { useCurrentElement } from '@vueuse/core'
 const el = useCurrentElement() // ComputedRef<Element>
 ```
 
-Or pass a specific root vue component
+Or pass a specific vue component
 
 ```vue
 <script>

--- a/packages/core/useCurrentElement/index.md
+++ b/packages/core/useCurrentElement/index.md
@@ -17,35 +17,24 @@ const el = useCurrentElement() // ComputedRef<Element>
 Or pass a specific vue component
 
 ```vue
-<script>
+<script setup>
 import { ref } from 'vue'
 import { useCurrentElement } from '@vueuse/core'
 
-export default {
-  setup() {
-    const rootComponentRef = ref()
+const componentRef = ref()
 
-    const el = useCurrentElement(rootComponentRef) // ComputedRef<Element>
-    // use el any way you want
-
-    return {
-      rootComponentRef,
-      /* ... */
-    }
-  },
-}
+const el = useCurrentElement(componentRef) // ComputedRef<Element>
 </script>
 
 <template>
   <div>
-    <OtherVueComponent ref="rootComponentRef" />
-
+    <OtherVueComponent ref="componentRef" />
     <p>Hello world</p>
   </div>
 </template>
 ```
 
-::: warning
+::: info
 Only works for Vue 3 because it uses [computedWithControl](https://vueuse.org/shared/computedWithControl/#manual-triggering) under the hood
 :::
 

--- a/packages/core/useCurrentElement/index.test.ts
+++ b/packages/core/useCurrentElement/index.test.ts
@@ -1,4 +1,4 @@
-import { defineComponent, shallowRef } from 'vue'
+import { defineComponent, shallowRef } from 'vue-demi'
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 import { useCurrentElement } from '.'

--- a/packages/core/useCurrentElement/index.test.ts
+++ b/packages/core/useCurrentElement/index.test.ts
@@ -1,0 +1,57 @@
+import { defineComponent, shallowRef } from 'vue'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { useCurrentElement } from '.'
+
+describe('useCurrentElement', () => {
+  it('should be defined', () => {
+    expect(useCurrentElement).toBeDefined()
+  })
+
+  it('should return the root element from the current component', () => {
+    const wrapper = mount({
+      template: '<p ref="el">test</p>',
+      setup() {
+        const el = shallowRef<HTMLElement>()
+        const currentElement = useCurrentElement()
+
+        return { el, currentElement }
+      },
+    })
+    const vm = wrapper.vm
+
+    expect(vm.currentElement).toBe(vm.el)
+    wrapper.unmount()
+  })
+
+  it('should return the root element from the passed component', () => {
+    const TestVueComponent = defineComponent({
+      setup() {
+        const rootEl = shallowRef<HTMLElement>()
+
+        return { rootEl }
+      },
+      template: '<div ref="rootEl">Hello world</div>',
+    })
+    const wrapper = mount({
+      components: {
+        TestVueComponent,
+      },
+      template: `<p>
+      Testing
+      <TestVueComponent ref="el" />
+      </p>`,
+      setup() {
+        const el = shallowRef()
+        const currentElementEl = useCurrentElement(el)
+
+        return { el, currentElementEl }
+      },
+    })
+    const vm = wrapper.vm
+
+    expect(vm.currentElementEl).toBe((vm.el as typeof TestVueComponent).rootEl)
+    expect((vm.currentElementEl as HTMLElement).textContent).toBe('Hello world')
+    wrapper.unmount()
+  })
+})

--- a/packages/core/useCurrentElement/index.test.ts
+++ b/packages/core/useCurrentElement/index.test.ts
@@ -3,10 +3,8 @@ import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 import { useCurrentElement } from '.'
 
+// Manual triggering only works for Vue 3 - https://vueuse.org/shared/computedWithControl/#manual-triggering
 describe.skipIf(isVue2)('useCurrentElement', () => {
-  // WARNING
-  // Because: Manual triggering only works for Vue 3 - https://vueuse.org/shared/computedWithControl/#manual-triggering
-
   it('should be defined', () => {
     expect(useCurrentElement).toBeDefined()
   })

--- a/packages/core/useCurrentElement/index.test.ts
+++ b/packages/core/useCurrentElement/index.test.ts
@@ -1,9 +1,12 @@
-import { defineComponent, shallowRef } from 'vue-demi'
+import { defineComponent, isVue2, shallowRef } from 'vue-demi'
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 import { useCurrentElement } from '.'
 
-describe('useCurrentElement', () => {
+describe.skipIf(isVue2)('useCurrentElement', () => {
+  // WARNING
+  // Because: Manual triggering only works for Vue 3 - https://vueuse.org/shared/computedWithControl/#manual-triggering
+
   it('should be defined', () => {
     expect(useCurrentElement).toBeDefined()
   })

--- a/packages/core/useCurrentElement/index.ts
+++ b/packages/core/useCurrentElement/index.ts
@@ -1,12 +1,16 @@
 // eslint-disable-next-line no-restricted-imports
 import { getCurrentInstance, onMounted, onUpdated } from 'vue-demi'
 import { computedWithControl } from '@vueuse/shared'
+import type { MaybeElement, MaybeElementRef, VueInstance } from '../unrefElement'
+import { unrefElement } from '../unrefElement'
 
-export function useCurrentElement<T extends Element = Element>() {
+export function useCurrentElement<T extends VueInstance = VueInstance, R extends MaybeElement = MaybeElement>(
+  rootComponent?: MaybeElementRef<T>,
+) {
   const vm = getCurrentInstance()!
   const currentElement = computedWithControl(
     () => null,
-    () => vm.proxy!.$el as T,
+    () => (rootComponent ? unrefElement(rootComponent) : vm.proxy!.$el) as R,
   )
 
   onUpdated(currentElement.trigger)

--- a/packages/core/useCurrentElement/index.ts
+++ b/packages/core/useCurrentElement/index.ts
@@ -13,6 +13,8 @@ export function useCurrentElement<T extends MaybeElement = MaybeElement, R exten
     () => (rootComponent ? unrefElement(rootComponent) : vm.proxy!.$el) as T,
   )
 
+  // WARNING
+  // Manual triggering only works for Vue 3 - https://vueuse.org/shared/computedWithControl/#manual-triggering
   onUpdated(currentElement.trigger)
   onMounted(currentElement.trigger)
 

--- a/packages/core/useCurrentElement/index.ts
+++ b/packages/core/useCurrentElement/index.ts
@@ -4,7 +4,10 @@ import { computedWithControl } from '@vueuse/shared'
 import type { MaybeElement, MaybeElementRef, VueInstance } from '../unrefElement'
 import { unrefElement } from '../unrefElement'
 
-export function useCurrentElement<T extends MaybeElement = MaybeElement, R extends VueInstance = VueInstance >(
+export function useCurrentElement<
+  T extends MaybeElement = MaybeElement,
+  R extends VueInstance = VueInstance,
+>(
   rootComponent?: MaybeElementRef<R>,
 ) {
   const vm = getCurrentInstance()!
@@ -13,8 +16,6 @@ export function useCurrentElement<T extends MaybeElement = MaybeElement, R exten
     () => (rootComponent ? unrefElement(rootComponent) : vm.proxy!.$el) as T,
   )
 
-  // WARNING
-  // Manual triggering only works for Vue 3 - https://vueuse.org/shared/computedWithControl/#manual-triggering
   onUpdated(currentElement.trigger)
   onMounted(currentElement.trigger)
 

--- a/packages/core/useCurrentElement/index.ts
+++ b/packages/core/useCurrentElement/index.ts
@@ -4,13 +4,13 @@ import { computedWithControl } from '@vueuse/shared'
 import type { MaybeElement, MaybeElementRef, VueInstance } from '../unrefElement'
 import { unrefElement } from '../unrefElement'
 
-export function useCurrentElement<T extends VueInstance = VueInstance, R extends MaybeElement = MaybeElement>(
-  rootComponent?: MaybeElementRef<T>,
+export function useCurrentElement<T extends MaybeElement = MaybeElement, R extends VueInstance = VueInstance >(
+  rootComponent?: MaybeElementRef<R>,
 ) {
   const vm = getCurrentInstance()!
   const currentElement = computedWithControl(
     () => null,
-    () => (rootComponent ? unrefElement(rootComponent) : vm.proxy!.$el) as R,
+    () => (rootComponent ? unrefElement(rootComponent) : vm.proxy!.$el) as T,
   )
 
   onUpdated(currentElement.trigger)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

PR adds the possibility of passing another component, allowing you to get its root element.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
