### PR TITLE
feat(useElementBounding): add `updateTiming` option

### DIFF
--- a/packages/core/useElementBounding/index.ts
+++ b/packages/core/useElementBounding/index.ts
@@ -101,7 +101,8 @@ export function useElementBounding(
   }
 
   function update() {
-    if (!waitTillNextFrame) return recalculate()
+    if (!waitTillNextFrame)
+      return recalculate()
     requestAnimationFrame(() => recalculate())
   }
 

--- a/packages/core/useElementBounding/index.ts
+++ b/packages/core/useElementBounding/index.ts
@@ -35,13 +35,14 @@ export interface UseElementBoundingOptions {
   immediate?: boolean
 
   /**
-   * Recalculate all values only at the next frame, instead of immediately when update is called.
+   * Timing to recalculate the bounding box
    *
-   * This can be useful when using this together with something like {@link useBreakpoints} and therefore the layout (which influences the bounding box of the observed element) is not updated on the this tick.
+   * Setting to `next-frame` can be useful when using this together with something like {@link useBreakpoints}
+   * and therefore the layout (which influences the bounding box of the observed element) is not updated on the current tick.
    *
-   * @default false
+   * @default 'sync'
    */
-  calculateOnNextFrame?: boolean
+  updateTiming?: 'sync' | 'next-frame'
 }
 
 /**
@@ -59,7 +60,7 @@ export function useElementBounding(
     windowResize = true,
     windowScroll = true,
     immediate = true,
-    calculateOnNextFrame = false,
+    updateTiming = 'sync',
   } = options
 
   const height = ref(0)
@@ -101,9 +102,10 @@ export function useElementBounding(
   }
 
   function update() {
-    if (!calculateOnNextFrame)
-      return recalculate()
-    requestAnimationFrame(() => recalculate())
+    if (updateTiming === 'sync')
+      recalculate()
+    else if (updateTiming === 'next-frame')
+      requestAnimationFrame(() => recalculate())
   }
 
   useResizeObserver(target, update)

--- a/packages/core/useElementBounding/index.ts
+++ b/packages/core/useElementBounding/index.ts
@@ -41,7 +41,7 @@ export interface UseElementBoundingOptions {
    *
    * @default false
    */
-  waitTillNextFrame?: boolean
+  calculateOnNextFrame?: boolean
 }
 
 /**
@@ -59,7 +59,7 @@ export function useElementBounding(
     windowResize = true,
     windowScroll = true,
     immediate = true,
-    waitTillNextFrame = false,
+    calculateOnNextFrame = false,
   } = options
 
   const height = ref(0)
@@ -101,7 +101,7 @@ export function useElementBounding(
   }
 
   function update() {
-    if (!waitTillNextFrame)
+    if (!calculateOnNextFrame)
       return recalculate()
     requestAnimationFrame(() => recalculate())
   }

--- a/packages/core/useElementBounding/index.ts
+++ b/packages/core/useElementBounding/index.ts
@@ -33,6 +33,15 @@ export interface UseElementBoundingOptions {
    * @default true
    */
   immediate?: boolean
+
+  /**
+   * Recalculate all values only at the next frame, instead of immediately when update is called.
+   *
+   * This can be useful when using this together with something like {@link useBreakpoints} and therefore the layout (which influences the bounding box of the observed element) is not updated on the this tick.
+   *
+   * @default false
+   */
+  waitTillNextFrame?: boolean
 }
 
 /**
@@ -50,6 +59,7 @@ export function useElementBounding(
     windowResize = true,
     windowScroll = true,
     immediate = true,
+    waitTillNextFrame = false,
   } = options
 
   const height = ref(0)
@@ -61,7 +71,7 @@ export function useElementBounding(
   const x = ref(0)
   const y = ref(0)
 
-  function update() {
+  function recalculate() {
     const el = unrefElement(target)
 
     if (!el) {
@@ -88,6 +98,11 @@ export function useElementBounding(
     width.value = rect.width
     x.value = rect.x
     y.value = rect.y
+  }
+
+  function update() {
+    if (!waitTillNextFrame) return recalculate()
+    requestAnimationFrame(() => recalculate())
   }
 
   useResizeObserver(target, update)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description
This PR adds a `calculateOnNextFrame` option to `useElementBounding`, which ensures that the bounding box is calculate on the next frame every time `update` is called (both when called manually and when called by EHs).

### A bit of background
In my application I use `useBreakpoints` in a grandparent component which indirectly influences the layout of the element which is observed with `useElementBounding`. When I resize the window (especially when big changes happen like maximizing from a small viewport) the `useElementBounding` is calculated, but before any of the layout changes connected to `useBreakpoints` are applied. This is just my use case tho, but I think there are many similar use cases where calculating the bounding box position only on the next frame can be beneficial.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context
None
<!-- e.g. is there anything you'd like reviewers to focus on? -->
