### PR TITLE
fix(useChangeCase): use the exported key for filter

### DIFF
--- a/packages/integrations/useChangeCase/index.ts
+++ b/packages/integrations/useChangeCase/index.ts
@@ -12,7 +12,11 @@ type ChangeCaseKeys = FilterKeys<typeof changeCase>
 export type ChangeCaseType = ChangeCaseKeys[keyof ChangeCaseKeys]
 
 const changeCaseTransforms: any = /* @__PURE__ */ Object.entries(changeCase)
-  .filter(([name, fn]) => typeof fn === 'function' && name.endsWith('Case')).reduce((acc, [name, fn]) => ({ ...acc, [name]: fn }), {} as any)
+  .filter(([name, fn]) => typeof fn === 'function' && name.endsWith('Case'))
+  .reduce((acc, [name, fn]) => {
+    acc[name] = fn
+    return acc
+  }, {} as any)
 
 export function useChangeCase(input: MaybeRef<string>, type: MaybeRefOrGetter<ChangeCaseType>, options?: MaybeRefOrGetter<Options> | undefined): WritableComputedRef<string>
 export function useChangeCase(input: MaybeRefOrGetter<string>, type: MaybeRefOrGetter<ChangeCaseType>, options?: MaybeRefOrGetter<Options> | undefined): ComputedRef<string>

--- a/packages/integrations/useChangeCase/index.ts
+++ b/packages/integrations/useChangeCase/index.ts
@@ -12,7 +12,7 @@ type ChangeCaseKeys = FilterKeys<typeof changeCase>
 export type ChangeCaseType = ChangeCaseKeys[keyof ChangeCaseKeys]
 
 const changeCaseTransforms: any = /* @__PURE__ */ Object.entries(changeCase)
-  .filter(([name, fn]) => typeof fn === "function" && name.endsWith("Case")).reduce((acc, [name, fn]) => ({ ...acc, [name]: fn }), {} as any);   
+  .filter(([name, fn]) => typeof fn === 'function' && name.endsWith('Case')).reduce((acc, [name, fn]) => ({ ...acc, [name]: fn }), {} as any)
 
 export function useChangeCase(input: MaybeRef<string>, type: MaybeRefOrGetter<ChangeCaseType>, options?: MaybeRefOrGetter<Options> | undefined): WritableComputedRef<string>
 export function useChangeCase(input: MaybeRefOrGetter<string>, type: MaybeRefOrGetter<ChangeCaseType>, options?: MaybeRefOrGetter<Options> | undefined): ComputedRef<string>

--- a/packages/integrations/useChangeCase/index.ts
+++ b/packages/integrations/useChangeCase/index.ts
@@ -11,11 +11,8 @@ type ChangeCaseKeys = FilterKeys<typeof changeCase>
 
 export type ChangeCaseType = ChangeCaseKeys[keyof ChangeCaseKeys]
 
-const changeCaseTransforms: any = /* @__PURE__ */ Object.values(changeCase)
-  .filter(v => typeof v === 'function' && v.name.endsWith('Case')).reduce((acc, fn) => {
-    acc[fn.name] = fn
-    return acc
-  }, {} as any)
+const changeCaseTransforms: any = /* @__PURE__ */ Object.entries(changeCase)
+  .filter(([name, fn]) => typeof fn === "function" && name.endsWith("Case")).reduce((acc, [name, fn]) => ({ ...acc, [name]: fn }), {} as any);   
 
 export function useChangeCase(input: MaybeRef<string>, type: MaybeRefOrGetter<ChangeCaseType>, options?: MaybeRefOrGetter<Options> | undefined): WritableComputedRef<string>
 export function useChangeCase(input: MaybeRefOrGetter<string>, type: MaybeRefOrGetter<ChangeCaseType>, options?: MaybeRefOrGetter<Options> | undefined): ComputedRef<string>


### PR DESCRIPTION
**changeCaseTransforms** will return a null object of funcions becasue on the non-dev build the functions names comes minified/mangles, 
```
changeCase VALUES 
(14) [ƒ, ƒ, ƒ, ƒ, ƒ, ƒ, ƒ, ƒ, ƒ, ƒ, ƒ, ƒ, ƒ, ƒ]
ƒ ir(t,e)
ƒ yt(t,e)
ƒ lr(t,e)
ƒ sr(t,e)
ƒ ur(t,e)
ƒ Oe(t,e)
ƒ or(t,e)
ƒ ar(t,e)
ƒ cr(t,e)
ƒ dr(t,e)
ƒ fr(t,e)
ƒ Et(t)
ƒ Kt(t)
ƒ hr(t,e)
```
making the v.name.endsWith('Case') never maching.

Not sure this is the best aproach to fix. changed Object.values to use Object.entries in other to be able to use theyh object key instead of the function name.

Issue: https://github.com/vueuse/vueuse/issues/4139
Duplicate PR: https://github.com/vueuse/vueuse/pull/4140
