### PR TITLE
fix(isDefined): moves most specific overload to the top

### DIFF
--- a/packages/shared/isDefined/index.ts
+++ b/packages/shared/isDefined/index.ts
@@ -3,8 +3,8 @@ import type { ComputedRef, Ref } from 'vue-demi'
 // eslint-disable-next-line no-restricted-imports
 import { unref } from 'vue-demi'
 
-export function isDefined<T>(v: Ref<T>): v is Ref<Exclude<T, null | undefined>>
 export function isDefined<T>(v: ComputedRef<T>): v is ComputedRef<Exclude<T, null | undefined>>
+export function isDefined<T>(v: Ref<T>): v is Ref<Exclude<T, null | undefined>>
 export function isDefined<T>(v: T): v is Exclude<T, null | undefined>
 export function isDefined<T>(v: Ref<T>): boolean {
   return unref(v) != null


### PR DESCRIPTION
### Description

- TS matches overloads by finding the topmost signature that's compatible with the parameters
- instances of `ComputedRef` were matching to the overload with the `Ref` parameter rather than `ComputedRef`
- later in the scope where `isDefined` was used, the type was still narrowed, but to something that Typescript might find hard to resolve in reasonable time: `ComputedRef<SomeType | null> & Ref<SomeType>` rather than `ComputedRef<SomeType>`
- this made it difficult for `get` to resolve the types starting in v10.11.1 with [this change](https://github.com/vueuse/vueuse/commit/19f2ad34e938b6a0d03fc227bf817dc5f41f25cc).
  - something to do with `get` asking for `MaybeRef`

### Additional context

- Sorry for no reproduction, there's no TS StackBlitz for VueUse, otherwise I would've forked off of it!