### PR TITLE
fix(useMouse): prevent double counting scroll offset when using pageX/Y

### DIFF
--- a/packages/core/useMouse/index.ts
+++ b/packages/core/useMouse/index.ts
@@ -52,7 +52,7 @@ export interface UseMouseOptions extends ConfigurableWindow, ConfigurableEventFi
 }
 
 const UseMouseBuiltinExtractors: Record<UseMouseCoordType, UseMouseEventExtractor> = {
-  page: event => [event.pageX, event.pageY],
+  page: event => [event.clientX, event.clientY],
   client: event => [event.clientX, event.clientY],
   screen: event => [event.screenX, event.screenY],
   movement: event => (event instanceof Touch

--- a/packages/core/useMouse/index.ts
+++ b/packages/core/useMouse/index.ts
@@ -80,6 +80,7 @@ export function useMouse(options: UseMouseOptions = {}) {
   } = options
 
   let _prevMouseEvent: MouseEvent | null = null
+  let _prevScroll: number[] = [0, 0]
 
   const x = ref(initialValue.x)
   const y = ref(initialValue.y)
@@ -93,6 +94,9 @@ export function useMouse(options: UseMouseOptions = {}) {
     const result = extractor(event)
     _prevMouseEvent = event
 
+    if (type === 'page')
+      _prevScroll = [window?.scrollX ?? 0, window?.scrollY ?? 0]
+
     if (result) {
       [x.value, y.value] = result
       sourceType.value = 'mouse'
@@ -102,6 +106,10 @@ export function useMouse(options: UseMouseOptions = {}) {
   const touchHandler = (event: TouchEvent) => {
     if (event.touches.length > 0) {
       const result = extractor(event.touches[0])
+
+      if (type === 'page')
+        _prevScroll = [window?.scrollX ?? 0, window?.scrollY ?? 0]
+
       if (result) {
         [x.value, y.value] = result
         sourceType.value = 'touch'
@@ -115,8 +123,10 @@ export function useMouse(options: UseMouseOptions = {}) {
     const pos = extractor(_prevMouseEvent)
 
     if (_prevMouseEvent instanceof MouseEvent && pos) {
-      x.value = pos[0] + window.scrollX
-      y.value = pos[1] + window.scrollY
+      const deltaX = type === 'page' ? window.scrollX - _prevScroll[0] : window.scrollX
+      const deltaY = type === 'page' ? window.scrollY - _prevScroll[1] : window.scrollY
+      x.value = pos[0] + deltaX
+      y.value = pos[1] + deltaY
     }
   }
 

--- a/packages/core/useMouse/index.ts
+++ b/packages/core/useMouse/index.ts
@@ -52,7 +52,7 @@ export interface UseMouseOptions extends ConfigurableWindow, ConfigurableEventFi
 }
 
 const UseMouseBuiltinExtractors: Record<UseMouseCoordType, UseMouseEventExtractor> = {
-  page: event => [event.clientX, event.clientY],
+  page: event => [event.pageX, event.pageY],
   client: event => [event.clientX, event.clientY],
   screen: event => [event.screenX, event.screenY],
   movement: event => (event instanceof Touch


### PR DESCRIPTION
<!-- Thank you for contributing! -->

fix #4186

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR fixes incorrect mouse position tracking in `useMouse` when scrolling occurs. Previously, when `type='page'`, we were **double counting scroll offsets** because pageX/Y already includes scroll position, while we were adding scrollX/Y again during scroll events.