### PR TITLE
feat(useBreakpoints): add breakpoints for ElementUI/ElementPlus

### DIFF
--- a/packages/core/useBreakpoints/breakpoints.ts
+++ b/packages/core/useBreakpoints/breakpoints.ts
@@ -128,3 +128,17 @@ export const breakpointsPrimeFlex = {
   lg: 992,
   xl: 1200,
 }
+
+/**
+ * Breakpoints from ElementUI/ElementPlus
+ *
+ * @see https://element.eleme.io/#/en-US/component/layout
+ * @see https://element-plus.org/en-US/component/layout.html
+ */
+export const breakpointsElement = {
+  xs: 0,
+  sm: 768,
+  md: 992,
+  lg: 1200,
+  xl: 1920,
+}

--- a/packages/core/useBreakpoints/index.md
+++ b/packages/core/useBreakpoints/index.md
@@ -55,6 +55,7 @@ const laptop = breakpoints.between('laptop', 'desktop')
 - Sematic: `breakpointsSematic`
 - Master CSS: `breakpointsMasterCss`
 - Prime Flex: `breakpointsPrimeFlex`
+- ElementUI / ElementPlus: `breakpointsElement`
 
 _Breakpoint presets are deliberately not auto-imported, as they do not start with `use` to have the scope of VueUse. They have to be explicitly imported:_
 


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Close: #4080 
Add breakpoints for ElementUI/ElementPlus.

```js
/**
 * Breakpoints from ElementUI/ElementPlus
 *
 * @see https://element.eleme.io/#/en-US/component/layout
 * @see https://element-plus.org/en-US/component/layout.html
 */
export const breakpointsElement = {
  xs: 0,
  sm: 768,
  md: 992,
  lg: 1200,
  xl: 1920,
}
```

### Additional context
