### PR TITLE
docs: adds default values to useThrottleFn notation

### DIFF
--- a/packages/shared/useThrottleFn/index.ts
+++ b/packages/shared/useThrottleFn/index.ts
@@ -8,12 +8,13 @@ import { createFilterWrapper, throttleFilter } from '../utils'
  * @param   fn             A function to be executed after delay milliseconds. The `this` context and all arguments are passed through, as-is,
  *                                    to `callback` when the throttled-function is executed.
  * @param   ms             A zero-or-greater delay in milliseconds. For event callbacks, values around 100 or 250 (or even higher) are most useful.
+ *                                    (default value: 200)
  *
- * @param [trailing] if true, call fn again after the time is up
+ * @param [trailing] if true, call fn again after the time is up (default value: false)
  *
- * @param [leading] if true, call fn on the leading edge of the ms timeout
+ * @param [leading] if true, call fn on the leading edge of the ms timeout (default value: true)
  *
- * @param [rejectOnCancel] if true, reject the last call if it's been cancel
+ * @param [rejectOnCancel] if true, reject the last call if it's been cancel (default value: false)
  *
  * @return  A new, throttled, function.
  */


### PR DESCRIPTION
adds default values into docs notation as they are not explicitly visible in docs web https://vueuse.org/shared/useThrottleFn/

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
adds default values into docs notation as they are not explicitly visible in docs web https://vueuse.org/shared/useThrottleFn/

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
