### PR TITLE
docs(useClipboardItems): fix example

### DIFF
--- a/packages/core/useClipboardItems/index.md
+++ b/packages/core/useClipboardItems/index.md
@@ -20,7 +20,7 @@ import { useClipboardItems } from '@vueuse/core'
 const mime = 'text/html'
 const source = ref([
   new ClipboardItem({
-    [mime]: new Blob([`<b>HTML content</b>`], { type: mime }),
+    [mime]: new Blob(['<b>HTML content</b>'], { type: mime }),
   })
 ])
 

--- a/packages/core/useClipboardItems/index.md
+++ b/packages/core/useClipboardItems/index.md
@@ -20,7 +20,7 @@ import { useClipboardItems } from '@vueuse/core'
 const mime = 'text/html'
 const source = ref([
   new ClipboardItem({
-    [mime]: new Blob(['\'<b>HTML content</b>\'', { type: mime }]),
+    [mime]: new Blob([`<b>HTML content</b>`], { type: mime }),
   })
 ])
 


### PR DESCRIPTION
#### Description:
Fixed an error in the usage of the Blob constructor when creating a ClipboardItem. 
The original code nested `{ type: mime }` in Array, which resulted in improperly generated Blob content.

#### Change:
modify
```javascript
new ClipboardItem({
    [mime]: new Blob(['\'<b>HTML content</b>\'', { type: mime }]),
})
```
to
```javascript
new ClipboardItem({
    [mime]: new Blob([`<b>HTML content</b>`], { type: mime }),
})
```
