### PR TITLE
docs(useMediaControls): use useTemplateRef instead of ref

### DIFF
--- a/packages/core/useMediaControls/index.md
+++ b/packages/core/useMediaControls/index.md
@@ -12,9 +12,12 @@ Reactive media controls for both `audio` and `video` elements
 
 ```vue
 <script setup lang="ts">
+import { ref, onMounted } from 'vue'
 import { useMediaControls } from '@vueuse/core'
-import { onMounted, ref } from 'vue'
 
+// if using Vue 3.5+
+// import { useTemplateRef } from 'vue'
+// const video = useTemplateRef('video')
 const video = ref()
 const { playing, currentTime, duration, volume } = useMediaControls(video, {
   src: 'video.mp4',
@@ -48,6 +51,9 @@ be `-1` if there is no selected track.
 <script setup lang="ts">
 import { useMediaControls } from '@vueuse/core'
 import { ref } from 'vue'
+// if using Vue 3.5+
+// import { useTemplateRef } from 'vue'
+// const video = useTemplateRef('video')
 const video = ref()
 const {
   tracks,

--- a/packages/core/useMediaControls/index.md
+++ b/packages/core/useMediaControls/index.md
@@ -12,13 +12,10 @@ Reactive media controls for both `audio` and `video` elements
 
 ```vue
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
 import { useMediaControls } from '@vueuse/core'
+import { onMounted, useTemplateRef } from 'vue'
 
-// if using Vue 3.5+
-// import { useTemplateRef } from 'vue'
-// const video = useTemplateRef('video')
-const video = ref()
+const video = useTemplateRef('video')
 const { playing, currentTime, duration, volume } = useMediaControls(video, {
   src: 'video.mp4',
 })
@@ -50,11 +47,9 @@ be `-1` if there is no selected track.
 ```vue
 <script setup lang="ts">
 import { useMediaControls } from '@vueuse/core'
-import { ref } from 'vue'
-// if using Vue 3.5+
-// import { useTemplateRef } from 'vue'
-// const video = useTemplateRef('video')
-const video = ref()
+import { useTemplateRef } from 'vue'
+
+const video = useTemplateRef('video')
 const {
   tracks,
   enableTrack


### PR DESCRIPTION
`useTemplateRef` is the preferred approach for direct DOM access, as recommended in the [Vue.js documentation](https://vuejs.org/guide/essentials/template-refs.html)
