### PR TITLE
docs(usePermission): add `geolocation` to demo

### DIFF
--- a/packages/core/usePermission/demo.vue
+++ b/packages/core/usePermission/demo.vue
@@ -10,6 +10,7 @@ const backgroundSync = usePermission('background-sync')
 const camera = usePermission('camera')
 const clipboardRead = usePermission('clipboard-read')
 const clipboardWrite = usePermission('clipboard-write')
+const geolocation = usePermission('geolocation')
 const gyroscope = usePermission('gyroscope')
 const magnetometer = usePermission('magnetometer')
 const microphone = usePermission('microphone')
@@ -28,6 +29,7 @@ const code = computed(() => YAML.dump(reactive({
   camera,
   clipboardRead,
   clipboardWrite,
+  geolocation,
   gyroscope,
   magnetometer,
   microphone,


### PR DESCRIPTION


<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

---

### Description

Just a small documentation style change. 
As a common use-case of permissions API, I thought it would make sense to include it in the demo component

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
