### PR TITLE
types(useBase64): passing dataUrl leading to type error

### DIFF
--- a/packages/core/useBase64/index.test.ts
+++ b/packages/core/useBase64/index.test.ts
@@ -1,15 +1,5 @@
-import { Buffer } from 'node:buffer'
 import { describe, expect, it } from 'vitest'
 import { useBase64 } from '.'
-
-function decode(encoded: string) {
-  const decodedStr = Buffer.from(encoded.split(',')[1], 'base64').toString('utf-8')
-
-  if (!decodedStr)
-    return ''
-
-  return JSON.parse(decodedStr)
-}
 
 describe('useBase64', () => {
   it('should work with record', async () => {
@@ -19,7 +9,7 @@ describe('useBase64', () => {
 
     await promise.value
 
-    expect(decode(base64.value)).toEqual(template)
+    expect(base64.value).toMatchInlineSnapshot(`"data:application/json;base64,eyJ0ZXN0Ijo1fQ=="`)
   })
 
   it('should work with map and default serialize function', async () => {
@@ -29,7 +19,7 @@ describe('useBase64', () => {
 
     await promise.value
 
-    expect(decode(base64.value)).toEqual(Object.fromEntries(map))
+    expect(base64.value).toMatchInlineSnapshot(`"data:application/json;base64,eyJ0ZXN0IjoxfQ=="`)
   })
 
   it('should work with set', async () => {
@@ -39,7 +29,7 @@ describe('useBase64', () => {
 
     await promise.value
 
-    expect(decode(base64.value)).toEqual(Array.from(set))
+    expect(base64.value).toMatchInlineSnapshot(`"data:application/json;base64,WzFd"`)
   })
 
   it('should work with array', async () => {
@@ -49,7 +39,7 @@ describe('useBase64', () => {
 
     await promise.value
 
-    expect(decode(base64.value)).toEqual(arr)
+    expect(base64.value).toMatchInlineSnapshot(`"data:application/json;base64,WzEsMiwzXQ=="`)
   })
 
   it('should work with custom serialize function', async () => {
@@ -63,6 +53,16 @@ describe('useBase64', () => {
 
     await promise.value
 
-    expect(decode(base64.value)).toEqual(JSON.parse(serializer(arr)))
+    expect(base64.value).toMatchInlineSnapshot(`"data:application/json;base64,WzIsNCw2XQ=="`)
+  })
+
+  it('should work with dataUrl false', async () => {
+    const arr = [1, 2, 3]
+
+    const { promise, base64 } = useBase64(arr, { dataUrl: false })
+
+    await promise.value
+
+    expect(base64.value).toMatchInlineSnapshot(`"WzEsMiwzXQ=="`)
   })
 })

--- a/packages/core/useBase64/index.ts
+++ b/packages/core/useBase64/index.ts
@@ -25,7 +25,7 @@ export interface ToDataURLOptions extends UseBase64Options {
 }
 
 export interface UseBase64ObjectOptions<T> extends UseBase64Options {
-  serializer: (v: T) => string
+  serializer?: (v: T) => string
 }
 
 export interface UseBase64Return {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

updated the tests of `useBase64` and got a type issue when passing `options.dataUrl`.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
