### PR TITLE
Clarify code documentation in useIntervalFn

### DIFF
--- a/packages/shared/useIntervalFn/index.ts
+++ b/packages/shared/useIntervalFn/index.ts
@@ -13,7 +13,7 @@ export interface UseIntervalFnOptions {
   immediate?: boolean
 
   /**
-   * Execute the callback immediate after calling this function
+   * Execute the callback immediately after calling `resume`
    *
    * @default false
    */


### PR DESCRIPTION
The documentation for the option `immediateCallback` in `useIntervalFn` was very misleading, making me search for a solution for a long time. Actually, `immediateCallback` already _was_ the solution, but the documentation made me think otherwise: `immediateCallback` decides whether the callback is called immediately **after `resume` is called**. The former documentation said "_Execute the callback immediate after calling this function_", leaving it unclear what is meant by "this function"  (I assumed it referred to the actual composable, `useIntervalFn`, but that's not the case).

Thank you for this absolutely lifesaving library :heart: 
