### PR TITLE
docs(watchImmediate): corrected variable name in example

### DIFF
--- a/packages/shared/watchImmediate/index.md
+++ b/packages/shared/watchImmediate/index.md
@@ -18,7 +18,7 @@ const obj = ref('vue-use')
 // changing the value from some external store/composables
 obj.value = 'VueUse'
 
-watchImmediate(nestedObject, (updated) => {
+watchImmediate(obj, (updated) => {
   console.log(updated) // Console.log will be logged twice
 })
 ```


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Small PR to correct a typo in the docs for this file. `nestedObject` should be `obj` in the watchImmediate docs example code snippet.


