### PR TITLE
test(core): suppress some output in test runs

### DIFF
--- a/packages/integrations/useAsyncValidator/index.test.ts
+++ b/packages/integrations/useAsyncValidator/index.test.ts
@@ -291,7 +291,10 @@ describe('set manual true', () => {
       },
     }) as Ref<Rules>
 
-    const { execute, pass, errors } = useAsyncValidator(form, rules, { manual: true })
+    const { execute, pass, errors } = useAsyncValidator(form, rules, {
+      manual: true,
+      validateOption: { suppressWarning: true },
+    })
 
     expect(pass.value).toBe(true)
     expect(errors.value).toMatchObject([])

--- a/packages/rxjs/watchExtractedObservable/index.test.ts
+++ b/packages/rxjs/watchExtractedObservable/index.test.ts
@@ -30,7 +30,7 @@ describe('watchExtractedObservable', () => {
       numRef = ref<number>()
       obj = computed(() => typeof numRef.value == 'number' ? new TestWrapper(numRef.value) : null)
       extractor = vi.fn().mockImplementation((wrapper: TestWrapper) => wrapper.obs$)
-      callback = vi.fn().mockImplementation((num: number) => console.log(num))
+      callback = vi.fn()
     })
 
     it('calls neither the extractor nor the callback if the provided ref is nullish', () => {

--- a/packages/shared/utils/index.test.ts
+++ b/packages/shared/utils/index.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest'
 import { ref } from 'vue'
 import { assert, clamp, createFilterWrapper, createSingletonPromise, debounceFilter, hasOwn, increaseWithUnit, isClient, isDef, isIOS, isObject, noop, now, objectOmit, objectPick, promiseTimeout, rand, throttleFilter, timestamp } from '.'
 
@@ -260,8 +260,14 @@ describe('filters', () => {
 })
 
 describe('is', () => {
+  let warnSpy: MockInstance
+
   beforeEach(() => {
-    console.warn = vi.fn()
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   it('should be client', () => {
@@ -274,9 +280,9 @@ describe('is', () => {
 
   it('should assert', () => {
     assert(true)
-    expect(console.warn).not.toBeCalled()
+    expect(warnSpy).not.toBeCalled()
     assert(false, 'error')
-    expect(console.warn).toHaveBeenCalledWith('error')
+    expect(warnSpy).toHaveBeenCalledWith('error')
   })
 
   it('should be defined', () => {
@@ -306,9 +312,9 @@ describe('is', () => {
     expect(noop()).toBeUndefined()
   })
 
-  it('should be rand', () => {
+  it('should be rand', { retry: 20 }, () => {
     expect(rand(1, 2)).not.toBe(rand(1, 2))
-  }, { retry: 20 })
+  })
 
   it('hasOwn', () => {
     class Parent {a = 1}


### PR DESCRIPTION
Three things in tests:

- Very minor, but a couple of tests were logging out to `stdout`. This simply changes them to no longer do so.
- Stubs out `console.warn` through `vi.spyOn` rather than an assignment. This allows `vi.restoreAllMocks()` to restore it later
- Passes a vitest options as 2nd arg in `it`. passing it as the third arg is deprecated and will stop working at some point

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
