### PR TITLE
fix(useFileDialog): check if input value exists before trigger onChange

### DIFF
--- a/packages/core/useFileDialog/index.ts
+++ b/packages/core/useFileDialog/index.ts
@@ -72,7 +72,7 @@ export function useFileDialog(options: UseFileDialogOptions = {}): UseFileDialog
 
   const reset = () => {
     files.value = null
-    if (input) {
+    if (input && input.value) {
       input.value = ''
       trigger(null)
     }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Check if input value exists on resetting to fix the onChange event being triggered repeatedly when reset is called when the input value is null.

```javascript
const { onChange } = useFileDialog({
  reset: true
})

onChange(files => {
  // before: when user cancels the file dialog, the onChange event is triggered repeatedly, console logged with multiple null values
  // after: only one null value is console logged
  console.log(files)
})
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
