### PR TITLE
feat: more passive event handlers

### DIFF
--- a/packages/.vitepress/theme/components/FunctionsList.vue
+++ b/packages/.vitepress/theme/components/FunctionsList.vue
@@ -12,7 +12,7 @@ useEventListener('click', (e) => {
   // @ts-expect-error cast
   if (e.target.tagName === 'A')
     window.dispatchEvent(new Event('hashchange'))
-})
+}, { passive: true })
 
 const isMounted = useMounted()
 

--- a/packages/core/useAnimate/index.ts
+++ b/packages/core/useAnimate/index.ts
@@ -266,12 +266,12 @@ export function useAnimate(
     onReady?.(animate.value)
   }
 
-  useEventListener(animate, ['cancel', 'finish', 'remove'], syncPause)
-
+  const listenerOptions = { passive: true }
+  useEventListener(animate, ['cancel', 'finish', 'remove'], syncPause, listenerOptions)
   useEventListener(animate, 'finish', () => {
     if (commitStyles)
       animate.value?.commitStyles()
-  })
+  }, listenerOptions)
 
   const { resume: resumeRef, pause: pauseRef } = useRafFn(() => {
     if (!animate.value)

--- a/packages/core/useBrowserLocation/index.ts
+++ b/packages/core/useBrowserLocation/index.ts
@@ -71,8 +71,9 @@ export function useBrowserLocation(options: ConfigurableWindow = {}) {
   const state = ref(buildState('load'))
 
   if (window) {
-    useEventListener(window, 'popstate', () => state.value = buildState('popstate'), { passive: true })
-    useEventListener(window, 'hashchange', () => state.value = buildState('hashchange'), { passive: true })
+    const listenerOptions = { passive: true }
+    useEventListener(window, 'popstate', () => state.value = buildState('popstate'), listenerOptions)
+    useEventListener(window, 'hashchange', () => state.value = buildState('hashchange'), listenerOptions)
   }
 
   return state

--- a/packages/core/useElementByPoint/demo.vue
+++ b/packages/core/useElementByPoint/demo.vue
@@ -6,7 +6,7 @@ const { x, y } = useMouse({ type: 'client' })
 const { element } = useElementByPoint({ x, y })
 const bounding = reactive(useElementBounding(element))
 
-useEventListener('scroll', bounding.update, true)
+useEventListener('scroll', bounding.update, { passive: true, capture: true })
 
 const boxStyles = computed(() => {
   if (element.value) {

--- a/packages/core/useEventSource/index.ts
+++ b/packages/core/useEventSource/index.ts
@@ -191,7 +191,7 @@ export function useEventSource<Events extends string[]>(
       useEventListener(es, event_name, (e: Event & { data?: string }) => {
         event.value = event_name
         data.value = e.data || null
-      })
+      }, { passive: true })
     }
   }
 

--- a/packages/core/useKeyModifier/index.ts
+++ b/packages/core/useKeyModifier/index.ts
@@ -41,7 +41,7 @@ export function useKeyModifier<Initial extends boolean | null>(modifier: KeyModi
       useEventListener(document, listenerEvent, (evt: KeyboardEvent | MouseEvent) => {
         if (typeof evt.getModifierState === 'function')
           state.value = evt.getModifierState(modifier)
-      })
+      }, { passive: true })
     })
   }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Follow-up of #4477. I forgot some `useEventListener` in some composables because, at a first glance while I was working with all the other composables, I thought they were not using native DOM elements but custom events (hence passive being useless). I also missed some components from the demo and docs.

Sorry for the hassle! 😅 I re-reviewed twice to verify all the usages were properly (and correctly covered) when relevant!

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
