### PR TITLE
feat(useWebSocket): introduce `autoConnect` options to control auto connections on url changes

### DIFF
--- a/packages/core/useWebSocket/index.md
+++ b/packages/core/useWebSocket/index.md
@@ -16,21 +16,25 @@ const { status, data, send, open, close } = useWebSocket('ws://websocketurl')
 
 See the [Type Declarations](#type-declarations) for more options.
 
-### Immediate
+### immediate
 
-Auto-connect (enabled by default).
+Enable by default.
 
-This will call `open()` automatically for you and you don't need to call it by yourself.
+Establish the connection immediately when the composable is called.
 
-If url is provided as a ref, this also controls whether a connection is re-established when its value is changed (or whether you need to call open() again for the change to take effect).
+### autoConnect
 
-### Auto-close
+Enable by default.
 
-Auto-close-connection (enabled by default).
+If url is provided as a ref, when the url changes, it will automatically reconnect to the new url.
+
+### autoClose
+
+Enable by default.
 
 This will call `close()` automatically when the `beforeunload` event is triggered or the associated effect scope is stopped.
 
-### Auto-reconnection
+### autoReconnect
 
 Reconnect on errors automatically (disabled by default).
 
@@ -56,7 +60,7 @@ const { status, data, close } = useWebSocket('ws://websocketurl', {
 
 Explicitly calling `close()` won't trigger the auto reconnection.
 
-### Heartbeat
+### heartbeat
 
 It's common practice to send a small message (heartbeat) for every given time passed to keep the connection active. In this function we provide a convenient helper to do it:
 

--- a/packages/core/useWebSocket/index.test.ts
+++ b/packages/core/useWebSocket/index.test.ts
@@ -62,6 +62,26 @@ describe('useWebSocket', () => {
     expect(vm.ref.status.value).toBe('CONNECTING')
   })
 
+  it('should not reconnect on URL change if immediate is false', async () => {
+    const url = ref('ws://localhost')
+    vm = useSetup(() => {
+      const ref = useWebSocket(url, {
+        immediate: false,
+      })
+
+      return {
+        ref,
+      }
+    })
+
+    url.value = 'ws://127.0.0.1'
+    await nextTick()
+
+    expect(mockWebSocket.prototype.close).not.toHaveBeenCalled()
+    expect(mockWebSocket).not.toHaveBeenCalledWith('ws://127.0.0.1', [])
+    expect(vm.ref.status.value).toBe('CLOSED')
+  })
+
   it('should remain closed if immediate is false', () => {
     vm = useSetup(() => {
       const ref = useWebSocket('ws://localhost', {

--- a/packages/core/useWebSocket/index.test.ts
+++ b/packages/core/useWebSocket/index.test.ts
@@ -62,11 +62,12 @@ describe('useWebSocket', () => {
     expect(vm.ref.status.value).toBe('CONNECTING')
   })
 
-  it('should not reconnect on URL change if immediate is false', async () => {
+  it('should not reconnect on URL change if immediate and autoConnect are false', async () => {
     const url = ref('ws://localhost')
     vm = useSetup(() => {
       const ref = useWebSocket(url, {
         immediate: false,
+        autoConnect: false,
       })
 
       return {

--- a/packages/core/useWebSocket/index.ts
+++ b/packages/core/useWebSocket/index.ts
@@ -76,11 +76,16 @@ export interface UseWebSocketOptions {
   }
 
   /**
-   * Automatically open a connection
+   * Immediately open the connection when calling this composable
    *
    * @default true
    */
   immediate?: boolean
+
+  /**
+   * Automatically connect to the websocket when URL changes
+   */
+  autoConnect?: boolean
 
   /**
    * Automatically close a connection
@@ -157,6 +162,7 @@ export function useWebSocket<Data = any>(
     onError,
     onMessage,
     immediate = true,
+    autoConnect = true,
     autoClose = true,
     protocols = [],
   } = options
@@ -315,10 +321,11 @@ export function useWebSocket<Data = any>(
   if (immediate)
     open()
 
-  watch(urlRef, () => {
-    if (immediate)
+  if (autoConnect) {
+    watch(urlRef, () => {
       open()
-  })
+    })
+  }
 
   return {
     data,

--- a/packages/core/useWebSocket/index.ts
+++ b/packages/core/useWebSocket/index.ts
@@ -315,7 +315,10 @@ export function useWebSocket<Data = any>(
   if (immediate)
     open()
 
-  watch(urlRef, open)
+  watch(urlRef, () => {
+    if (immediate)
+      open()
+  })
 
   return {
     data,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

fix: #4193 

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR fixes the WebSocket auto-reconnection behavior when the URL changes. According to the [documentation](https://vueuse.org/core/useWebSocket/#immediate), when `immediate` is set to `false`, the WebSocket should not automatically reconnect even when the URL changes. Users need to explicitly call `open()` to establish the connection.

---

I'm not entirely certain if this implementation is the optimal approach. Perhaps we should consider updating the documentation.