### PR TITLE
docs: new team page, introduce Team Emeriti

### DIFF
--- a/packages/.vitepress/config.ts
+++ b/packages/.vitepress/config.ts
@@ -44,6 +44,11 @@ const Learn = [
   { text: 'Official Vue Certification', link: 'https://certification.vuejs.org/?utm_source=vueuse&utm_medium=website&utm_campaign=affiliate&utm_content=guide&banner_type=text&friend=VUEUSE' },
 ]
 
+const Resources = [
+  { text: 'Team & Contributors', link: '/team' },
+  { text: 'Learn', items: Learn },
+]
+
 const DefaultSideBar = [
   { text: 'Guide', items: Guide },
   { text: 'Core Functions', items: CoreCategories },
@@ -99,7 +104,6 @@ export default withPwa(defineConfig({
         text: 'Guide',
         items: [
           { text: 'Guide', items: Guide },
-          { text: 'Learn', items: Learn },
           { text: 'Links', items: Links },
         ],
       },
@@ -118,8 +122,8 @@ export default withPwa(defineConfig({
         ],
       },
       {
-        text: 'Add-ons',
-        link: '/add-ons',
+        text: 'Resources',
+        items: Resources,
       },
       {
         text: 'Playground',

--- a/packages/.vitepress/theme/components/Home.vue
+++ b/packages/.vitepress/theme/components/Home.vue
@@ -1,9 +1,5 @@
 <template>
-  <div class="home" mt-4 flex flex-col items-center>
-    <HomeTeam />
-
+  <div class="home vp-doc" mt-4 flex flex-col items-center>
     <HomeSponsors />
-
-    <HomeContributors />
   </div>
 </template>

--- a/packages/.vitepress/theme/components/HomeContributors.vue
+++ b/packages/.vitepress/theme/components/HomeContributors.vue
@@ -1,19 +1,21 @@
 <script setup lang="ts">
 import { contributors } from '../../../contributors'
+import HomeSection from './HomeSection.vue'
 </script>
 
 <template>
   <div class="vp-doc">
-    <h2 op50 font-normal pt-5 pb-2>
-      Contributors
-    </h2>
-  </div>
-  <div text-lg max-w-200 text-center leading-7 p-10>
-    <div flex="~ wrap gap-1" justify-center>
-      <a v-for="{ name, avatar } of contributors" :key="name" :href="`https://github.com/${name}`" m-0 rel="noopener noreferrer" :aria-label="`${name} on GitHub`">
-        <img loading="lazy" :src="avatar" width="40" height="40" rounded-full min-w-10 min-h-10 h-10 w-10 :alt="`${name}'s avatar`">
-      </a>
+    <HomeSection
+      title="Contributors"
+      description="Thanks to the following people who have contributed to VueUse."
+    />
+    <div text-lg text-center leading-7 p-10>
+      <div flex="~ wrap gap-1" justify-center>
+        <a v-for="{ name, avatar } of contributors" :key="name" :href="`https://github.com/${name}`" m-0 rel="noopener noreferrer" :aria-label="`${name} on GitHub`">
+          <img loading="lazy" :src="avatar" width="40" height="40" rounded-full min-w-10 min-h-10 h-10 w-10 :alt="`${name}'s avatar`">
+        </a>
+      </div>
+      <br>
     </div>
-    <br>
   </div>
 </template>

--- a/packages/.vitepress/theme/components/HomeSection.vue
+++ b/packages/.vitepress/theme/components/HomeSection.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+defineProps<{
+  title: string
+  description: string
+}>()
+</script>
+
+<template>
+  <h2 font-normal pt-5 pb-2 px4 flex="~ gap-4 items-center" w-full>
+    <div border="t main solid" h-1px w-full />
+    <span ws-nowrap>{{ title }}</span>
+    <div border="t main solid" h-1px w-full />
+  </h2>
+  <div op50 text-center max-w-130 mxa>
+    {{ description }}
+  </div>
+</template>

--- a/packages/.vitepress/theme/components/HomeSponsors.vue
+++ b/packages/.vitepress/theme/components/HomeSponsors.vue
@@ -1,9 +1,12 @@
+<script setup lang="ts">
+import HomeSection from './HomeSection.vue'
+</script>
+
 <template>
-  <div class="vp-doc">
-    <h2 op50 font-normal pt-5 pb-2>
-      Anthony's Sponsors
-    </h2>
-  </div>
+  <HomeSection
+    title="Anthony's Sponsors"
+    description="The development of VueUse is supported by the following sponsors."
+  />
   <p id="sponsor" class="mt-5 text-center">
     <a href="https://github.com/sponsors/antfu">
       <img src="https://cdn.jsdelivr.net/gh/antfu/static/sponsors.svg" class="m-auto">

--- a/packages/.vitepress/theme/components/HomeTeam.vue
+++ b/packages/.vitepress/theme/components/HomeTeam.vue
@@ -1,18 +1,24 @@
 <script setup lang="ts">
-import { coreTeamMembers } from '../../../contributors'
+import { emeriti, team } from '../../../contributors'
+import HomeSection from './HomeSection.vue'
+import TeamMembersGrid from './TeamMembersGrid.vue'
 </script>
 
 <template>
   <div class="vp-doc">
-    <h2 op50 font-normal pt-5 pb-2>
-      Meet The Team
-    </h2>
-  </div>
-  <div grid="~ sm:cols-2 md:cols-3 lg:cols-4 gap-x-3 gap-y-20 items-start" p-10>
-    <TeamMember
-      v-for="c of coreTeamMembers"
-      :key="c.github"
-      :data="c"
+    <HomeSection
+      title="Team Members"
+      description="The development of VueUse is guided by an international team, some of whom have chosen to be featured below."
+    />
+    <TeamMembersGrid
+      :members="team"
+    />
+    <HomeSection
+      title="Team Emeriti"
+      description="Here we honor some no-longer-active team members who have made valuable contributions in the past."
+    />
+    <TeamMembersGrid
+      :members="emeriti"
     />
   </div>
 </template>

--- a/packages/.vitepress/theme/components/TeamMember.vue
+++ b/packages/.vitepress/theme/components/TeamMember.vue
@@ -1,75 +1,60 @@
 <script setup lang="ts">
-import type { CoreTeam } from '../../../contributors'
+import type { TeamMember } from '../../../contributors'
 
 defineProps<{
-  data: CoreTeam
+  data: TeamMember
 }>()
 </script>
 
 <template>
-  <div text-center>
+  <div text-center h-full relative flex="~ col">
     <img
       loading="lazy"
-      width="100" height="100" m-auto rounded-full min-w-25 min-h-25 h-25 w-25
+      m-auto rounded-full min-w-25 min-h-25 h-30 w-30 mb--15
+      shadow
       :src="data.avatar"
       :alt="`${data.name}'s avatar`"
     >
-    <div text-xl mt-2 mb-1>
-      {{ data.name }}
-    </div>
-    <div op60 h-80px v-html="data.description" />
+    <div bg-gray:5 rounded-xl pt-18 p4 flex="~ col gap-2 items-center" flex-auto>
+      <div text-xl>
+        {{ data.name }}
+      </div>
+      <div op60 v-html="data.description" />
 
-    <div flex="~ inline gap-2" py2 text-2xl>
-      <a
-        class="i-carbon-logo-github inline-block text-current op30 hover:op100 mya transition duration-200"
-        :href="`https://github.com/${data.github}`"
-        target="_blank"
-        rel="noopener noreferrer"
-        :aria-label="`${data.name} on GitHub`"
-      />
-      <a
-        v-if="data.twitter"
-        class="i-carbon-logo-x inline-block mya text-current op30 hover:op100 transition duration-200"
-        :href="`https://x.com/${data.twitter}`"
-        target="_blank"
-        rel="noopener noreferrer"
-        :aria-label="`${data.name} on X`"
-      />
-      <a
-        v-if="data.bluesky"
-        class="i-ri-bluesky-fill inline-block mya text-current op30 hover:op100 transition duration-200"
-        :href="`https://bsky.app/profile/${data.bluesky}`"
-        target="_blank"
-        rel="noopener noreferrer"
-        :aria-label="`${data.name} on Bluesky`"
-      />
-      <a
-        v-if="data.sponsors"
-        class="i-carbon-favorite-filled inline-block mya text-current op30 hover:op100 transition duration-200"
-        :href="`https://github.com/sponsors/${data.github}`"
-        target="_blank"
-        rel="noopener noreferrer"
-        :title="`Sponsor ${data.name}`"
-        :aria-label="`Sponsor ${data.name}`"
-      />
-    </div>
-    <div v-if="data.functions || data.packages" bg-gray:5 mb2 p3 rounded grid="~ cols-[20px_1fr] gap-x-1 gap-y-2" items-start w="5/6" mxa>
-      <template v-if="data.functions">
-        <div op50 ma i-carbon:function-math title="Functions" />
-        <div flex="~ col gap-1" text-left text-sm w-max>
-          <a v-for="f of data.functions" :key="f" :href="`/${f}`" target="_blank">
-            <code>{{ f }}</code>
-          </a>
-        </div>
-      </template>
-      <template v-if="data.packages">
-        <div op50 ma i-carbon-cube title="Packages" />
-        <div flex="~ col gap-1" text-left text-sm w-max>
-          <a v-for="f of data.packages" :key="f" href="/add-ons">
-            <code>@vueuse/{{ f }}</code>
-          </a>
-        </div>
-      </template>
+      <div flex="~ inline gap-2" py4 text-2xl>
+        <a
+          class="i-carbon-logo-github inline-block color-inherit! op75 hover:op100 hover:text-primary! mya transition duration-200"
+          :href="`https://github.com/${data.github}`"
+          target="_blank"
+          rel="noopener noreferrer"
+          :aria-label="`${data.name} on GitHub`"
+        />
+        <a
+          v-if="data.bluesky"
+          class="i-ri-bluesky-fill inline-block mya color-inherit! op75 hover:op100 hover:text-primary! transition duration-200"
+          :href="`https://bsky.app/profile/${data.bluesky}`"
+          target="_blank"
+          rel="noopener noreferrer"
+          :aria-label="`${data.name} on Bluesky`"
+        />
+        <a
+          v-if="data.twitter"
+          class="i-carbon-logo-x inline-block mya color-inherit! op75 hover:op100 hover:text-primary! transition duration-200"
+          :href="`https://x.com/${data.twitter}`"
+          target="_blank"
+          rel="noopener noreferrer"
+          :aria-label="`${data.name} on X`"
+        />
+        <a
+          v-if="data.sponsors"
+          class="i-carbon-favorite-filled inline-block mya color-inherit! op75 hover:op100 hover:text-rose! transition duration-200"
+          :href="`https://github.com/sponsors/${data.github}`"
+          target="_blank"
+          rel="noopener noreferrer"
+          :title="`Sponsor ${data.name}`"
+          :aria-label="`Sponsor ${data.name}`"
+        />
+      </div>
     </div>
   </div>
 </template>

--- a/packages/.vitepress/theme/components/TeamMembersGrid.vue
+++ b/packages/.vitepress/theme/components/TeamMembersGrid.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import type { TeamMember } from '../../../contributors'
+
+defineProps<{
+  members: TeamMember[]
+}>()
+</script>
+
+<template>
+  <div grid="~ sm:cols-1 md:cols-2 lg:cols-3 gap-x-3 gap-y-20 items-start" p-10>
+    <TeamMember
+      v-for="c of members"
+      :key="c.github"
+      :data="c"
+    />
+  </div>
+</template>

--- a/packages/contributors.ts
+++ b/packages/contributors.ts
@@ -171,6 +171,7 @@ export const emeriti: TeamMember[] = [
   },
   {
     avatar: contributorsAvatars.sibbng,
+    name: 'sibbng',
     github: 'sibbng',
     sponsors: false,
     description: '',

--- a/packages/contributors.ts
+++ b/packages/contributors.ts
@@ -171,9 +171,7 @@ export const emeriti: TeamMember[] = [
   },
   {
     avatar: contributorsAvatars.sibbng,
-    name: 'Nurettin Kaya',
     github: 'sibbng',
-    twitter: 'sibbng',
     sponsors: false,
     description: '',
     functions: [

--- a/packages/contributors.ts
+++ b/packages/contributors.ts
@@ -1,11 +1,11 @@
-import contributors from './contributors.json'
+import contributorsGenerated from './contributors.json'
 
 export interface Contributor {
   name: string
   avatar: string
 }
 
-export interface CoreTeam {
+export interface TeamMember {
   avatar: string
   name: string
   github: string
@@ -23,13 +23,13 @@ function getAvatarUrl(name: string) {
   return `https://avatars.githubusercontent.com/${name}?v=4`
 }
 
-const contributorList = (contributors as string[]).reduce((acc, name) => {
+export const contributors = (contributorsGenerated as string[]).reduce((acc, name) => {
   contributorsAvatars[name] = getAvatarUrl(name)
   acc.push({ name, avatar: contributorsAvatars[name] })
   return acc
 }, [] as Contributor[])
 
-const coreTeamMembers: CoreTeam[] = [
+export const team: TeamMember[] = [
   {
     avatar: contributorsAvatars.antfu,
     name: 'Anthony Fu',
@@ -65,6 +65,34 @@ const coreTeamMembers: CoreTeam[] = [
     packages: ['components'],
   },
   {
+    avatar: contributorsAvatars['harlan-zw'],
+    name: 'Harlan Wilton',
+    github: 'harlan-zw',
+    twitter: 'harlan_zw',
+    bluesky: 'harlanzw.com',
+    sponsors: true,
+    description: 'Building delightful open source<br>Nuxt freelance developer',
+    packages: ['schema-org'],
+  },
+  {
+    avatar: contributorsAvatars['Alfred-Skyblue'],
+    name: 'Alfred-Skyblue',
+    github: 'Alfred-Skyblue',
+    description: 'open source enthusiast',
+    functions: [
+      'useSortable',
+    ],
+  },
+  {
+    avatar: contributorsAvatars['Doctor-wu'],
+    name: 'Doctorwu',
+    github: 'Doctor-wu',
+    twitter: 'Doctorwu666',
+    bluesky: 'doctorwu.me',
+    description: 'Dangerous Coder<br>Open source enthusiast',
+  },
+
+  {
     avatar: contributorsAvatars.Tahul,
     name: 'Tahul',
     github: 'Tahul',
@@ -73,6 +101,42 @@ const coreTeamMembers: CoreTeam[] = [
     sponsors: true,
     description: '',
     packages: ['motion', 'gesture', 'sound'],
+  },
+  {
+    avatar: contributorsAvatars.BobbieGoede,
+    name: 'Bobbie Goede',
+    github: 'BobbieGoede',
+    twitter: 'BobbieGoede',
+    bluesky: 'goede.dev',
+    sponsors: true,
+    description: '',
+    packages: ['motion'],
+  },
+]
+  .sort((pre, cur) => contributorsGenerated.findIndex(name => name === pre.github) - contributorsGenerated.findIndex(name => name === cur.github))
+
+export const emeriti: TeamMember[] = [
+  {
+    avatar: contributorsAvatars.egoist,
+    name: 'EGOIST',
+    github: 'egoist',
+    twitter: '_egoistlily',
+    bluesky: 'egoist.dev',
+    sponsors: true,
+    description: '',
+    packages: ['head'],
+  },
+  {
+    avatar: contributorsAvatars.webfansplz,
+    name: 'webfansplz',
+    github: 'webfansplz',
+    twitter: 'webfansplz',
+    sponsors: false,
+    functions: [
+      'useDateFormat',
+      'useAsyncQueue',
+    ],
+    description: 'FE Developer<br>Love open source',
   },
   {
     avatar: contributorsAvatars.anteriovieira,
@@ -141,66 +205,4 @@ const coreTeamMembers: CoreTeam[] = [
     ],
     description: '',
   },
-  {
-    avatar: contributorsAvatars.webfansplz,
-    name: 'webfansplz',
-    github: 'webfansplz',
-    twitter: 'webfansplz',
-    sponsors: false,
-    functions: [
-      'useDateFormat',
-      'useAsyncQueue',
-    ],
-    description: 'FE Developer<br>Love open source',
-  },
-  {
-    avatar: contributorsAvatars.egoist,
-    name: 'EGOIST',
-    github: 'egoist',
-    twitter: '_egoistlily',
-    bluesky: 'egoist.dev',
-    sponsors: true,
-    description: '',
-    packages: ['head'],
-  },
-  {
-    avatar: contributorsAvatars['harlan-zw'],
-    name: 'Harlan Wilton',
-    github: 'harlan-zw',
-    twitter: 'harlan_zw',
-    bluesky: 'harlanzw.com',
-    sponsors: true,
-    description: 'Building delightful open source<br>Nuxt freelance developer',
-    packages: ['schema-org'],
-  },
-  {
-    avatar: contributorsAvatars['Alfred-Skyblue'],
-    name: 'Alfred-Skyblue',
-    github: 'Alfred-Skyblue',
-    description: 'open source enthusiast',
-    functions: [
-      'useSortable',
-    ],
-  },
-  {
-    avatar: contributorsAvatars['Doctor-wu'],
-    name: 'Doctorwu',
-    github: 'Doctor-wu',
-    twitter: 'Doctorwu666',
-    bluesky: 'doctorwu.me',
-    description: 'Dangerous Coder<br>Open source enthusiast',
-  },
-  {
-    avatar: contributorsAvatars.BobbieGoede,
-    name: 'Bobbie Goede',
-    github: 'BobbieGoede',
-    twitter: 'BobbieGoede',
-    bluesky: 'goede.dev',
-    sponsors: true,
-    description: '',
-    packages: ['motion'],
-  },
 ]
-  .sort((pre, cur) => contributors.findIndex(name => name === pre.github) - contributors.findIndex(name => name === cur.github))
-
-export { contributorList as contributors, coreTeamMembers }

--- a/packages/team.md
+++ b/packages/team.md
@@ -1,0 +1,9 @@
+---
+layout: home
+title: Meet the Team
+description: Meet the team behind VueUse
+---
+
+<HomeTeam />
+
+<HomeContributors />


### PR DESCRIPTION
The new team page is under `/team`. I also introduced Team Emeriti for inactive team members. 

I picked members who didn't contribute in the past year. Please feel free to let me know if you have any questions or doubts. Moving to "Team Emeriti" doesn't change anything other than better communication with the community. You are more than welcome to come back anytime to help with VueUse. We sincerely appreciate your previous contributions to the team and projects.

/cc Emeriti Candiates:

- @egoist 
- @webfansplz
- @anteriovieira 
- @cawa-93 
- @scottbedard 
- @sibbng (close #4431)
- @okxiaoliang4 
- @lstoeferle