### PR TITLE
fix(useMouse): correct spelling error,

### DIFF
--- a/packages/core/useMouse/index.ts
+++ b/packages/core/useMouse/index.ts
@@ -102,7 +102,7 @@ export function useMouse(options: UseMouseOptions = {}) {
 
     if (window) {
       _prevScrollX = window.scrollX
-      _prevScrollY = window.screenY
+      _prevScrollY = window.scrollY
     }
   }
 


### PR DESCRIPTION

### Description
I’m sorry, I think I wrote the wrong field.

Correct spelling error, changed `screenY` to `scrollY`.

