### PR TITLE
feat(watchOnce): allow watching until certain condition is met

### DIFF
--- a/packages/shared/watchOnce/index.md
+++ b/packages/shared/watchOnce/index.md
@@ -18,3 +18,31 @@ watchOnce(source, () => {
   console.log('source changed!')
 })
 ```
+
+### Options: `until`
+
+The option allows keeping the watcher until certain condition is met, then run the callback once and stop the watcher automatically.
+
+```ts
+import { getCurrentInstance } from 'vue'
+import { useElementVisibility, watchOnce } from '@vueuse/core'
+
+const instance = getCurrentInstance()
+
+watchOnce(
+  [
+    // Check whether the element is within the viewport.
+    useElementVisibility(instance.proxy),
+    // Check whether the element is not visually hidden.
+    () => !!instance.vnode.el?.offsetParent,
+  ],
+  () => {
+    // Triggers only once.
+    console.log('The component is in the viewport and visible')
+  },
+  {
+    immediate: true,
+    until: ([isInViewport, isVisible]) => isInViewport && isVisible,
+  },
+)
+```

--- a/packages/shared/watchOnce/index.test.ts
+++ b/packages/shared/watchOnce/index.test.ts
@@ -14,4 +14,18 @@ describe('watchOnce', () => {
     await nextTick()
     expect(spy).toBeCalledTimes(1)
   })
+
+  it('should watch until', async () => {
+    const num = ref(0)
+    const spy = vi.fn()
+
+    watchOnce(num, spy, { until: (value) => value === 2 })
+    num.value = 1
+    await nextTick()
+    num.value = 2
+    await nextTick()
+    num.value = 3
+    await nextTick()
+    expect(spy).toBeCalledTimes(2)
+  })
 })

--- a/packages/shared/watchOnce/index.ts
+++ b/packages/shared/watchOnce/index.ts
@@ -2,21 +2,35 @@ import type { WatchCallback, WatchOptions, WatchSource, WatchStopHandle } from '
 import { nextTick, watch } from 'vue-demi'
 import type { MapOldSources, MapSources } from '../utils'
 
-// overloads
-export function watchOnce<T extends Readonly<WatchSource<unknown>[]>, Immediate extends Readonly<boolean> = false>(source: [...T], cb: WatchCallback<MapSources<T>, MapOldSources<T, Immediate>>, options?: WatchOptions<Immediate>): WatchStopHandle
+interface WatchOnceOptions<Callback extends WatchCallback, Immediate extends boolean> extends WatchOptions<Immediate> {
+  readonly until?: (...args: Parameters<Callback>) => boolean
+}
 
-export function watchOnce<T, Immediate extends Readonly<boolean> = false>(sources: WatchSource<T>, cb: WatchCallback<T, Immediate extends true ? T | undefined : T>, options?: WatchOptions<Immediate>): WatchStopHandle
+// overloads
+export function watchOnce<T extends Readonly<WatchSource<unknown>[]>, Immediate extends Readonly<boolean> = false>(
+  source: [...T],
+  cb: WatchCallback<MapSources<T>, MapOldSources<T, Immediate>>,
+  options?: WatchOnceOptions<typeof cb, Immediate>,
+): WatchStopHandle
+
+export function watchOnce<T, Immediate extends Readonly<boolean> = false>(
+  sources: WatchSource<T>,
+  cb: WatchCallback<T, Immediate extends true ? T | undefined : T>,
+  options?: WatchOnceOptions<typeof cb, Immediate>,
+): WatchStopHandle
 
 // implementation
 export function watchOnce<Immediate extends Readonly<boolean> = false>(
   source: any,
   cb: any,
-  options?: WatchOptions<Immediate>,
+  options?: WatchOnceOptions<typeof cb, Immediate>,
 ): WatchStopHandle {
   const stop = watch(source, (...args) => {
-    nextTick(() => stop())
+    if (!options?.until || options.until(...args)) {
+      nextTick(() => stop())
 
-    return cb(...args)
+      return cb(...args)
+    }
   }, options)
 
   return stop


### PR DESCRIPTION
### Description

Add the optional `until` callback to the `watchOnce` options to keep watching until certain condition is met.