### PR TITLE
fix(utils): objectEntries

### DIFF
--- a/packages/shared/utils/index.ts
+++ b/packages/shared/utils/index.ts
@@ -112,8 +112,8 @@ export function objectOmit<O extends object, T extends keyof O>(obj: O, keys: T[
   })) as Omit<O, T>
 }
 
-export function objectEntries<T extends object>(obj: T) {
-  return Object.entries(obj) as Array<[keyof T, T[keyof T]]>
+export function objectEntries<T>(obj: T) {
+  return Object.entries(obj as object) as Array<[keyof T, T[keyof T]]>
 }
 
 export function getLifeCycleTarget(target?: any) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

I guess the original intention of this function, is to solve the problem about the key of the entries method is a string.

But in some cases, such as passing in number/string, Object.entries can run normally, while our objectEntries may have errors.Here is an example.

https://www.typescriptlang.org/play/?#code/GYVwdgxgLglg9mABHARgKwKbQKJigJxgwGcB5AGwBMAeAFUQwA8oMxLjl0soA+AClRoAXIloBKRAG8AUIkT4MUEPiSku0AHSsCRYgPQSAhhwCC+fIYCe1ANoBrDJbjBRAGlH3Hz0QF0fPaQBfaVBIWAROTBw8QhIAOQwAdzp+QRFxKVl5RWVVdSgtGN19NERjSO4jU3MrWwcnF1p3Wk8G338g6WkIBGI4cgwNcjgAcz41KILtWL0CEAwxMW7e-sHhscFuXB0SCko+OYWlnrA+gaHRkq2i+KSD-HnFoA

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
