### PR TITLE
refactor: use `useTemplateRef` instead of `ref` in demos and docs

### DIFF
--- a/packages/core/useAnimate/demo.vue
+++ b/packages/core/useAnimate/demo.vue
@@ -2,9 +2,9 @@
 import type { MaybeElement } from '@vueuse/core'
 import { useAnimate } from '@vueuse/core'
 import { stringify } from '@vueuse/docs-utils'
-import { reactive, shallowRef } from 'vue'
+import { reactive, useTemplateRef } from 'vue'
 
-const el = shallowRef<MaybeElement>()
+const el = useTemplateRef<MaybeElement>('el')
 
 const {
   play,

--- a/packages/core/useAnimate/index.md
+++ b/packages/core/useAnimate/index.md
@@ -15,9 +15,9 @@ The `useAnimate` function will return the animate and its control function.
 ```vue
 <script setup>
 import { useAnimate } from '@vueuse/core'
-import { ref } from 'vue'
+import { useTemplateRef } from 'vue'
 
-const el = ref()
+const el = useTemplateRef('el')
 const {
   isSupported,
   animate,

--- a/packages/core/useCssVar/demo.vue
+++ b/packages/core/useCssVar/demo.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { useCssVar } from '@vueuse/core'
-import { ref } from 'vue'
+import { ref, useTemplateRef } from 'vue'
 
-const el = ref(null)
+const el = useTemplateRef('el')
 const color = useCssVar('--color', el)
 
 function switchColor() {
@@ -12,7 +12,7 @@ function switchColor() {
     color.value = '#df8543'
 }
 
-const elv = ref(null)
+const elv = useTemplateRef('elv')
 const key = ref('--color')
 const colorVal = useCssVar(key, elv)
 function changeVar() {

--- a/packages/core/useCssVar/index.md
+++ b/packages/core/useCssVar/index.md
@@ -9,15 +9,16 @@ Manipulate CSS variables
 ## Usage
 
 ```js
+import { useTemplateRef } from 'vue'
 import { useCssVar } from '@vueuse/core'
 
-const el = ref(null)
+const el = useTemplateRef('el')
 const color1 = useCssVar('--color', el)
 
-const elv = ref(null)
+const elv = useTemplateRef('elv')
 const key = ref('--color')
 const colorVal = useCssVar(key, elv)
 
-const someEl = ref(null)
+const someEl = useTemplateRef('someEl')
 const color2 = useCssVar('--color', someEl, { initialValue: '#eee' })
 ```

--- a/packages/core/useDraggable/demo.vue
+++ b/packages/core/useDraggable/demo.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import { useDraggable } from '@vueuse/core'
 import { isClient } from '@vueuse/shared'
-import { ref } from 'vue'
+import { ref, useTemplateRef } from 'vue'
 import { UseDraggable as Draggable } from './component'
 
-const el = ref<HTMLElement | null>(null)
-const handle = ref<HTMLElement | null>(null)
+const el = useTemplateRef<HTMLElement>('el')
+const handle = useTemplateRef<HTMLElement>('handle')
 
 const innerWidth = isClient ? window.innerWidth : 200
 

--- a/packages/core/useDraggable/index.md
+++ b/packages/core/useDraggable/index.md
@@ -11,9 +11,9 @@ Make elements draggable.
 ```vue
 <script setup lang="ts">
 import { useDraggable } from '@vueuse/core'
-import { ref } from 'vue'
+import { useTemplateRef } from 'vue'
 
-const el = ref<HTMLElement | null>(null)
+const el = useTemplateRef<HTMLElement>('el')
 
 // `style` will be a helper computed for `left: ?px; top: ?px;`
 const { x, y, style } = useDraggable(el, {

--- a/packages/core/useElementBounding/demo.vue
+++ b/packages/core/useElementBounding/demo.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { useElementBounding } from '@vueuse/core'
 import { stringify } from '@vueuse/docs-utils'
-import { reactive, ref } from 'vue'
+import { reactive, useTemplateRef } from 'vue'
 
-const el = ref(null)
+const el = useTemplateRef('el')
 const rect = reactive(useElementBounding(el))
 const text = stringify(rect)
 </script>

--- a/packages/core/useElementBounding/index.md
+++ b/packages/core/useElementBounding/index.md
@@ -11,11 +11,11 @@ Reactive [bounding box](https://developer.mozilla.org/en-US/docs/Web/API/Element
 ```vue
 <script>
 import { useElementBounding } from '@vueuse/core'
-import { ref } from 'vue'
+import { useTemplateRef } from 'vue'
 
 export default {
   setup() {
-    const el = ref(null)
+    const el = useTemplateRef('el')
     const { x, y, top, right, bottom, left, width, height }
         = useElementBounding(el)
 

--- a/packages/core/useElementHover/demo.vue
+++ b/packages/core/useElementHover/demo.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { useElementHover } from '@vueuse/core'
-import { ref } from 'vue'
+import { ref, useTemplateRef } from 'vue'
 import { vElementHover } from './directive'
 
-const el = ref<HTMLButtonElement>()
+const el = useTemplateRef<HTMLButtonElement>('el')
 const isDirectiveHovered = ref(false)
 const isHovered = useElementHover(el, { delayEnter: 200, delayLeave: 600 })
 function onHover(hovered: boolean) {

--- a/packages/core/useElementSize/demo.vue
+++ b/packages/core/useElementSize/demo.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { useElementSize } from '@vueuse/core'
 import { stringify } from '@vueuse/docs-utils'
-import { reactive, ref } from 'vue'
+import { reactive, useTemplateRef } from 'vue'
 
-const el = ref(null)
+const el = useTemplateRef('el')
 const size = reactive(
   useElementSize(
     el,

--- a/packages/core/useElementSize/index.md
+++ b/packages/core/useElementSize/index.md
@@ -11,11 +11,11 @@ Reactive size of an HTML element. [ResizeObserver MDN](https://developer.mozilla
 ```vue
 <script>
 import { useElementSize } from '@vueuse/core'
-import { ref } from 'vue'
+import { useTemplateRef } from 'vue'
 
 export default {
   setup() {
-    const el = ref(null)
+    const el = useTemplateRef('el')
     const { width, height } = useElementSize(el)
 
     return {

--- a/packages/core/useElementVisibility/demo.vue
+++ b/packages/core/useElementVisibility/demo.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { useElementVisibility } from '@vueuse/core'
-import { ref } from 'vue'
+import { useTemplateRef } from 'vue'
 
-const el = ref(null)
+const el = useTemplateRef('el')
 const isVisible = useElementVisibility(el)
 </script>
 

--- a/packages/core/useEventListener/index.md
+++ b/packages/core/useEventListener/index.md
@@ -20,8 +20,9 @@ You can also pass a ref as the event target, `useEventListener` will unregister 
 
 ```ts
 import { useEventListener } from '@vueuse/core'
+import { useTemplateRef } from 'vue'
 
-const element = ref<HTMLDivElement>()
+const element = useTemplateRef<HTMLDivElement>('element')
 useEventListener(element, 'keydown', (e) => {
   console.log(e.key)
 })

--- a/packages/core/useFullscreen/demo.vue
+++ b/packages/core/useFullscreen/demo.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { useFullscreen } from '@vueuse/core'
-import { ref } from 'vue'
+import { useTemplateRef } from 'vue'
 
-const el = ref(null)
+const el = useTemplateRef('el')
 const { toggle } = useFullscreen(el)
 </script>
 

--- a/packages/core/useFullscreen/index.md
+++ b/packages/core/useFullscreen/index.md
@@ -10,6 +10,7 @@ Reactive [Fullscreen API](https://developer.mozilla.org/en-US/docs/Web/API/Fulls
 
 ```js
 import { useFullscreen } from '@vueuse/core'
+import { useTemplateRef } from 'vue'
 
 const { isFullscreen, enter, exit, toggle } = useFullscreen()
 ```
@@ -17,7 +18,7 @@ const { isFullscreen, enter, exit, toggle } = useFullscreen()
 Fullscreen specified element. Some platforms (like iOS's Safari) only allow fullscreen on video elements.
 
 ```ts
-const el = ref<HTMLElement | null>(null)
+const el = useTemplateRef<HTMLElement>('el')
 
 const { isFullscreen, enter, exit, toggle } = useFullscreen(el)
 ```

--- a/packages/core/useInfiniteScroll/demo.vue
+++ b/packages/core/useInfiniteScroll/demo.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { useInfiniteScroll } from '@vueuse/core'
-import { ref } from 'vue'
+import { ref, useTemplateRef } from 'vue'
 
-const el = ref<HTMLElement | null>(null)
+const el = useTemplateRef<HTMLElement>('el')
 const data = ref<number[]>([])
 
 const { reset } = useInfiniteScroll(

--- a/packages/core/useInfiniteScroll/index.md
+++ b/packages/core/useInfiniteScroll/index.md
@@ -11,9 +11,9 @@ Infinite scrolling of the element.
 ```vue
 <script setup lang="ts">
 import { useInfiniteScroll } from '@vueuse/core'
-import { ref } from 'vue'
+import { ref, useTemplateRef } from 'vue'
 
-const el = ref<HTMLElement | null>(null)
+const el = useTemplateRef<HTMLElement>('el')
 const data = ref([1, 2, 3, 4, 5, 6])
 
 const { reset } = useInfiniteScroll(

--- a/packages/core/useMousePressed/demo.vue
+++ b/packages/core/useMousePressed/demo.vue
@@ -2,9 +2,9 @@
 import { useMousePressed } from '@vueuse/core'
 import { stringify } from '@vueuse/docs-utils'
 import { useToggle } from '@vueuse/shared'
-import { computed, reactive, ref } from 'vue'
+import { computed, reactive, useTemplateRef } from 'vue'
 
-const el = ref<HTMLElement | null>()
+const el = useTemplateRef<HTMLElement>('el')
 const [withTarget, toggle] = useToggle()
 const target = computed<HTMLElement | null>(() =>
   (withTarget.value ? el.value : window) as HTMLElement)

--- a/packages/core/useMousePressed/index.md
+++ b/packages/core/useMousePressed/index.md
@@ -24,7 +24,9 @@ To only capture `mousedown` and `touchstart` on specific element, you can specif
 
 ```vue
 <script setup>
-const el = ref(null)
+import { useTemplateRef } from 'vue'
+
+const el = useTemplateRef('el')
 
 const { pressed } = useMousePressed({ target: el })
 </script>

--- a/packages/core/useMutationObserver/index.md
+++ b/packages/core/useMutationObserver/index.md
@@ -10,11 +10,11 @@ Watch for changes being made to the DOM tree. [MutationObserver MDN](https://dev
 
 ```ts
 import { useMutationObserver } from '@vueuse/core'
-import { ref } from 'vue'
+import { ref, useTemplateRef } from 'vue'
 
 export default {
   setup() {
-    const el = ref(null)
+    const el = useTemplateRef('el')
     const messages = ref([])
 
     useMutationObserver(el, (mutations) => {

--- a/packages/core/usePointerSwipe/index.md
+++ b/packages/core/usePointerSwipe/index.md
@@ -11,9 +11,9 @@ Reactive swipe detection based on [PointerEvents](https://developer.mozilla.org/
 ```vue
 <script setup>
 import { usePointerSwipe } from '@vueuse/core'
-import { ref } from 'vue'
+import { useTemplateRef } from 'vue'
 
-const el = ref(null)
+const el = useTemplateRef('el')
 const { isSwiping, direction } = usePointerSwipe(el)
 </script>
 

--- a/packages/core/useResizeObserver/demo.vue
+++ b/packages/core/useResizeObserver/demo.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { useResizeObserver } from '@vueuse/core'
-import { ref } from 'vue'
+import { ref, useTemplateRef } from 'vue'
 
-const el = ref(null)
+const el = useTemplateRef('el')
 const text = ref('')
 
 useResizeObserver(el, (entries) => {

--- a/packages/core/useResizeObserver/index.md
+++ b/packages/core/useResizeObserver/index.md
@@ -11,9 +11,9 @@ Reports changes to the dimensions of an Element's content or the border-box
 ```vue
 <script setup>
 import { useResizeObserver } from '@vueuse/core'
-import { ref } from 'vue'
+import { ref, useTemplateRef } from 'vue'
 
-const el = ref(null)
+const el = useTemplateRef('el')
 const text = ref('')
 
 useResizeObserver(el, (entries) => {

--- a/packages/core/useScroll/demo.vue
+++ b/packages/core/useScroll/demo.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { useScroll } from '@vueuse/core'
-import { computed, ref, toRefs } from 'vue'
+import { computed, ref, toRefs, useTemplateRef } from 'vue'
 
-const el = ref<HTMLElement | null>(null)
+const el = useTemplateRef<HTMLElement>('el')
 const smooth = ref(false)
 const behavior = computed(() => smooth.value ? 'smooth' : 'auto')
 const { x, y, isScrolling, arrivedState, directions } = useScroll(el, { behavior })

--- a/packages/core/useScroll/index.md
+++ b/packages/core/useScroll/index.md
@@ -11,8 +11,9 @@ Reactive scroll position and state.
 ```vue
 <script setup lang="ts">
 import { useScroll } from '@vueuse/core'
+import { useTemplateRef } from 'vue'
 
-const el = ref<HTMLElement | null>(null)
+const el = useTemplateRef<HTMLElement>('el')
 const { x, y, isScrolling, arrivedState, directions } = useScroll(el)
 </script>
 
@@ -36,8 +37,9 @@ Set the `x` and `y` values to make the element scroll to that position.
 ```vue
 <script setup lang="ts">
 import { useScroll } from '@vueuse/core'
+import { useTemplateRef } from 'vue'
 
-const el = ref<HTMLElement | null>(null)
+const el = useTemplateRef<HTMLElement>('el')
 const { x, y } = useScroll(el)
 </script>
 
@@ -58,8 +60,9 @@ Set `behavior: smooth` to enable smooth scrolling. The `behavior` option default
 
 ```ts
 import { useScroll } from '@vueuse/core'
+import { useTemplateRef } from 'vue'
 
-const el = ref<HTMLElement | null>(null)
+const el = useTemplateRef<HTMLElement>('el')
 const { x, y } = useScroll(el, { behavior: 'smooth' })
 
 // Or as a `ref`:

--- a/packages/core/useScrollLock/demo.vue
+++ b/packages/core/useScrollLock/demo.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { useScroll, useScrollLock } from '@vueuse/core'
 import { useToggle } from '@vueuse/shared'
-import { ref } from 'vue'
+import { useTemplateRef } from 'vue'
 
-const el = ref<HTMLElement | null>(null)
+const el = useTemplateRef<HTMLElement>('el')
 useScroll(el)
 const isLocked = useScrollLock(el)
 const toggleLock = useToggle(isLocked)

--- a/packages/core/useScrollLock/index.md
+++ b/packages/core/useScrollLock/index.md
@@ -11,8 +11,9 @@ Lock scrolling of the element.
 ```vue
 <script setup lang="ts">
 import { useScrollLock } from '@vueuse/core'
+import { useTemplateRef } from 'vue'
 
-const el = ref<HTMLElement | null>(null)
+const el = useTemplateRef<HTMLElement>('el')
 const isLocked = useScrollLock(el)
 
 isLocked.value = true // lock

--- a/packages/core/useSwipe/index.md
+++ b/packages/core/useSwipe/index.md
@@ -10,7 +10,9 @@ Reactive swipe detection based on [`TouchEvents`](https://developer.mozilla.org/
 
 ```vue
 <script setup>
-const el = ref(null)
+import { useTemplateRef } from 'vue'
+
+const el = useTemplateRef('el')
 const { isSwiping, direction } = useSwipe(el)
 </script>
 

--- a/packages/guide/components.md
+++ b/packages/guide/components.md
@@ -15,9 +15,9 @@ For example of `onClickOutside`, instead of binding the component ref for functi
 ```vue
 <script setup>
 import { onClickOutside } from '@vueuse/core'
-import { ref } from 'vue'
+import { useTemplateRef } from 'vue'
 
-const el = ref()
+const el = useTemplateRef('el')
 
 function close() {
   /* ... */

--- a/packages/integrations/useSortable/demo.vue
+++ b/packages/integrations/useSortable/demo.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, useTemplateRef } from 'vue'
 import { useSortable } from '.'
 
-const el = ref<HTMLElement | null>(null)
+const el = useTemplateRef<HTMLElement>('el')
 const list = ref([{ id: 1, name: 'a' }, { id: 2, name: 'b' }, { id: 3, name: 'c' }])
 
 const { option } = useSortable(el, list, {

--- a/packages/integrations/useSortable/index.md
+++ b/packages/integrations/useSortable/index.md
@@ -25,9 +25,9 @@ npm i sortablejs@^1
 ```vue
 <script setup lang="ts">
 import { useSortable } from '@vueuse/integrations/useSortable'
-import { ref } from 'vue'
+import { ref, useTemplateRef } from 'vue'
 
-const el = ref<HTMLElement | null>(null)
+const el = useTemplateRef<HTMLElement>('el')
 const list = ref([{ id: 1, name: 'a' }, { id: 2, name: 'b' }, { id: 3, name: 'c' }])
 
 useSortable(el, list)
@@ -47,9 +47,9 @@ useSortable(el, list)
 ```vue
 <script setup lang="ts">
 import { useSortable } from '@vueuse/integrations/useSortable'
-import { ref } from 'vue'
+import { ref, useTemplateRef } from 'vue'
 
-const el = ref<HTMLElement | null>(null)
+const el = useTemplateRef<HTMLElement>('el')
 const list = ref([{ id: 1, name: 'a' }, { id: 2, name: 'b' }, { id: 3, name: 'c' }])
 
 const animation = 200


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Based on #4467 and #4480, I have replaced all instances of `const el = ref()` with `const el = useTemplateRef('el')`.
