### PR TITLE
fix(useIntersectionObserver)!: update the `threshold` default to 0

### DIFF
--- a/packages/core/useIntersectionObserver/index.ts
+++ b/packages/core/useIntersectionObserver/index.ts
@@ -28,6 +28,7 @@ export interface UseIntersectionObserverOptions extends ConfigurableWindow {
 
   /**
    * Either a single number or an array of numbers between 0.0 and 1.
+   * @default 0
    */
   threshold?: number | number[]
 }
@@ -53,7 +54,7 @@ export function useIntersectionObserver(
   const {
     root,
     rootMargin = '0px',
-    threshold = 0.1,
+    threshold = 0,
     window = defaultWindow,
     immediate = true,
   } = options


### PR DESCRIPTION


### Description

resolve #2184

According to the [MDN documentation on the IntersectionObserver API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#threshold), the default value of `threshold` should be 0. In #115, I did not find any discussion regarding `threshold` defaulting to 0.1. Should we maintain consistency with the IntersectionObserver API's default value? However, this would be a breaking change.

https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#threshold

