### PR TITLE
feat(usePermission): add local-fonts permission

### DIFF
--- a/packages/core/usePermission/demo.vue
+++ b/packages/core/usePermission/demo.vue
@@ -18,6 +18,7 @@ const paymentHandler = usePermission('payment-handler')
 const persistentStorage = usePermission('persistent-storage')
 const push = usePermission('push')
 const speaker = usePermission('speaker')
+const localFonts = usePermission('local-fonts')
 
 const code = computed(() => YAML.dump(reactive({
   accelerometer,
@@ -35,6 +36,7 @@ const code = computed(() => YAML.dump(reactive({
   persistentStorage,
   push,
   speaker,
+  localFonts
 })))
 </script>
 

--- a/packages/core/usePermission/index.ts
+++ b/packages/core/usePermission/index.ts
@@ -21,7 +21,8 @@ type DescriptorNamePolyfill =
   'payment-handler' |
   'persistent-storage' |
   'push' |
-  'speaker'
+  'speaker' |
+  'local-fonts'
 
 export type GeneralPermissionDescriptor =
   | PermissionDescriptor


### PR DESCRIPTION
### Description
Adds a type for the local-font permission

### Additional context
The local fonts permission is currently supported by chromium, and has entered draft at W3C on Jun 7th 2024 so it should be coming to more browsers shortly

https://wicg.github.io/local-font-access/
