### PR TITLE
docs(useGamepad): fix missing `.value` in example

### DIFF
--- a/packages/core/useGamepad/index.md
+++ b/packages/core/useGamepad/index.md
@@ -16,7 +16,7 @@ import { computed } from 'vue'
 import { useGamepad } from '@vueuse/core'
 
 const { isSupported, gamepads } = useGamepad()
-const gamepad = computed(() => gamepads.find(g => g.mapping === 'standard'))
+const gamepad = computed(() => gamepads.value.find(g => g.mapping === 'standard'))
 </script>
 
 <template>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Fix missing `.value` in `useGamepad` example. `gamepads` is a `Ref`, and therefore the `.value` is needed here.

### Additional context

N/A
