### PR TITLE
fix(useRouteHash, useRouteParams, useRouteQuery): fix effect triggering multiple times

### DIFF
--- a/packages/router/useRouteHash/index.test.ts
+++ b/packages/router/useRouteHash/index.test.ts
@@ -1,5 +1,5 @@
-import { nextTick, reactive, ref } from 'vue-demi'
-import { describe, expect, it } from 'vitest'
+import { computed, nextTick, reactive, ref, watch } from 'vue-demi'
+import { describe, expect, it, vi } from 'vitest'
 import { useRouteHash } from '.'
 
 describe('useRouteHash', () => {
@@ -72,6 +72,28 @@ describe('useRouteHash', () => {
     route.hash = 'foo'
 
     expect(hash.value).toBe('foo')
+  })
+
+  it('should trigger effects only once', async () => {
+    const route = getRoute()
+    const router = { replace: (r: any) => Object.assign(route, r) } as any
+    const onUpdate = vi.fn()
+
+    const hash = useRouteHash('baz', { route, router })
+    const hashObj = computed(() => ({
+      hash: hash.value,
+    }))
+
+    watch(hashObj, onUpdate)
+
+    hash.value = 'foo'
+
+    await nextTick()
+    await nextTick()
+
+    expect(hash.value).toBe('foo')
+    expect(route.hash).toBe('foo')
+    expect(onUpdate).toHaveBeenCalledTimes(1)
   })
 
   it('should allow ref or getter as default value', () => {

--- a/packages/router/useRouteHash/index.ts
+++ b/packages/router/useRouteHash/index.ts
@@ -51,6 +51,9 @@ export function useRouteHash(
   watch(
     () => route.hash,
     () => {
+      if (route.hash === _hash)
+        return
+
       _hash = route.hash
       _trigger()
     },

--- a/packages/router/useRouteParams/index.test.ts
+++ b/packages/router/useRouteParams/index.test.ts
@@ -1,4 +1,4 @@
-import { effectScope, nextTick, reactive, ref, watch } from 'vue-demi'
+import { computed, effectScope, nextTick, reactive, ref, watch } from 'vue-demi'
 import { describe, expect, it, vi } from 'vitest'
 import type { Ref } from 'vue-demi'
 import { useRouteParams } from '.'
@@ -214,6 +214,28 @@ describe('useRouteParams', () => {
     expect(page.value).toBe(1)
     expect(route.params.page).toBeUndefined()
     expect(onUpdate).not.toHaveBeenCalled()
+  })
+
+  it('should trigger effects only once', async () => {
+    const route = getRoute()
+    const router = { replace: (r: any) => Object.assign(route, r) } as any
+    const onUpdate = vi.fn()
+
+    const page = useRouteParams('page', 1, { transform: Number, route, router })
+    const pageObj = computed(() => ({
+      page: page.value,
+    }))
+
+    watch(pageObj, onUpdate)
+
+    page.value = 2
+
+    await nextTick()
+    await nextTick()
+
+    expect(page.value).toBe(2)
+    expect(route.params.page).toBe(2)
+    expect(onUpdate).toHaveBeenCalledTimes(1)
   })
 
   it('should keep current query and hash', async () => {

--- a/packages/router/useRouteParams/index.ts
+++ b/packages/router/useRouteParams/index.ts
@@ -92,6 +92,9 @@ export function useRouteParams<
   watch(
     () => route.params[name],
     (v) => {
+      if (param === v)
+        return
+
       param = v
 
       _trigger()

--- a/packages/router/useRouteQuery/index.test.ts
+++ b/packages/router/useRouteQuery/index.test.ts
@@ -1,4 +1,4 @@
-import { effectScope, nextTick, reactive, ref, watch } from 'vue-demi'
+import { computed, effectScope, nextTick, reactive, ref, watch } from 'vue-demi'
 import { describe, expect, it, vi } from 'vitest'
 import type { Ref } from 'vue-demi'
 import { useRouteQuery } from '.'
@@ -224,6 +224,28 @@ describe('useRouteQuery', () => {
     expect(page.value).toBe(1)
     expect(route.query.page).toBeUndefined()
     expect(onUpdate).not.toHaveBeenCalled()
+  })
+
+  it('should trigger effects only once', async () => {
+    const route = getRoute()
+    const router = { replace: (r: any) => Object.assign(route, r) } as any
+    const onUpdate = vi.fn()
+
+    const page = useRouteQuery('page', 1, { transform: Number, route, router })
+    const pageObj = computed(() => ({
+      page: page.value,
+    }))
+
+    watch(pageObj, onUpdate)
+
+    page.value = 2
+
+    await nextTick()
+    await nextTick()
+
+    expect(page.value).toBe(2)
+    expect(route.query.page).toBe(2)
+    expect(onUpdate).toHaveBeenCalledTimes(1)
   })
 
   it('should keep current query and hash', async () => {

--- a/packages/router/useRouteQuery/index.ts
+++ b/packages/router/useRouteQuery/index.ts
@@ -89,6 +89,9 @@ export function useRouteQuery<
   watch(
     () => route.query[name],
     (v) => {
+      if (query === v)
+        return
+
       query = v
 
       _trigger()


### PR DESCRIPTION
Resolves #4112.

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

When a ref is created with `useRouteQuery`, assigning a new value to the ref calls `trigger` twice for each change. It is called once immediately by the `set` operation, and the route is updated in a `nextTick`. When the route updates in the following tick, it triggers a watcher on the route query, which calls `trigger` again.

The extra call to `trigger` means that effects on the ref are triggered multiple times for the same value in different ticks.

More details are available in #4112.

### Additional context

This behavior was probably introduced in d52524441ae08c1ef7a9d3bc86c7fa32bbb0cd75.

Previously, the setter would only update the route, and we would rely on the route watcher to update the value and trigger the effect. This commit introduced a `trigger` call into the `set` method, but didn't add a guard against the `trigger` being called again in the subsequent tick.
