### PR TITLE
feat(useDraggable): auto-scroll with restricted dragging within the container

### DIFF
--- a/packages/core/useDraggable/index.md
+++ b/packages/core/useDraggable/index.md
@@ -39,6 +39,17 @@ const { x, y, style } = useDraggable(el, {
 })
 ```
 
+Set `autoScroll: true` to enable auto-scroll when dragging near the edges.
+
+```ts
+const { x, y, style } = useDraggable(el, {
+  autoScroll: true,
+  scrollSpeed: 2, // Control the speed of auto-scroll.
+  scrollMargin: 30, // Set the margin from the edge that triggers auto-scroll.
+  scrollDirection: 'both' // Determine the direction of auto-scroll.
+})
+```
+
 ## Component Usage
 
 ```vue

--- a/packages/core/useDraggable/index.ts
+++ b/packages/core/useDraggable/index.ts
@@ -148,37 +148,6 @@ export interface UseDraggableOptions {
   scrollDirection?: 'x' | 'y' | 'both'
 }
 
-function handleAutoScroll(
-  container: HTMLElement | SVGElement,
-  targetRect: DOMRect,
-  position: Position,
-  scrollSpeed: number,
-  scrollMargin: number,
-  direction: 'x' | 'y' | 'both',
-) {
-  const { clientWidth, clientHeight } = container
-  let deltaX = 0
-  let deltaY = 0
-
-  if ((direction === 'x' || direction === 'both')) {
-    if (position.x <= scrollMargin)
-      deltaX = -scrollSpeed
-    else if ((position.x + targetRect.width >= clientWidth - scrollMargin))
-      deltaX = scrollSpeed
-  }
-
-  if ((direction === 'y' || direction === 'both')) {
-    if (position.y <= scrollMargin)
-      deltaY = -scrollSpeed
-    else if ((position.y + targetRect.height >= clientHeight - scrollMargin))
-      deltaY = scrollSpeed
-  }
-
-  if (deltaX || deltaY) {
-    container.scrollBy({ left: deltaX, top: deltaY, behavior: 'auto' })
-  }
-}
-
 /**
  * Make elements draggable.
  *
@@ -228,6 +197,37 @@ export function useDraggable(
       e.preventDefault()
     if (toValue(stopPropagation))
       e.stopPropagation()
+  }
+
+  const handleAutoScroll = (
+    container: HTMLElement | SVGElement,
+    targetRect: DOMRect,
+    position: Position,
+    scrollSpeed: number,
+    scrollMargin: number,
+    direction: 'x' | 'y' | 'both',
+  ) => {
+    const { clientWidth, clientHeight } = container
+    let deltaX = 0
+    let deltaY = 0
+
+    if ((direction === 'x' || direction === 'both')) {
+      if (position.x <= scrollMargin)
+        deltaX = -scrollSpeed
+      else if ((position.x + targetRect.width >= clientWidth - scrollMargin))
+        deltaX = scrollSpeed
+    }
+
+    if ((direction === 'y' || direction === 'both')) {
+      if (position.y <= scrollMargin)
+        deltaY = -scrollSpeed
+      else if ((position.y + targetRect.height >= clientHeight - scrollMargin))
+        deltaY = scrollSpeed
+    }
+
+    if (deltaX || deltaY) {
+      container.scrollBy({ left: deltaX, top: deltaY, behavior: 'auto' })
+    }
   }
 
   const intervalId = ref<NodeJS.Timeout | null>(null)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

This PR resolves this issue https://github.com/vueuse/vueuse/issues/4035

I created the auto-scroll functionality and added 4 new options:  

- **autoScroll**  
  Enable auto-scroll when dragging near the edges.  
- **scrollSpeed**  
  Control the speed of auto-scroll.
- **scrollMargin**  
  Set the margin from the edge that triggers auto-scroll.  
- **scrollDirection**  
  Determine the direction of auto-scroll. 


https://github.com/user-attachments/assets/975604d1-83c0-491f-baa6-20a9eb7f22da


### Additional context

Before that, I made another adjustment by adding another option and setting the style: 

- **restrictInContainer** (please tell me if someone has a better name for this)
  Restrict dragging within the container. If the pointer drags the element beyond the container area, the element will stay within the edge of the current dragging axis.  

  This adjustment is necessary (imo) because I want the auto-scroll to behave similarly (kinda) to [PlainDraggable](https://anseki.github.io/plain-draggable/#options-autoscroll). I am unsure whether this option should be the default behavior for `useDraggable` or not.

  If `autoScroll` is enabled, this option is automatically activated because (imo) it creates a poor user experience if an element is dragged out of view but auto-scroll continues.

  Additionally, `containerElement` must be defined for this to work.

- **text-wrap: nowrap**  
  Prevents text from wrapping when auto-scroll is initialized.