### PR TITLE
fix: use undefined as vue2 onMounted second parameter

### DIFF
--- a/packages/core/useMounted/index.ts
+++ b/packages/core/useMounted/index.ts
@@ -13,7 +13,7 @@ export function useMounted() {
   if (instance) {
     onMounted(() => {
       isMounted.value = true
-    }, isVue2 ? null : instance)
+    }, isVue2 ? undefined : instance)
   }
 
   return isMounted


### PR DESCRIPTION
Related to #3803 

see here:
https://github.com/vuejs/vue/blob/bed04a77e575d6c4c1d903f60087dca874f7213e/src/v3/apiLifecycle.ts#L6-L23

There is an optional parameter `target`, if you pass a null, the default value won't be applied, you must pass a undefined.

This caused that all APIs which use `useMounted` behind doesn't work with vue2 at 10.9.0.
