### PR TITLE
feat(useCloned): return `isModified`

### DIFF
--- a/packages/core/useCloned/index.md
+++ b/packages/core/useCloned/index.md
@@ -48,5 +48,5 @@ import { klona } from 'klona'
 
 const original = ref({ key: 'value' })
 
-const { cloned, isCloneModified, sync } = useCloned(original, { clone: klona })
+const { cloned, isModified, sync } = useCloned(original, { clone: klona })
 ```

--- a/packages/core/useCloned/index.md
+++ b/packages/core/useCloned/index.md
@@ -48,5 +48,5 @@ import { klona } from 'klona'
 
 const original = ref({ key: 'value' })
 
-const { cloned, sync } = useCloned(original, { clone: klona })
+const { cloned, isCloneModified, sync } = useCloned(original, { clone: klona })
 ```

--- a/packages/core/useCloned/index.test.ts
+++ b/packages/core/useCloned/index.test.ts
@@ -93,4 +93,20 @@ describe('useCloned', () => {
 
     expect(cloned.value).toEqual(data.value)
   })
+
+  it('works with use isModified', async () => {
+    const data = ref({ test: 'test' })
+
+    const { cloned, isModified, sync } = useCloned(data)
+
+    expect(isModified.value).toEqual(false)
+
+    cloned.value.test = 'vitest'
+
+    expect(isModified.value).toEqual(true)
+
+    sync()
+
+    expect(isModified.value).toEqual(false)
+  })
 })

--- a/packages/core/useCloned/index.ts
+++ b/packages/core/useCloned/index.ts
@@ -24,7 +24,7 @@ export interface UseClonedReturn<T> {
    */
   cloned: Ref<T>
   /**
-   * IsModified ref
+   * Ref indicates whether the cloned data is modified
    */
   isModified: Ref<boolean>
   /**
@@ -45,7 +45,8 @@ export function useCloned<T>(
 ): UseClonedReturn<T> {
   const cloned = ref({} as T) as Ref<T>
   const isModified = ref<boolean>(false)
-  let _isSync = false
+  let _lastSync = false
+
   const {
     manual,
     clone = cloneFnJSON,
@@ -55,8 +56,8 @@ export function useCloned<T>(
   } = options
 
   watch(cloned, () => {
-    if (_isSync) {
-      _isSync = false
+    if (_lastSync) {
+      _lastSync = false
       return
     }
     isModified.value = true
@@ -66,7 +67,7 @@ export function useCloned<T>(
   })
 
   function sync() {
-    _isSync = true
+    _lastSync = true
     isModified.value = false
 
     cloned.value = clone(toValue(source))

--- a/packages/core/useCloned/index.ts
+++ b/packages/core/useCloned/index.ts
@@ -56,7 +56,7 @@ export function useCloned<T>(
 
   watch(cloned, () => {
     if (_isSync) {
-    	_isSync = false
+      _isSync = false
       return
     }
     isModified.value = true

--- a/packages/core/useCloned/index.ts
+++ b/packages/core/useCloned/index.ts
@@ -26,7 +26,7 @@ export interface UseClonedReturn<T> {
   /**
    * IsCloneModified ref
    */
-  isCloneModified: Ref<boolean>
+  isClonedModified: Ref<boolean>
   /**
    * Sync cloned data with source manually
    */
@@ -44,7 +44,7 @@ export function useCloned<T>(
   options: UseClonedOptions = {},
 ): UseClonedReturn<T> {
   const cloned = ref({} as T) as Ref<T>
-  const isCloneModified = ref<boolean>(false)
+  const isClonedModified = ref<boolean>(false)
   const {
     manual,
     clone = cloneFnJSON,
@@ -69,12 +69,12 @@ export function useCloned<T>(
   }
 
   const { stop } = watch(cloned, () => {
-    isCloneModified.value = true
+    isClonedModified.value = true
     stop()
   }, {
     deep: true,
     flush: 'sync',
   })
 
-  return { cloned, isCloneModified, sync }
+  return { cloned, isClonedModified, sync }
 }

--- a/packages/core/useCloned/index.ts
+++ b/packages/core/useCloned/index.ts
@@ -55,8 +55,10 @@ export function useCloned<T>(
   } = options
 
   watch(cloned, () => {
-    if (_isSync)
-      return _isSync = false
+    if (_isSync) {
+    	_isSync = false
+      return
+    }
     isModified.value = true
   }, {
     deep: true,

--- a/packages/core/useCloned/index.ts
+++ b/packages/core/useCloned/index.ts
@@ -24,6 +24,10 @@ export interface UseClonedReturn<T> {
    */
   cloned: Ref<T>
   /**
+   * IsCloneModified ref
+   */
+  isCloneModified: Ref<boolean>
+  /**
    * Sync cloned data with source manually
    */
   sync: () => void
@@ -40,6 +44,7 @@ export function useCloned<T>(
   options: UseClonedOptions = {},
 ): UseClonedReturn<T> {
   const cloned = ref({} as T) as Ref<T>
+  const isCloneModified = ref<boolean>(false)
   const {
     manual,
     clone = cloneFnJSON,
@@ -63,5 +68,13 @@ export function useCloned<T>(
     sync()
   }
 
-  return { cloned, sync }
+  const { stop } = watch(cloned, () => {
+    isCloneModified.value = true
+    stop()
+  }, {
+    deep: true,
+    flush: 'sync',
+  })
+
+  return { cloned, isCloneModified, sync }
 }

--- a/packages/core/useCloned/index.ts
+++ b/packages/core/useCloned/index.ts
@@ -45,7 +45,7 @@ export function useCloned<T>(
 ): UseClonedReturn<T> {
   const cloned = ref({} as T) as Ref<T>
   const isModified = ref<boolean>(false)
-  const _isSync = ref<boolean>(false)
+  let _isSync = false
   const {
     manual,
     clone = cloneFnJSON,
@@ -54,22 +54,20 @@ export function useCloned<T>(
     immediate = true,
   } = options
 
-  const { resume, pause } = watch(cloned, () => {
-    if (_isSync.value)
-      return _isSync.value = false
+  watch(cloned, () => {
+    if (_isSync)
+      return _isSync = false
     isModified.value = true
-    pause()
   }, {
     deep: true,
     flush: 'sync',
   })
 
   function sync() {
-    _isSync.value = true
+    _isSync = true
     isModified.value = false
 
     cloned.value = clone(toValue(source))
-    resume()
   }
 
   if (!manual && (isRef(source) || typeof source === 'function')) {


### PR DESCRIPTION
reference: #4393 

Add a new `isModifed` feature to `useCloned`. This reactive attribute tracks whether the cloned value has been modified.
