### PR TITLE
feat(useMousePressed): add `right` option to control right mousedown

### DIFF
--- a/packages/core/useMousePressed/index.md
+++ b/packages/core/useMousePressed/index.md
@@ -20,6 +20,12 @@ Touching is enabled by default. To make it only detects mouse changes, set `touc
 const { pressed } = useMousePressed({ touch: false })
 ```
 
+The right mouse button mousedown event is enabled by default. Set `right` to `false` disables it.
+
+```js
+const { pressed } = useMousePressed({ right: false })
+```
+
 To only capture `mousedown` and `touchstart` on specific element, you can specify `target` by passing a ref of the element.
 
 ```vue

--- a/packages/core/useMousePressed/index.ts
+++ b/packages/core/useMousePressed/index.ts
@@ -15,6 +15,12 @@ export interface MousePressedOptions extends ConfigurableWindow {
   touch?: boolean
 
   /**
+   * Listen to right mouse 'mousedown' event
+   * @default true
+   */
+  right?: boolean
+
+  /**
    * Listen to `dragstart` `drop` and `dragend` events
    *
    * @default true
@@ -51,6 +57,7 @@ export interface MousePressedOptions extends ConfigurableWindow {
 export function useMousePressed(options: MousePressedOptions = {}) {
   const {
     touch = true,
+    right = true,
     drag = true,
     capture = false,
     initialValue = false,
@@ -78,7 +85,16 @@ export function useMousePressed(options: MousePressedOptions = {}) {
 
   const target = computed(() => unrefElement(options.target) || window)
 
-  useEventListener(target, 'mousedown', onPressed('mouse'), { passive: true, capture })
+  if (right) {
+    useEventListener(target, 'mousedown', onPressed('mouse'), { passive: true, capture })
+  }
+  else {
+    useEventListener(target, 'mousedown', (e: MouseEvent) => {
+      if (e.button === 2)
+        return
+      onPressed('mouse')()
+    }, { passive: true, capture })
+  }
 
   useEventListener(window, 'mouseleave', onReleased, { passive: true, capture })
   useEventListener(window, 'mouseup', onReleased, { passive: true, capture })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description
Add `right` option for `useMousePressed` to control right mousedown.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

