### PR TITLE
fix(useDevicesList): handle NotAllowedError on reject/close

### DIFF
--- a/packages/core/useDevicesList/index.ts
+++ b/packages/core/useDevicesList/index.ts
@@ -84,8 +84,9 @@ export function useDevicesList(options: UseDevicesListOptions = {}): UseDevicesL
     if (state.value !== 'granted') {
       let granted = true
       try {
-        await navigator!.mediaDevices.getUserMedia(constraints)
+        stream = await navigator!.mediaDevices.getUserMedia(constraints)
       } catch {
+        stream = null
         granted = false
       }
       update()

--- a/packages/core/useDevicesList/index.ts
+++ b/packages/core/useDevicesList/index.ts
@@ -82,9 +82,14 @@ export function useDevicesList(options: UseDevicesListOptions = {}): UseDevicesL
     const { state, query } = usePermission('camera', { controls: true })
     await query()
     if (state.value !== 'granted') {
-      stream = await navigator!.mediaDevices.getUserMedia(constraints)
+      let granted = true
+      try {
+        await navigator!.mediaDevices.getUserMedia(constraints)
+      } catch {
+        granted = false
+      }
       update()
-      permissionGranted.value = true
+      permissionGranted.value = granted
     }
     else {
       permissionGranted.value = true

--- a/packages/core/useDevicesList/index.ts
+++ b/packages/core/useDevicesList/index.ts
@@ -85,7 +85,8 @@ export function useDevicesList(options: UseDevicesListOptions = {}): UseDevicesL
       let granted = true
       try {
         stream = await navigator!.mediaDevices.getUserMedia(constraints)
-      } catch {
+      }
+      catch {
         stream = null
         granted = false
       }


### PR DESCRIPTION
In Safari the reject/not allowed action throws an NotAllowedError in the `navigator.mediaDevices.getUserMedia(constraints)`.
This also happens if you press the x on Chrome and you get an `NotAllowedError: Permission dismissed`.

This is not handled within the `ensurePermissions()` function, so added a try catch to collect and set always `false` on error.
