### PR TITLE
feat(useStorage): make storage key reactive

### DIFF
--- a/packages/core/useLocalStorage/index.ts
+++ b/packages/core/useLocalStorage/index.ts
@@ -3,11 +3,11 @@ import type { UseStorageOptions } from '../useStorage'
 import { defaultWindow } from '../_configurable'
 import { useStorage } from '../useStorage'
 
-export function useLocalStorage(key: string, initialValue: MaybeRefOrGetter<string>, options?: UseStorageOptions<string>): RemovableRef<string>
-export function useLocalStorage(key: string, initialValue: MaybeRefOrGetter<boolean>, options?: UseStorageOptions<boolean>): RemovableRef<boolean>
-export function useLocalStorage(key: string, initialValue: MaybeRefOrGetter<number>, options?: UseStorageOptions<number>): RemovableRef<number>
-export function useLocalStorage<T>(key: string, initialValue: MaybeRefOrGetter<T>, options?: UseStorageOptions<T>): RemovableRef<T>
-export function useLocalStorage<T = unknown>(key: string, initialValue: MaybeRefOrGetter<null>, options?: UseStorageOptions<T>): RemovableRef<T>
+export function useLocalStorage(key: MaybeRefOrGetter<string>, initialValue: MaybeRefOrGetter<string>, options?: UseStorageOptions<string>): RemovableRef<string>
+export function useLocalStorage(key: MaybeRefOrGetter<string>, initialValue: MaybeRefOrGetter<boolean>, options?: UseStorageOptions<boolean>): RemovableRef<boolean>
+export function useLocalStorage(key: MaybeRefOrGetter<string>, initialValue: MaybeRefOrGetter<number>, options?: UseStorageOptions<number>): RemovableRef<number>
+export function useLocalStorage<T>(key: MaybeRefOrGetter<string>, initialValue: MaybeRefOrGetter<T>, options?: UseStorageOptions<T>): RemovableRef<T>
+export function useLocalStorage<T = unknown>(key: MaybeRefOrGetter<string>, initialValue: MaybeRefOrGetter<null>, options?: UseStorageOptions<T>): RemovableRef<T>
 
 /**
  * Reactive LocalStorage.
@@ -18,7 +18,7 @@ export function useLocalStorage<T = unknown>(key: string, initialValue: MaybeRef
  * @param options
  */
 export function useLocalStorage<T extends(string | number | boolean | object | null)>(
-  key: string,
+  key: MaybeRefOrGetter<string>,
   initialValue: MaybeRefOrGetter<T>,
   options: UseStorageOptions<T> = {},
 ): RemovableRef<any> {

--- a/packages/core/useSessionStorage/index.ts
+++ b/packages/core/useSessionStorage/index.ts
@@ -3,11 +3,11 @@ import type { UseStorageOptions } from '../useStorage'
 import { defaultWindow } from '../_configurable'
 import { useStorage } from '../useStorage'
 
-export function useSessionStorage(key: string, initialValue: MaybeRefOrGetter<string>, options?: UseStorageOptions<string>): RemovableRef<string>
-export function useSessionStorage(key: string, initialValue: MaybeRefOrGetter<boolean>, options?: UseStorageOptions<boolean>): RemovableRef<boolean>
-export function useSessionStorage(key: string, initialValue: MaybeRefOrGetter<number>, options?: UseStorageOptions<number>): RemovableRef<number>
-export function useSessionStorage<T>(key: string, initialValue: MaybeRefOrGetter<T>, options?: UseStorageOptions<T>): RemovableRef<T>
-export function useSessionStorage<T = unknown>(key: string, initialValue: MaybeRefOrGetter<null>, options?: UseStorageOptions<T>): RemovableRef<T>
+export function useSessionStorage(key: MaybeRefOrGetter<string>, initialValue: MaybeRefOrGetter<string>, options?: UseStorageOptions<string>): RemovableRef<string>
+export function useSessionStorage(key: MaybeRefOrGetter<string>, initialValue: MaybeRefOrGetter<boolean>, options?: UseStorageOptions<boolean>): RemovableRef<boolean>
+export function useSessionStorage(key: MaybeRefOrGetter<string>, initialValue: MaybeRefOrGetter<number>, options?: UseStorageOptions<number>): RemovableRef<number>
+export function useSessionStorage<T>(key: MaybeRefOrGetter<string>, initialValue: MaybeRefOrGetter<T>, options?: UseStorageOptions<T>): RemovableRef<T>
+export function useSessionStorage<T = unknown>(key: MaybeRefOrGetter<string>, initialValue: MaybeRefOrGetter<null>, options?: UseStorageOptions<T>): RemovableRef<T>
 
 /**
  * Reactive SessionStorage.
@@ -18,7 +18,7 @@ export function useSessionStorage<T = unknown>(key: string, initialValue: MaybeR
  * @param options
  */
 export function useSessionStorage<T extends(string | number | boolean | object | null)>(
-  key: string,
+  key: MaybeRefOrGetter<string>,
   initialValue: MaybeRefOrGetter<T>,
   options: UseStorageOptions<T> = {},
 ): RemovableRef<any> {

--- a/packages/core/useStorage/index.md
+++ b/packages/core/useStorage/index.md
@@ -17,6 +17,9 @@ When using with Nuxt 3, this function will **NOT** be auto imported in favor of 
 
 ```js
 import { useStorage } from '@vueuse/core'
+import { ref } from 'vue'
+
+const key = ref('key')
 
 // bind object
 const state = useStorage('my-store', { hello: 'hi', greeting: 'Hello' })
@@ -29,6 +32,12 @@ const count = useStorage('my-count', 0) // returns Ref<number>
 
 // bind string with SessionStorage
 const id = useStorage('my-id', 'some-string-id', sessionStorage) // returns Ref<string>
+
+// set a reactive value as key
+const value = useStorage(key, 'your-value')
+
+// change the reactive key - the returned value will be taken from storage, otherwise from the default value
+key.value = 'new-key'
 
 // delete data from storage
 state.value = null

--- a/packages/core/useStorage/index.md
+++ b/packages/core/useStorage/index.md
@@ -17,9 +17,6 @@ When using with Nuxt 3, this function will **NOT** be auto imported in favor of 
 
 ```js
 import { useStorage } from '@vueuse/core'
-import { ref } from 'vue'
-
-const key = ref('key')
 
 // bind object
 const state = useStorage('my-store', { hello: 'hi', greeting: 'Hello' })
@@ -32,13 +29,6 @@ const count = useStorage('my-count', 0) // returns Ref<number>
 
 // bind string with SessionStorage
 const id = useStorage('my-id', 'some-string-id', sessionStorage) // returns Ref<string>
-
-// set a reactive value as key
-const value = useStorage(key, 'your-value')
-
-// change the reactive key - the returned value will be taken from storage, otherwise from the default value
-key.value = 'new-key'
-
 // delete data from storage
 state.value = null
 ```

--- a/packages/core/useStorage/index.test.ts
+++ b/packages/core/useStorage/index.test.ts
@@ -5,6 +5,7 @@ import { customStorageEventName, StorageSerializers, useStorage } from '.'
 import { mount, nextTwoTick, useSetup } from '../../.test'
 
 const KEY = 'custom-key'
+const ANOTHER_KEY = 'another-key'
 
 vi.mock('../ssr-handlers', () => ({
   getSSRHandler: vi.fn().mockImplementationOnce((_, cb) => () => cb()).mockImplementationOnce(() => () => {
@@ -546,5 +547,58 @@ describe('useStorage', () => {
     state1.value = 1
     await nextTick()
     expect(state2.value).toBe(1)
+  })
+
+  it('updates on key change when thew new storage value is presented', async () => {
+    storage.setItem(ANOTHER_KEY, '1')
+    const key = ref(KEY)
+    const data = useStorage(key, 0, storage)
+
+    data.value = 2
+    await nextTick()
+    key.value = ANOTHER_KEY
+    await nextTick()
+    expect(data.value).toBe(1)
+    expect(storage.getItem(KEY)).toBe('2')
+    expect(storage.getItem(ANOTHER_KEY)).toBe('1')
+
+    key.value = KEY
+    data.value = 3
+    await nextTick()
+    expect(storage.getItem(KEY)).toBe('2')
+    expect(storage.getItem(ANOTHER_KEY)).toBe('1')
+  })
+
+  it('changes to defaults on key change when the new storage value is undefined', async () => {
+    const key = ref(KEY)
+    const data = useStorage(key, 0, storage)
+
+    data.value = 1
+    key.value = ANOTHER_KEY
+    await nextTick()
+    expect(data.value).toBe(1)
+    expect(storage.getItem(KEY)).toBe('0')
+    expect(storage.getItem(ANOTHER_KEY)).toBe('1')
+
+    data.value = 2
+    await nextTick()
+    key.value = KEY
+    await nextTick()
+    expect(data.value).toBe(0)
+    expect(storage.getItem(KEY)).toBe('0')
+    expect(storage.getItem(ANOTHER_KEY)).toBe('2')
+  })
+
+  it('listens to new storage value changes after key change', async () => {
+    const key = ref(KEY)
+    const data = useStorage(key, 0, localStorage)
+
+    key.value = ANOTHER_KEY
+    await nextTick()
+    expect(data.value).toBe(0)
+
+    window.dispatchEvent(new StorageEvent('storage', { storageArea: localStorage, key: ANOTHER_KEY, newValue: '1' }))
+    window.dispatchEvent(new StorageEvent('storage', { storageArea: localStorage, key: KEY, newValue: '2' }))
+    expect(data.value).toBe(1)
   })
 })

--- a/packages/core/useStorage/index.ts
+++ b/packages/core/useStorage/index.ts
@@ -2,7 +2,7 @@ import type { Awaitable, ConfigurableEventFilter, ConfigurableFlush, MaybeRefOrG
 import type { ConfigurableWindow } from '../_configurable'
 import type { StorageLike } from '../ssr-handlers'
 import { pausableWatch, tryOnMounted } from '@vueuse/shared'
-import { nextTick, ref, shallowRef, toValue } from 'vue'
+import { computed, nextTick, ref, shallowRef, toValue, watch } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { getSSRHandler } from '../ssr-handlers'
 import { useEventListener } from '../useEventListener'
@@ -121,11 +121,11 @@ export interface UseStorageOptions<T> extends ConfigurableEventFilter, Configura
   initOnMounted?: boolean
 }
 
-export function useStorage(key: string, defaults: MaybeRefOrGetter<string>, storage?: StorageLike, options?: UseStorageOptions<string>): RemovableRef<string>
-export function useStorage(key: string, defaults: MaybeRefOrGetter<boolean>, storage?: StorageLike, options?: UseStorageOptions<boolean>): RemovableRef<boolean>
-export function useStorage(key: string, defaults: MaybeRefOrGetter<number>, storage?: StorageLike, options?: UseStorageOptions<number>): RemovableRef<number>
-export function useStorage<T>(key: string, defaults: MaybeRefOrGetter<T>, storage?: StorageLike, options?: UseStorageOptions<T>): RemovableRef<T>
-export function useStorage<T = unknown>(key: string, defaults: MaybeRefOrGetter<null>, storage?: StorageLike, options?: UseStorageOptions<T>): RemovableRef<T>
+export function useStorage(key: MaybeRefOrGetter<string>, defaults: MaybeRefOrGetter<string>, storage?: StorageLike, options?: UseStorageOptions<string>): RemovableRef<string>
+export function useStorage(key: MaybeRefOrGetter<string>, defaults: MaybeRefOrGetter<boolean>, storage?: StorageLike, options?: UseStorageOptions<boolean>): RemovableRef<boolean>
+export function useStorage(key: MaybeRefOrGetter<string>, defaults: MaybeRefOrGetter<number>, storage?: StorageLike, options?: UseStorageOptions<number>): RemovableRef<number>
+export function useStorage<T>(key: MaybeRefOrGetter<string>, defaults: MaybeRefOrGetter<T>, storage?: StorageLike, options?: UseStorageOptions<T>): RemovableRef<T>
+export function useStorage<T = unknown>(key: MaybeRefOrGetter<string>, defaults: MaybeRefOrGetter<null>, storage?: StorageLike, options?: UseStorageOptions<T>): RemovableRef<T>
 
 /**
  * Reactive LocalStorage/SessionStorage.
@@ -133,7 +133,7 @@ export function useStorage<T = unknown>(key: string, defaults: MaybeRefOrGetter<
  * @see https://vueuse.org/useStorage
  */
 export function useStorage<T extends (string | number | boolean | object | null)>(
-  key: string,
+  key: MaybeRefOrGetter<string>,
   defaults: MaybeRefOrGetter<T>,
   storage: StorageLike | undefined,
   options: UseStorageOptions<T> = {},
@@ -154,6 +154,7 @@ export function useStorage<T extends (string | number | boolean | object | null)
   } = options
 
   const data = (shallow ? shallowRef : ref)(typeof defaults === 'function' ? defaults() : defaults) as RemovableRef<T>
+  const keyComputed = computed<string>(() => toValue(key))
 
   if (!storage) {
     try {
@@ -176,6 +177,8 @@ export function useStorage<T extends (string | number | boolean | object | null)
     () => write(data.value),
     { flush, deep, eventFilter },
   )
+
+  watch(keyComputed, () => update(), { flush })
 
   if (window && listenToStorageChanges) {
     tryOnMounted(() => {
@@ -205,7 +208,7 @@ export function useStorage<T extends (string | number | boolean | object | null)
     // send custom event to communicate within same page
     if (window) {
       const payload = {
-        key,
+        key: keyComputed.value,
         oldValue,
         newValue,
         storageArea: storage as Storage,
@@ -222,16 +225,16 @@ export function useStorage<T extends (string | number | boolean | object | null)
 
   function write(v: unknown) {
     try {
-      const oldValue = storage!.getItem(key)
+      const oldValue = storage!.getItem(keyComputed.value)
 
       if (v == null) {
         dispatchWriteEvent(oldValue, null)
-        storage!.removeItem(key)
+        storage!.removeItem(keyComputed.value)
       }
       else {
         const serialized = serializer.write(v as any)
         if (oldValue !== serialized) {
-          storage!.setItem(key, serialized)
+          storage!.setItem(keyComputed.value, serialized)
           dispatchWriteEvent(oldValue, serialized)
         }
       }
@@ -244,11 +247,11 @@ export function useStorage<T extends (string | number | boolean | object | null)
   function read(event?: StorageEventLike) {
     const rawValue = event
       ? event.newValue
-      : storage!.getItem(key)
+      : storage!.getItem(keyComputed.value)
 
     if (rawValue == null) {
       if (writeDefaults && rawInit != null)
-        storage!.setItem(key, serializer.write(rawInit))
+        storage!.setItem(keyComputed.value, serializer.write(rawInit))
       return rawInit
     }
     else if (!event && mergeDefaults) {
@@ -276,7 +279,7 @@ export function useStorage<T extends (string | number | boolean | object | null)
       return
     }
 
-    if (event && event.key !== key)
+    if (event && event.key !== keyComputed.value)
       return
 
     pauseWatch()


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

This PR makes `key` argument for `useStorage` composable reactive. It means if we change the key the data value should be taken from the appropriate key in storage, otherwise if the storage's value doesn't exist we use a default value as a new value for the data value and apply it to the storage by the new key.

Due to Vue updates flush and pausing/resuming writing to storage on the data value update in the current implementation, it requires to use `nextTick` after the first change if we change data and key together independently on the order. For example:

```js
const key = ref('key')
const data = useStorage(key,  0)

// BAD: changes the key but writes to storage by new one, not old one
data.value = 1
key.value = 'new-key'

// BAD: changes the key and data according to the new storage value, but skips the data update due to the data watch pause
key.value = 'new-key'
data.value = 1

// GOOD: writes to storage by the current key and then changes the key and data appropriately
data.value = 1
await nextTick()
key.value = 'new-key'

// GOOD: changes the key and then writes to storage by the new key
key.value = 'new-key'
nextTick(() => data.value = 1)
```

Implements #4289

### Additional context

Additionally, updated `useLocalStorage` and `useSessionStorage` types according to the new type of the `useStorage` key.