### PR TITLE
fix(useElementBounding): modify the `handler` parameter

### DIFF
--- a/packages/core/useElementBounding/directive.ts
+++ b/packages/core/useElementBounding/directive.ts
@@ -1,10 +1,11 @@
-import type { ObjectDirective } from 'vue'
+import type { ObjectDirective, Reactive } from 'vue'
 import type { UseElementBoundingOptions, UseElementBoundingReturn } from '.'
-import { watch } from 'vue'
+import { reactiveOmit } from '@vueuse/shared'
+import { reactive, watch } from 'vue'
 import { useElementBounding } from '.'
 
 type ElementBounding = Omit<UseElementBoundingReturn, 'update'>
-type BindingValueFunction = (bounding: ElementBounding) => void
+type BindingValueFunction = (bounding: Reactive<ElementBounding>) => void
 type BindingValueArray = [BindingValueFunction, UseElementBoundingOptions]
 
 export const vElementBounding: ObjectDirective<
@@ -14,16 +15,7 @@ export const vElementBounding: ObjectDirective<
   mounted(el, binding) {
     const [handler, options] = (typeof binding.value === 'function' ? [binding.value, {}] : binding.value) as BindingValueArray
 
-    const {
-      height,
-      bottom,
-      left,
-      right,
-      top,
-      width,
-      x,
-      y,
-    } = useElementBounding(el, options)
-    watch([height, bottom, left, right, top, width, x, y], () => handler({ height, bottom, left, right, top, width, x, y }))
+    const state = reactiveOmit(reactive(useElementBounding(el, options)), 'update')
+    watch(state, val => handler(val))
   },
 }


### PR DESCRIPTION
The parameter of the handler shouldn't be a ref.

fix: #4609 