### PR TITLE
feat(useFetch): Add `query` option

### DIFF
--- a/packages/core/useFetch/index.md
+++ b/packages/core/useFetch/index.md
@@ -25,6 +25,17 @@ import { useFetch } from '@vueuse/core'
 const { isFetching, error, data } = useFetch(url)
 ```
 
+### Query parameters
+
+`useFetch` accepts `query` option to generate URL query params automatically from an object. `query` object can also work with existing query parameters in the URL.
+
+```ts
+useFetch('https://my-api.com/users', { query: { sortBy: 'username' } })
+
+// Object query will be merged with existing query in the URL
+useFetch('https://my-api.com/users?q=john', { query: { sortBy: 'username' } })
+```
+
 ### Asynchronous Usage
 
 `useFetch` can also be awaited just like a normal fetch. Note that whenever a component is asynchronous, whatever component that uses
@@ -36,16 +47,18 @@ import { useFetch } from '@vueuse/core'
 const { isFetching, error, data } = await useFetch(url)
 ```
 
-### Refetching on URL change
+### Refetching on URL and query change
 
-Using a `ref` for the url parameter will allow the `useFetch` function to automatically trigger another request when the url is changed.
+Using a `ref` for the url parameter or a reactive value for the `query` option will allow the `useFetch` function to automatically trigger another request when the url is changed.
 
 ```ts
 const url = ref('https://my-api.com/user/1')
+const query = reactive({ include: 'favorites' })
 
-const { data } = useFetch(url, { refetch: true })
+const { data } = useFetch(url, { query, refetch: true })
 
 url.value = 'https://my-api.com/user/2' // Will trigger another request
+query.include = 'friends' // Will trigger another request
 ```
 
 ### Prevent request from firing immediately

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -1,7 +1,7 @@
 import type { EventHookOn, Fn, MaybeRefOrGetter, Stoppable } from '@vueuse/shared'
 import type { ComputedRef, Ref } from 'vue'
 import { containsProp, createEventHook, toRef, until, useTimeoutFn } from '@vueuse/shared'
-import { computed, isRef, readonly, ref, shallowRef, toValue, watch } from 'vue'
+import { computed, isRef, reactive, readonly, ref, shallowRef, toValue, watch } from 'vue'
 import { defaultWindow } from '../_configurable'
 
 export interface UseFetchReturn<T> {
@@ -133,6 +133,11 @@ export interface UseFetchOptions {
   fetch?: typeof window.fetch
 
   /**
+   * Adds query search params to URL
+   */
+  query?: MaybeRefOrGetter<Record<string, any>>
+
+  /**
    * Will automatically run fetch when `useFetch` is used
    *
    * @default true
@@ -218,7 +223,7 @@ export interface CreateFetchOptions {
  * to include the new options
  */
 function isFetchOptions(obj: object): obj is UseFetchOptions {
-  return obj && containsProp(obj, 'immediate', 'refetch', 'initialData', 'timeout', 'beforeFetch', 'afterFetch', 'onFetchError', 'fetch', 'updateDataOnError')
+  return obj && containsProp(obj, 'query', 'immediate', 'refetch', 'initialData', 'timeout', 'beforeFetch', 'afterFetch', 'onFetchError', 'fetch', 'updateDataOnError')
 }
 
 const reAbsolute = /^(?:[a-z][a-z\d+\-.]*:)?\/\//i
@@ -433,9 +438,17 @@ export function useFetch<T>(url: MaybeRefOrGetter<string>, ...args: any[]): UseF
         : payload as BodyInit
     }
 
+    const urlValue = new URL(toValue(url))
+
+    if (options.query) {
+      for (const [key, val] of new URLSearchParams(toValue(reactive(options.query)))) {
+        urlValue.searchParams.append(key, val)
+      }
+    }
+
     let isCanceled = false
     const context: BeforeFetchContext = {
-      url: toValue(url),
+      url: urlValue.toString(),
       options: {
         ...defaultFetchOptions,
         ...fetchOptions,
@@ -524,6 +537,7 @@ export function useFetch<T>(url: MaybeRefOrGetter<string>, ...args: any[]): UseF
     [
       refetch,
       toRef(url),
+      () => options.query,
     ],
     ([refetch]) => refetch && execute(),
     { deep: true },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

---

### Description

This adds a `query` option to `useFetch` that will append query parameters to the URL. This is particularly useful for `GET` requests, which don't currently have a way of including a dynamic payload like `POST`, `PUT`, etc.

> ### Query parameters
>
> `useFetch` accepts `query` option to generate URL query params automatically from an object. `query` object can also work with existing query parameters in the URL.
>
> ```ts
> useFetch('https://my-api.com/users', { query: { sortBy: 'username' } })
>
> // Object query will be merged with existing query in the URL
> useFetch('https://my-api.com/users?q=john', { query: { sortBy: 'username' } })
> ```

Replaces #3191, which is a little outdated and has merge conflicts. cc @jd-solanki
