### PR TITLE
feat(useDateFormat): add `z...zzzz` for timezone information

### DIFF
--- a/packages/shared/useDateFormat/index.md
+++ b/packages/shared/useDateFormat/index.md
@@ -4,7 +4,8 @@ category: Time
 
 # useDateFormat
 
-Get the formatted date according to the string of tokens passed in, inspired by [dayjs](https://github.com/iamkun/dayjs).
+Get the formatted date according to the string of tokens passed in, inspired
+by [dayjs](https://github.com/iamkun/dayjs).
 
 **List of all available formats (HH:mm:ss by default):**
 
@@ -42,6 +43,10 @@ Get the formatted date according to the string of tokens passed in, inspired by 
 | `dd`   | S-S                      | The min name of the day of the week     |
 | `ddd`  | Sun-Sat                  | The short name of the day of the week   |
 | `dddd` | Sunday-Saturday          | The name of the day of the week         |
+| `z`    | GMT, GMT+1               | The timezone with offset                |
+| `zz`   | GMT, GMT+1               | The timezone with offset                |
+| `zzz`  | GMT, GMT+1               | The timezone with offset                |
+| `zzzz` | GMT, GMT+01:00           | The long timezone with offset           |
 
 - Meridiem is customizable by defining `customMeridiem` in `options`.
 

--- a/packages/shared/useDateFormat/index.test.ts
+++ b/packages/shared/useDateFormat/index.test.ts
@@ -120,4 +120,18 @@ describe('useDateFormat', () => {
     expect(formatDate(new Date('Sun Jul 30 2023 21:15:42 GMT+0800'), 'd'))
       .toMatchInlineSnapshot('"0"')
   })
+
+  describe('timezone', () => {
+    it.each([
+      { dateStr: '2022-01-01 03:05:05', formatStr: 'hh:mm:ss z', expected: '03:05:05 GMT+1' },
+      { dateStr: '2022-01-01 03:05:05', formatStr: 'hh:mm:ss zz', expected: '03:05:05 GMT+1' },
+      { dateStr: '2022-01-01 03:05:05', formatStr: 'hh:mm:ss zzz', expected: '03:05:05 GMT+1' },
+      { dateStr: '2022-01-01 03:05:05', formatStr: 'hh:mm:ss zzzz', expected: '03:05:05 GMT+01:00' },
+    ])(
+      'should work with $formatStr',
+      ({ dateStr, formatStr, expected }) => {
+        expect(useDateFormat(new Date(dateStr), formatStr).value).toBe(expected)
+      },
+    )
+  })
 })

--- a/packages/shared/useDateFormat/index.ts
+++ b/packages/shared/useDateFormat/index.ts
@@ -35,7 +35,6 @@ function formatOrdinal(num: number) {
   return num + (suffixes[(v - 20) % 10] || suffixes[v] || suffixes[0])
 }
 
-
 export function formatDate(date: Date, formatStr: string, options: UseDateFormatOptions = {}) {
   const years = date.getFullYear()
   const month = date.getMonth()

--- a/packages/shared/useDateFormat/index.ts
+++ b/packages/shared/useDateFormat/index.ts
@@ -35,7 +35,6 @@ function formatOrdinal(num: number) {
   return num + (suffixes[(v - 20) % 10] || suffixes[v] || suffixes[0])
 }
 
-Intl.DateTimeFormat().format(new Date())
 
 export function formatDate(date: Date, formatStr: string, options: UseDateFormatOptions = {}) {
   const years = date.getFullYear()

--- a/packages/shared/useDateFormat/index.ts
+++ b/packages/shared/useDateFormat/index.ts
@@ -20,7 +20,7 @@ export interface UseDateFormatOptions {
 
 // eslint-disable-next-line regexp/no-misleading-capturing-group
 const REGEX_PARSE = /* #__PURE__ */ /^(\d{4})[-/]?(\d{1,2})?[-/]?(\d{0,2})[T\s]*(\d{1,2})?:?(\d{1,2})?:?(\d{1,2})?[.:]?(\d+)?$/i
-const REGEX_FORMAT = /* #__PURE__ */ /[YMDHhms]o|\[([^\]]+)\]|Y{1,4}|M{1,4}|D{1,2}|d{1,4}|H{1,2}|h{1,2}|a{1,2}|A{1,2}|m{1,2}|s{1,2}|Z{1,2}|SSS/g
+const REGEX_FORMAT = /* #__PURE__ */ /[YMDHhms]o|\[([^\]]+)\]|Y{1,4}|M{1,4}|D{1,2}|d{1,4}|H{1,2}|h{1,2}|a{1,2}|A{1,2}|m{1,2}|s{1,2}|Z{1,2}|z{1,4}|SSS/g
 
 function defaultMeridiem(hours: number, minutes: number, isLowercase?: boolean, hasPeriod?: boolean) {
   let m = (hours < 12 ? 'AM' : 'PM')
@@ -35,6 +35,8 @@ function formatOrdinal(num: number) {
   return num + (suffixes[(v - 20) % 10] || suffixes[v] || suffixes[0])
 }
 
+Intl.DateTimeFormat().format(new Date())
+
 export function formatDate(date: Date, formatStr: string, options: UseDateFormatOptions = {}) {
   const years = date.getFullYear()
   const month = date.getMonth()
@@ -45,6 +47,9 @@ export function formatDate(date: Date, formatStr: string, options: UseDateFormat
   const milliseconds = date.getMilliseconds()
   const day = date.getDay()
   const meridiem = options.customMeridiem ?? defaultMeridiem
+  const stripTimeZone = (dateString: string) => {
+    return dateString.split(' ')[1] ?? ''
+  }
   const matches: Record<string, () => string | number> = {
     Yo: () => formatOrdinal(years),
     YY: () => String(years).slice(-2),
@@ -78,6 +83,10 @@ export function formatDate(date: Date, formatStr: string, options: UseDateFormat
     AA: () => meridiem(hours, minutes, false, true),
     a: () => meridiem(hours, minutes, true),
     aa: () => meridiem(hours, minutes, true, true),
+    z: () => stripTimeZone(date.toLocaleDateString(toValue(options.locales), { timeZoneName: 'shortOffset' })),
+    zz: () => stripTimeZone(date.toLocaleDateString(toValue(options.locales), { timeZoneName: 'shortOffset' })),
+    zzz: () => stripTimeZone(date.toLocaleDateString(toValue(options.locales), { timeZoneName: 'shortOffset' })),
+    zzzz: () => stripTimeZone(date.toLocaleDateString(toValue(options.locales), { timeZoneName: 'longOffset' })),
   }
   return formatStr.replace(REGEX_FORMAT, (match, $1) => $1 ?? matches[match]?.() ?? match)
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,6 +23,9 @@ export default defineConfig({
   cacheDir: resolve(import.meta.dirname, 'node_modules/.vite'),
   test: {
     reporters: 'dot',
+    env: {
+      TZ: 'UTC-1', // to have some actual results with timezone offset
+    },
     coverage: {
       exclude: ['./packages/**/demo.vue'],
     },


### PR DESCRIPTION
fixes #4495

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

This PR add `z...zzzz` to add timezone with offset. 

> [!IMPORTANT]
> we should use `Intl.DateTimeFormat` longterm. It is more performant with many calls than `toLocaleDateString`

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
