### PR TITLE
fix(until): Prevent Memory Leak with Immediate Condition Cleanup in `until` Function

### DIFF
--- a/packages/shared/until/index.test.ts
+++ b/packages/shared/until/index.test.ts
@@ -251,4 +251,18 @@ describe('until', () => {
       'test' as any as Expect<Equal<typeof zNot1, 2 | 3>>
     }
   })
+
+  it('should cleanup listeners at end of event loop when until condition is already satisifed', async () => {
+    const n = ref(1)
+    const n2 = ref(1)
+    await until(() => n.value).toMatch(v => v === 1)
+    // .toBe() has it's own implementation of watch() and resolve, which only gets activated when
+    // the passed value is a Ref
+    await until(() => n2.value).toBe(ref(1))
+    await new Promise(r => setTimeout(r, 0))
+    // @ts-expect-error checking private property .dep on the vue Ref
+    expect(n.dep?.size).toBeFalsy()
+    // @ts-expect-error checking private property .dep on the vue Ref
+    expect(n2.dep?.size).toBeFalsy()
+  })
 })

--- a/packages/shared/until/index.ts
+++ b/packages/shared/until/index.ts
@@ -76,7 +76,13 @@ function createUntil<T>(r: any, isNot = false) {
         r,
         (v) => {
           if (condition(v) !== isNot) {
-            stop?.()
+            if (stop) {
+              stop()
+            }
+            else {
+              // stop is null, meaning it's the immediate check
+              setTimeout(() => stop?.(), 0)
+            }
             resolve(v)
           }
         },
@@ -111,7 +117,13 @@ function createUntil<T>(r: any, isNot = false) {
         [r, value],
         ([v1, v2]) => {
           if (isNot !== (v1 === v2)) {
-            stop?.()
+            if (stop) {
+              stop()
+            }
+            else {
+              // stop is null, meaning it's the immediate check
+              setTimeout(() => stop?.(), 0)
+            }
             resolve(v1)
           }
         },


### PR DESCRIPTION
### Description

This PR addresses an issue in the `until` utility's `toBe()` and `toMatch()` methods, where event listeners were not being correctly cleaned up when the condition was immediately satisfied. The core of the problem lay in the immediate invocation of the callback before the `stop` function was assigned, resulting in the `stop` function never being executed and leading to potential memory leaks.

To resolve this issue, the fix introduced ensures that the `stop` function for the created watcher is called at the end of the event loop when the condition is immediately satisfied. This adjustment guarantees that no listeners remain after the condition has been met, effectively preventing memory leaks that could result from frequent invocations of this method without changes in the dependencies of the watch getter.

Additionally, to ensure the robustness of this fix, a test case has been added to verify that event listeners are correctly cleaned up in scenarios where the `until` condition is immediately met. This test serves as a safeguard against potential regressions in the future, ensuring that the `until` function behaves as expected in all cases.

### Additional context

This fix is crucial for maintaining the stability and performance of applications utilizing the `@vueuse/shared` package, especially those that rely heavily on the `until` function. By ensuring the proper cleanup of event listeners, we prevent the occurrence of hard-to-diagnose memory leaks, improving the overall user experience and reliability of VueUse-based projects.