### PR TITLE
fix(useStorage): sync within the same document

### DIFF
--- a/packages/core/useStorage/index.test.ts
+++ b/packages/core/useStorage/index.test.ts
@@ -527,4 +527,27 @@ describe('useStorage', () => {
     const objectRef = useStorage(KEY, value, storage)
     expect(objectRef.value).toEqual(value)
   })
+
+  it('syncs properly within the same document', async () => {
+    const state1 = useStorage(KEY, 0, storage)
+    const state2 = useStorage(KEY, 0, storage)
+
+    state1.value = 1
+    await nextTick()
+    expect(state2.value).toBe(1)
+  })
+
+  it('syncs properly within the same document (custom storages)', async () => {
+    const customStorage = {
+      getItem: storage.getItem,
+      setItem: storage.setItem,
+      removeItem: storage.removeItem,
+    }
+    const state1 = useStorage(KEY, 0, customStorage)
+    const state2 = useStorage(KEY, 0, customStorage)
+
+    state1.value = 1
+    await nextTick()
+    expect(state2.value).toBe(1)
+  })
 })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Fixes a regression introduced in https://github.com/vueuse/vueuse/pull/3822 where the use of the composable within the same document will not sync (between documents and a single composable would still work fine). Also add a test to avoid this kind of regressions.

### Additional context

Improve some code documentation, stating the fact that custom storage backends can't be synced across different documents.
