### PR TITLE
fix(useRouteParams, useRouteQuery): effect triggers twice with object getter as watch source

### DIFF
--- a/packages/router/useRouteParams/index.test.ts
+++ b/packages/router/useRouteParams/index.test.ts
@@ -238,6 +238,27 @@ describe('useRouteParams', () => {
     expect(onUpdate).toHaveBeenCalledTimes(1)
   })
 
+  it('should trigger effects only once with getter object as watch source', async () => {
+    const route = getRoute({ page: '1' })
+    const router = { replace: (r: any) => {
+      Object.keys(r.params).forEach(paramsKey => r.params[paramsKey] = String(r.params[paramsKey]))
+      return Object.assign(route, r)
+    } } as any
+    const onUpdate = vi.fn()
+
+    const page = useRouteParams('page', 1, { transform: Number, route, router })
+
+    watch(() => ({ page: page.value }), onUpdate)
+
+    page.value = 2
+    await nextTick()
+    await nextTick()
+
+    expect(page.value).toBe(2)
+    expect(route.params.page).toBe('2')
+    expect(onUpdate).toHaveBeenCalledTimes(1)
+  })
+
   it('should keep current query and hash', async () => {
     let route = getRoute()
     const router = { replace: (r: any) => route = r } as any

--- a/packages/router/useRouteParams/index.ts
+++ b/packages/router/useRouteParams/index.ts
@@ -1,10 +1,10 @@
 import type { MaybeRefOrGetter } from '@vueuse/shared'
 import type { Ref } from 'vue-demi'
 import type { LocationAsRelativeRaw, RouteParamValueRaw, Router } from 'vue-router'
+import type { ReactiveRouteOptionsWithTransform } from '../_types'
 import { toValue, tryOnScopeDispose } from '@vueuse/shared'
 import { customRef, nextTick, watch } from 'vue-demi'
 import { useRoute, useRouter } from 'vue-router'
-import type { ReactiveRouteOptionsWithTransform } from '../_types'
 
 const _queue = new WeakMap<Router, Map<string, any>>()
 

--- a/packages/router/useRouteParams/index.ts
+++ b/packages/router/useRouteParams/index.ts
@@ -1,10 +1,10 @@
 import type { MaybeRefOrGetter } from '@vueuse/shared'
 import type { Ref } from 'vue-demi'
 import type { LocationAsRelativeRaw, RouteParamValueRaw, Router } from 'vue-router'
-import type { ReactiveRouteOptionsWithTransform } from '../_types'
 import { toValue, tryOnScopeDispose } from '@vueuse/shared'
 import { customRef, nextTick, watch } from 'vue-demi'
 import { useRoute, useRouter } from 'vue-router'
+import type { ReactiveRouteOptionsWithTransform } from '../_types'
 
 const _queue = new WeakMap<Router, Map<string, any>>()
 
@@ -92,7 +92,7 @@ export function useRouteParams<
   watch(
     () => route.params[name],
     (v) => {
-      if (param === v)
+      if (param === transform(v as T))
         return
 
       param = v

--- a/packages/router/useRouteQuery/index.test.ts
+++ b/packages/router/useRouteQuery/index.test.ts
@@ -248,6 +248,27 @@ describe('useRouteQuery', () => {
     expect(onUpdate).toHaveBeenCalledTimes(1)
   })
 
+  it('should trigger effects only once with getter object as watch source', async () => {
+    const route = getRoute({ page: '1' })
+    const router = { replace: (r: any) => {
+      Object.keys(r.query).forEach(queryKey => r.query[queryKey] = String(r.query[queryKey]))
+      return Object.assign(route, r)
+    } } as any
+    const onUpdate = vi.fn()
+
+    const page = useRouteQuery('page', 1, { transform: Number, route, router })
+
+    watch(() => ({ page: page.value }), onUpdate)
+
+    page.value = 2
+    await nextTick()
+    await nextTick()
+
+    expect(page.value).toBe(2)
+    expect(route.query.page).toBe('2')
+    expect(onUpdate).toHaveBeenCalledTimes(1)
+  })
+
   it('should keep current query and hash', async () => {
     let route = getRoute()
     const router = { replace: (r: any) => route = r } as any

--- a/packages/router/useRouteQuery/index.ts
+++ b/packages/router/useRouteQuery/index.ts
@@ -1,10 +1,10 @@
 import type { MaybeRefOrGetter } from '@vueuse/shared'
 import type { Ref } from 'vue-demi'
 import type { Router } from 'vue-router'
-import type { ReactiveRouteOptionsWithTransform, RouteQueryValueRaw } from '../_types'
 import { toValue, tryOnScopeDispose } from '@vueuse/shared'
 import { customRef, nextTick, watch } from 'vue-demi'
 import { useRoute, useRouter } from 'vue-router'
+import type { ReactiveRouteOptionsWithTransform, RouteQueryValueRaw } from '../_types'
 
 const _queue = new WeakMap<Router, Map<string, any>>()
 
@@ -89,7 +89,7 @@ export function useRouteQuery<
   watch(
     () => route.query[name],
     (v) => {
-      if (query === v)
+      if (query === transform(v as T))
         return
 
       query = v

--- a/packages/router/useRouteQuery/index.ts
+++ b/packages/router/useRouteQuery/index.ts
@@ -1,10 +1,10 @@
 import type { MaybeRefOrGetter } from '@vueuse/shared'
 import type { Ref } from 'vue-demi'
 import type { Router } from 'vue-router'
+import type { ReactiveRouteOptionsWithTransform, RouteQueryValueRaw } from '../_types'
 import { toValue, tryOnScopeDispose } from '@vueuse/shared'
 import { customRef, nextTick, watch } from 'vue-demi'
 import { useRoute, useRouter } from 'vue-router'
-import type { ReactiveRouteOptionsWithTransform, RouteQueryValueRaw } from '../_types'
 
 const _queue = new WeakMap<Router, Map<string, any>>()
 


### PR DESCRIPTION
Resolves https://github.com/vueuse/vueuse/issues/4281

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Fixes case where reactivity double triggers when the watch source is an object getter.

### Additional context
