### PR TITLE
fix(usePermission): state setting

### DIFF
--- a/packages/core/usePermission/index.ts
+++ b/packages/core/usePermission/index.ts
@@ -74,12 +74,11 @@ export function usePermission(
     : permissionDesc as PermissionDescriptor
   const state = shallowRef<PermissionState | undefined>()
 
-  const onChange = () => {
-    if (permissionStatus.value)
-      state.value = permissionStatus.value.state
+  const update = () => {
+    state.value = permissionStatus.value?.state ?? 'prompt'
   }
 
-  useEventListener(permissionStatus, 'change', onChange)
+  useEventListener(permissionStatus, 'change', update)
 
   const query = createSingletonPromise(async () => {
     if (!isSupported.value)
@@ -88,10 +87,12 @@ export function usePermission(
     if (!permissionStatus.value) {
       try {
         permissionStatus.value = await navigator!.permissions.query(desc)
-        onChange()
       }
       catch {
-        state.value = 'prompt'
+        permissionStatus.value = undefined
+      }
+      finally {
+        update()
       }
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

As discussed in #4149 (starting from [this comment](https://github.com/vueuse/vueuse/issues/4149#issuecomment-2294844421)), the way the state is setted in this composable is not ideal:

* If the composable failed, the state is setted as `prompt`, but it won't be queried again, since ``permissionStatus`` is not set to undefined. Another solution would be to remove the `if` from the query (I'm not sure if it's strictly necessary there).
* If permissionStatus is undefined, previously we did nothing, now we set it to 'prompt'. All of this has been refactored into an `update` function and simplified with the use of the `finally` statement.
