### PR TITLE
fix(useWebSocket): only reconnect if is the current ws socket

### DIFF
--- a/packages/core/useWebSocket/index.ts
+++ b/packages/core/useWebSocket/index.ts
@@ -230,7 +230,7 @@ export function useWebSocket<Data = any>(
       status.value = 'CLOSED'
       onDisconnected?.(ws, ev)
 
-      if (!explicitlyClosed && options.autoReconnect) {
+      if (!explicitlyClosed && options.autoReconnect && ws === wsRef.value) {
         const {
           retries = -1,
           delay = 1000,


### PR DESCRIPTION
### Description

This PR addresses issue #4160.
It verifies when doing an autoReconnect that the ws and wsRef are pointing to the same object.
If the wsRef is pointing to something new, we should not try and reconnect the ws WebSocket, since it is considered stale.