### PR TITLE
feat: use `useEventListener` where it was not being used

### DIFF
--- a/packages/core/onClickOutside/index.ts
+++ b/packages/core/onClickOutside/index.ts
@@ -51,9 +51,10 @@ export function onClickOutside<T extends OnClickOutsideOptions>(
   // How it works: https://stackoverflow.com/a/39712411
   if (isIOS && !_iOSWorkaround) {
     _iOSWorkaround = true
+    const listenerOptions = { passive: true }
     Array.from(window.document.body.children)
-      .forEach(el => el.addEventListener('click', noop))
-    window.document.documentElement.addEventListener('click', noop)
+      .forEach(el => useEventListener(el, 'click', noop, listenerOptions))
+    useEventListener(window.document.documentElement, 'click', noop, listenerOptions)
   }
 
   let shouldListen = true

--- a/packages/core/useBluetooth/index.md
+++ b/packages/core/useBluetooth/index.md
@@ -47,7 +47,7 @@ This sample illustrates the use of the Web Bluetooth API to read battery level a
 Here, we use the characteristicvaluechanged event listener to handle reading battery level characteristic value. This event listener will optionally handle upcoming notifications as well.
 
 ```ts
-import { pausableWatch, useBluetooth } from '@vueuse/core'
+import { pausableWatch, useBluetooth, useEventListener } from '@vueuse/core'
 
 const {
   isSupported,
@@ -78,9 +78,9 @@ async function getBatteryLevels() {
   )
 
   // Listen to when characteristic value changes on `characteristicvaluechanged` event:
-  batteryLevelCharacteristic.addEventListener('characteristicvaluechanged', (event) => {
+  useEventListener(batteryLevelCharacteristic, 'characteristicvaluechanged', (event) => {
     batteryPercent.value = event.target.value.getUint8(0)
-  })
+  }, { passive: true })
 
   // Convert received buffer to number:
   const batteryLevel = await batteryLevelCharacteristic.readValue()

--- a/packages/core/useBluetooth/index.ts
+++ b/packages/core/useBluetooth/index.ts
@@ -4,6 +4,7 @@ import { tryOnMounted, tryOnScopeDispose } from '@vueuse/shared'
 import { readonly, shallowRef, watch } from 'vue'
 
 import { defaultNavigator } from '../_configurable'
+import { useEventListener } from '../useEventListener'
 import { useSupported } from '../useSupported'
 
 export interface UseBluetoothRequestDeviceOptions {
@@ -102,7 +103,7 @@ export function useBluetooth(options?: UseBluetoothOptions): UseBluetoothReturn 
 
     if (device.value && device.value.gatt) {
       // Add reset fn to gattserverdisconnected event:
-      device.value.addEventListener('gattserverdisconnected', reset)
+      useEventListener(device, 'gattserverdisconnected', reset, { passive: true })
 
       try {
         // Connect to the device:

--- a/packages/core/useBroadcastChannel/index.ts
+++ b/packages/core/useBroadcastChannel/index.ts
@@ -3,6 +3,7 @@ import type { ConfigurableWindow } from '../_configurable'
 import { tryOnMounted, tryOnScopeDispose } from '@vueuse/shared'
 import { ref, shallowRef } from 'vue'
 import { defaultWindow } from '../_configurable'
+import { useEventListener } from '../useEventListener'
 import { useSupported } from '../useSupported'
 
 export interface UseBroadcastChannelOptions extends ConfigurableWindow {
@@ -49,17 +50,21 @@ export function useBroadcastChannel<D, P>(options: UseBroadcastChannelOptions): 
       error.value = null
       channel.value = new BroadcastChannel(name)
 
-      channel.value.addEventListener('message', (e: MessageEvent) => {
+      const listenerOptions = {
+        passive: true,
+      }
+
+      useEventListener(channel, 'message', (e: MessageEvent) => {
         data.value = e.data
-      }, { passive: true })
+      }, listenerOptions)
 
-      channel.value.addEventListener('messageerror', (e: MessageEvent) => {
+      useEventListener(channel, 'messageerror', (e: MessageEvent) => {
         error.value = e
-      }, { passive: true })
+      }, listenerOptions)
 
-      channel.value.addEventListener('close', () => {
+      useEventListener(channel, 'close', () => {
         isClosed.value = true
-      })
+      }, listenerOptions)
     })
   }
 

--- a/packages/core/useDisplayMedia/index.ts
+++ b/packages/core/useDisplayMedia/index.ts
@@ -3,6 +3,7 @@ import type { Ref } from 'vue'
 import type { ConfigurableNavigator } from '../_configurable'
 import { ref, shallowRef, watch } from 'vue'
 import { defaultNavigator } from '../_configurable'
+import { useEventListener } from '../useEventListener'
 import { useSupported } from '../useSupported'
 
 export interface UseDisplayMediaOptions extends ConfigurableNavigator {
@@ -43,7 +44,7 @@ export function useDisplayMedia(options: UseDisplayMediaOptions = {}) {
     if (!isSupported.value || stream.value)
       return
     stream.value = await navigator!.mediaDevices.getDisplayMedia(constraint)
-    stream.value?.getTracks().forEach(t => t.addEventListener('ended', stop))
+    stream.value?.getTracks().forEach(t => useEventListener(t, 'ended', stop, { passive: true }))
     return stream.value
   }
 

--- a/packages/core/useMediaControls/index.ts
+++ b/packages/core/useMediaControls/index.ts
@@ -159,6 +159,8 @@ export function useMediaControls(target: MaybeRef<HTMLMediaElement | null | unde
     document = defaultDocument,
   } = options
 
+  const listenerOptions = { passive: true }
+
   const currentTime = ref(0)
   const duration = ref(0)
   const seeking = ref(false)
@@ -265,7 +267,6 @@ export function useMediaControls(target: MaybeRef<HTMLMediaElement | null | unde
 
     // Clear the sources
     el.querySelectorAll('source').forEach((e) => {
-      e.removeEventListener('error', sourceErrorEvent.trigger)
       e.remove()
     })
 
@@ -277,22 +278,13 @@ export function useMediaControls(target: MaybeRef<HTMLMediaElement | null | unde
       source.setAttribute('type', type || '')
       source.setAttribute('media', media || '')
 
-      source.addEventListener('error', sourceErrorEvent.trigger)
+      useEventListener(source, 'error', sourceErrorEvent.trigger, listenerOptions)
 
       el.appendChild(source)
     })
 
     // Finally, load the new sources.
     el.load()
-  })
-
-  // Remove source error listeners
-  tryOnScopeDispose(() => {
-    const el = toValue(target)
-    if (!el)
-      return
-
-    el.querySelectorAll('source').forEach(e => e.removeEventListener('error', sourceErrorEvent.trigger))
   })
 
   /**
@@ -393,8 +385,6 @@ export function useMediaControls(target: MaybeRef<HTMLMediaElement | null | unde
       el.pause()
     }
   })
-
-  const listenerOptions = { passive: true }
 
   useEventListener(
     target,

--- a/packages/core/useScriptTag/index.ts
+++ b/packages/core/useScriptTag/index.ts
@@ -3,6 +3,7 @@ import type { ConfigurableDocument } from '../_configurable'
 import { noop, tryOnMounted, tryOnUnmounted } from '@vueuse/shared'
 import { ref, toValue } from 'vue'
 import { defaultDocument } from '../_configurable'
+import { useEventListener } from '../useEventListener'
 
 export interface UseScriptTagOptions extends ConfigurableDocument {
   /**
@@ -128,14 +129,17 @@ export function useScriptTag(
     }
 
     // Event listeners
-    el.addEventListener('error', event => reject(event))
-    el.addEventListener('abort', event => reject(event))
-    el.addEventListener('load', () => {
+    const listenerOptions = {
+      passive: true,
+    }
+    useEventListener(el, 'error', event => reject(event), listenerOptions)
+    useEventListener(el, 'abort', event => reject(event), listenerOptions)
+    useEventListener(el, 'load', () => {
       el!.setAttribute('data-loaded', 'true')
 
       onLoaded(el!)
       resolveWithElement(el!)
-    })
+    }, listenerOptions)
 
     // Append the <script> tag to head.
     if (shouldAppend)

--- a/packages/guidelines.md
+++ b/packages/guidelines.md
@@ -50,6 +50,7 @@ Learn more about the implementation: [`_configurable.ts`](https://github.com/vue
 ```ts
 import type { ConfigurableWindow } from '../_configurable'
 import { defaultWindow } from '../_configurable'
+import { useEventListener } from '../useEventListener'
 
 export function useActiveElement<T extends HTMLElement>(
   options: ConfigurableWindow = {},
@@ -63,7 +64,7 @@ export function useActiveElement<T extends HTMLElement>(
 
   // skip when in Node.js environment (SSR)
   if (window) {
-    window.addEventListener('blur', () => {
+    useEventListener(window, 'blur', () => {
       el = window?.document.activeElement
     }, true)
   }

--- a/packages/shared/useDebounceFn/index.md
+++ b/packages/shared/useDebounceFn/index.md
@@ -12,19 +12,19 @@ Debounce execution of a function.
 ## Usage
 
 ```js
-import { useDebounceFn } from '@vueuse/core'
+import { useDebounceFn, useEventListener } from '@vueuse/core'
 
 const debouncedFn = useDebounceFn(() => {
   // do something
 }, 1000)
 
-window.addEventListener('resize', debouncedFn)
+useEventListener(window, 'resize', debouncedFn)
 ```
 
 You can also pass a 3rd parameter to this, with a maximum wait time, similar to [lodash debounce](https://lodash.com/docs/4.17.15#debounce)
 
 ```js
-import { useDebounceFn } from '@vueuse/core'
+import { useDebounceFn, useEventListener } from '@vueuse/core'
 
 // If no invokation after 5000ms due to repeated input,
 // the function will be called anyway.
@@ -32,7 +32,7 @@ const debouncedFn = useDebounceFn(() => {
   // do something
 }, 1000, { maxWait: 5000 })
 
-window.addEventListener('resize', debouncedFn)
+useEventListener(window, 'resize', debouncedFn)
 ```
 
 Optionally, you can get the return value of the function using promise operations.

--- a/packages/shared/useThrottleFn/index.md
+++ b/packages/shared/useThrottleFn/index.md
@@ -18,7 +18,7 @@ const throttledFn = useThrottleFn(() => {
   // do something, it will be called at most 1 time per second
 }, 1000)
 
-window.addEventListener('resize', throttledFn)
+useEventListener(window, 'resize', throttledFn)
 ```
 
 ## Recommended Reading


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

`useEventListener` was not being used in all the contexts. With this PR, we're sure the events are correctly disposed always.

### Additional context

* Some composables have been refactored a little, given `useEventListener` simplifies the cleanup logic
* All references to `àddEventListener` in docs have been updated as well to give the best practices rightaway to users.
* Only 1 usage of ``addEventListener`` has been left untouched because it's been removed in #4481 
