### PR TITLE
fix(useFileSystemAccess): updateData on modified file

### DIFF
--- a/packages/core/useFileSystemAccess/demo.vue
+++ b/packages/core/useFileSystemAccess/demo.vue
@@ -37,6 +37,9 @@ async function onSave() {
       <button @click="res.open()">
         Open
       </button>
+      <button @click="res.updateData()">
+        Update
+      </button>
       <button @click="res.create()">
         New file
       </button>

--- a/packages/core/useFileSystemAccess/index.ts
+++ b/packages/core/useFileSystemAccess/index.ts
@@ -121,7 +121,6 @@ export function useFileSystemAccess(options: UseFileSystemAccessOptions = {}): U
       return
     const [handle] = await window.showOpenFilePicker({ ...toValue(options), ..._options })
     fileHandle.value = handle
-    await updateFile()
     await updateData()
   }
 
@@ -130,7 +129,6 @@ export function useFileSystemAccess(options: UseFileSystemAccessOptions = {}): U
       return
     fileHandle.value = await (window as FileSystemAccessWindow).showSaveFilePicker({ ...options, ..._options })
     data.value = undefined
-    await updateFile()
     await updateData()
   }
 
@@ -170,6 +168,7 @@ export function useFileSystemAccess(options: UseFileSystemAccessOptions = {}): U
   }
 
   async function updateData() {
+    await updateFile()
     const type = toValue(dataType)
     if (type === 'Text')
       data.value = await file.value?.text()


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

---

### Description

Fix the bug #3779 that prevent the content of a modified file to be updated in `useFileSystemAccess`.
Calling `updateData()` now succeeds and the modified file content is correctly exposed.

### Additional context

My first PR, be gentle :wink: 
