### PR TITLE
fix(computedWithControl): allow optional oldValue parameter in computedWithControl getter

### DIFF
--- a/packages/shared/computedWithControl/index.test.ts
+++ b/packages/shared/computedWithControl/index.test.ts
@@ -25,6 +25,23 @@ describe('computedWithControl', () => {
     expect(computed.value).toBe('BAR')
   })
 
+  it.runIf(isVue3)('optional old value', () => {
+    const trigger = ref(0)
+
+    const computed = computedWithControl(trigger, (oldValue?: number) =>
+      oldValue ? oldValue * 2 : 1)
+
+    expect(computed.value).toBe(1)
+
+    trigger.value += 1
+
+    expect(computed.value).toBe(2)
+
+    trigger.value -= 1
+
+    expect(computed.value).toBe(4)
+  })
+
   it.runIf(isVue3)('custom trigger', () => {
     let count = 0
     const computed = computedWithControl(() => {}, () => count)

--- a/packages/shared/computedWithControl/index.ts
+++ b/packages/shared/computedWithControl/index.ts
@@ -54,7 +54,7 @@ export function computedWithControl<T, S>(
     return {
       get() {
         if (dirty.value) {
-          v = get()
+          v = get(v)
           dirty.value = false
         }
         track()


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

---

### Description

Since vue 3.4, [`computedGetter`](https://vuejs.org/api/reactivity-core.html#computed) is of type `(oldValue?) => T`. Similar behavior could be easily implemented for `computedWithControl`. Related: https://github.com/vuejs/rfcs/discussions/594

