### PR TITLE
docs: update nuxt readme to show all disabled functions

### DIFF
--- a/packages/nuxt/README.md
+++ b/packages/nuxt/README.md
@@ -23,12 +23,15 @@ export default defineNuxtConfig({
 
 The following utils are **disabled** from auto-import for Nuxt to avoid conflicts with Nuxt's built-in utils:
 
+- `toRef`
 - `toRefs`
+- `toValue`
 - `useFetch`
 - `useCookie`
 - `useHead`
 - `useTitle`
 - `useStorage`
+- `useImage`
 
 You can always use them by explicitly import from `@vueuse/core`
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
I ran in to some issues while trying to override a vueuse composable within nuxt using the `~/composables` directory.

As an example; I should be able to define my own `useBreakpoints` composable, without having to worry about `autoImports` from `@vueuse/nuxt` globally overriding it.

I've tried using the `imports:extend` and `imports:sources` nuxt hooks in `nuxt.config.ts` to disable `useBreakpoints`, but this didn't work as `@vueuse/nuxt` is registered after those hooks, and `unjs/hookable` doesn't support  priorities (unjs/hookable#104)

I also tried creating my own module (`zz_test`) to try and get around that by making it register last, but that also did not work.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
I took the liberty to update the docs to include all default-excluded functions.