### PR TITLE
feat(useStorage): conditionally use event based on the used storage backend

### DIFF
--- a/packages/core/useStorage/index.ts
+++ b/packages/core/useStorage/index.ts
@@ -180,8 +180,11 @@ export function useStorage<T extends(string | number | boolean | object | null)>
   if (window && listenToStorageChanges) {
     tryOnMounted(() => {
       // this should be fine since we are in a mounted hook
-      useEventListener(window, 'storage', update)
-      useEventListener(window, customStorageEventName, updateFromCustomEvent)
+      if (storage instanceof Storage)
+        useEventListener(window, 'storage', update)
+      else
+        useEventListener(window, customStorageEventName, updateFromCustomEvent)
+
       if (initOnMounted)
         update()
     })
@@ -195,7 +198,7 @@ export function useStorage<T extends(string | number | boolean | object | null)>
     // send custom event to communicate within same page
     // importantly this should _not_ be a StorageEvent since those cannot
     // be constructed with a non-built-in storage area
-    if (window) {
+    if (window && !(storage instanceof Storage)) {
       window.dispatchEvent(new CustomEvent<StorageEventLike>(customStorageEventName, {
         detail: {
           key,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Build upon the work of #2630. Adds a single event listener every time (instead of 2 in all cases), depending on the type of storage backend used.

### Additional context

Besides using strictly the minimum amount of event listeners needed, this might prevent race conditions in the future.
