### PR TITLE
fix(useStorage): ensure `defaults` is only called once when it is a getter

### DIFF
--- a/packages/core/useStorage/index.test.ts
+++ b/packages/core/useStorage/index.test.ts
@@ -244,22 +244,6 @@ describe('useStorage', () => {
     expect(storage.removeItem).toBeCalledWith(KEY)
   })
 
-  it('getter', async () => {
-    expect(storage.getItem(KEY)).toEqual(undefined)
-
-    const defaults = vi.fn().mockReturnValue('1')
-    const store = useStorage(KEY, defaults, storage)
-
-    expect(defaults).toBeCalledTimes(1)
-    expect(storage.setItem).toBeCalledWith(KEY, '1')
-    expect(store.value).toBe('1')
-
-    store.value = '2'
-    await nextTwoTick()
-
-    expect(storage.setItem).toBeCalledWith(KEY, '2')
-  })
-
   it('pass ref as initialValue', async () => {
     expect(storage.getItem(KEY)).toEqual(undefined)
 
@@ -534,9 +518,14 @@ describe('useStorage', () => {
     new Map([[1, 2]]),
     new Set([1, 2]),
   ])('should work in conjunction with defaults', (value) => {
-    const basicRef = useStorage(KEY, () => value, storage)
+    const defaults = vi.fn().mockReturnValue(value)
+    const basicRef = useStorage(KEY, defaults, storage)
+
+    expect(defaults).toBeCalledTimes(1)
     expect(basicRef.value).toEqual(value)
+
     storage.removeItem(KEY)
+
     const objectRef = useStorage(KEY, value, storage)
     expect(objectRef.value).toEqual(value)
   })

--- a/packages/core/useStorage/index.test.ts
+++ b/packages/core/useStorage/index.test.ts
@@ -244,6 +244,22 @@ describe('useStorage', () => {
     expect(storage.removeItem).toBeCalledWith(KEY)
   })
 
+  it('getter', async () => {
+    expect(storage.getItem(KEY)).toEqual(undefined)
+
+    const defaults = vi.fn().mockReturnValue('1')
+    const store = useStorage(KEY, defaults, storage)
+
+    expect(defaults).toBeCalledTimes(1)
+    expect(storage.setItem).toBeCalledWith(KEY, '1')
+    expect(store.value).toBe('1')
+
+    store.value = '2'
+    await nextTwoTick()
+
+    expect(storage.setItem).toBeCalledWith(KEY, '2')
+  })
+
   it('pass ref as initialValue', async () => {
     expect(storage.getItem(KEY)).toEqual(undefined)
 

--- a/packages/core/useStorage/index.ts
+++ b/packages/core/useStorage/index.ts
@@ -153,7 +153,8 @@ export function useStorage<T extends (string | number | boolean | object | null)
     initOnMounted,
   } = options
 
-  const data = (shallow ? shallowRef : ref)(typeof defaults === 'function' ? defaults() : defaults) as RemovableRef<T>
+  const _defaults = typeof defaults === 'function' ? defaults() : defaults
+  const data = (shallow ? shallowRef : ref)(_defaults) as RemovableRef<T>
 
   if (!storage) {
     try {
@@ -167,7 +168,7 @@ export function useStorage<T extends (string | number | boolean | object | null)
   if (!storage)
     return data
 
-  const rawInit: T = toValue(defaults)
+  const rawInit: T = toValue(_defaults)
   const type = guessSerializerType<T>(rawInit)
   const serializer = options.serializer ?? StorageSerializers[type]
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

fixes #4449 

Currently, during the initialization of `data` and `rawInit`, if `defaults` is provided as a getter function, it will be executed once for each initialization.

In this PR, a check is added to determine if `defaults` is a function. If it is, the returned value is retrieved upfront to ensure it is not executed repeatedly afterward. 

https://github.com/vueuse/vueuse/blob/eefc10f8afaa55efbdc59102fdb2046f06b31846/packages/core/useStorage/index.ts#L156-L171

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
