### PR TITLE
feat(useClipboard): should fall back to legacy clipboard when read/write fails

### DIFF
--- a/packages/core/useClipboard/index.browser.test.ts
+++ b/packages/core/useClipboard/index.browser.test.ts
@@ -1,0 +1,31 @@
+import { useClipboard, usePermission } from '@vueuse/core'
+import { describe, expect, it } from 'vitest'
+
+describe('useClipboard', () => {
+  it('should be be supported', () => {
+    const { isSupported } = useClipboard()
+    expect(isSupported.value).toBe(true)
+  })
+
+  describe('without permissions', () => {
+    it('should write to legacy clipboard', async () => {
+      const writePermission = usePermission('clipboard-write')
+      expect(writePermission.value).toBe(undefined) // currently no permissions testing legacy fallback
+      const { text, copy, copied } = useClipboard()
+      expect(text.value).toBe('')
+      expect(copied.value).toBe(false)
+      await copy('hello')
+      expect(text.value).toBe('hello')
+      expect(copied.value).toBe(true)
+    })
+    it.todo('should read from legacy clipboard')
+  })
+
+  describe('with permissions', () => {
+    // todo: mock navigator permissions
+    it.todo('should write to clipboard')
+    it.todo('should read from clipboard')
+    it.todo('should fall back to legacy clipboard if write fails')
+    it.todo('should fall back to legacy clipboard if read fails')
+  })
+})

--- a/packages/core/useClipboard/index.test.ts
+++ b/packages/core/useClipboard/index.test.ts
@@ -5,9 +5,4 @@ describe('useClipboard', () => {
   it('should be defined', () => {
     expect(useClipboard).toBeDefined()
   })
-
-  it('should be supported', () => {
-    const { isSupported } = useClipboard()
-    expect(isSupported.value).toBe(true)
-  })
 })

--- a/packages/core/useClipboard/index.test.ts
+++ b/packages/core/useClipboard/index.test.ts
@@ -1,0 +1,13 @@
+import { useClipboard } from '@vueuse/core'
+import { describe, expect, it } from 'vitest'
+
+describe('useClipboard', () => {
+  it('should be defined', () => {
+    expect(useClipboard).toBeDefined()
+  })
+
+  it('should be supported', () => {
+    const { isSupported } = useClipboard()
+    expect(isSupported.value).toBe(true)
+  })
+})


### PR DESCRIPTION
fixes https://github.com/vueuse/vueuse/issues/3813

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

This PR ensures that `useClipboard` falls back to legacy if the read or write fails.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

Tests are not fully developed. Waiting for #1259 

<!-- e.g. is there anything you'd like reviewers to focus on? -->
