### PR TITLE
refactor(useDevicePixelRatio): use `useMediaQuery`

### DIFF
--- a/packages/core/useDevicePixelRatio/index.ts
+++ b/packages/core/useDevicePixelRatio/index.ts
@@ -1,6 +1,6 @@
 import type { ConfigurableWindow } from '../_configurable'
 import { noop, watchImmediate } from '@vueuse/shared'
-import { ref } from 'vue'
+import { readonly, ref } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useMediaQuery } from '../useMediaQuery'
 
@@ -22,7 +22,10 @@ export function useDevicePixelRatio(options: ConfigurableWindow = {}) {
     stop = watchImmediate(query, () => pixelRatio.value = window!.devicePixelRatio)
   }
 
-  return { pixelRatio, stop }
+  return {
+    pixelRatio: readonly(pixelRatio),
+    stop,
+  }
 }
 
 export type UseDevicePixelRatioReturn = ReturnType<typeof useDevicePixelRatio>

--- a/packages/core/useDevicePixelRatio/index.ts
+++ b/packages/core/useDevicePixelRatio/index.ts
@@ -1,7 +1,8 @@
 import type { ConfigurableWindow } from '../_configurable'
-import { tryOnScopeDispose } from '@vueuse/shared'
+import { noop, watchImmediate } from '@vueuse/shared'
 import { ref } from 'vue'
 import { defaultWindow } from '../_configurable'
+import { useMediaQuery } from '../useMediaQuery'
 
 /**
  * Reactively track `window.devicePixelRatio`.
@@ -14,24 +15,14 @@ export function useDevicePixelRatio(options: ConfigurableWindow = {}) {
   } = options
 
   const pixelRatio = ref(1)
+  const query = useMediaQuery(() => `(resolution: ${pixelRatio.value}dppx)`, options)
+  let stop = noop
 
   if (window) {
-    let media: MediaQueryList
-    function observe() {
-      pixelRatio.value = window!.devicePixelRatio
-      cleanup()
-      media = window!.matchMedia(`(resolution: ${pixelRatio.value}dppx)`)
-      media.addEventListener('change', observe, { once: true })
-    }
-    function cleanup() {
-      media?.removeEventListener('change', observe)
-    }
-
-    observe()
-    tryOnScopeDispose(cleanup)
+    stop = watchImmediate(query, () => pixelRatio.value = window!.devicePixelRatio)
   }
 
-  return { pixelRatio }
+  return { pixelRatio, stop }
 }
 
 export type UseDevicePixelRatioReturn = ReturnType<typeof useDevicePixelRatio>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Use the `useMediaQuery` composable inside `useDevicePixelRatio` to greatly simplify the logic.

### Additional context

* The returned object from the composable has been changed. Does this qualify as a breaking change? Given a new property was added (not removed/modified) I believe it's good to go in a minor release.
* Related to https://github.com/vueuse/vueuse/pull/4479
