### PR TITLE
feat(useCssVars): remove property on null/undefined

### DIFF
--- a/packages/core/useCssVar/index.test.ts
+++ b/packages/core/useCssVar/index.test.ts
@@ -16,6 +16,18 @@ describe('useCssVar', () => {
     expect(variable.value).toBe('red')
   })
 
+  it('should handle null and undefined', () => {
+    const el = document.createElement('div')
+    const property = '---color'
+    const variable = useCssVar(property, el)
+
+    expect(window?.getComputedStyle(el).getPropertyValue('--color')).toBe('')
+    variable.value = 'red'
+    setTimeout(() => {
+      expect(window?.getComputedStyle(el).getPropertyValue('--color')).toBe('red')
+    }, 100)
+  })
+
   it('should work observe', async () => {
     const window = defaultWindow
     const el = document.createElement('div')

--- a/packages/core/useCssVar/index.ts
+++ b/packages/core/useCssVar/index.ts
@@ -25,18 +25,18 @@ export interface UseCssVarOptions extends ConfigurableWindow {
  * @param options
  */
 export function useCssVar(
-  prop: MaybeRefOrGetter<string>,
+  prop: MaybeRefOrGetter<string | null | undefined>,
   target?: MaybeElementRef,
   options: UseCssVarOptions = {},
 ) {
-  const { window = defaultWindow, initialValue = '', observe = false } = options
-  const variable = ref(initialValue)
+  const { window = defaultWindow, initialValue, observe = false } = options
+  const variable = ref<string | null | undefined>(initialValue)
   const elRef = computed(() => unrefElement(target) || window?.document?.documentElement)
 
   function updateCssVar() {
     const key = toValue(prop)
     const el = toValue(elRef)
-    if (el && window) {
+    if (el && window && key) {
       const value = window.getComputedStyle(el).getPropertyValue(key)?.trim()
       variable.value = value || initialValue
     }
@@ -51,15 +51,24 @@ export function useCssVar(
 
   watch(
     [elRef, () => toValue(prop)],
-    updateCssVar,
+    (_, old) => {
+      if (old[0] && old[1] && window)
+        window.getComputedStyle(old[0]).removeProperty(old[1])
+      updateCssVar()
+    },
     { immediate: true },
   )
 
   watch(
     variable,
     (val) => {
-      if (elRef.value?.style)
-        elRef.value.style.setProperty(toValue(prop), val)
+      const raw_prop = toValue(prop)
+      if (elRef.value?.style && raw_prop) {
+        if (val == null)
+          elRef.value.style.removeProperty(raw_prop)
+        else
+          elRef.value.style.setProperty(raw_prop, val)
+      }
     },
   )
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Handle null/undefined values in useCssVars. Now, when either the element, the prop or the value are undefined, the property will be removed.