### PR TITLE
fix issue#4357 (useAxios) : When executing the execute method, return a new promise

### DIFF
--- a/packages/integrations/useAxios/index.md
+++ b/packages/integrations/useAxios/index.md
@@ -83,6 +83,19 @@ const { execute } = useAxios()
 const result = await execute(url)
 ```
 
+The `execute` function call will abort prev request(if requesting) and send current request.
+the prev `execute` result will be rejected.
+every `execute` call will return a new `Promise`
+
+```ts
+import { useAxios } from '@vueuse/integrations/useAxios'
+
+const { execute } = useAxios(url1, { method: 'GET' }, { immediate: false })
+const result1 = execute(url1)
+const result2 = execute(url2)
+const result3 = await execute(url3)
+```
+
 use an instance of axios with `immediate` options
 
 ```ts

--- a/packages/integrations/useAxios/index.ts
+++ b/packages/integrations/useAxios/index.ts
@@ -237,25 +237,30 @@ export function useAxios<T = any, R = AxiosResponse<T>, D = any>(...args: any[])
     const currentExecuteCounter = executeCounter
     isAborted.value = false
 
-    instance(_url, { ...defaultConfig, ...typeof executeUrl === 'object' ? executeUrl : config, signal: abortController.signal })
-      .then((r: any) => {
-        if (isAborted.value)
-          return
-        response.value = r
-        const result = r.data
-        data.value = result
-        onSuccess(result)
-      })
-      .catch((e: any) => {
-        error.value = e
-        onError(e)
-      })
-      .finally(() => {
-        options.onFinish?.()
-        if (currentExecuteCounter === executeCounter)
-          loading(false)
-      })
-    return promise
+    // eslint-disable-next-line ts/no-use-before-define
+    const outerResult = result
+    return new Promise<OverallUseAxiosReturn<T, R, D>>((resolve, reject) => {
+      instance(_url, { ...defaultConfig, ...typeof executeUrl === 'object' ? executeUrl : config, signal: abortController.signal })
+        .then((r: any) => {
+          if (isAborted.value)
+            return
+          response.value = r
+          const result = r.data
+          data.value = result
+          resolve(outerResult)
+          onSuccess(result)
+        })
+        .catch((e: any) => {
+          error.value = e
+          reject(e)
+          onError(e)
+        })
+        .finally(() => {
+          options.onFinish?.()
+          if (currentExecuteCounter === executeCounter)
+            loading(false)
+        })
+    })
   }
 
   if (immediate && url)


### PR DESCRIPTION
### Description
Problem solved: The `execute` method is called multiple times, and the previous request is cancelled, resulting in the last actual request being successful but returning a Promise with a rejection status. 

And because the current return is the same shared promise object, even if the previous request has been canceled, multiple calls have to wait until all requests have been completed to obtain the same promise information, making it impossible to distinguish the data source of each request error.


### Additional context

---
### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

