### PR TITLE
fix(useSwipe): allow vertical scrolling during swipe

### DIFF
--- a/packages/core/useSwipe/index.ts
+++ b/packages/core/useSwipe/index.ts
@@ -128,8 +128,6 @@ export function useSwipe(
     useEventListener(target, 'touchstart', (e: TouchEvent) => {
       if (e.touches.length !== 1)
         return
-      if (listenerOptions.capture && !listenerOptions.passive)
-        e.preventDefault()
       const [x, y] = getTouchEventCoords(e)
       updateCoordsStart(x, y)
       updateCoordsEnd(x, y)
@@ -141,6 +139,8 @@ export function useSwipe(
         return
       const [x, y] = getTouchEventCoords(e)
       updateCoordsEnd(x, y)
+      if (listenerOptions.capture && !listenerOptions.passive && Math.abs(diffX.value) > Math.abs(diffY.value))
+        e.preventDefault()
       if (!isSwiping.value && isThresholdExceeded.value)
         isSwiping.value = true
       if (isSwiping.value)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

fix: #4171 

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

When scrolling on mobile, both `touchstart` and `touchmove` are triggered, and in `touchstart`, `preventDefault` blocks the vertical scroll event.

This PR fixes it by only calling the preventDefault when horizontal swipe is detected (when horizontal movement is greater than vertical movement).