### PR TITLE
docs(useIntersectionObserver): update syntax to handle stricter types

### DIFF
--- a/packages/core/useIntersectionObserver/demo.vue
+++ b/packages/core/useIntersectionObserver/demo.vue
@@ -8,8 +8,8 @@ const isVisible = ref(false)
 
 const { isActive, pause, resume } = useIntersectionObserver(
   target,
-  ([{ isIntersecting }]) => {
-    isVisible.value = isIntersecting
+  ([entry]) => {
+    isVisible.value = entry?.isIntersecting || false
   },
   { root },
 )

--- a/packages/core/useIntersectionObserver/index.md
+++ b/packages/core/useIntersectionObserver/index.md
@@ -18,8 +18,8 @@ const targetIsVisible = ref(false)
 
 const { stop } = useIntersectionObserver(
   target,
-  ([{ isIntersecting }], observerElement) => {
-    targetIsVisible.value = isIntersecting
+  ([entry], observerElement) => {
+    targetIsVisible.value = entry?.isIntersecting || false
   },
 )
 </script>
@@ -42,8 +42,8 @@ const root = ref(null)
 
 const isVisible = ref(false)
 
-function onIntersectionObserver([{ isIntersecting }]: IntersectionObserverEntry[]) {
-  isVisible.value = isIntersecting
+function onIntersectionObserver([entry]: IntersectionObserverEntry[]) {
+  isVisible.value = entry?.isIntersecting || false
 }
 </script>
 


### PR DESCRIPTION
## References:
- [vueuse issue](https://github.com/vueuse/vueuse/issues/4172) :bug: 
- [Nuxt v4 issue](https://github.com/nuxt/nuxt/issues/28694)

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.


---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Due to stricter types planned on the upcoming v4 of Nuxt, the demo example needs to be updated.
You can [look at this Nuxt issue](https://github.com/nuxt/nuxt/issues/28694) for reference.
The Typescript issue occurs when `future: { compatibilityVersion: 4 },` is applied in the `nuxt.config.ts` file.

The change is not Nuxt related though, it concerns anyone.
It's simply applying an extra check on the `IntersectionObserverCallback` argument to ensure we handle the possibility of having an `entry` being `undefined` instead of immediately de-structuring.

### Additional context

[Reproduction link of the issue](https://stackblitz.com/edit/nuxt-3-vueuse-motion-pmteh2?file=client%2Fapp.vue)

As a bonus, it makes the code a bit more beginner-friendly (we could even use the name `entries` and access it via `entries[0]?.isIntersecting` but I think that's out-of-scope from `vueuse`, as all information are already available on [MDN](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver).


I made a choice towards visibility but feel free to choose another way of writing it

For instance:  _(for brevity but less beginner-friendly)_ 

```diff
- targetIsVisible.value = entry?.isIntersecting || false
+ targetIsVisible.value = !!entry?.isIntersecting
```

<!-- e.g. is there anything you'd like reviewers to focus on? -->
