### PR TITLE
fix: useCountdown `start()` can provide a custom initial value

### DIFF
--- a/packages/core/useCountdown/index.test.ts
+++ b/packages/core/useCountdown/index.test.ts
@@ -123,7 +123,7 @@ describe('useCountdown', () => {
   })
 
   it('start can provide a custom interval', async () => {
-    const { start } = useCountdown(countdown, options)
+    const { start, reset } = useCountdown(countdown, options)
     vi.advanceTimersByTime(countdown * interval + 10)
     expect(completeCallback).toHaveBeenCalledTimes(1)
 
@@ -135,6 +135,11 @@ describe('useCountdown', () => {
     vi.advanceTimersByTime(110)
     expect(completeCallback).toHaveBeenCalledTimes(2)
     vi.advanceTimersByTime(countdown * interval + 10)
+    expect(completeCallback).toHaveBeenCalledTimes(3)
+
+    start(1)
+    reset()
+    vi.advanceTimersByTime(110)
     expect(completeCallback).toHaveBeenCalledTimes(3)
   })
 })

--- a/packages/core/useCountdown/index.test.ts
+++ b/packages/core/useCountdown/index.test.ts
@@ -132,6 +132,8 @@ describe('useCountdown', () => {
     expect(completeCallback).toHaveBeenCalledTimes(2)
 
     start()
+    vi.advanceTimersByTime(110)
+    expect(completeCallback).toHaveBeenCalledTimes(2)
     vi.advanceTimersByTime(countdown * interval + 10)
     expect(completeCallback).toHaveBeenCalledTimes(3)
   })

--- a/packages/core/useCountdown/index.test.ts
+++ b/packages/core/useCountdown/index.test.ts
@@ -1,7 +1,7 @@
 import type { Pausable } from '@vueuse/shared'
 import type { UseCountdownOptions } from '.'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { effectScope } from 'vue'
+import { effectScope, ref } from 'vue'
 import { useCountdown } from '.'
 
 describe('useCountdown', () => {
@@ -109,5 +109,30 @@ describe('useCountdown', () => {
     expect(isActive.value).toBeFalsy()
     vi.advanceTimersByTime(60)
     expect(tickCallback).toHaveBeenCalledTimes(0)
+  })
+
+  it('initial interval can be changed', async () => {
+    const countdown = ref(3)
+
+    const { start } = useCountdown(countdown, { ...options, immediate: false })
+
+    countdown.value = 2
+    start()
+    vi.advanceTimersByTime(210)
+    expect(completeCallback).toHaveBeenCalledTimes(1)
+  })
+
+  it('start can provide a custom interval', async () => {
+    const { start } = useCountdown(countdown, options)
+    vi.advanceTimersByTime(countdown * interval + 10)
+    expect(completeCallback).toHaveBeenCalledTimes(1)
+
+    start(1)
+    vi.advanceTimersByTime(110)
+    expect(completeCallback).toHaveBeenCalledTimes(2)
+
+    start()
+    vi.advanceTimersByTime(countdown * interval + 10)
+    expect(completeCallback).toHaveBeenCalledTimes(3)
   })
 })

--- a/packages/core/useCountdown/index.ts
+++ b/packages/core/useCountdown/index.ts
@@ -67,6 +67,8 @@ export function useCountdown(initialCountdown: MaybeRefOrGetter<number>, options
 
   const reset = () => {
     remaining.value = customInitialCountdown ?? toValue(initialCountdown)
+    if (customInitialCountdown)
+      customInitialCountdown = undefined
   }
 
   const stop = () => {

--- a/packages/core/useCountdown/index.ts
+++ b/packages/core/useCountdown/index.ts
@@ -53,6 +53,7 @@ export interface UseCountdownReturn extends Pausable {
  */
 export function useCountdown(initialCountdown: MaybeRefOrGetter<number>, options?: UseCountdownOptions): UseCountdownReturn {
   const remaining = ref(toValue(initialCountdown))
+  let customInitialCountdown: number | undefined
 
   const intervalController = useIntervalFn(() => {
     const value = remaining.value - 1
@@ -65,7 +66,7 @@ export function useCountdown(initialCountdown: MaybeRefOrGetter<number>, options
   }, options?.interval ?? 1000, { immediate: options?.immediate ?? false })
 
   const reset = () => {
-    remaining.value = toValue(initialCountdown)
+    remaining.value = customInitialCountdown ?? toValue(initialCountdown)
   }
 
   const stop = () => {
@@ -81,7 +82,8 @@ export function useCountdown(initialCountdown: MaybeRefOrGetter<number>, options
     }
   }
 
-  const start = () => {
+  const start = (initialCountdown?: MaybeRefOrGetter<number>) => {
+    customInitialCountdown = toValue(initialCountdown)
     reset()
     intervalController.resume()
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

`useCountdown` return type includes the `start()` function with the following signature:
```ts
start: (initialCountdown?: MaybeRefOrGetter<number>) => void
```

But the implementation before this PR does not use the value.
This PR makes so `start()` will actually set a custom value for `initialCountdown` (only that time).

### Additional context

I'm using `let` but not `ref`. I assume this would consume less memory and be faster, but I'm not sure if there is a drawback.

Current for behaviour for:
```ts
const { start, reset, resume } = useCountdown(5)

start(2)
reset()
```
is going back to the original 5 seconds countdown, but I'm not sure if this is the expected behaviour.

I included a simple test that check if everything is working as expected (setting a custom inicial value with `start(X)` and then checking if it goes back to the original value with `start()`)

There might be other edge cases with `stop()` or `resume()`, so maybe more tests are required.

I also included a test to check if the `interval` used in the composable can be a ref, and if changing the ref also changes the initial countdown when starting it again. (This passes even without the changes in this PR).

