### PR TITLE
feat(useManualRefHistory): add support to async data parsing/dumping

### DIFF
--- a/packages/core/useDebouncedRefHistory/index.ts
+++ b/packages/core/useDebouncedRefHistory/index.ts
@@ -11,10 +11,10 @@ import { useRefHistory } from '../useRefHistory'
  * @param source
  * @param options
  */
-export function useDebouncedRefHistory<Raw, Serialized = Raw>(
+export function useDebouncedRefHistory<Raw, Serialized = Raw, Async extends boolean = false>(
   source: Ref<Raw>,
-  options: Omit<UseRefHistoryOptions<Raw, Serialized>, 'eventFilter'> & { debounce?: MaybeRefOrGetter<number> } = {},
-): UseRefHistoryReturn<Raw, Serialized> {
+  options: Omit<UseRefHistoryOptions<Raw, Serialized, Async>, 'eventFilter'> & { debounce?: MaybeRefOrGetter<number> } = {},
+): UseRefHistoryReturn<Raw, Serialized, Async> {
   const filter = options.debounce ? debounceFilter(options.debounce) : undefined
   const history = useRefHistory(source, { ...options, eventFilter: filter })
 

--- a/packages/core/useManualRefHistory/index-async.test.ts
+++ b/packages/core/useManualRefHistory/index-async.test.ts
@@ -1,0 +1,224 @@
+import { isReactive, ref } from 'vue-demi'
+import { describe, expect, it } from 'vitest'
+import { useManualRefHistory } from '.'
+
+const wait = (ms = 50) => new Promise(r => setTimeout(r, ms))
+
+describe('useManualRefHistory async mode', () => {
+  it('should record', async () => {
+    const v = ref(0)
+    const { history, commit } = useManualRefHistory(v, { async: true })
+
+    expect(history.value.length).toBe(1)
+    expect(history.value[0].snapshot).toBe(0)
+
+    v.value = 2
+    await commit()
+
+    expect(history.value.length).toBe(2)
+    expect(history.value[0].snapshot).toBe(2)
+    expect(history.value[1].snapshot).toBe(0)
+  })
+
+  it('should be able to undo and redo', async () => {
+    const v = ref(0)
+
+    const { commit, undo, redo, clear, canUndo, canRedo, history, last } = useManualRefHistory(v, { async: true })
+
+    await wait()
+
+    expect(canUndo.value).toBe(false)
+    expect(canRedo.value).toBe(false)
+
+    v.value = 2
+    await commit()
+    v.value = 3
+    await commit()
+    v.value = 4
+    await commit()
+
+    expect(canUndo.value).toBe(true)
+    expect(canRedo.value).toBe(false)
+
+    expect(v.value).toBe(4)
+    expect(history.value.length).toBe(4)
+    expect(last.value.snapshot).toBe(4)
+    await undo()
+
+    expect(canUndo.value).toBe(true)
+    expect(canRedo.value).toBe(true)
+
+    expect(v.value).toBe(3)
+    expect(last.value.snapshot).toBe(3)
+    await undo()
+    expect(v.value).toBe(2)
+    expect(last.value.snapshot).toBe(2)
+    await redo()
+    expect(v.value).toBe(3)
+    expect(last.value.snapshot).toBe(3)
+    await redo()
+    expect(v.value).toBe(4)
+    expect(last.value.snapshot).toBe(4)
+
+    expect(canUndo.value).toBe(true)
+    expect(canRedo.value).toBe(false)
+
+    await redo()
+    expect(v.value).toBe(4)
+    expect(last.value.snapshot).toBe(4)
+
+    clear()
+    expect(canUndo.value).toBe(false)
+    expect(canRedo.value).toBe(false)
+  })
+
+  it('object with deep', async () => {
+    const v = ref({ foo: 'bar' })
+    const { commit, undo, history } = useManualRefHistory(v, {
+      async: true,
+      clone: true,
+    })
+
+    await wait()
+
+    expect(history.value.length).toBe(1)
+    expect(history.value[0].snapshot.foo).toBe('bar')
+
+    v.value.foo = 'foo'
+    await commit()
+
+    expect(history.value.length).toBe(2)
+    expect(history.value[0].snapshot.foo).toBe('foo')
+
+    // different references
+    expect(history.value[1].snapshot.foo).toBe('bar')
+    expect(history.value[0].snapshot).not.toBe(history.value[1].snapshot)
+
+    await undo()
+
+    // history references should not be equal to the source
+    expect(history.value[0].snapshot).not.toBe(v.value)
+  })
+
+  it('object with clone function', async () => {
+    const v = ref({ foo: 'bar' })
+    const { commit, undo, history } = useManualRefHistory(v, { async: true, clone: x => JSON.parse(JSON.stringify(x)) })
+
+    await wait()
+
+    expect(history.value.length).toBe(1)
+    expect(history.value[0].snapshot.foo).toBe('bar')
+
+    v.value.foo = 'foo'
+    await commit()
+
+    expect(history.value.length).toBe(2)
+    expect(history.value[0].snapshot.foo).toBe('foo')
+
+    // different references
+    expect(history.value[1].snapshot.foo).toBe('bar')
+    expect(history.value[0].snapshot).not.toBe(history.value[1].snapshot)
+
+    await undo()
+
+    // history references should not be equal to the source
+    expect(history.value[0].snapshot).not.toBe(v.value)
+  })
+
+  it('dump + parse', async () => {
+    const v = ref({ a: 'bar' })
+    const { history, commit, undo } = useManualRefHistory(v, {
+      async: true,
+      dump: async v => JSON.stringify(await v),
+      parse: async (v: string) => JSON.parse(v),
+    })
+
+    await wait()
+
+    expect(history.value.length).toBe(1)
+    expect(history.value[0].snapshot).toBe('{"a":"bar"}')
+
+    v.value.a = 'foo'
+    await commit()
+
+    expect(history.value.length).toBe(2)
+    expect(history.value[0].snapshot).toBe('{"a":"foo"}')
+    expect(history.value[1].snapshot).toBe('{"a":"bar"}')
+
+    await undo()
+
+    expect(v.value.a).toBe('bar')
+  })
+
+  it('reset', async () => {
+    const v = ref(0)
+    const { history, commit, undoStack, redoStack, reset, undo } = useManualRefHistory(v, { async: true })
+
+    await wait()
+
+    expect(history.value.length).toBe(1)
+    expect(history.value[0].snapshot).toBe(0)
+
+    v.value = 1
+    await commit()
+
+    v.value = 2
+
+    expect(history.value.length).toBe(2)
+    expect(history.value[0].snapshot).toBe(1)
+    expect(history.value[1].snapshot).toBe(0)
+
+    await reset()
+
+    // v value needs to be the last history point, but history is unchanged
+    expect(v.value).toBe(1)
+
+    expect(history.value.length).toBe(2)
+    expect(history.value[0].snapshot).toBe(1)
+    expect(history.value[1].snapshot).toBe(0)
+
+    await reset()
+
+    // Calling reset twice is a no-op
+    expect(v.value).toBe(1)
+
+    expect(history.value.length).toBe(2)
+    expect(history.value[1].snapshot).toBe(0)
+    expect(history.value[0].snapshot).toBe(1)
+
+    // Same test, but with a non empty redoStack
+
+    v.value = 3
+    await commit()
+
+    await undo()
+
+    v.value = 2
+
+    await reset()
+
+    expect(v.value).toBe(1)
+
+    expect(undoStack.value.length).toBe(1)
+    expect(undoStack.value[0].snapshot).toBe(0)
+
+    expect(redoStack.value.length).toBe(1)
+    expect(redoStack.value[0].snapshot).toBe(3)
+  })
+
+  it('snapshots should not be reactive', async () => {
+    const v = ref(0)
+    const { history, commit } = useManualRefHistory(v, { async: true })
+
+    await wait()
+
+    expect(history.value.length).toBe(1)
+    expect(history.value[0].snapshot).toBe(0)
+
+    v.value = 2
+    await commit()
+
+    expect(isReactive(history.value[0])).toBe(false)
+    expect(isReactive(history.value[1])).toBe(false)
+  })
+})

--- a/packages/core/useManualRefHistory/index.md
+++ b/packages/core/useManualRefHistory/index.md
@@ -103,3 +103,25 @@ const refHistory = useManualRefHistory(target, {
 
 refHistory.clear() // explicitly clear all the history
 ```
+
+### Asynchronous Usage
+
+By default, asynchronous parsing and dumping of data are disabled. However, you can enable them by setting the `async` option to `true`.
+
+Keep in mind that when `async` is set to `true`, certain methods such as `commit`, `undo`, `redo`, and `reset` will return promises.
+
+```ts
+useManualRefHistory(target, {
+  async: true,
+  dump: async (v) => {
+    /** Perform asynchronous request */
+
+    return JSON.stringify(await v)
+  },
+  parse: async (v) => {
+    /** Perform asynchronous request */
+
+    return JSON.parse(v)
+  },
+})
+```

--- a/packages/core/useThrottledRefHistory/index.ts
+++ b/packages/core/useThrottledRefHistory/index.ts
@@ -4,9 +4,9 @@ import type { Ref } from 'vue-demi'
 import type { UseRefHistoryOptions, UseRefHistoryReturn } from '../useRefHistory'
 import { useRefHistory } from '../useRefHistory'
 
-export type UseThrottledRefHistoryOptions<Raw, Serialized = Raw> = Omit<UseRefHistoryOptions<Raw, Serialized>, 'eventFilter'> & { throttle?: MaybeRef<number>, trailing?: boolean }
+export type UseThrottledRefHistoryOptions<Raw, Serialized = Raw, Async extends boolean = false> = Omit<UseRefHistoryOptions<Raw, Serialized, Async>, 'eventFilter'> & { throttle?: MaybeRef<number>, trailing?: boolean }
 
-export type UseThrottledRefHistoryReturn<Raw, Serialized = Raw> = UseRefHistoryReturn<Raw, Serialized>
+export type UseThrottledRefHistoryReturn<Raw, Serialized = Raw, Async extends boolean = false> = UseRefHistoryReturn<Raw, Serialized, Async>
 
 /**
  * Shorthand for [useRefHistory](https://vueuse.org/useRefHistory) with throttled filter.
@@ -15,10 +15,10 @@ export type UseThrottledRefHistoryReturn<Raw, Serialized = Raw> = UseRefHistoryR
  * @param source
  * @param options
  */
-export function useThrottledRefHistory<Raw, Serialized = Raw>(
+export function useThrottledRefHistory<Raw, Serialized = Raw, Async extends boolean = false>(
   source: Ref<Raw>,
-  options: UseThrottledRefHistoryOptions<Raw, Serialized> = {},
-): UseThrottledRefHistoryReturn<Raw, Serialized> {
+  options: UseThrottledRefHistoryOptions<Raw, Serialized, Async> = {},
+): UseThrottledRefHistoryReturn<Raw, Serialized, Async> {
   const { throttle = 200, trailing = true } = options
   const filter = throttleFilter(throttle, trailing)
   const history = useRefHistory(source, { ...options, eventFilter: filter })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

This PR adds support for asynchronous data parsing and dumping in the `useManualRefHistory` hook (and all others hooks which use this one as base). With this enhancement, users can now handle asynchronous requests before dumping or parsing data.

### Additional context

While this feature is initially developed for my project, its utility extends to others as well. For example, it facilitates data synchronization with a database prior to frontend display during undo and redo operations, thereby averting application inconsistencies. Here's a specific use case:

In my project, I'm constructing a dashboard featuring resizable objects with customizable colors and text, resembling a basic editor. When users initiate undo (Ctrl+Z) or redo (Ctrl+Shift+Z or Ctrl+Y) actions, some components may be deleted and subsequently recovered. Before presenting these recovered items on the dashboard, I must recreate them in the database to maintain consistency.

```typescript
const history = useDebouncedRefHistory(components, {
  async: true,
  debounce: 300,
  deep: true,
  parse: async (v) => {
    const current = components.value;
    const updated = JSON.parse(v) as typeof components.value;

    // Items that have been recovered and need to be recreated in the database before they can be used again on the frontend.
    const added = updated.filter((u) => !current.some((c) => c.id === u.id));

    if (added.length) state.loading = true;

    for (const component of added) {
      const c = await actions.createComponent(component);

      if (!c) continue;

      component.id = c.id;
    }

    state.loading = false;

    return updated;
  },
});
```

**NOTE**: I've duplicated the test file and named it `index-async.test.ts` to rerun all original tests but in async mode. If there's a better approach, please advise.
