### PR TITLE
feat(useTimeout): add pause and resume methods 

### DIFF
--- a/packages/shared/useTimeout/index.ts
+++ b/packages/shared/useTimeout/index.ts
@@ -1,8 +1,8 @@
-import type { ComputedRef } from 'vue-demi'
+import type { ComputedRef, ShallowRef } from 'vue-demi'
 import { computed } from 'vue-demi'
 import type { UseTimeoutFnOptions } from '../useTimeoutFn'
 import { useTimeoutFn } from '../useTimeoutFn'
-import type { Fn, Stoppable } from '../utils'
+import type { Fn, Pausable, Stoppable } from '../utils'
 import { noop } from '../utils'
 
 export interface UseTimeoutOptions<Controls extends boolean> extends UseTimeoutFnOptions {
@@ -26,7 +26,7 @@ export interface UseTimeoutOptions<Controls extends boolean> extends UseTimeoutF
  * @param options
  */
 export function useTimeout(interval?: number, options?: UseTimeoutOptions<false>): ComputedRef<boolean>
-export function useTimeout(interval: number, options: UseTimeoutOptions<true>): { ready: ComputedRef<boolean> } & Stoppable
+export function useTimeout(interval: number, options: UseTimeoutOptions<true>): { ready: ComputedRef<boolean> } & Stoppable & Pausable & { timeLeft: ShallowRef<number> }
 export function useTimeout(interval = 1000, options: UseTimeoutOptions<boolean> = {}) {
   const {
     controls: exposeControls = false,

--- a/packages/shared/useTimeoutFn/demo.vue
+++ b/packages/shared/useTimeoutFn/demo.vue
@@ -4,7 +4,7 @@ import { useTimeoutFn } from '@vueuse/core'
 
 const defaultText = 'Please wait for 3 seconds'
 const text = ref(defaultText)
-const { start, isPending } = useTimeoutFn(() => {
+const { start, isPending, pause, resume, isActive, timeLeft } = useTimeoutFn(() => {
   text.value = 'Fired!'
 }, 3000)
 
@@ -15,8 +15,19 @@ function restart() {
 </script>
 
 <template>
-  <p>{{ text }}</p>
+  <p>
+    {{ text }}
+    <template v-if="isPending && !isActive">
+      - Paused - Time left: {{ timeLeft }}
+    </template>
+  </p>
   <button :class="{ disabled: isPending }" @click="restart()">
     Restart
+  </button>
+  <button v-if="isPending && isActive" @click="pause()">
+    Pause
+  </button>
+  <button v-if="isPending && !isActive" @click="resume()">
+    Resume
   </button>
 </template>

--- a/packages/shared/useTimeoutFn/index.test.ts
+++ b/packages/shared/useTimeoutFn/index.test.ts
@@ -41,25 +41,31 @@ describe('useTimeoutFn', () => {
     expect(callback).toBeCalled()
   })
 
-  it('supports pausing timer', async () => {
+  it('supports pause control', async () => {
     vi.useFakeTimers()
 
     const callback = vi.fn()
-    const { pause, resume, isActive, timeLeft } = useTimeoutFn(callback, 50)
+    const { pause, resume, isActive, timeLeft } = useTimeoutFn(callback.bind(null, 1, 2, 3), 50)
 
     vi.advanceTimersByTime(20)
     pause()
-    expect(isActive, 'Timer should not be active')
+    expect(isActive.value, 'Timer should not be active').toBe(false)
     expect(timeLeft.value, 'Time left should be the original timeout minus time passed').toBe(30)
 
-    vi.advanceTimersByTime(31)
-    expect(timeLeft.value, 'Time left should be the same after some more time has passed').toBe(30)
+    resume()
+    vi.advanceTimersByTime(20)
+    pause()
+    expect(isActive.value, 'Timer should not be active').toBe(false)
+    expect(timeLeft.value, 'Time left should be the original timeout minus time passed').toBe(10)
+
+    vi.advanceTimersByTime(11)
+    expect(timeLeft.value, 'Time left should be the same while it\'s paused').toBe(10)
     expect(callback).not.toBeCalled()
 
     resume()
     expect(isActive.value, 'Timer should be active again').toBe(true)
-    vi.advanceTimersByTime(31)
-    expect(callback).toBeCalled()
+    vi.advanceTimersByTime(11)
+    expect(callback).toBeCalledWith(1, 2, 3)
 
     vi.useRealTimers()
   })

--- a/packages/shared/useTimeoutFn/index.test.ts
+++ b/packages/shared/useTimeoutFn/index.test.ts
@@ -40,4 +40,27 @@ describe('useTimeoutFn', () => {
     expect(isPending.value).toBe(false)
     expect(callback).toBeCalled()
   })
+
+  it('supports pausing timer', async () => {
+    vi.useFakeTimers()
+
+    const callback = vi.fn()
+    const { pause, resume, isActive, timeLeft } = useTimeoutFn(callback, 50)
+
+    vi.advanceTimersByTime(20)
+    pause()
+    expect(isActive, 'Timer should not be active')
+    expect(timeLeft.value, 'Time left should be the original timeout minus time passed').toBe(30)
+
+    vi.advanceTimersByTime(31)
+    expect(timeLeft.value, 'Time left should be the same after some more time has passed').toBe(30)
+    expect(callback).not.toBeCalled()
+
+    resume()
+    expect(isActive.value, 'Timer should be active again').toBe(true)
+    vi.advanceTimersByTime(31)
+    expect(callback).toBeCalled()
+
+    vi.useRealTimers()
+  })
 })

--- a/packages/shared/useTimeoutFn/index.ts
+++ b/packages/shared/useTimeoutFn/index.ts
@@ -34,7 +34,7 @@ export function useTimeoutFn<CallbackFn extends AnyFn>(
 
   const isActive = ref(false)
   const startedAt = ref(-1)
-  const timeLeft = ref<number>(toValue(interval))
+  const timeLeft = ref(-1)
 
   let timer: ReturnType<typeof setTimeout> | null = null
 
@@ -66,8 +66,9 @@ export function useTimeoutFn<CallbackFn extends AnyFn>(
     startedAt.value = new Date().getTime()
     isPending.value = true
     isActive.value = true
+    timeLeft.value = toValue(interval)
 
-    setTimer(timeLeft.value, ...args)
+    setTimer(toValue(interval), ...args)
   }
 
   function pause() {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Implements Pausable controls on `useTimeout` and `useTimeoutFn` as described here: #3807

![demo-timeout-pause](https://github.com/vueuse/vueuse/assets/216738/5aa31e15-8a48-4eaa-ba2d-64f22aa25f9a)

### Additional context

Any optimization on internal variables used to control Pausable feature
