### PR TITLE
docs: add bluesky and replace twitter with x branding

### DIFF
--- a/packages/.vitepress/config.ts
+++ b/packages/.vitepress/config.ts
@@ -91,7 +91,6 @@ export default withPwa(defineConfig({
     socialLinks: [
       { icon: 'github', link: 'https://github.com/vueuse/vueuse' },
       { icon: 'discord', link: 'https://chat.antfu.me' },
-      { icon: 'x', link: 'https://x.com/vueuse' },
       { icon: 'bluesky', link: 'https://bsky.app/profile/vueuse.org' },
     ],
 

--- a/packages/.vitepress/config.ts
+++ b/packages/.vitepress/config.ts
@@ -91,7 +91,8 @@ export default withPwa(defineConfig({
     socialLinks: [
       { icon: 'github', link: 'https://github.com/vueuse/vueuse' },
       { icon: 'discord', link: 'https://chat.antfu.me' },
-      { icon: 'twitter', link: 'https://twitter.com/vueuse' },
+      { icon: 'x', link: 'https://x.com/vueuse' },
+      { icon: 'bluesky', link: 'https://bsky.app/profile/vueuse.org' },
     ],
 
     nav: [

--- a/packages/.vitepress/theme/components/TeamMember.vue
+++ b/packages/.vitepress/theme/components/TeamMember.vue
@@ -29,11 +29,19 @@ defineProps<{
       />
       <a
         v-if="data.twitter"
-        class="i-carbon-logo-twitter inline-block text-1.3em mya text-current op30 hover:op100 transition duration-200"
-        :href="`https://twitter.com/${data.twitter}`"
+        class="i-carbon-logo-x inline-block mya text-current op30 hover:op100 transition duration-200"
+        :href="`https://x.com/${data.twitter}`"
         target="_blank"
         rel="noopener noreferrer"
-        :aria-label="`${data.name} on Twitter`"
+        :aria-label="`${data.name} on X`"
+      />
+      <a
+        v-if="data.bluesky"
+        class="i-ri-bluesky-fill inline-block mya text-current op30 hover:op100 transition duration-200"
+        :href="`https://bsky.app/profile/${data.bluesky}`"
+        target="_blank"
+        rel="noopener noreferrer"
+        :aria-label="`${data.name} on Bluesky`"
       />
       <a
         v-if="data.sponsors"

--- a/packages/contributors.ts
+++ b/packages/contributors.ts
@@ -10,6 +10,7 @@ export interface CoreTeam {
   name: string
   github: string
   twitter?: string
+  bluesky?: string
   sponsors?: boolean
   description: string
   packages?: string[]
@@ -34,6 +35,7 @@ const coreTeamMembers: CoreTeam[] = [
     name: 'Anthony Fu',
     github: 'antfu',
     twitter: 'antfu7',
+    bluesky: 'antfu.me',
     sponsors: true,
     description: 'A fanatical open sourceror<br>Core team member of Vite & Vue<br>Working at NuxtLabs',
     packages: ['core'],
@@ -43,6 +45,7 @@ const coreTeamMembers: CoreTeam[] = [
     name: 'Patak',
     github: 'patak-dev',
     twitter: 'patak_dev',
+    bluesky: 'patak.dev',
     sponsors: true,
     functions: [
       'useRefHistory',
@@ -55,6 +58,7 @@ const coreTeamMembers: CoreTeam[] = [
     name: 'wheatjs',
     github: 'wheatjs',
     twitter: 'wheatjs',
+    bluesky: 'wheatjs.dev',
     sponsors: false,
     description: 'Software Developer<br>Open Source Contributor<br>Electrical Engineer.',
     functions: ['useFetch'],
@@ -65,6 +69,7 @@ const coreTeamMembers: CoreTeam[] = [
     name: 'Tahul',
     github: 'Tahul',
     twitter: 'yaeeelglx',
+    bluesky: 'yael.dev',
     sponsors: true,
     description: '',
     packages: ['motion', 'gesture', 'sound'],
@@ -82,6 +87,7 @@ const coreTeamMembers: CoreTeam[] = [
     name: 'Alex Kozack',
     github: 'cawa-93',
     twitter: 'alex_kozack',
+    bluesky: 'kozack.me',
     sponsors: false,
     functions: ['useMediaControls'],
     description: 'Open Source Contributor from Ukraine',
@@ -90,6 +96,7 @@ const coreTeamMembers: CoreTeam[] = [
     avatar: contributorsAvatars.scottbedard,
     name: 'Scott Bedard',
     github: 'scottbedard',
+    bluesky: 'scottbedard.net',
     sponsors: false,
     functions: [
       'useTransition',
@@ -151,6 +158,7 @@ const coreTeamMembers: CoreTeam[] = [
     name: 'EGOIST',
     github: 'egoist',
     twitter: '_egoistlily',
+    bluesky: 'egoist.dev',
     sponsors: true,
     description: '',
     packages: ['head'],
@@ -160,6 +168,7 @@ const coreTeamMembers: CoreTeam[] = [
     name: 'Harlan Wilton',
     github: 'harlan-zw',
     twitter: 'harlan_zw',
+    bluesky: 'harlanzw.com',
     sponsors: true,
     description: 'Building delightful open source<br>Nuxt freelance developer',
     packages: ['schema-org'],
@@ -178,6 +187,7 @@ const coreTeamMembers: CoreTeam[] = [
     name: 'Doctorwu',
     github: 'Doctor-wu',
     twitter: 'Doctorwu666',
+    bluesky: 'doctorwu.me',
     description: 'Dangerous Coder<br>Open source enthusiast',
   },
   {
@@ -185,6 +195,7 @@ const coreTeamMembers: CoreTeam[] = [
     name: 'Bobbie Goede',
     github: 'BobbieGoede',
     twitter: 'BobbieGoede',
+    bluesky: 'goede.dev',
     sponsors: true,
     description: '',
     packages: ['motion'],


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description
This adds Bluesky links to the team members and the main menu and replaces the twitter logo with the 'x' logo. Honestly since the 'x' logo is not filled it looks a bit less clean and more noisy.

In the interest of keeping changes small I have left the `TeamMember` `twitter` property unchanged, I can rename it to `x` as well if preferred.

I did my best to find each member's Bluesky handle, sorry to those I missed that do have an account 🙏

Feel free to close/disregard if we have no intention to add Bluesky links to the website.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
