### PR TITLE
fix(useDropZone): remove file kind restriction

### DIFF
--- a/packages/core/useDropZone/index.ts
+++ b/packages/core/useDropZone/index.ts
@@ -65,12 +65,10 @@ export function useDropZone(
 
     const checkValidity = (event: DragEvent) => {
       const items = Array.from(event.dataTransfer?.items ?? [])
-      const types = items
-        .filter(item => item.kind === 'file')
-        .map(item => item.type)
+      const types = items.map(item => item.type)
 
       const dataTypesValid = checkDataTypes(types)
-      const multipleFilesValid = multiple || items.filter(item => item.kind === 'file').length <= 1
+      const multipleFilesValid = multiple || items.length <= 1
 
       return dataTypesValid && multipleFilesValid
     }


### PR DESCRIPTION
fixes: #4302 

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

This PR removes the restriction on file kind filtering to allow useDropZone to handle internal drops (HTML elements).

In version v10.11.1, useDropZone supported both external drops (files) and internal drops. However, in v11.1.0, the drop event no longer fires for HTML elements due to this file kind restriction.

It looks like the [Demo](https://vueuse.org/core/useDropZone/#usedropzone) in the docs has been fixed as well

Before:

https://github.com/user-attachments/assets/b824d1bd-d106-4ce3-bd8d-48f17426ae0b

After:

https://github.com/user-attachments/assets/41eaf59a-f31d-4935-9e94-e1d594b0752b


