### PR TITLE
test: add useWebSocket tests

### DIFF
--- a/packages/core/useWebSocket/index.test.ts
+++ b/packages/core/useWebSocket/index.test.ts
@@ -1,0 +1,336 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
+import { useWebSocket, type UseWebSocketReturn } from '.'
+import { useSetup } from '../../.test'
+
+describe('useWebSocket', () => {
+  const mockWebSocket = vi.fn<(host: string) => WebSocket>()
+  let vm: ReturnType<typeof useSetup<{ ref: UseWebSocketReturn<any> }>> | null = null
+
+  mockWebSocket.prototype.send = vi.fn()
+  mockWebSocket.prototype.close = vi.fn()
+
+  beforeEach(() => {
+    vi.stubGlobal('WebSocket', mockWebSocket)
+  })
+
+  afterEach(() => {
+    vm?.unmount()
+    vi.unstubAllGlobals()
+    mockWebSocket.mockClear()
+    mockWebSocket.prototype.send.mockClear()
+    mockWebSocket.prototype.close.mockClear()
+  })
+
+  it('should be defined', () => {
+    expect(useWebSocket).toBeDefined()
+  })
+
+  it('should initialise web socket', () => {
+    vm = useSetup(() => {
+      const ref = useWebSocket('ws://localhost')
+
+      return {
+        ref,
+      }
+    })
+
+    expect(vm.ref.data.value).toBe(null)
+    expect(vm.ref.status.value).toBe('CONNECTING')
+    expect(mockWebSocket).toBeCalledWith('ws://localhost', [])
+    expect(vm.ref.close).toBeDefined()
+    expect(vm.ref.send).toBeDefined()
+    expect(vm.ref.open).toBeDefined()
+    expect(vm.ref.ws.value).toBeDefined()
+  })
+
+  it('should reconnect if URL changes', async () => {
+    const url = ref('ws://localhost')
+    vm = useSetup(() => {
+      const ref = useWebSocket(url)
+
+      return {
+        ref,
+      }
+    })
+
+    url.value = 'ws://127.0.0.1'
+    await nextTick()
+
+    expect(mockWebSocket.prototype.close).toBeCalledWith(1000, undefined)
+    expect(mockWebSocket).toBeCalledWith('ws://127.0.0.1', [])
+    expect(vm.ref.status.value).toBe('CONNECTING')
+  })
+
+  it('should remain closed if immediate is false', () => {
+    vm = useSetup(() => {
+      const ref = useWebSocket('ws://localhost', {
+        immediate: false,
+      })
+
+      return {
+        ref,
+      }
+    })
+
+    expect(vm.ref.status.value).toBe('CLOSED')
+  })
+
+  describe('open', () => {
+    it('should reconnect if called while still open', () => {
+      vm = useSetup(() => {
+        const ref = useWebSocket('ws://localhost')
+
+        return {
+          ref,
+        }
+      })
+
+      expect(vm.ref.status.value).toBe('CONNECTING')
+      expect(mockWebSocket).toHaveBeenCalledTimes(1)
+
+      vm.ref.open()
+
+      expect(vm.ref.status.value).toBe('CONNECTING')
+      expect(mockWebSocket).toHaveBeenCalledTimes(2)
+    })
+
+    it('should open socket', () => {
+      vm = useSetup(() => {
+        const ref = useWebSocket('ws://localhost', {
+          immediate: false,
+        })
+
+        return {
+          ref,
+        }
+      })
+
+      expect(vm.ref.status.value).toBe('CLOSED')
+      expect(mockWebSocket).not.toHaveBeenCalled()
+
+      vm.ref.open()
+
+      expect(vm.ref.status.value).toBe('CONNECTING')
+      expect(mockWebSocket).toBeCalledWith('ws://localhost', [])
+    })
+  })
+
+  describe('close', () => {
+    it('should close socket', () => {
+      vm = useSetup(() => {
+        const ref = useWebSocket('ws://localhost')
+
+        return {
+          ref,
+        }
+      })
+
+      expect(vm.ref.status.value).toBe('CONNECTING')
+
+      vm.ref.close()
+
+      expect(mockWebSocket.prototype.close).toBeCalledWith(1000, undefined)
+    })
+  })
+
+  describe('autoClose', () => {
+    it('should close on unload if true', () => {
+      vm = useSetup(() => {
+        const ref = useWebSocket('ws://localhost', {
+          autoClose: true,
+        })
+
+        return {
+          ref,
+        }
+      })
+
+      window.dispatchEvent(new Event('beforeunload'))
+
+      expect(mockWebSocket.prototype.close).toHaveBeenCalled()
+    })
+
+    it.skip('should close when scope disposed if true')
+
+    it('should not close on unload if false', () => {
+      vm = useSetup(() => {
+        const ref = useWebSocket('ws://localhost', {
+          autoClose: false,
+        })
+
+        return {
+          ref,
+        }
+      })
+
+      window.dispatchEvent(new Event('beforeunload'))
+
+      expect(mockWebSocket.prototype.close).not.toHaveBeenCalled()
+    })
+  })
+
+  it('should set data on message', () => {
+    vm = useSetup(() => {
+      const ref = useWebSocket('ws://localhost')
+
+      return {
+        ref,
+      }
+    })
+
+    vm.ref.ws.value?.onopen?.(new Event('open'))
+
+    const ev = new MessageEvent('message', {
+      data: 'bleep bloop',
+    })
+
+    vm.ref.ws.value?.onmessage?.(ev)
+
+    expect(vm.ref.data.value).toBe('bleep bloop')
+  })
+
+  it('should call onMessage on message', () => {
+    const onMessage = vi.fn()
+
+    vm = useSetup(() => {
+      const ref = useWebSocket('ws://localhost', { onMessage })
+
+      return {
+        ref,
+      }
+    })
+
+    vm.ref.ws.value?.onopen?.(new Event('open'))
+
+    const ev = new MessageEvent('message', {
+      data: 'bleep bloop',
+    })
+
+    vm.ref.ws.value?.onmessage?.(ev)
+
+    expect(onMessage).toBeCalledWith(vm.ref.ws.value, ev)
+  })
+
+  it('should call onError on error', () => {
+    const onError = vi.fn()
+
+    vm = useSetup(() => {
+      const ref = useWebSocket('ws://localhost', { onError })
+
+      return {
+        ref,
+      }
+    })
+
+    vm.ref.ws.value?.onopen?.(new Event('open'))
+
+    const ev = new Event('error')
+
+    vm.ref.ws.value?.onerror?.(ev)
+
+    expect(onError).toBeCalledWith(vm.ref.ws.value, ev)
+  })
+
+  it('should call onDisconnected on close', () => {
+    const onDisconnected = vi.fn()
+
+    vm = useSetup(() => {
+      const ref = useWebSocket('ws://localhost', { onDisconnected })
+
+      return {
+        ref,
+      }
+    })
+
+    vm.ref.ws.value?.onopen?.(new Event('open'))
+
+    const ev = new CloseEvent('close')
+
+    vm.ref.ws.value?.onclose?.(ev)
+
+    expect(onDisconnected).toBeCalledWith(vm.ref.ws.value, ev)
+  })
+
+  it('should be CLOSED on close', () => {
+    vm = useSetup(() => {
+      const ref = useWebSocket('ws://localhost')
+
+      return {
+        ref,
+      }
+    })
+
+    vm.ref.ws.value?.onopen?.(new Event('open'))
+
+    expect(vm.ref.status.value).toBe('OPEN')
+
+    vm.ref.ws.value?.onclose?.(new CloseEvent('close'))
+
+    expect(vm.ref.status.value).toBe('CLOSED')
+  })
+
+  it('should be OPEN on open', () => {
+    vm = useSetup(() => {
+      const ref = useWebSocket('ws://localhost')
+
+      return {
+        ref,
+      }
+    })
+
+    vm.ref.ws.value?.onopen?.(new Event('open'))
+
+    expect(vm.ref.status.value).toBe('OPEN')
+  })
+
+  it('should call onConnected on open', () => {
+    const onConnected = vi.fn()
+
+    vm = useSetup(() => {
+      const ref = useWebSocket('ws://localhost', { onConnected })
+
+      return {
+        ref,
+      }
+    })
+
+    vm.ref.ws.value?.onopen?.(new Event('open'))
+
+    expect(onConnected).toBeCalledWith(vm.ref.ws.value)
+  })
+
+  describe('send', () => {
+    it('should buffer data until connect if buffer=true', () => {
+      vm = useSetup(() => {
+        const ref = useWebSocket('ws://localhost')
+
+        return {
+          ref,
+        }
+      })
+
+      vm.ref.send('bleep bloop', true)
+
+      vm.ref.ws.value?.onopen?.(new Event('open'))
+
+      expect(mockWebSocket.prototype.send).toBeCalledWith('bleep bloop')
+    })
+
+    it('should send data', () => {
+      vm = useSetup(() => {
+        const ref = useWebSocket('ws://localhost')
+
+        return {
+          ref,
+        }
+      })
+
+      vm.ref.ws.value?.onopen?.(new Event('open'))
+
+      vm.ref.send('bleep bloop')
+
+      expect(mockWebSocket.prototype.send).toBeCalledWith('bleep bloop')
+    })
+  })
+})


### PR DESCRIPTION
Adds a few tests for `useWebSocket`.

Unfortunately, this creates a mock `WebSocket` for now. We could possibly use something like MSW in future.

I know we have a _lot_ of PRs to review right now, so this is ofc **a low priority PR**. feel free to ignore it for a while! I've also not contributed to this codebase in a long time, so its possible much of this is nonsense - let me know if it is

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.