### PR TITLE
feat(useMediaControls): add playback error event 

### DIFF
--- a/packages/core/useMediaControls/index.ts
+++ b/packages/core/useMediaControls/index.ts
@@ -173,6 +173,7 @@ export function useMediaControls(target: MaybeRef<HTMLMediaElement | null | unde
 
   // Events
   const sourceErrorEvent = createEventHook<Event>()
+  const playbackErrorEvent = createEventHook<Event>()
 
   /**
    * Disables the specified track. If no track is specified then
@@ -377,7 +378,7 @@ export function useMediaControls(target: MaybeRef<HTMLMediaElement | null | unde
       return
 
     if (isPlaying)
-      el.play()
+      el.play().catch(playbackErrorEvent.trigger)
     else
       el.pause()
   })
@@ -463,6 +464,7 @@ export function useMediaControls(target: MaybeRef<HTMLMediaElement | null | unde
 
     // Events
     onSourceError: sourceErrorEvent.on,
+    onPlaybackError: playbackErrorEvent.on,
   }
 }
 

--- a/packages/core/useMediaControls/index.ts
+++ b/packages/core/useMediaControls/index.ts
@@ -377,10 +377,15 @@ export function useMediaControls(target: MaybeRef<HTMLMediaElement | null | unde
     if (!el)
       return
 
-    if (isPlaying)
-      el.play().catch(playbackErrorEvent.trigger)
-    else
+    if (isPlaying) {
+      el.play().catch((e) => {
+        playbackErrorEvent.trigger(e)
+        throw e
+      })
+    }
+    else {
       el.pause()
+    }
   })
 
   useEventListener(target, 'timeupdate', () => ignoreCurrentTimeUpdates(() => currentTime.value = (toValue(target))!.currentTime))


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Added an event hook when `play()` throws an error, e.g. when browser blocks the playing of video.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
