### PR TITLE
fix(until): cleanup at next tick to avoid memory leak

### DIFF
--- a/packages/shared/until/index.ts
+++ b/packages/shared/until/index.ts
@@ -1,5 +1,5 @@
 import type { WatchOptions, WatchSource } from 'vue-demi'
-import { isRef, watch } from 'vue-demi'
+import { isRef, nextTick, watch } from 'vue-demi'
 import { toValue } from '../toValue'
 import type { ElementOf, MaybeRefOrGetter, ShallowUnwrapRef } from '../utils'
 import { promiseTimeout } from '../utils'
@@ -76,7 +76,7 @@ function createUntil<T>(r: any, isNot = false) {
         r,
         (v) => {
           if (condition(v) !== isNot) {
-            stop?.()
+            nextTick(() => stop?.())
             resolve(v)
           }
         },
@@ -111,7 +111,7 @@ function createUntil<T>(r: any, isNot = false) {
         [r, value],
         ([v1, v2]) => {
           if (isNot !== (v1 === v2)) {
-            stop?.()
+            nextTick(() => stop?.())
             resolve(v1)
           }
         },

--- a/packages/shared/until/index.ts
+++ b/packages/shared/until/index.ts
@@ -76,7 +76,10 @@ function createUntil<T>(r: any, isNot = false) {
         r,
         (v) => {
           if (condition(v) !== isNot) {
-            nextTick(() => stop?.())
+            if (stop)
+              stop()
+            else
+              nextTick(() => stop?.())
             resolve(v)
           }
         },
@@ -111,7 +114,10 @@ function createUntil<T>(r: any, isNot = false) {
         [r, value],
         ([v1, v2]) => {
           if (isNot !== (v1 === v2)) {
-            nextTick(() => stop?.())
+            if (stop)
+              stop()
+            else
+              nextTick(() => stop?.())
             resolve(v1)
           }
         },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

call stop in `until` in nextTick() instead of immediatly to fix #4034
close #4034. close  #3867
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
