### PR TITLE
fix(useActiveElement/useFocusWithin): replace computedWithControl with locally tracked ref

### DIFF
--- a/packages/core/useActiveElement/index.ts
+++ b/packages/core/useActiveElement/index.ts
@@ -1,4 +1,4 @@
-import { computedWithControl } from '@vueuse/shared'
+import { ref } from 'vue-demi'
 import { useEventListener } from '../useEventListener'
 import type { ConfigurableDocumentOrShadowRoot, ConfigurableWindow } from '../_configurable'
 import { defaultWindow } from '../_configurable'
@@ -36,19 +36,21 @@ export function useActiveElement<T extends HTMLElement>(
     return element
   }
 
-  const activeElement = computedWithControl(
-    () => null,
-    () => getDeepActiveElement() as T | null | undefined,
-  )
+  const activeElement = ref<T | null | undefined>()
+  const trigger = () => {
+    activeElement.value = getDeepActiveElement() as T | null | undefined
+  }
 
   if (window) {
     useEventListener(window, 'blur', (event) => {
       if (event.relatedTarget !== null)
         return
-      activeElement.trigger()
+      trigger()
     }, true)
-    useEventListener(window, 'focus', activeElement.trigger, true)
+    useEventListener(window, 'focus', trigger, true)
   }
+
+  trigger()
 
   return activeElement
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
useActiveElement and useFocusWithin are currently broken due to computedWithControl being used inside of computed triggering the following warning:
```
[Vue warn] Computed is still dirty after getter evaluation, likely because a computed is mutating its own dependency in its getter. State mutations in computed getters should be avoided.  Check the docs for more details: https://vuejs.org/guide/essentials/computed.html#getters-should-be-side-effect-free
```

This PR replaces computedWithControl with a locally tracked ref so useActiveElement can be used inside a computed as done in useFocusWithin:

https://github.com/vueuse/vueuse/blob/1b67d96570cc9b5a35859ea99693113e6cb5ee24/packages/core/useFocusWithin/index.ts#L23-L25

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

related issues: #3799, #3794, #3787, #3774, #3760

upstream issue: https://github.com/vuejs/core/issues/10341