### PR TITLE
fix(useClipboard,useClipboardItems): avoid running "copied" timeout during initialization

### DIFF
--- a/packages/core/useClipboard/index.ts
+++ b/packages/core/useClipboard/index.ts
@@ -68,7 +68,7 @@ export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<strin
   const isSupported = computed(() => isClipboardApiSupported.value || legacy)
   const text = ref('')
   const copied = ref(false)
-  const timeout = useTimeoutFn(() => copied.value = false, copiedDuring)
+  const timeout = useTimeoutFn(() => copied.value = false, copiedDuring, { immediate: false })
 
   function updateText() {
     if (isClipboardApiSupported.value && isAllowed(permissionRead.value)) {

--- a/packages/core/useClipboardItems/index.ts
+++ b/packages/core/useClipboardItems/index.ts
@@ -54,7 +54,7 @@ export function useClipboardItems(options: UseClipboardItemsOptions<MaybeRefOrGe
   const isSupported = useSupported(() => (navigator && 'clipboard' in navigator))
   const content = ref<ClipboardItems>([])
   const copied = ref(false)
-  const timeout = useTimeoutFn(() => copied.value = false, copiedDuring)
+  const timeout = useTimeoutFn(() => copied.value = false, copiedDuring, { immediate: false })
 
   function updateContent() {
     if (isSupported.value) {


### PR DESCRIPTION
### Description

Currently calling `useClipboard()` will immediately start timer intended for resetting `copied` value. This pull request aims avoid doing that as it can be somewhat costly during init when composable is extensively used.

### Additional context

I believe there is still room for improvement by making all `useClipboard` instances share common `usePermission` states. As I understand currently new ones are created for every `useClipboard` call, but I could also be mistaken. Any thoughts or guidance on this would be appreciated.