### PR TITLE
fix: side effect when element turn from null to element

### DIFF
--- a/packages/core/useMediaControls/index.ts
+++ b/packages/core/useMediaControls/index.ts
@@ -294,7 +294,10 @@ export function useMediaControls(target: MaybeRef<HTMLMediaElement | null | unde
   /**
    * Apply composable state to the element, also when element is changed
    */
-  watch([target, volume], () => {
+  watch([target, volume], (_, [oldTarget]) => {
+    if (!oldTarget)
+      return
+
     const el = toValue(target)
     if (!el)
       return
@@ -302,7 +305,10 @@ export function useMediaControls(target: MaybeRef<HTMLMediaElement | null | unde
     el.volume = volume.value
   })
 
-  watch([target, muted], () => {
+  watch([target, muted], (_, [oldTarget]) => {
+    if (!oldTarget)
+      return
+
     const el = toValue(target)
     if (!el)
       return
@@ -310,7 +316,10 @@ export function useMediaControls(target: MaybeRef<HTMLMediaElement | null | unde
     el.muted = muted.value
   })
 
-  watch([target, rate], () => {
+  watch([target, rate], (_, [oldTarget]) => {
+    if (!oldTarget)
+      return
+
     const el = toValue(target)
     if (!el)
       return


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [v] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [v] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [v] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [v] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
in `useMediaControls`, if the target element is assigned by a callback function, then the properties of the element will be set to the initial value of the refs.

For example:
```js
<script>
  const elRef = ref(null)
  const useMediaControls()
  const elRefRegister = (e) => {
    elRef.value = e
  }
</script>
<html>
  <video :ref="elRefRegister" muted />
</html>
```

In this case, elRef will be set to unmuted

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

I also considered to sync up internal refs with the target element if the element changes. While it changes the behavior, also the [previous commit](https://github.com/vueuse/vueuse/commit/b20aacf5f1f8da9bd5ebcb198480617526ce5ed1) shows it was designed to overwrite new the element when the element changing.
