### PR TITLE
types(vitest): modify `SpyInstance` to `MockInstance`

### DIFF
--- a/packages/core/useEventListener/index.test.ts
+++ b/packages/core/useEventListener/index.test.ts
@@ -1,5 +1,5 @@
 import type { Fn } from '@vueuse/shared'
-import type { SpyInstance } from 'vitest'
+import type { MockInstance } from 'vitest'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { noop } from '@vueuse/shared'
 import { isVue2 } from 'vue-demi'
@@ -11,8 +11,8 @@ describe('useEventListener', () => {
   const options = { capture: true }
   let stop: Fn
   let target: HTMLDivElement
-  let removeSpy: SpyInstance
-  let addSpy: SpyInstance
+  let removeSpy: MockInstance
+  let addSpy: MockInstance
 
   beforeEach(() => {
     target = document.createElement('div')

--- a/packages/core/useFetch/index.test.ts
+++ b/packages/core/useFetch/index.test.ts
@@ -1,6 +1,6 @@
 import { until } from '@vueuse/shared'
 import { nextTick, ref } from 'vue-demi'
-import type { SpyInstance } from 'vitest'
+import type { MockInstance } from 'vitest'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { isBelowNode18, retry } from '../../.test'
 import { createFetch, useFetch } from '.'
@@ -11,7 +11,7 @@ const jsonUrl = `https://example.com?json=${encodeURI(JSON.stringify(jsonMessage
 
 // Listen to make sure fetch is actually called.
 // Use msw to stub out the req/res
-let fetchSpy = vi.spyOn(window, 'fetch') as SpyInstance<any>
+let fetchSpy = vi.spyOn(window, 'fetch') as MockInstance<any>
 let onFetchErrorSpy = vi.fn()
 let onFetchResponseSpy = vi.fn()
 let onFetchFinallySpy = vi.fn()


### PR DESCRIPTION
type `SpyInstance ` is deprecated

docs: https://vitest.dev/guide/migration#mock-types-4400