### PR TITLE
fix(useDropZone): ensure files ref is updated even without onDrop callback

### DIFF
--- a/packages/core/useDropZone/index.ts
+++ b/packages/core/useDropZone/index.ts
@@ -57,13 +57,15 @@ export function useDropZone(
       event.preventDefault()
       counter += 1
       isOverDropZone.value = true
-      _options.onEnter?.(getFiles(event), event)
+      const files = getFiles(event)
+      _options.onEnter?.(files, event)
     })
     useEventListener<DragEvent>(target, 'dragover', (event) => {
       if (!isDataTypeIncluded)
         return
       event.preventDefault()
-      _options.onOver?.(getFiles(event), event)
+      const files = getFiles(event)
+      _options.onOver?.(files, event)
     })
     useEventListener<DragEvent>(target, 'dragleave', (event) => {
       if (!isDataTypeIncluded)
@@ -72,13 +74,15 @@ export function useDropZone(
       counter -= 1
       if (counter === 0)
         isOverDropZone.value = false
-      _options.onLeave?.(getFiles(event), event)
+      const files = getFiles(event)
+      _options.onLeave?.(files, event)
     })
     useEventListener<DragEvent>(target, 'drop', (event) => {
       event.preventDefault()
       counter = 0
       isOverDropZone.value = false
-      _options.onDrop?.(getFiles(event), event)
+      const files = getFiles(event)
+      _options.onDrop?.(files, event)
     })
   }
 


### PR DESCRIPTION

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

fix https://github.com/vueuse/vueuse/issues/4165

Set to file even if no callback is set

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
