### PR TITLE
fix(useDisplayMedia): stop stream when screen is not shared anymore

### DIFF
--- a/packages/core/useDisplayMedia/index.ts
+++ b/packages/core/useDisplayMedia/index.ts
@@ -45,6 +45,7 @@ export function useDisplayMedia(options: UseDisplayMediaOptions = {}) {
     if (!isSupported.value || stream.value)
       return
     stream.value = await navigator!.mediaDevices.getDisplayMedia(constraint)
+    stream.value?.getTracks().forEach(t => t.addEventListener('ended', stop))
     return stream.value
   }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

---

### Description

When the user stops sharing the screen, we need to stop the stream. Hence I've added an event listener to catch when the track ends, and call the stop function.

### Additional context

Steps to reproduce the bug:
1. Open Google Chrome (on mac).
2. Start sharing screen (select a window, not just a tab).
3. Look for the small notification that says "vueuse.org is sharing a window" (1. in the attachment).
4. Click "Stop sharing".
5. Before this fix the stream turns black, but is still in enabled state (2. in the attachment). After this fix it is properly stopped.

![image](https://github.com/vueuse/vueuse/assets/2410669/fcbc918b-64ff-4b4f-8d22-5a66ba64c913)
