### PR TITLE
chore: upgrade playwright

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,8 +172,8 @@ catalogs:
       specifier: ^1.4.1
       version: 1.4.1
     playwright:
-      specifier: ^1.49.1
-      version: 1.49.1
+      specifier: ^1.50.0
+      version: 1.50.0
     pnpm:
       specifier: ^9.15.3
       version: 9.15.3
@@ -329,7 +329,7 @@ importers:
         version: 5.2.1(vite@6.0.7(@types/node@22.10.5)(jiti@2.4.2)(terser@5.24.0)(tsx@4.19.2)(yaml@2.6.1))(vue@3.5.13(typescript@5.7.3))
       '@vitest/browser':
         specifier: 'catalog:'
-        version: 3.0.1(@types/node@22.10.5)(playwright@1.49.1)(typescript@5.7.3)(vite@6.0.7(@types/node@22.10.5)(jiti@2.4.2)(terser@5.24.0)(tsx@4.19.2)(yaml@2.6.1))(vitest@3.0.1)
+        version: 3.0.1(@types/node@22.10.5)(playwright@1.50.0)(typescript@5.7.3)(vite@6.0.7(@types/node@22.10.5)(jiti@2.4.2)(terser@5.24.0)(tsx@4.19.2)(yaml@2.6.1))(vitest@3.0.1)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 3.0.1(@vitest/browser@3.0.1)(vitest@3.0.1)
@@ -428,7 +428,7 @@ importers:
         version: 1.4.1
       playwright:
         specifier: 'catalog:'
-        version: 1.49.1
+        version: 1.50.0
       pnpm:
         specifier: 'catalog:'
         version: 9.15.3
@@ -6255,13 +6255,13 @@ packages:
   pkg-types@1.3.0:
     resolution: {integrity: sha512-kS7yWjVFCkIw9hqdJBoMxDdzEngmkr5FXeWZZfQ6GoYacjVnsW6l2CcYW/0ThD0vF4LPJgVYnrg4d0uuhwYQbg==}
 
-  playwright-core@1.49.1:
-    resolution: {integrity: sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==}
+  playwright-core@1.50.0:
+    resolution: {integrity: sha512-CXkSSlr4JaZs2tZHI40DsZUN/NIwgaUPsyLuOAaIZp2CyF2sN5MM5NJsyB188lFSSozFxQ5fPT4qM+f0tH/6wQ==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.49.1:
-    resolution: {integrity: sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==}
+  playwright@1.50.0:
+    resolution: {integrity: sha512-+GinGfGTrd2IfX1TA4N2gNmeIksSb+IAe589ZH+FlmpV3MYTx6+buChGIuDLQwrGNCw2lWibqV50fU510N7S+w==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -11037,7 +11037,7 @@ snapshots:
       vite: 6.0.7(@types/node@22.10.5)(jiti@2.4.2)(terser@5.24.0)(tsx@4.19.2)(yaml@2.6.1)
       vue: 3.5.13(typescript@5.7.3)
 
-  '@vitest/browser@3.0.1(@types/node@22.10.5)(playwright@1.49.1)(typescript@5.7.3)(vite@6.0.7(@types/node@22.10.5)(jiti@2.4.2)(terser@5.24.0)(tsx@4.19.2)(yaml@2.6.1))(vitest@3.0.1)':
+  '@vitest/browser@3.0.1(@types/node@22.10.5)(playwright@1.50.0)(typescript@5.7.3)(vite@6.0.7(@types/node@22.10.5)(jiti@2.4.2)(terser@5.24.0)(tsx@4.19.2)(yaml@2.6.1))(vitest@3.0.1)':
     dependencies:
       '@testing-library/dom': 10.4.0
       '@testing-library/user-event': 14.6.0(@testing-library/dom@10.4.0)
@@ -11050,7 +11050,7 @@ snapshots:
       vitest: 3.0.1(@types/node@22.10.5)(@vitest/browser@3.0.1)(@vitest/ui@3.0.1)(jiti@2.4.2)(jsdom@26.0.0)(msw@2.3.0(typescript@5.7.3))(terser@5.24.0)(tsx@4.19.2)(yaml@2.6.1)
       ws: 8.18.0
     optionalDependencies:
-      playwright: 1.49.1
+      playwright: 1.50.0
     transitivePeerDependencies:
       - '@types/node'
       - bufferutil
@@ -11074,7 +11074,7 @@ snapshots:
       tinyrainbow: 2.0.0
       vitest: 3.0.1(@types/node@22.10.5)(@vitest/browser@3.0.1)(@vitest/ui@3.0.1)(jiti@2.4.2)(jsdom@26.0.0)(msw@2.3.0(typescript@5.7.3))(terser@5.24.0)(tsx@4.19.2)(yaml@2.6.1)
     optionalDependencies:
-      '@vitest/browser': 3.0.1(@types/node@22.10.5)(playwright@1.49.1)(typescript@5.7.3)(vite@6.0.7(@types/node@22.10.5)(jiti@2.4.2)(terser@5.24.0)(tsx@4.19.2)(yaml@2.6.1))(vitest@3.0.1)
+      '@vitest/browser': 3.0.1(@types/node@22.10.5)(playwright@1.50.0)(typescript@5.7.3)(vite@6.0.7(@types/node@22.10.5)(jiti@2.4.2)(terser@5.24.0)(tsx@4.19.2)(yaml@2.6.1))(vitest@3.0.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -14814,11 +14814,11 @@ snapshots:
       mlly: 1.7.3
       pathe: 1.1.2
 
-  playwright-core@1.49.1: {}
+  playwright-core@1.50.0: {}
 
-  playwright@1.49.1:
+  playwright@1.50.0:
     dependencies:
-      playwright-core: 1.49.1
+      playwright-core: 1.50.0
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -16432,7 +16432,7 @@ snapshots:
 
   vitest-browser-vue@0.0.1(@vitest/browser@3.0.1)(vitest@3.0.1)(vue@3.5.13(typescript@5.7.3)):
     dependencies:
-      '@vitest/browser': 3.0.1(@types/node@22.10.5)(playwright@1.49.1)(typescript@5.7.3)(vite@6.0.7(@types/node@22.10.5)(jiti@2.4.2)(terser@5.24.0)(tsx@4.19.2)(yaml@2.6.1))(vitest@3.0.1)
+      '@vitest/browser': 3.0.1(@types/node@22.10.5)(playwright@1.50.0)(typescript@5.7.3)(vite@6.0.7(@types/node@22.10.5)(jiti@2.4.2)(terser@5.24.0)(tsx@4.19.2)(yaml@2.6.1))(vitest@3.0.1)
       '@vue/test-utils': 2.4.6
       vitest: 3.0.1(@types/node@22.10.5)(@vitest/browser@3.0.1)(@vitest/ui@3.0.1)(jiti@2.4.2)(jsdom@26.0.0)(msw@2.3.0(typescript@5.7.3))(terser@5.24.0)(tsx@4.19.2)(yaml@2.6.1)
       vue: 3.5.13(typescript@5.7.3)
@@ -16461,7 +16461,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.10.5
-      '@vitest/browser': 3.0.1(@types/node@22.10.5)(playwright@1.49.1)(typescript@5.7.3)(vite@6.0.7(@types/node@22.10.5)(jiti@2.4.2)(terser@5.24.0)(tsx@4.19.2)(yaml@2.6.1))(vitest@3.0.1)
+      '@vitest/browser': 3.0.1(@types/node@22.10.5)(playwright@1.50.0)(typescript@5.7.3)(vite@6.0.7(@types/node@22.10.5)(jiti@2.4.2)(terser@5.24.0)(tsx@4.19.2)(yaml@2.6.1))(vitest@3.0.1)
       '@vitest/ui': 3.0.1(vitest@3.0.1)
       jsdom: 26.0.0
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -60,7 +60,7 @@ catalog:
   nprogress: ^0.2.0
   nuxt: ^3.15.1
   ofetch: ^1.4.1
-  playwright: ^1.49.1
+  playwright: ^1.50.0
   pnpm: ^9.15.3
   postcss: ^8.4.49
   postcss-nested: ^7.0.2


### PR DESCRIPTION
CI is failing at the minute because `nlx playwright install` will install the _latest_ playwright browsers. These then mismatch the version of playwright we have installed (which tries to resolve older browser versions).

For now, this upgrades playwright to use the same version.

Later, we should investigate how to constrain `nlx playwright install` to the same version so it has to be manually updated in future.

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
