### PR TITLE
feat(useElementVisibility): add `once` options

### DIFF
--- a/packages/core/useElementVisibility/index.test.ts
+++ b/packages/core/useElementVisibility/index.test.ts
@@ -28,7 +28,12 @@ describe('useElementVisibility', () => {
   describe('when internally using useIntersectionObserver', async () => {
     beforeAll(() => {
       vi.resetAllMocks()
-      vi.mock('../useIntersectionObserver')
+      vi.mock('../useIntersectionObserver', () => ({
+        useIntersectionObserver: vi.fn((_target) => {
+          const stop = vi.fn()
+          return { stop }
+        }),
+      }))
     })
 
     const { useIntersectionObserver } = await import('../useIntersectionObserver')

--- a/packages/core/useElementVisibility/index.ts
+++ b/packages/core/useElementVisibility/index.ts
@@ -1,7 +1,7 @@
-import type { MaybeRefOrGetter } from '@vueuse/shared'
 import type { ConfigurableWindow } from '../_configurable'
 import type { MaybeComputedElementRef } from '../unrefElement'
 import type { UseIntersectionObserverOptions } from '../useIntersectionObserver'
+import { type MaybeRefOrGetter, watchOnce } from '@vueuse/shared'
 import { ref, toValue } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useIntersectionObserver } from '../useIntersectionObserver'
@@ -15,6 +15,12 @@ export interface UseElementVisibilityOptions extends ConfigurableWindow, Pick<Us
    * The element that is used as the viewport for checking visibility of the target.
    */
   scrollTarget?: MaybeRefOrGetter<HTMLElement | undefined | null>
+  /**
+   * Stop tracking when element visibility changes for the first time
+   *
+   * @default false
+   */
+  once?: boolean
 }
 
 /**
@@ -31,10 +37,11 @@ export function useElementVisibility(
     scrollTarget,
     threshold = 0,
     rootMargin,
+    once = false,
   } = options
   const elementIsVisible = ref(false)
 
-  useIntersectionObserver(
+  const { stop } = useIntersectionObserver(
     element,
     (intersectionObserverEntries) => {
       let isIntersecting = elementIsVisible.value
@@ -48,6 +55,12 @@ export function useElementVisibility(
         }
       }
       elementIsVisible.value = isIntersecting
+
+      if (once) {
+        watchOnce(elementIsVisible, () => {
+          stop()
+        })
+      }
     },
     {
       root: scrollTarget,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

Implement: #4007

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR adds `once` option to stop tracking element visibility after its first change.