### PR TITLE
perf(useTimeoutPoll): update type declarations

### DIFF
--- a/packages/core/useTimeoutPoll/index.ts
+++ b/packages/core/useTimeoutPoll/index.ts
@@ -1,11 +1,20 @@
-import type { Awaitable, MaybeRefOrGetter, Pausable, UseTimeoutFnOptions } from '@vueuse/shared'
+import type { Awaitable, MaybeRefOrGetter, Pausable } from '@vueuse/shared'
 import { isClient, tryOnScopeDispose, useTimeoutFn } from '@vueuse/shared'
 import { ref } from 'vue'
+
+export interface UseTimeoutPollOptions {
+  /**
+   * When set to true, the first poll will be triggered immediately and start the timer
+   *
+   * @default true
+   */
+  immediate?: boolean
+}
 
 export function useTimeoutPoll(
   fn: () => Awaitable<void>,
   interval: MaybeRefOrGetter<number>,
-  options: UseTimeoutFnOptions = {},
+  options: UseTimeoutPollOptions = {},
 ): Pausable {
   const {
     immediate = true,

--- a/packages/core/useTimeoutPoll/index.ts
+++ b/packages/core/useTimeoutPoll/index.ts
@@ -4,7 +4,7 @@ import { ref } from 'vue'
 
 export interface UseTimeoutPollOptions {
   /**
-   * When set to true, the first poll will be triggered immediately and start the timer
+   * Triggers the first poll immediate and start the timer
    *
    * @default true
    */


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR updates the `type declarations` here. Originally using the `UseTimeoutFnOptions` interface, but due to different trigger timing when `immediate: true`, to avoid confusion, added `UseTimeoutPollOptions` and included `description` for `immediate: true` behavior.

<img width="728" alt="截圖 2025-01-24 下午6 34 01" src="https://github.com/user-attachments/assets/456a5418-f9c0-4c51-888e-a428c199e47e" />