### PR TITLE
feat(useTimtoutFn,useTimeoutPoll): align behavior

### DIFF
--- a/packages/core/useTimeoutPoll/index.test.ts
+++ b/packages/core/useTimeoutPoll/index.test.ts
@@ -1,61 +1,52 @@
-import { describe, expect, it, vi } from 'vitest'
-import { effectScope, nextTick, ref } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { effectScope, ref } from 'vue'
 import { useTimeoutPoll } from '.'
 
 describe('useTimeoutPoll', () => {
-  vi.useFakeTimers()
-  function createTests(immediate: boolean) {
-    it(`supports reactive intervals when immediate is ${immediate}`, async () => {
-      const callback = vi.fn()
-      const interval = ref(0)
-      const { pause, resume } = useTimeoutPoll(callback, interval, { immediate })
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
 
-      if (!immediate)
-        resume()
-      expect(callback).toBeCalled()
-      pause()
+  it('basic pause/resume', async () => {
+    const callback = vi.fn()
+    const interval = ref(0)
+    const { pause, resume } = useTimeoutPoll(callback, interval)
 
-      interval.value = 10
+    await vi.advanceTimersByTimeAsync(1)
+    expect(callback).toBeCalled()
+    pause()
+    interval.value = 10
 
-      resume()
-      callback.mockReset()
-      expect(callback).not.toBeCalled()
-      await vi.advanceTimersByTimeAsync(11)
-      expect(callback).toBeCalled()
+    resume()
+    callback.mockReset()
+    vi.advanceTimersByTime(1)
+    expect(callback).not.toBeCalled()
+    vi.advanceTimersByTime(10)
+    expect(callback).toBeCalled()
+  })
 
-      callback.mockReset()
-      pause()
-      await vi.advanceTimersByTimeAsync(11)
-      expect(callback).not.toBeCalled()
+  it('pause/resume with immediateCallback', async () => {
+    const callback = vi.fn()
+    useTimeoutPoll(callback, 50, { immediateCallback: true })
 
-      resume()
-      expect(callback).toBeCalled()
+    expect(callback).toHaveBeenCalledTimes(1)
 
-      callback.mockReset()
-      await vi.advanceTimersByTimeAsync(11)
+    vi.advanceTimersByTime(100)
+    expect(callback).toHaveBeenCalledTimes(2)
+  })
+
+  it('pause/resume in scope', async () => {
+    const callback = vi.fn()
+    const interval = ref(0)
+    const scope = effectScope()
+    await scope.run(async () => {
+      useTimeoutPoll(callback, interval)
+      vi.advanceTimersByTime(1)
       expect(callback).toBeCalled()
     })
-
-    it(`should pause when scope dispose and immediate is ${immediate}`, async () => {
-      const callback = vi.fn()
-      const interval = ref(0)
-      const scope = effectScope()
-      await scope.run(async () => {
-        const { resume } = useTimeoutPoll(callback, interval, { immediate })
-
-        if (!immediate)
-          resume()
-        await nextTick()
-        expect(callback).toBeCalled()
-      })
-      callback.mockReset()
-      scope.stop()
-      interval.value = 10
-      await vi.advanceTimersByTimeAsync(11)
-      expect(callback).not.toBeCalled()
-    })
-  }
-
-  createTests(true)
-  createTests(false)
+    callback.mockClear()
+    await scope.stop()
+    vi.advanceTimersByTime(60)
+    expect(callback).toHaveBeenCalledTimes(0)
+  })
 })

--- a/packages/core/useTimeoutPoll/index.ts
+++ b/packages/core/useTimeoutPoll/index.ts
@@ -4,7 +4,7 @@ import { ref } from 'vue'
 
 export interface UseTimeoutPollOptions {
   /**
-   * Start the timer immediate
+   * Start the timer immediately
    *
    * @default true
    */

--- a/packages/core/useTimeoutPoll/index.ts
+++ b/packages/core/useTimeoutPoll/index.ts
@@ -2,6 +2,22 @@ import type { Awaitable, MaybeRefOrGetter, Pausable, UseTimeoutFnOptions } from 
 import { isClient, tryOnScopeDispose, useTimeoutFn } from '@vueuse/shared'
 import { ref } from 'vue'
 
+export interface UseTimeoutPollOptions {
+  /**
+   * Start the timer immediate
+   *
+   * @default true
+   */
+  immediate?: boolean
+
+  /**
+   * Execute the callback immediately after calling `resume`
+   *
+   * @default false
+   */
+  immediateCallback?: boolean
+}
+
 export function useTimeoutPoll(
   fn: () => Awaitable<void>,
   interval: MaybeRefOrGetter<number>,
@@ -9,9 +25,10 @@ export function useTimeoutPoll(
 ): Pausable {
   const {
     immediate = true,
+    immediateCallback = false,
   } = options
 
-  const { start } = useTimeoutFn(loop, interval, { immediate: false })
+  const { start } = useTimeoutFn(loop, interval, { immediate })
 
   const isActive = ref(false)
 
@@ -26,7 +43,9 @@ export function useTimeoutPoll(
   function resume() {
     if (!isActive.value) {
       isActive.value = true
-      loop()
+      if (immediateCallback)
+        fn()
+      start()
     }
   }
 

--- a/packages/shared/useTimeoutFn/index.test.ts
+++ b/packages/shared/useTimeoutFn/index.test.ts
@@ -6,12 +6,12 @@ describe('useTimeoutFn', () => {
   beforeEach(() => {
     vi.useFakeTimers()
   })
-  it('supports reactive intervals', async () => {
+
+  it('basic start/stop', async () => {
     const callback = vi.fn()
     const interval = ref(0)
     const { start } = useTimeoutFn(callback, interval)
 
-    start()
     vi.advanceTimersByTime(1)
     expect(callback).toBeCalled()
 
@@ -23,6 +23,16 @@ describe('useTimeoutFn', () => {
     expect(callback).not.toBeCalled()
     vi.advanceTimersByTime(100)
     expect(callback).toBeCalled()
+  })
+
+  it('stop/start with immediateCallback', async () => {
+    const callback = vi.fn()
+    useTimeoutFn(callback, 50, { immediateCallback: true })
+
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(100)
+    expect(callback).toHaveBeenCalledTimes(2)
   })
 
   it('supports getting pending status', async () => {

--- a/packages/shared/useTimeoutFn/index.ts
+++ b/packages/shared/useTimeoutFn/index.ts
@@ -5,11 +5,18 @@ import { isClient } from '../utils'
 
 export interface UseTimeoutFnOptions {
   /**
-   * Start the timer immediate after calling this function
+   * Start the timer immediate
    *
    * @default true
    */
   immediate?: boolean
+
+  /**
+   * Execute the callback immediately after calling `start`
+   *
+   * @default false
+   */
+  immediateCallback?: boolean
 }
 
 /**
@@ -26,6 +33,7 @@ export function useTimeoutFn<CallbackFn extends AnyFn>(
 ): Stoppable<Parameters<CallbackFn> | []> {
   const {
     immediate = true,
+    immediateCallback = false,
   } = options
 
   const isPending = ref(false)
@@ -45,6 +53,8 @@ export function useTimeoutFn<CallbackFn extends AnyFn>(
   }
 
   function start(...args: Parameters<CallbackFn> | []) {
+    if (immediateCallback)
+      cb()
     clear()
     isPending.value = true
     timer = setTimeout(() => {

--- a/packages/shared/useTimeoutFn/index.ts
+++ b/packages/shared/useTimeoutFn/index.ts
@@ -5,7 +5,7 @@ import { isClient } from '../utils'
 
 export interface UseTimeoutFnOptions {
   /**
-   * Start the timer immediate
+   * Start the timer immediately
    *
    * @default true
    */


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR adds `immediateCallback` option to both `useTimeoutFn` and `useTimeoutPoll`, aligning their behavior with `useIntervalFn`. The `immediate` option will `Start the timer immediately`, while `immediateCallback` will `Execute the callback immediately after calling start or resume`.