### PR TITLE
fix(useIDBKeyval): use toRaw instead of overriding the original object

### DIFF
--- a/packages/integrations/useIDBKeyval/index.ts
+++ b/packages/integrations/useIDBKeyval/index.ts
@@ -2,7 +2,7 @@ import type { ConfigurableFlush, MaybeRefOrGetter, RemovableRef } from '@vueuse/
 import { toValue } from '@vueuse/shared'
 import { watchPausable } from '@vueuse/core'
 import type { Ref } from 'vue-demi'
-import { ref, shallowRef } from 'vue-demi'
+import { ref, shallowRef, toRaw } from 'vue-demi'
 import { del, get, set, update } from 'idb-keyval'
 
 export interface UseIDBOptions extends ConfigurableFlush {
@@ -92,12 +92,7 @@ export function useIDBKeyval<T>(
       }
       else {
         // IndexedDB does not support saving proxies, convert from proxy before saving
-        if (Array.isArray(data.value))
-          await update(key, () => (JSON.parse(JSON.stringify(data.value))))
-        else if (typeof data.value === 'object')
-          await update(key, () => ({ ...data.value }))
-        else
-          await update(key, () => (data.value))
+        await update(key, () => toRaw(data.value))
       }
     }
     catch (e) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Given that IndexedDB doesn't accept proxies, I think it makes more sense to use Vue's ``toRaw`` instead of our own guessing of the given object type (the current codebase doesn't cover ES6 Maps and assume everything is a normal object by default).
