### PR TITLE
fix(makeDestructurable):  fix Typescript < 5.0.0 support

### DIFF
--- a/packages/shared/makeDestructurable/index.md
+++ b/packages/shared/makeDestructurable/index.md
@@ -20,8 +20,8 @@ const foo = { name: 'foo' }
 const bar = 1024
 
 const obj = makeDestructurable(
-  { foo, bar },
-  [foo, bar],
+  { foo, bar } as const,
+  [foo, bar] as const,
 )
 ```
 

--- a/packages/shared/makeDestructurable/index.ts
+++ b/packages/shared/makeDestructurable/index.ts
@@ -1,6 +1,6 @@
 export function makeDestructurable<
   T extends Record<string, unknown>,
-  const A extends readonly any[],
+  A extends readonly any[],
 >(obj: T, arr: A): T & A {
   if (typeof Symbol !== 'undefined') {
     const clone = { ...obj }


### PR DESCRIPTION
This reverts commit 4ea131a2ccff41742a0de8600f790edc1f8632e2. (#3971),
Closes #4006, #4023

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

After our discussion at https://github.com/vueuse/vueuse/issues/4006#issuecomment-2144658344,
we noticed that [this commit](https://github.com/vueuse/vueuse/commit/4ea131a2ccff41742a0de8600f790edc1f8632e2) broke VueUse's compatibility with TypeScript projects prior to version 5.0.0. Many developers, including myself, use frameworks that rely on TypeScript 4.x.x. Therefore, it might be beneficial to revert this change and issue a patch release. If [`const` modifier on type parameters](https://github.com/microsoft/TypeScript/pull/51865) for `makeDestructurable` is deemed very important, it should be marked as a minor or major update, as patch releases should not introduce breaking changes.

### Additional context

Thank you to the maintainers for your hard work in keeping this project running smoothly despite the high volume of pull requests. Your dedication and efforts are greatly appreciated❤️
