### PR TITLE
docs(useInfiniteScroll): add warning and examples for `canLoadMore`

### DIFF
--- a/packages/core/useInfiniteScroll/demo.vue
+++ b/packages/core/useInfiniteScroll/demo.vue
@@ -11,7 +11,14 @@ const { reset } = useInfiniteScroll(
     const length = data.value.length + 1
     data.value.push(...Array.from({ length: 5 }, (_, i) => length + i))
   },
-  { distance: 10 },
+  {
+    distance: 10,
+    canLoadMore: () => {
+      // inidicate when there is no more content to load so onLoadMore stops triggering
+      // if (noMoreContent) return false
+      return true // for demo purposes
+    },
+  },
 )
 
 function resetList() {

--- a/packages/core/useInfiniteScroll/index.md
+++ b/packages/core/useInfiniteScroll/index.md
@@ -22,7 +22,14 @@ const { reset } = useInfiniteScroll(
     // load more
     data.value.push(...moreData)
   },
-  { distance: 10 }
+  {
+    distance: 10,
+    canLoadMore: () => {
+      // inidicate when there is no more content to load so onLoadMore stops triggering
+      // if (noMoreContent) return false
+      return true // for demo purposes
+    },
+  }
 )
 
 function resetList() {
@@ -43,6 +50,10 @@ function resetList() {
 </template>
 ```
 
+::: warning
+Make sure to indicate when there is no more content to load with `canLoadMore`, otherwise `onLoadMore` will trigger as long as there is space for more content.
+:::
+
 ## Directive Usage
 
 ```vue
@@ -56,6 +67,11 @@ function onLoadMore() {
   const length = data.value.length + 1
   data.value.push(...Array.from({ length: 5 }, (_, i) => length + i))
 }
+function canLoadMore() {
+  // inidicate when there is no more content to load so onLoadMore stops triggering
+  // if (noMoreContent) return false
+  return true // for demo purposes
+}
 </script>
 
 <template>
@@ -66,7 +82,7 @@ function onLoadMore() {
   </div>
 
   <!-- with options -->
-  <div v-infinite-scroll="[onLoadMore, { distance: 10 }]">
+  <div v-infinite-scroll="[onLoadMore, { distance: 10, canLoadMore }]">
     <div v-for="item in data" :key="item">
       {{ item }}
     </div>


### PR DESCRIPTION
See #4000

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [-] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

The PR adds a warning that the `canLoadMore` should be specified to avoid `onLoadMore` triggering forever in some situations (all the loaded content doesn't reach the end of the scroll container).

It also adds the option to all the examples so it's more obvious the use needs to specify the option. The only exception being the directive example that doesn't use options.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
