### PR TITLE
fix(useDropZone): update type to allow readonly array param

### DIFF
--- a/packages/core/useDropZone/index.ts
+++ b/packages/core/useDropZone/index.ts
@@ -17,7 +17,7 @@ export interface UseDropZoneOptions {
    * Allowed data types, if not set, all data types are allowed.
    * Also can be a function to check the data types.
    */
-  dataTypes?: MaybeRef<string[]> | ((types: readonly string[]) => boolean)
+  dataTypes?: MaybeRef<readonly string[]> | ((types: readonly string[]) => boolean)
   onDrop?: (files: File[] | null, event: DragEvent) => void
   onEnter?: (files: File[] | null, event: DragEvent) => void
   onLeave?: (files: File[] | null, event: DragEvent) => void


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Currently, attempting to do the following (in TypeScript) causes a type error even though the code works correctly:

```typescript
const dataTypes = ['image/png'] as const
const dropZoneRef = useTemplateRef('drop-zone')
useDropZone(dropZoneRef, { dataTypes })
// error TS2322: Type 'readonly ["image/png"]' is not assignable to type 'MaybeRef<string[]> | ((types: readonly string[]) => boolean) | undefined'.
```

Since this composable never mutates the `dataTypes` array, we can just mark it readonly, which fixes this issue.