### PR TITLE
docs: improve the team member layout style

### DIFF
--- a/packages/.vitepress/theme/components/HomeTeam.vue
+++ b/packages/.vitepress/theme/components/HomeTeam.vue
@@ -8,7 +8,7 @@ import { coreTeamMembers } from '../../../contributors'
       Meet The Team
     </h2>
   </div>
-  <div grid="~ sm:cols-2 md:cols-3 lg:cols-4 gap-x-3 gap-y-20 items-center" p-10>
+  <div grid="~ sm:cols-2 md:cols-3 lg:cols-4 gap-x-3 gap-y-20 items-start" p-10>
     <TeamMember
       v-for="c of coreTeamMembers"
       :key="c.github"


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Make the team member layout more consistent.

Before:
<img width="1263" alt="截圖 2024-07-13 上午8 21 32" src="https://github.com/user-attachments/assets/eda3a811-8ce9-41ab-a85c-f540fd128e07">

After:
<img width="1263" alt="截圖 2024-07-13 上午8 20 50" src="https://github.com/user-attachments/assets/950c5528-a9a8-4932-84a9-ef53f4411605">

Additionally, I noticed that the profile picture of team member Tahul is missing in the official documentation.
<img width="289" alt="截圖 2024-07-13 上午8 17 52" src="https://github.com/user-attachments/assets/d779504f-2c95-4651-b3e0-245410c1cadb">



### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
