### PR TITLE
fix(useFocusWithin): correctly track the state when switching the focus of elements in the same container

### DIFF
--- a/packages/core/useFocusWithin/index.test.ts
+++ b/packages/core/useFocusWithin/index.test.ts
@@ -6,6 +6,7 @@ import { useFocusWithin } from '.'
 describe('useFocusWithin', () => {
   let parent: Ref<HTMLFormElement>
   let child: Ref<HTMLDivElement>
+  let child2: Ref<HTMLDivElement>
   let grandchild: Ref<HTMLInputElement>
 
   beforeEach(() => {
@@ -16,6 +17,10 @@ describe('useFocusWithin', () => {
     child = ref(document.createElement('div'))
     child.value.tabIndex = 0
     parent.value.appendChild(child.value)
+
+    child2 = ref(document.createElement('div'))
+    child2.value.tabIndex = 0
+    parent.value.appendChild(child2.value)
 
     grandchild = ref(document.createElement('input'))
     grandchild.value.tabIndex = 0
@@ -59,6 +64,24 @@ describe('useFocusWithin', () => {
     expect(focused.value).toBeTruthy()
 
     grandchild.value?.blur()
+    expect(focused.value).toBeFalsy()
+  })
+
+  it('should track the state while the descendants switch focus state', () => {
+    const { focused } = useFocusWithin(parent)
+
+    expect(focused.value).toBeFalsy()
+
+    child.value?.focus()
+    expect(focused.value).toBeTruthy()
+
+    child2.value?.focus()
+    expect(focused.value).toBeTruthy()
+
+    child.value?.focus()
+    expect(focused.value).toBeTruthy()
+
+    child.value?.blur()
     expect(focused.value).toBeFalsy()
   })
 

--- a/packages/core/useFocusWithin/index.ts
+++ b/packages/core/useFocusWithin/index.ts
@@ -16,6 +16,7 @@ export interface UseFocusWithinReturn {
 
 const EVENT_FOCUS_IN = 'focusin'
 const EVENT_FOCUS_OUT = 'focusout'
+const PSEUDO_CLASS_FOCUS_WITHIN = ':focus-within'
 
 /**
  * Track if focus is contained within the target element
@@ -36,7 +37,8 @@ export function useFocusWithin(target: MaybeElementRef, options: ConfigurableWin
   }
 
   useEventListener(targetElement, EVENT_FOCUS_IN, () => _focused.value = true)
-  useEventListener(targetElement, EVENT_FOCUS_OUT, () => _focused.value = false)
+  useEventListener(targetElement, EVENT_FOCUS_OUT, () =>
+    _focused.value = targetElement.value?.matches?.(PSEUDO_CLASS_FOCUS_WITHIN) ?? false)
 
   return { focused }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

closes #4372 . When you switch the focus state of two descendant elements of the same container, the focus state of the container element will briefly turn into `false`, however the `focus-within` pseudo-element behavior will not be like this.
I used the element.prototype.matches during the `focusout` event, sothat it will act like `:focus-within` in this situation

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
