### PR TITLE
fix(useScroll): sync scroll val to internal state #3809

### DIFF
--- a/packages/core/useScroll/index.ts
+++ b/packages/core/useScroll/index.ts
@@ -144,12 +144,14 @@ export function useScroll(
       left: toValue(_x) ?? x.value,
       behavior: toValue(behavior),
     })
-    const scrollContainer =
-      (_element as Window)?.document?.documentElement ||
-      (_element as Document)?.documentElement ||
-      (_element as Element);
-    if (x) internalX.value = scrollContainer.scrollLeft;
-    if (y) internalY.value = scrollContainer.scrollTop;
+    const scrollContainer
+      = (_element as Window)?.document?.documentElement
+      || (_element as Document)?.documentElement
+      || (_element as Element)
+    if (x)
+      internalX.value = scrollContainer.scrollLeft
+    if (y)
+      internalY.value = scrollContainer.scrollTop
   }
 
   const isScrolling = ref(false)

--- a/packages/core/useScroll/index.ts
+++ b/packages/core/useScroll/index.ts
@@ -144,6 +144,12 @@ export function useScroll(
       left: toValue(_x) ?? x.value,
       behavior: toValue(behavior),
     })
+    const scrollContainer =
+      (_element as Window)?.document?.documentElement ||
+      (_element as Document)?.documentElement ||
+      (_element as Element);
+    if (x) internalX.value = scrollContainer.scrollLeft;
+    if (y) internalY.value = scrollContainer.scrollTop;
   }
 
   const isScrolling = ref(false)

--- a/packages/core/useScroll/index.ts
+++ b/packages/core/useScroll/index.ts
@@ -148,9 +148,9 @@ export function useScroll(
       = (_element as Window)?.document?.documentElement
       || (_element as Document)?.documentElement
       || (_element as Element)
-    if (x)
+    if (x != null)
       internalX.value = scrollContainer.scrollLeft
-    if (y)
+    if (y != null)
       internalY.value = scrollContainer.scrollTop
   }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Currently internal scroll state only be upated on scroll event, so the `x | y` value could not respond to latest scroll state after calling `scrollTo`. This PR fix the problem through manually sync dom scroll value to internal state after `scrollTo`.

#### Before

Demo from #3809

https://stackblitz.com/edit/vitejs-vite-helfwa?file=src%2FApp.vue

#### After

https://stackblitz.com/edit/vitejs-vite-s8aks2?file=src%2FuseScroll.ts

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
