### PR TITLE
fix(useWebSocket): should reset retry count when connection is established

### DIFF
--- a/packages/core/useWebSocket/index.ts
+++ b/packages/core/useWebSocket/index.ts
@@ -221,6 +221,7 @@ export function useWebSocket<Data = any>(
 
     ws.onopen = () => {
       status.value = 'OPEN'
+      retried = 0
       onConnected?.(ws!)
       heartbeatResume?.()
       _sendBuffer()

--- a/packages/core/useWebSocket/index.ts
+++ b/packages/core/useWebSocket/index.ts
@@ -237,11 +237,11 @@ export function useWebSocket<Data = any>(
           delay = 1000,
           onFailed,
         } = resolveNestedOptions(options.autoReconnect)
-        retried += 1
 
-        if (typeof retries === 'number' && (retries < 0 || retried < retries))
+        if (typeof retries === 'number' && (retries < 0 || retried < retries)) {
+          retried += 1
           setTimeout(_init, delay)
-        else if (typeof retries === 'function' && retries())
+        } else if (typeof retries === 'function' && retries())
           setTimeout(_init, delay)
         else
           onFailed?.()

--- a/packages/core/useWebSocket/index.ts
+++ b/packages/core/useWebSocket/index.ts
@@ -241,10 +241,13 @@ export function useWebSocket<Data = any>(
         if (typeof retries === 'number' && (retries < 0 || retried < retries)) {
           retried += 1
           setTimeout(_init, delay)
-        } else if (typeof retries === 'function' && retries())
+        }
+        else if (typeof retries === 'function' && retries()) {
           setTimeout(_init, delay)
-        else
+        }
+        else {
           onFailed?.()
+        }
       }
     }
 


### PR DESCRIPTION
### Description

This ticket is a PR for  issue #4163

autoReconnect should reset retries once a connection is successfully established and the guard you be checked before increasing retried count.