### PR TITLE
fix(useClipboard): fix issue when permission is not defined

### DIFF
--- a/packages/core/useClipboard/index.ts
+++ b/packages/core/useClipboard/index.ts
@@ -71,7 +71,7 @@ export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<strin
   const timeout = useTimeoutFn(() => copied.value = false, copiedDuring)
 
   function updateText() {
-    if (isClipboardApiSupported.value && permissionRead.value && permissionRead.value !== 'denied') {
+    if (isClipboardApiSupported.value && isAllowed(permissionRead.value)) {
       navigator!.clipboard.readText().then((value) => {
         text.value = value
       })
@@ -86,7 +86,7 @@ export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<strin
 
   async function copy(value = toValue(source)) {
     if (isSupported.value && value != null) {
-      if (isClipboardApiSupported.value && permissionWrite.value && permissionWrite.value !== 'denied')
+      if (isClipboardApiSupported.value && isAllowed(permissionWrite.value))
         await navigator!.clipboard.writeText(value)
       else
         legacyCopy(value)
@@ -110,6 +110,10 @@ export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<strin
 
   function legacyRead() {
     return document?.getSelection?.()?.toString() ?? ''
+  }
+
+  function isAllowed(status: PermissionStatus | undefined) {
+    return status === 'granted' || status === 'prompt'
   }
 
   return {

--- a/packages/core/useClipboard/index.ts
+++ b/packages/core/useClipboard/index.ts
@@ -71,7 +71,7 @@ export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<strin
   const timeout = useTimeoutFn(() => copied.value = false, copiedDuring)
 
   function updateText() {
-    if (isClipboardApiSupported.value && permissionRead.value !== 'denied') {
+    if (isClipboardApiSupported.value && permissionRead.value && permissionRead.value !== 'denied') {
       navigator!.clipboard.readText().then((value) => {
         text.value = value
       })
@@ -86,7 +86,7 @@ export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<strin
 
   async function copy(value = toValue(source)) {
     if (isSupported.value && value != null) {
-      if (isClipboardApiSupported.value && permissionWrite.value !== 'denied')
+      if (isClipboardApiSupported.value && permissionWrite.value && permissionWrite.value !== 'denied')
         await navigator!.clipboard.writeText(value)
       else
         legacyCopy(value)

--- a/packages/core/useClipboard/index.ts
+++ b/packages/core/useClipboard/index.ts
@@ -112,7 +112,7 @@ export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<strin
     return document?.getSelection?.()?.toString() ?? ''
   }
 
-  function isAllowed(status: PermissionStatus | undefined) {
+  function isAllowed(status: PermissionState | undefined) {
     return status === 'granted' || status === 'prompt'
   }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

  No, it's hard to simulate a browser like wechat browser


### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

There are a lot of built-in browsers (Chinese app likes them), which does not implement permission api return value, for example on latest Wechat client  8.0.47, the demo of the usePermission page looks like this:

![Screenshot_2024-02-22-14-21-02-41_e39d2c7de19156b](https://github.com/vueuse/vueuse/assets/33315834/230d964b-6ce8-4362-8517-15d1873ddef5)

That is because when calling with `usePermission('xxx')`, these browsers return `undefined` (including the 'clipboard-write' and 'clipboard-read' used in `useClipboard`

When the value is undefined, we'd better treat it as `denied`, e.g. wechat browser just denied it with out any asking for security reasons:

![Screenshot_2024-02-22-13-58-03-41_e39d2c7de19156b](https://github.com/vueuse/vueuse/assets/33315834/99c38c52-6878-41d7-bbc6-e705950c80a5)

The issue is included in https://github.com/vueuse/vueuse/pull/3379 as a feature for falling back to legacy if possible.