### PR TITLE
fix(useCssVar): ensure MutationObserver detects CSS variable changes

### DIFF
--- a/packages/core/useCssVar/index.ts
+++ b/packages/core/useCssVar/index.ts
@@ -55,13 +55,5 @@ export function useCssVar(
     { immediate: true },
   )
 
-  watch(
-    variable,
-    (val) => {
-      if (elRef.value?.style)
-        elRef.value.style.setProperty(toValue(prop), val)
-    },
-  )
-
   return variable
 }


### PR DESCRIPTION
### Description:
This PR addresses an issue with the useCssVar function where the MutationObserver was not detecting changes to CSS variables after the initial style property was set.

### Changes:

Removed the code responsible for setting the style property within the useCssVar function.
Ensured that the useCssVar function now correctly detects changes to the CSS variable using the MutationObserver without any interference.

### Context:
The original implementation set the style property directly, which prevented the MutationObserver from detecting subsequent changes. By removing this code, the function can now observe changes more reliably, improving its reactivity and functionality.