### PR TITLE
fix(useRouteParams,useRouteQuery): set route param/query to undefined when function-based defaultValue

### DIFF
--- a/packages/router/useRouteParams/index.test.ts
+++ b/packages/router/useRouteParams/index.test.ts
@@ -243,4 +243,22 @@ describe('useRouteParams', () => {
     expect(page.value).toBe(2)
     expect(lang.value).toBe('en-US')
   })
+
+  it('should reset value when default function value', async () => {
+    let route = getRoute({
+      page: 2,
+    })
+    const router = { replace: (r: any) => route = r } as any
+
+    const page = useRouteParams('page', () => 1, { transform: Number, route, router })
+
+    expect(page.value).toBe(2)
+    expect(route.params.page).toBe(2)
+
+    page.value = 1
+
+    await nextTick()
+
+    expect(route.params.page).toBeUndefined()
+  })
 })

--- a/packages/router/useRouteParams/index.ts
+++ b/packages/router/useRouteParams/index.ts
@@ -62,8 +62,8 @@ export function useRouteParams<
         if (param === v)
           return
 
-        param = (v === defaultValue || v === null) ? undefined : v
-        _paramsQueue.set(name, (v === defaultValue || v === null) ? undefined : v)
+        param = (v === toValue(defaultValue) || v === null) ? undefined : v
+        _paramsQueue.set(name, param)
 
         trigger()
 

--- a/packages/router/useRouteQuery/index.test.ts
+++ b/packages/router/useRouteQuery/index.test.ts
@@ -281,4 +281,22 @@ describe('useRouteQuery', () => {
 
     expect(route.query.search).toBeUndefined()
   })
+
+  it('should reset value when default function value', async () => {
+    let route = getRoute({
+      search: 'vue3',
+    })
+    const router = { replace: (r: any) => route = r } as any
+
+    const search: Ref<any> = useRouteQuery('search', () => 'default', { route, router })
+
+    expect(search.value).toBe('vue3')
+    expect(route.query.search).toBe('vue3')
+
+    search.value = 'default'
+
+    await nextTick()
+
+    expect(route.query.search).toBeUndefined()
+  })
 })

--- a/packages/router/useRouteQuery/index.ts
+++ b/packages/router/useRouteQuery/index.ts
@@ -62,8 +62,8 @@ export function useRouteQuery<
         if (query === v)
           return
 
-        query = (v === defaultValue || v === null) ? undefined : v
-        _queriesQueue.set(name, (v === defaultValue || v === null) ? undefined : v)
+        query = (v === toValue(defaultValue) || v === null) ? undefined : v
+        _queriesQueue.set(name, query)
 
         trigger()
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This PR follows up on the changes from https://github.com/vueuse/vueuse/pull/3583. That PR ensured that if you set a route param/query to the default value, it was removed from the query string. However, it doesn't handle function-based default values, so if you set the param/query to the value the default function evaluates to, it remains in the query string. This PR evaluates function-based default before the comparison to avoid that.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
