### PR TITLE
docs: preserve character after function names when linkifying

### DIFF
--- a/packages/.vitepress/plugins/markdownTransform.ts
+++ b/packages/.vitepress/plugins/markdownTransform.ts
@@ -28,7 +28,7 @@ export function MarkdownTransform(): Plugin {
           if (ending === ']') // already a link
             return _
           const fn = getFunction(name)!
-          return `[\`${fn.name}\`](${fn.docs}) `
+          return `[\`${fn.name}\`](${fn.docs})${ending}`
         },
       )
       // convert links to relative


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

The `transform` function in the `MarkdownTransform` plugin loses characters after function names. For example, on the page https://vueuse.org/guide/config.html#reactive-timing, the `,` and `)` characters after useStorage and useRefHistory are missing.
<img width="764" alt="Snipaste_2025-02-07_16-23-10" src="https://github.com/user-attachments/assets/96eace2e-213f-4c18-b8dc-346bfcad2950" />

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
