### PR TITLE
feat(createReusableTemplate): explicit props

### DIFF
--- a/packages/core/createReusableTemplate/index.md
+++ b/packages/core/createReusableTemplate/index.md
@@ -181,6 +181,31 @@ const TemplateFoo = createReusableTemplate<{ msg: string }>()
 Passing boolean props without `v-bind` is not supported. See the [Caveats](#boolean-props) section for more details.
 :::
 
+### Props and Attributes
+
+By default, all props and attributes passed to `<ReuseTemplate>` will be passed to the template. If you don't want certain props to be passed to the DOM, you need to define the runtime props:
+
+```ts
+import { createReusableTemplate } from '@vueuse/core'
+
+const [DefineTemplate, ReuseTemplate] = createReusableTemplate({
+  props: {
+    msg: String,
+    enable: Boolean,
+  }
+})
+```
+
+If you don't want to pass any props to the template, you can pass the `inheritAttrs` option:
+
+```ts
+import { createReusableTemplate } from '@vueuse/core'
+
+const [DefineTemplate, ReuseTemplate] = createReusableTemplate({
+  inheritAttrs: false,
+})
+```
+
 ### Passing Slots
 
 It's also possible to pass slots back from `<ReuseTemplate>`. You can access the slots on `<DefineTemplate>` from `$slots`:


### PR DESCRIPTION
Before this PR, `createReusableTemplate` always treated all props as attributes and made the props appear on the DOM. In some cases, it might not be desired. This PR allows explicit provide the props to prevent those props to be leaking on the DOM.