### PR TITLE
fix(useSortable): wrong order of elements

### DIFF
--- a/packages/integrations/useSortable/index.md
+++ b/packages/integrations/useSortable/index.md
@@ -102,7 +102,7 @@ import { moveArrayElement } from '@vueuse/integrations/useSortable'
 useSortable(el, list, {
   onUpdate: (e) => {
     // do something
-    moveArrayElement(list.value, e.oldIndex, e.newIndex)
+    moveArrayElement(list.value, e.oldIndex, e.newIndex, e)
     // nextTick required here as moveArrayElement is executed in a microtask
     // so we need to wait until the next tick until that is finished.
     nextTick(() => {

--- a/packages/integrations/useSortable/index.ts
+++ b/packages/integrations/useSortable/index.ts
@@ -46,7 +46,7 @@ export function useSortable<T>(
 
   const defaultOptions: Options = {
     onUpdate: (e) => {
-      moveArrayElement(list, e.oldIndex!, e.newIndex!)
+      moveArrayElement(list, e.oldIndex!, e.newIndex!, e)
     },
   }
 
@@ -80,21 +80,49 @@ export function useSortable<T>(
   }
 }
 
+/**
+ * Inserts a element into the DOM at a given index.
+ * @param parentElement
+ * @param element
+ * @param {number} index
+ * @see https://github.com/Alfred-Skyblue/vue-draggable-plus/blob/a3829222095e1949bf2c9a20979d7b5930e66f14/src/utils/index.ts#L81C1-L94C2
+ */
+export function insertNodeAt(
+  parentElement: Element,
+  element: Element,
+  index: number,
+) {
+  const refElement = parentElement.children[index]
+  parentElement.insertBefore(element, refElement)
+}
+
+/**
+ * Removes a node from the DOM.
+ * @param {Node} node
+ * @see https://github.com/Alfred-Skyblue/vue-draggable-plus/blob/a3829222095e1949bf2c9a20979d7b5930e66f14/src/utils/index.ts#L96C1-L102C2
+ */
+export function removeNode(node: Node) {
+  if (node.parentNode)
+    node.parentNode.removeChild(node)
+}
+
 export function moveArrayElement<T>(
   list: MaybeRefOrGetter<T[]>,
   from: number,
   to: number,
+  e: Sortable.SortableEvent | null = null,
 ): void {
+  if (e != null) {
+    removeNode(e.item)
+    insertNodeAt(e.from, e.item, from)
+  }
+
   const _valueIsRef = isRef(list)
   // When the list is a ref, make a shallow copy of it to avoid repeatedly triggering side effects when moving elements
   const array = _valueIsRef ? [...toValue(list)] : toValue(list)
 
   if (to >= 0 && to < array.length) {
     const element = array.splice(from, 1)[0]
-
-    if (_valueIsRef)
-      (list as MaybeRef).value.length = 0
-
     nextTick(() => {
       array.splice(to, 0, element)
       // When list is ref, assign array to list.value

--- a/packages/integrations/useSortable/index.ts
+++ b/packages/integrations/useSortable/index.ts
@@ -91,6 +91,10 @@ export function moveArrayElement<T>(
 
   if (to >= 0 && to < array.length) {
     const element = array.splice(from, 1)[0]
+
+    if (_valueIsRef)
+      (list as MaybeRef).value.length = 0
+
     nextTick(() => {
       array.splice(to, 0, element)
       // When list is ref, assign array to list.value


### PR DESCRIPTION
<!-- Thank you for contributing! -->

fix: #4222 #3724 

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR fixes the discrepancy between the DOM order and the array order.

Steps to Reproduce the Error
```
a -> b -> c
a -> c -> b
c -> b -> a
```

The implementation references [vue-draggable-plus](https://github.com/Alfred-Skyblue/vue-draggable-plus/blob/a3829222095e1949bf2c9a20979d7b5930e66f14/src/useDraggable.ts#L195C2-L213C4), but has been slightly adjusted to avoid too many breaking changes.

Before this PR is merged, you can use `key` to force `Vue` to update the view. Here is an example
```vue
<script setup lang="ts">
import { ref } from 'vue'
import { useSortable } from '.'

const el = ref<HTMLElement | null>(null)
const list = ref([{ id: 1, name: 'a' }, { id: 2, name: 'b' }, { id: 3, name: 'c' }])

useSortable(el, list, {
  animation: 150,
})
</script>

<template>
  <div ref="el" class="flex flex-col gap-2 p-4 w-300px h-200px m-auto bg-gray-500/5 rounded">
    <div v-for="(item, index) in list" :key="`${item.id}-${index}`" class="h20 bg-gray-500/5 rounded p-3">
      {{ item.name }}
    </div>
  </div>
  <div class="text-center">
    {{ JSON.stringify(list) }}
  </div>
</template>
```
