### PR TITLE
doc(FunctionsList): Refresh browser query with missing values and no filtering performed fixes(#4224)

### DIFF
--- a/packages/.vitepress/theme/components/FunctionsList.vue
+++ b/packages/.vitepress/theme/components/FunctionsList.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { Ref } from 'vue'
-import { computed, toRef } from 'vue'
+import { computed, onMounted, toRef } from 'vue'
 import Fuse from 'fuse.js'
 import { useEventListener, useUrlSearchParams } from '@vueuse/core'
 import { categoryNames, functions } from '../../../../packages/metadata/metadata'
@@ -8,7 +8,6 @@ import { categoryNames, functions } from '../../../../packages/metadata/metadata
 const coreCategories = categoryNames.filter(i => !i.startsWith('@'))
 const addonCategories = categoryNames.filter(i => i.startsWith('@'))
 const sortMethods = ['category', 'name', 'updated']
-
 useEventListener('click', (e) => {
   // @ts-expect-error cast
   if (e.target.tagName === 'A')
@@ -69,6 +68,14 @@ function toggleCategory(cate: string) {
 function toggleSort(method: string) {
   sortMethod.value = method as any
 }
+
+onMounted(() => {
+  // fix https://github.com/vueuse/vueuse/issues/4224
+  // desc Refresh browser query with missing values and no filtering performed
+  if (!category.value) {
+    toggleCategory(category.value)
+  }
+})
 </script>
 
 <template>


### PR DESCRIPTION
…n filtered

When mounting the component, check if the query has a value. If there is a value, call the filtering method

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [ ✓] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [ ✓] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ ✓] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ✓] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ✓] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

fix Refresh browser query with missing values and no filtering performed
solution:When mounting the component, check if the query has a value. If there is a value, call the filtering method

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
