### PR TITLE
fix(useGamepad): handle case where hapticActuators is not present

### DIFF
--- a/packages/core/useGamepad/components/Gamepad.vue
+++ b/packages/core/useGamepad/components/Gamepad.vue
@@ -5,7 +5,7 @@ import Controller from './Controller.vue'
 
 const props = defineProps<{ gamepad: Gamepad }>()
 
-const supportsVibration = computed(() => props.gamepad.hapticActuators.length > 0)
+const supportsVibration = computed(() => props.gamepad?.hapticActuators?.length > 0)
 function vibrate() {
   if (supportsVibration.value) {
     const actuator: any = props.gamepad.hapticActuators[0]


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

### Description

there may be cases where hapticActuators is not present, which would cause an error in this code.

![image](https://github.com/vueuse/vueuse/assets/47178158/9dfaa3d6-5a2d-4770-8bfb-ca36f8389cf2)


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
