### PR TITLE
feat(refDebounced): add support for objects

### DIFF
--- a/packages/shared/refDebounced/index.md
+++ b/packages/shared/refDebounced/index.md
@@ -23,7 +23,25 @@ await sleep(1100)
 console.log(debounced.value) // 'bar'
 ```
 
-You can also pass an optional 3rd parameter including maxWait option. See `useDebounceFn` for details.
+An example with object ref.
+
+```js {4}
+import { refDebounced } from '@vueuse/core'
+
+const input = ref({ type: 'foo' })
+const debounced = refDebounced(input, 1000, { deep: true }) // Add deep to deeply watch changes of input
+
+input.value.type = 'bar'
+console.log(debounced.value) // { type: 'foo' }
+
+await sleep(1100)
+
+console.log(debounced.value) // { type: 'bar' }
+```
+
+The 2nd parameter is the debounce wait time in milliseconds, default to `200`ms.
+
+You can also pass an optional 3rd parameter including `deep` and `maxWait` options. See `useDebounceFn` for details.
 
 ## Recommended Reading
 

--- a/packages/shared/refDebounced/index.test.ts
+++ b/packages/shared/refDebounced/index.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { ref } from 'vue-demi'
+import { refDebounced } from '@vueuse/shared'
+
+describe('refDebounced', () => {
+  it('should debounce updates of a ref', async () => {
+    const source = ref('John')
+    const debounced = refDebounced(source, 10)
+
+    expect(debounced.value).toBe('John')
+
+    source.value = 'Jack'
+
+    expect(debounced.value).toBe('John')
+
+    await new Promise(resolve => setTimeout(resolve, 20))
+
+    expect(debounced.value).toBe('Jack')
+  })
+
+  it('should debounce updates of an object ref', async () => {
+    const source = ref({ name: 'John' })
+    const debounced = refDebounced(source, 10, { deep: true })
+
+    expect(debounced.value.name).toBe('John')
+
+    source.value.name = 'Jack'
+
+    expect(debounced.value.name).toBe('John')
+
+    await new Promise(resolve => setTimeout(resolve, 20))
+
+    expect(debounced.value.name).toBe('Jack')
+  })
+
+  it('should debounce updates of a nested object ref', async () => {
+    const source = ref({ user: { name: 'John' } })
+    const debounced = refDebounced(source, 10, { deep: true })
+
+    expect(debounced.value.user.name).toBe('John')
+
+    source.value.user.name = 'Jack'
+
+    expect(debounced.value.user.name).toBe('John')
+
+    await new Promise(resolve => setTimeout(resolve, 20))
+
+    expect(debounced.value.user.name).toBe('Jack')
+  })
+})

--- a/packages/shared/refDebounced/index.ts
+++ b/packages/shared/refDebounced/index.ts
@@ -1,21 +1,26 @@
-import type { Ref } from 'vue-demi'
+import type { Ref, WatchOptions } from 'vue-demi'
 import { ref, watch } from 'vue-demi'
 import { useDebounceFn } from '../useDebounceFn'
 import type { DebounceFilterOptions, MaybeRefOrGetter } from '../utils'
+import { deepClone, isObject } from '../utils'
+
+export interface RefDebouncedFilterOptions extends DebounceFilterOptions, Pick<WatchOptions, 'deep'> {
+}
 
 /**
  * Debounce updates of a ref.
  *
  * @return A new debounced ref.
  */
-export function refDebounced<T>(value: Ref<T>, ms: MaybeRefOrGetter<number> = 200, options: DebounceFilterOptions = {}): Readonly<Ref<T>> {
-  const debounced = ref(value.value as T) as Ref<T>
+export function refDebounced<T>(value: Ref<T>, ms: MaybeRefOrGetter<number> = 200, options: RefDebouncedFilterOptions = {}): Readonly<Ref<T>> {
+  const getValue = (): T => isObject(value.value) ? deepClone(value.value) : value.value
+  const debounced = ref(getValue()) as Ref<T>
 
   const updater = useDebounceFn(() => {
-    debounced.value = value.value
+    debounced.value = getValue()
   }, ms, options)
 
-  watch(value, () => updater())
+  watch(value, () => updater(), { deep: options.deep })
 
   return debounced
 }

--- a/packages/shared/utils/index.ts
+++ b/packages/shared/utils/index.ts
@@ -119,3 +119,7 @@ export function objectEntries<T extends object>(obj: T) {
 export function getLifeCycleTarget(target?: any) {
   return target || getCurrentInstance()
 }
+
+export function deepClone<T>(obj: T): T {
+  return JSON.parse(JSON.stringify(obj))
+}


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Objects did not work with `refDebounced`. An object need to be deeply clone to avoid JavaScript memory references.
Added a `deep` parameter to deeply watch object changes.

Closes: #3158
