### PR TITLE
feat: add delay to immediate option and relativeToContainer feature

### DIFF
--- a/packages/core/useElementBounding/index.ts
+++ b/packages/core/useElementBounding/index.ts
@@ -119,10 +119,10 @@ export function useElementBounding(
       const parentRect = boundingParent.getBoundingClientRect()
 
       if (parentRect) {
-        top.value -= parentRect.top
-        left.value -= parentRect.left
-        bottom.value -= parentRect.top
-        right.value -= parentRect.left
+        top.value -= Math.max(0, parentRect.top)
+        left.value -= Math.max(0, parentRect.left)
+        bottom.value -= Math.max(0, parentRect.top)
+        right.value -= Math.max(0, parentRect.left)
       }
     }
   }

--- a/packages/core/useElementBounding/index.ts
+++ b/packages/core/useElementBounding/index.ts
@@ -79,6 +79,8 @@ export function useElementBounding(
   } = options
 
   const container = createDomRect()
+  const { el, ...containerDomRect } = container
+
   const { height, bottom, left, right, top, width, x, y } = createDomRect()
 
   function recalculate() {
@@ -86,7 +88,6 @@ export function useElementBounding(
 
     if (!el) {
       if (reset) {
-        const { el, ...containerDomRect } = container
         resetDomRect({ height, bottom, left, right, top, width, x, y })
         resetDomRect(containerDomRect)
       }
@@ -95,14 +96,7 @@ export function useElementBounding(
 
     const rect = el.getBoundingClientRect()
 
-    height.value = rect.height
-    bottom.value = rect.bottom
-    left.value = rect.left
-    right.value = rect.right
-    top.value = rect.top
-    width.value = rect.width
-    x.value = rect.x
-    y.value = rect.y
+    setDomRect({ height, bottom, left, right, top, width, x, y }, rect)
 
     if (relativeToContainer) {
       container.el = getBoundingParent(el)
@@ -114,16 +108,7 @@ export function useElementBounding(
         bottom.value -= Math.max(0, parentRect.top)
         right.value -= Math.max(0, parentRect.left)
 
-        Object.assign(container, {
-          height: { value: parentRect.height },
-          bottom: { value: parentRect.bottom },
-          left: { value: parentRect.left },
-          right: { value: parentRect.right },
-          top: { value: parentRect.top },
-          width: { value: parentRect.width },
-          x: { value: parentRect.x },
-          y: { value: parentRect.y },
-        })
+        setDomRect(containerDomRect, parentRect)
       }
     }
   }
@@ -139,6 +124,13 @@ export function useElementBounding(
     Object.keys(target).forEach((key) => {
       if (isRef(target[key]))
         target[key].value = 0
+    })
+  }
+
+  function setDomRect(target: Record<string, Ref<number>>, domRect: DOMRect) {
+    Object.keys(target).forEach((key) => {
+      if (isRef(target[key]))
+        target[key].value = domRect[key as keyof DOMRect] as number
     })
   }
 


### PR DESCRIPTION
## Overview
This PR introduces two new features to enhance the flexibility and usability of the `useElementBounding` hook:

1. **Delay for the `immediate` Option**:
   - The `immediate` option now supports a numeric value, allowing users to specify a delay (in milliseconds) before the `update()` function is called upon component mount.
   - This is particularly useful for synchronizing layout recalculations with animations or transitions.

2. **`relativeToContainer` Option**:
   - Added a new `relativeToContainer` option to calculate the bounding box relative to the nearest container (bounding parent), instead of always relying relative the the viewport.
   - Ensures compatibility with scenarios where the viewport might not be the desired reference due to positioning contexts (e.g., `position: fixed` or `overflow`).

---

## Changes
- Updated the `immediate` option to accept `boolean | number`.
- Added the `relativeToContainer` option to `UseElementBoundingOptions`.
- Modified logic to support relative container bounding box calculations.
- Updated documentation comments to reflect the new features.
- Enhanced tests and examples to demonstrate the new functionality.

---

## Why This Is Needed
- **Animation Synchronization**: The delay for `immediate` ensures bounding calculations align with layout stability after animations or transitions.
- **Flexible Bounding Calculations**: The `relativeToContainer` option provides more accurate bounding box results in complex layout scenarios with nested containers.

---

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Fixes #4373).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
