### PR TITLE
feat(useDebounceFn): Add cancel option

### DIFF
--- a/packages/shared/useDebounceFn/demo.vue
+++ b/packages/shared/useDebounceFn/demo.vue
@@ -4,13 +4,23 @@ import { ref } from 'vue'
 
 const updated = ref(0)
 const clicked = ref(0)
+const pending = ref(false)
 const debouncedFn = useDebounceFn(() => {
   updated.value += 1
-}, 1000, { maxWait: 5000 })
+  pending.value = false
+}, 1000, { maxWait: 5000, rejectOnCancel: true })
 
 function clickedFn() {
   clicked.value += 1
+  pending.value = true
   debouncedFn()
+}
+
+function cancelPending() {
+  if (pending.value) {
+    debouncedFn.cancel()
+    pending.value = false
+  }
 }
 </script>
 
@@ -18,8 +28,19 @@ function clickedFn() {
   <button @click="clickedFn">
     Smash me!
   </button>
+  <button
+    :disabled="!pending"
+    class="warn opacity-50 disabled:opacity-25"
+    @click="cancelPending"
+  >
+    Cancel pending
+  </button>
+
   <note>Delay is set to 1000ms and maxWait is set to 5000ms for this demo.</note>
 
   <p>Button clicked: {{ clicked }}</p>
   <p>Event handler called: {{ updated }}</p>
+  <p v-if="pending">
+    Pending update...
+  </p>
 </template>

--- a/packages/shared/useDebounceFn/index.md
+++ b/packages/shared/useDebounceFn/index.md
@@ -21,6 +21,40 @@ const debouncedFn = useDebounceFn(() => {
 useEventListener(window, 'resize', debouncedFn)
 ```
 
+The debounced function includes a `cancel()` method to stop pending executions.
+
+```js
+import { useDebounceFn } from '@vueuse/core'
+
+// Basic cancellation
+const debouncedFn = useDebounceFn(() => {
+  // do something
+}, 1000)
+
+// Later, cancel any pending execution
+debouncedFn.cancel()
+```
+
+When working with promises, cancellation behavior can be customized.
+
+```js
+const debouncedRequest = useDebounceFn(() => 'response', 1000, { rejectOnCancel: true })
+
+debouncedRequest()
+  .then(value => console.log('Success:', value))
+  .catch(() => console.log('Cancelled!'))
+
+debouncedRequest.cancel() // Promise will reject
+
+// Default behavior (rejectOnCancel: false)
+const debouncedFn = useDebounceFn(() => 'response', 1000)
+
+debouncedFn()
+  .then(value => console.log(value)) // resolves with undefined when cancelled
+
+debouncedFn.cancel() // Promise resolves with undefined
+```
+
 You can also pass a 3rd parameter to this, with a maximum wait time, similar to [lodash debounce](https://lodash.com/docs/4.17.15#debounce)
 
 ```js

--- a/packages/shared/useDebounceFn/index.test.ts
+++ b/packages/shared/useDebounceFn/index.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { useDebounceFn } from '.'
+
+describe('useDebounceFn', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  it('should export function', () => {
+    expect(useDebounceFn).toBeDefined()
+  })
+
+  it('should debounce function', async () => {
+    const fn = vi.fn()
+    const debouncedFn = useDebounceFn(fn, 100)
+
+    debouncedFn()
+    debouncedFn()
+    debouncedFn()
+
+    expect(fn).not.toBeCalled()
+
+    await vi.advanceTimersByTime(100)
+    expect(fn).toBeCalledTimes(1)
+  })
+
+  it('should work with ref delay', async () => {
+    const fn = vi.fn()
+    const ms = ref(100)
+    const debouncedFn = useDebounceFn(fn, ms)
+
+    debouncedFn()
+    await vi.advanceTimersByTime(50)
+
+    ms.value = 200
+    debouncedFn()
+
+    await vi.advanceTimersByTime(150)
+    expect(fn).not.toBeCalled()
+
+    await vi.advanceTimersByTime(50)
+    expect(fn).toBeCalledTimes(1)
+  })
+
+  it('should respect maxWait option', async () => {
+    const fn = vi.fn()
+    const debouncedFn = useDebounceFn(fn, 200, { maxWait: 300 })
+
+    debouncedFn()
+
+    for (let i = 0; i < 5; i++) {
+      await vi.advanceTimersByTime(100)
+      debouncedFn()
+    }
+
+    expect(fn).toBeCalledTimes(1)
+
+    await vi.advanceTimersByTime(200)
+
+    expect(fn).toBeCalledTimes(2)
+  })
+
+  it('should handle promise resolution', async () => {
+    const fn = vi.fn().mockResolvedValue('result')
+    const debouncedFn = useDebounceFn(fn, 100)
+
+    const promise = debouncedFn()
+    await vi.advanceTimersByTime(100)
+
+    await expect(promise).resolves.toBe('result')
+  })
+
+  it('should cancel pending execution', async () => {
+    const fn = vi.fn()
+    const debouncedFn = useDebounceFn(fn, 100)
+
+    debouncedFn()
+    debouncedFn.cancel()
+
+    await vi.advanceTimersByTime(100)
+    expect(fn).not.toBeCalled()
+  })
+
+  it('should reject on cancel when rejectOnCancel is true', async () => {
+    const fn = vi.fn().mockResolvedValue('result')
+    const debouncedFn = useDebounceFn(fn, 100, { rejectOnCancel: true })
+
+    const promise = debouncedFn()
+    debouncedFn.cancel()
+
+    await expect(promise).rejects.toBeUndefined()
+  })
+
+  it('should resolve with undefined on cancel by default', async () => {
+    const fn = vi.fn().mockResolvedValue('result')
+    const debouncedFn = useDebounceFn(fn, 100)
+
+    const promise = debouncedFn()
+    debouncedFn.cancel()
+
+    await expect(promise).resolves.toBeUndefined()
+  })
+})

--- a/packages/shared/useDebounceFn/index.ts
+++ b/packages/shared/useDebounceFn/index.ts
@@ -15,9 +15,9 @@ export function useDebounceFn<T extends FunctionArgs>(
   fn: T,
   ms: MaybeRefOrGetter<number> = 200,
   options: DebounceFilterOptions = {},
-): PromisifyFn<T> {
-  return createFilterWrapper(
-    debounceFilter(ms, options),
-    fn,
-  )
+): PromisifyFn<T> & { cancel: () => void } {
+  const filter = debounceFilter(ms, options)
+  const wrapped = createFilterWrapper(filter, fn) as PromisifyFn<T> & { cancel: () => void }
+  wrapped.cancel = () => filter.cancel?.()
+  return wrapped
 }

--- a/packages/shared/utils/filters.ts
+++ b/packages/shared/utils/filters.ts
@@ -75,7 +75,7 @@ export function debounceFilter(ms: MaybeRefOrGetter<number>, options: DebounceFi
 
   let lastInvoker: () => void
 
-  const filter: EventFilter = (invoke) => {
+  const filter: EventFilter & { cancel?: () => void } = (invoke) => {
     const duration = toValue(ms)
     const maxDuration = toValue(options.maxWait)
 
@@ -111,6 +111,14 @@ export function debounceFilter(ms: MaybeRefOrGetter<number>, options: DebounceFi
         resolve(invoke())
       }, duration)
     })
+  }
+
+  filter.cancel = () => {
+    if (timer)
+      _clearTimeout(timer)
+    if (maxTimer)
+      _clearTimeout(maxTimer)
+    maxTimer = null
   }
 
   return filter


### PR DESCRIPTION
### Description

Implements cancel option for debounced functions (fixes #3375)
Show:
https://github.com/user-attachments/assets/885f326b-9c86-44e2-ab71-8c6b177f8d74

This implementation:
- Adds a `cancel()` method to debounced functions
- Extends `EventFilter` type to support cancellation

### Documentation
- Basic cancellation usage
- `rejectOnCancel` option usage