### PR TITLE
test(watchDebounced): add tests to solve debounce max wait issue

### DIFF
--- a/packages/shared/watchDebounced/index.test.ts
+++ b/packages/shared/watchDebounced/index.test.ts
@@ -45,7 +45,7 @@ describe('watchDebounced', () => {
     expect(cb).toHaveBeenCalledWith(4, 2, expect.anything())
   })
 
-  it.todo('should work with constant changes over multiple maxWaits', async () => {
+  it.fails('should work with constant changes over multiple maxWaits', async () => {
     vi.useFakeTimers()
     const num = ref(0)
     const cb = vi.fn()

--- a/packages/shared/watchDebounced/index.test.ts
+++ b/packages/shared/watchDebounced/index.test.ts
@@ -44,4 +44,31 @@ describe('watchDebounced', () => {
     expect(cb).toHaveBeenCalledTimes(2)
     expect(cb).toHaveBeenCalledWith(4, 2, expect.anything())
   })
+
+  it.todo('should work with constant changes over multiple maxWaits', async () => {
+    vi.useFakeTimers()
+    const num = ref(0)
+    const cb = vi.fn()
+
+    const constantUpdateOverTime = async (ms: number) => {
+      for (let i = 0; i < ms; i++) {
+        num.value += 1
+        await vi.advanceTimersByTimeAsync(1)
+      }
+    }
+    watchDebounced(num, cb, { debounce: 10, maxWait: 50 })
+    expect(cb).toHaveBeenCalledTimes(0)
+    await constantUpdateOverTime(49)
+    expect(cb).toHaveBeenCalledTimes(0)
+    await constantUpdateOverTime(1)
+    expect(cb).toHaveBeenCalledTimes(1)
+    await constantUpdateOverTime(50)
+    expect(cb).toHaveBeenCalledTimes(2)
+    await constantUpdateOverTime(50)
+
+    expect(cb).toHaveBeenCalledTimes(3)
+    expect(cb.mock.calls[0][0]).toBe(50) // or 51
+    expect(cb.mock.calls[1][0]).toBe(100) // or 101
+    expect(cb.mock.calls[2][0]).toBe(150) // or 151
+  })
 })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

this pr adds minimal reproduction of #3665. Added this test with `it.todo`. Not sure how to fix it yet. Looks like the callback is being called at the right time, but with old values.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
