### PR TITLE
fix(useDropZone): validate all file types individually when dropping multiple files

### DIFF
--- a/packages/core/useDropZone/demo.vue
+++ b/packages/core/useDropZone/demo.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useDropZone, useEventListener } from '@vueuse/core'
+import { useDropZone } from '@vueuse/core'
 import { ref } from 'vue'
 
 const filesData = ref<{ name: string, size: number, type: string, lastModified: number }[]>([])
@@ -31,13 +31,8 @@ function onImageDrop(files: File[] | null) {
 
 const dropZoneRef = ref<HTMLElement>()
 const imageDropZoneRef = ref<HTMLElement>()
-const pngRef = ref()
 
 const { isOverDropZone } = useDropZone(dropZoneRef, onDrop)
-
-useEventListener(pngRef, 'dragstart', (event) => {
-  event.dataTransfer?.setData('image/png', '/vue.png')
-})
 
 const { isOverDropZone: isOverImageDropZone } = useDropZone(imageDropZoneRef, { dataTypes: ['image/png'], onDrop: onImageDrop })
 </script>
@@ -45,18 +40,7 @@ const { isOverDropZone: isOverImageDropZone } = useDropZone(imageDropZoneRef, { 
 <template>
   <div class="flex flex-col gap-2">
     <div class="w-full h-auto relative">
-      <p>Drop files on to drop zones</p>
-
-      <div class="flex gap-6">
-        <div class="flex flex-col items-center">
-          <img ref="pngRef" src="/vue.png" alt="Drag me" h-10>
-          <span>PNG</span>
-        </div>
-        <div class="flex flex-col items-center">
-          <img src="/favicon.svg" alt="Drag me" h-10>
-          <span>SVG</span>
-        </div>
-      </div>
+      <p>Drop files from your computer on to drop zones</p>
 
       <div grid="~ cols-2 gap-2">
         <div

--- a/packages/core/useDropZone/index.md
+++ b/packages/core/useDropZone/index.md
@@ -6,6 +6,12 @@ category: Elements
 
 Create a zone where files can be dropped.
 
+::: warning
+
+Due to Safari browser limitations, file type validation is only possible during the drop event, not during drag events. As a result, the `isOverDropZone` value will always be `true` during drag operations in Safari, regardless of file type.
+
+:::
+
 ## Usage
 
 ```vue

--- a/packages/core/useDropZone/index.ts
+++ b/packages/core/useDropZone/index.ts
@@ -52,15 +52,17 @@ export function useDropZone(
     }
 
     const checkDataTypes = (types: string[]) => {
-      if (_options.dataTypes) {
-        const dataTypes = unref(_options.dataTypes)
-        return typeof dataTypes === 'function'
-          ? dataTypes(types)
-          : dataTypes
-            ? dataTypes.some(item => types.includes(item))
-            : true
-      }
-      return true
+      const dataTypes = unref(_options.dataTypes)
+
+      if (typeof dataTypes === 'function')
+        return dataTypes(types)
+
+      if (!dataTypes?.length)
+        return true
+
+      return types.every(type =>
+        dataTypes.some(allowedType => type.includes(allowedType)),
+      )
     }
 
     const checkValidity = (event: DragEvent) => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

This PR fixes a bug in the `useDropzone` composable related to file type validation. Previously, the validation would pass if any of the dropped files matched any of the allowed types, potentially allowing invalid file types to be accepted.

**Bug details:**
- In the current implementation, the `some()` method checks if any file type matches the allowed types, making the validation pass even if some files don't match the criteria
- This creates a security issue as users could drop files with unauthorized types along with valid ones

**Fix:**
- Modified the `checkDataTypes` function to validate each file type individually
- Now ensures all dropped files match the allowed types before accepting them
- Maintains backward compatibility with both function and array validation approaches
- Preserves the existing API while fixing the validation logic

### Additional context

The fix changes the validation approach from an any-match to an all-match strategy, which better aligns with expected dropzone behavior. This is particularly important for security-conscious applications where file type validation is critical.

Example of the issue:
If allowed types are `['image/jpg', 'image/png']` and someone drops both a `.jpg` and `.exe` file, the previous implementation would incorrectly validate this as acceptable because at least one file (the `.jpg`) matched the criteria.