### PR TITLE
fix(useVirtualList): add containerRef to watch list

### DIFF
--- a/packages/core/useVirtualList/index.ts
+++ b/packages/core/useVirtualList/index.ts
@@ -201,8 +201,8 @@ function createGetDistance<T>(itemSize: UseVirtualListItemSize, source: UseVirtu
   }
 }
 
-function useWatchForSizes<T>(size: UseVirtualElementSizes, list: MaybeRef<T[]>, calculateRange: () => void) {
-  watch([size.width, size.height, list], () => {
+function useWatchForSizes<T>(size: UseVirtualElementSizes, list: MaybeRef<T[]>, containerRef: Ref<HTMLElement | null>, calculateRange: () => void) {
+  watch([size.width, size.height, list, containerRef], () => {
     calculateRange()
   })
 }
@@ -249,7 +249,7 @@ function useHorizontalVirtualList<T>(options: UseHorizontalVirtualListOptions, l
 
   const totalWidth = createComputedTotalSize(itemWidth, source)
 
-  useWatchForSizes(size, list, calculateRange)
+  useWatchForSizes(size, list, containerRef, calculateRange)
 
   const scrollTo = createScrollTo('horizontal', calculateRange, getDistanceLeft, containerRef)
 
@@ -295,7 +295,7 @@ function useVerticalVirtualList<T>(options: UseVerticalVirtualListOptions, list:
 
   const totalHeight = createComputedTotalSize(itemHeight, source)
 
-  useWatchForSizes(size, list, calculateRange)
+  useWatchForSizes(size, list, containerRef, calculateRange)
 
   const scrollTo = createScrollTo('vertical', calculateRange, getDistanceTop, containerRef)
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR is intended to solve an issue found in `useVirtualList` where the `watch` doesn't contain an element that is referenced in `calculateRange`. In this PR, it is specifically related to `containerRef`. While doing tests it was detected that the change on `containerRef` may happen after the first `calculateRange` call and therefore the `currentList` is not updated making the `list` empty.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
