### PR TITLE
fix(useMounted): compatible with vue2.7

### DIFF
--- a/packages/core/useMounted/index.ts
+++ b/packages/core/useMounted/index.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-restricted-imports
-import { getCurrentInstance, onMounted, ref } from 'vue-demi'
+import { getCurrentInstance, isVue2, onMounted, ref } from 'vue-demi'
 
 /**
  * Mounted state in ref.
@@ -13,7 +13,7 @@ export function useMounted() {
   if (instance) {
     onMounted(() => {
       isMounted.value = true
-    }, instance)
+    }, isVue2 ? null : getCurrentInstance())
   }
 
   return isMounted


### PR DESCRIPTION
在vue2.7中 onMounted第二个参数的值应该为instance?.proxy，设置为instance会导致报错，由于vue-demi中的onMounted的参数类型不支持ComponentPublicInstance，先设置为null保证在vue2.7中可以正常运行
