### PR TITLE
feat(useWindowSize): add ability to get outer sizes of the window

### DIFF
--- a/packages/core/useWindowSize/index.test.ts
+++ b/packages/core/useWindowSize/index.test.ts
@@ -43,6 +43,13 @@ describe('useWindowSize', () => {
     expect(height.value).toBe(window.document.documentElement.clientHeight)
   })
 
+  it('should use outer size', () => {
+    const { width, height } = useWindowSize({ initialWidth: 100, initialHeight: 200, useOuterSize: true })
+
+    expect(width.value).toBe(window.outerWidth)
+    expect(height.value).toBe(window.outerHeight)
+  })
+
   it('sets handler for window "resize" event', async () => {
     useWindowSize({ initialWidth: 100, initialHeight: 200, listenOrientation: false })
 

--- a/packages/core/useWindowSize/index.test.ts
+++ b/packages/core/useWindowSize/index.test.ts
@@ -44,7 +44,7 @@ describe('useWindowSize', () => {
   })
 
   it('should use outer size', () => {
-    const { width, height } = useWindowSize({ initialWidth: 100, initialHeight: 200, useOuterSize: true })
+    const { width, height } = useWindowSize({ initialWidth: 100, initialHeight: 200, type: 'outer' })
 
     expect(width.value).toBe(window.outerWidth)
     expect(height.value).toBe(window.outerHeight)

--- a/packages/core/useWindowSize/index.ts
+++ b/packages/core/useWindowSize/index.ts
@@ -17,15 +17,18 @@ export interface UseWindowSizeOptions extends ConfigurableWindow {
 
   /**
    * Whether the scrollbar should be included in the width and height
+   * Only effective when `type` is `'inner'`
+   *
    * @default true
    */
   includeScrollbar?: boolean
 
   /**
-   * Whether to use the window.outerWidth and window.outerHeight instead of window.innerWidth and window.innerHeight
-   * @default false
+   * Use `window.innerWidth` or `window.outerWidth`
+   *
+   * @default 'inner'
    */
-  useOuterSize?: boolean
+  type?: 'inner' | 'outer'
 }
 
 /**
@@ -41,7 +44,7 @@ export function useWindowSize(options: UseWindowSizeOptions = {}) {
     initialHeight = Number.POSITIVE_INFINITY,
     listenOrientation = true,
     includeScrollbar = true,
-    useOuterSize = false,
+    type = 'inner',
   } = options
 
   const width = ref(initialWidth)
@@ -49,7 +52,7 @@ export function useWindowSize(options: UseWindowSizeOptions = {}) {
 
   const update = () => {
     if (window) {
-      if (useOuterSize) {
+      if (type === 'outer') {
         width.value = window.outerWidth
         height.value = window.outerHeight
       }

--- a/packages/core/useWindowSize/index.ts
+++ b/packages/core/useWindowSize/index.ts
@@ -20,6 +20,12 @@ export interface UseWindowSizeOptions extends ConfigurableWindow {
    * @default true
    */
   includeScrollbar?: boolean
+
+  /**
+   * Whether to use the window.outerWidth and window.outerHeight instead of window.innerWidth and window.innerHeight
+   * @default false
+   */
+  useOuterSize?: boolean
 }
 
 /**
@@ -35,6 +41,7 @@ export function useWindowSize(options: UseWindowSizeOptions = {}) {
     initialHeight = Number.POSITIVE_INFINITY,
     listenOrientation = true,
     includeScrollbar = true,
+    useOuterSize = false,
   } = options
 
   const width = ref(initialWidth)
@@ -42,7 +49,11 @@ export function useWindowSize(options: UseWindowSizeOptions = {}) {
 
   const update = () => {
     if (window) {
-      if (includeScrollbar) {
+      if (useOuterSize) {
+        width.value = window.outerWidth
+        height.value = window.outerHeight
+      }
+      else if (includeScrollbar) {
         width.value = window.innerWidth
         height.value = window.innerHeight
       }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Adding an optional parameter `useOuterSize` to get the outer sizes of the window from `useWindowSize` instead of inner sizes

### Additional context

Currently if `useOuterSize` is set to true `includeScrollbar` will be ignored. 
