### PR TITLE
fix(useMutationObserver): update target element type to allow usage of useTemplateRef

### DIFF
--- a/packages/core/useMutationObserver/demo.vue
+++ b/packages/core/useMutationObserver/demo.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { useMutationObserver } from '@vueuse/core'
-import { ref } from 'vue'
+import { ref, useTemplateRef } from 'vue'
 
-const el = ref(null)
+const el = useTemplateRef('el')
 const messages = ref<string[]>([])
 const className = ref({})
 const style = ref({})

--- a/packages/core/useMutationObserver/index.md
+++ b/packages/core/useMutationObserver/index.md
@@ -8,26 +8,19 @@ Watch for changes being made to the DOM tree. [MutationObserver MDN](https://dev
 
 ## Usage
 
-```ts
+```vue
+<script setup>
 import { useMutationObserver } from '@vueuse/core'
-import { ref } from 'vue'
+import { useTemplateRef } from 'vue'
 
-export default {
-  setup() {
-    const el = ref(null)
-    const messages = ref([])
+const el = useTemplateRef('el')
+const messages = ref([])
 
-    useMutationObserver(el, (mutations) => {
-      if (mutations[0])
-        messages.value.push(mutations[0].attributeName)
-    }, {
-      attributes: true,
-    })
-
-    return {
-      el,
-      messages,
-    }
-  },
-}
+useMutationObserver(el, (mutations) => {
+  if (mutations[0])
+    messages.value.push(mutations[0].attributeName)
+}, {
+  attributes: true,
+})
+</script>
 ```

--- a/packages/core/useMutationObserver/index.ts
+++ b/packages/core/useMutationObserver/index.ts
@@ -1,4 +1,5 @@
 import type { MaybeRefOrGetter } from '@vueuse/shared'
+import type { ShallowRef } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
 import type { MaybeComputedElementRef, MaybeElement } from '../unrefElement'
 import { notNullish, toArray, tryOnScopeDispose } from '@vueuse/shared'
@@ -19,7 +20,7 @@ export interface UseMutationObserverOptions extends MutationObserverInit, Config
  * @param options
  */
 export function useMutationObserver(
-  target: MaybeComputedElementRef | MaybeComputedElementRef[] | MaybeRefOrGetter<MaybeElement[]>,
+  target: MaybeComputedElementRef | MaybeComputedElementRef[] | MaybeRefOrGetter<MaybeElement[]> | Readonly<ShallowRef<MaybeElement>>,
   callback: MutationCallback,
   options: UseMutationObserverOptions = {},
 ) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

I've added the return Type from [`useTemplateRef`](https://vuejs.org/api/composition-api-helpers.html#usetemplateref) to the type declaration of `useMutationObserver` and updated the docs.

### Additional context

Currently there is a TypeScript issue when using `useTempalteRef` together with `useMutationObserver`, since the return type of `useTemplateRef` is read-only.

```
Argument of type 'Readonly<ShallowRef<HTMLDivElement | null>>' is not assignable to parameter of type 'MaybeComputedElementRef<MaybeElement> | MaybeComputedElementRef<MaybeElement>[] | MaybeRefOrGetter<MaybeElement[]>'.
```
