### PR TITLE
fix(useFetch): ensure single slash

### DIFF
--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -630,7 +630,7 @@ function joinPaths(start: string, end: string): string {
   }
 
   if (start.endsWith('/') && end.startsWith('/')) {
-    return `${start.slice(0, start.length - 1)}${end}`
+    return `${start.slice(0, -1)}${end}`
   }
 
   return `${start}${end}`

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -625,8 +625,13 @@ export function useFetch<T>(url: MaybeRefOrGetter<string>, ...args: any[]): UseF
 }
 
 function joinPaths(start: string, end: string): string {
-  if (!start.endsWith('/') && !end.startsWith('/'))
+  if (!start.endsWith('/') && !end.startsWith('/')) {
     return `${start}/${end}`
+  }
+
+  if (start.endsWith('/') && end.startsWith('/')) {
+    return `${start.slice(0, start.length - 1)}${end}`
+  }
 
   return `${start}${end}`
 }


### PR DESCRIPTION
### Description

When I call `createFetch` with a `baseUrl` that ends with a slash, and call `useFetch` with a path that starts with a slash, it will send a request like `https://example.com//api/something`.

This PR resolves this problem by checking if both the start and end have slashes, and removing the starting slash.

```javscript
function joinPaths(start: string, end: string): string {
  if (!start.endsWith('/') && !end.startsWith('/')) {
    return `${start}/${end}`
  }

  if (start.endsWith('/') && end.startsWith('/')) {
    return `${start.slice(0, start.length - 1)}${end}`
  }

  return `${start}${end}`
}
```
