### PR TITLE
Fix full page reflows when calling useColorMode and useDark

### DIFF
--- a/packages/core/useColorMode/index.test.ts
+++ b/packages/core/useColorMode/index.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue-demi'
+import { nextTick, ref } from 'vue-demi'
 import { nextTwoTick } from '../../.test'
 import { usePreferredDark } from '../usePreferredDark'
 import { useColorMode } from '.'
@@ -122,5 +122,52 @@ describe('useColorMode', () => {
     expect(mode.store.value).toBe('auto')
     expect(mode.system.value).toBe('light')
     expect(mode.state.value).toBe('light')
+  })
+
+  it('should call classList.add/classList.remove only if mode changed', async () => {
+    const target = document.createElement('div')
+
+    const mode = useColorMode({ selector: target, initialValue: 'light' })
+
+    await nextTick()
+
+    const addClass = vi.spyOn(target.classList, 'add')
+    const removeClass = vi.spyOn(target.classList, 'remove')
+
+    mode.value = 'light'
+
+    await nextTick()
+
+    expect(addClass).not.toHaveBeenCalled()
+    expect(removeClass).not.toHaveBeenCalled()
+
+    mode.value = 'dark'
+
+    await nextTick()
+
+    expect(addClass).toHaveBeenCalled()
+    expect(removeClass).toHaveBeenCalled()
+  })
+
+  it('should call setAttribute only if mode changed', async () => {
+    const target = document.createElement('div')
+
+    const mode = useColorMode({ selector: target, initialValue: 'light', attribute: 'data-color-mode' })
+
+    await nextTick()
+
+    const setAttr = vi.spyOn(target, 'setAttribute')
+
+    mode.value = 'light'
+
+    await nextTick()
+
+    expect(setAttr).not.toHaveBeenCalled()
+
+    mode.value = 'dark'
+
+    await nextTick()
+
+    expect(setAttr).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Avoid full page reflows when calling useDark or useColorMode if the mode didn't actually changed.

### Additional context

At least partially fixes this issue: https://github.com/vueuse/vueuse/issues/3955
