### PR TITLE
feat(computedRef): new function

### DIFF
--- a/packages/shared/computedRef/index.md
+++ b/packages/shared/computedRef/index.md
@@ -1,0 +1,43 @@
+---
+category: Reactivity
+---
+
+# computedRef
+
+Instead of returning a non-reactive ref that `computed` does, `computedRef` returns a fully reactive ref.
+
+It's similar to `reactiveComputed`, but returns a ref rather than reactive, and thus can be used for non-object values (including `undefined`).
+
+## Usage
+
+```ts
+import { computedRef } from '@vueuse/core'
+
+const data = ref('foo')
+
+const state = computedRef(() => data.value)
+
+console.log(state.value) // foo
+
+state.name = 'bar'
+
+console.log(state.value) // bar
+
+data.value = 'baz'
+
+console.log(state.name) // baz
+```
+
+### Manual Triggering
+
+You can also manually trigger the update by:
+
+```ts
+const ref = computedRef(() => { /* ... */ })
+
+ref.trigger()
+```
+
+::: warning
+Manual triggering only works for Vue 3
+:::

--- a/packages/shared/computedRef/index.test.ts
+++ b/packages/shared/computedRef/index.test.ts
@@ -1,0 +1,37 @@
+import { isVue3, ref } from 'vue-demi'
+import { describe, expect, it } from 'vitest'
+import { computedRef } from '.'
+
+describe('computedRef', () => {
+  it('should work', () => {
+    const data = ref('foo')
+
+    const state = computedRef(() => data.value.toUpperCase())
+
+    expect(state.value).toBe('FOO')
+
+    state.value = 'bar'
+
+    expect(state.value).toBe('bar')
+
+    data.value = 'baz'
+
+    expect(state.value).toBe('BAZ')
+  })
+
+  it.runIf(isVue3)('custom trigger', () => {
+    const data = ref('foo')
+
+    const state = computedRef(() => data.value.toUpperCase())
+
+    expect(state.value).toBe('FOO')
+
+    state.value = 'bar'
+
+    expect(state.value).toBe('bar')
+
+    state.trigger()
+
+    expect(state.value).toBe('FOO')
+  })
+})

--- a/packages/shared/computedRef/index.ts
+++ b/packages/shared/computedRef/index.ts
@@ -1,0 +1,33 @@
+import { ref, toValue, watch } from 'vue-demi'
+import type { Ref, WatchSource } from 'vue-demi'
+
+export interface RefWithControl<T> extends Ref<T> {
+  /**
+   * Force update the ref value.
+   */
+  trigger(): void
+}
+
+/**
+ * Ref that syncs to the watch source.
+ *
+ * It's similar to the built-in `computed`, but returns a fully reactive ref.
+ */
+export function computedRef<T>(source: WatchSource<T>) {
+  const result = ref() as RefWithControl<T>
+
+  watch(source, (value) => {
+    result.value = value
+  }, {
+    immediate: true,
+    flush: 'sync',
+  })
+
+  if (Object.isExtensible(result)) {
+    result.trigger = () => {
+      result.value = toValue(source)
+    }
+  }
+
+  return result
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

---

### Description

Adds `computedRef` function, which returns a ref that derives from a watch source.

Fixes #3485.

### Additional context

1. I am aware that there is a slowdown on new functions. I elaborated use-cases in #3485, and I personally use this approach very often on CRUD's. The function is fully generalized, it's short and doesn't bring along any new dependencies.
2. I didn't test this in Vue 2, and in particular I'm not sure if I correctly marked that ref.trigger() will only work in Vue 3. This is a copy/paste from `computedEager`.
