### PR TITLE
refactor: change primitive to `shallowRef`, rename `ref` usage to `deepRef`

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -129,6 +129,11 @@ export default antfu(
         from: 'vue',
         name: 'shallowRef',
       },
+      {
+        from: 'vue',
+        name: 'ref',
+        as: 'deepRef',
+      },
     ],
   }),
 )

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,7 @@
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import antfu from '@antfu/eslint-config'
+import { createSimplePlugin } from 'eslint-factory'
 import { createAutoInsert } from 'eslint-plugin-unimport'
 
 const dir = fileURLToPath(new URL('.', import.meta.url))
@@ -135,5 +136,21 @@ export default antfu(
         as: 'deepRef',
       },
     ],
+  }),
+  createSimplePlugin({
+    name: 'no-ref',
+    exclude: ['**/*.md'],
+    create(context) {
+      return {
+        CallExpression(node) {
+          if (node.callee.type === 'Identifier' && node.callee.name === 'ref') {
+            context.report({
+              node,
+              message: 'Usage of ref() is restricted. Use shallowRef() or deepRef() instead.',
+            })
+          }
+        },
+      }
+    },
   }),
 )

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,7 @@
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import antfu from '@antfu/eslint-config'
+import { createAutoInsert } from 'eslint-plugin-unimport'
 
 const dir = fileURLToPath(new URL('.', import.meta.url))
 const restricted = [
@@ -122,4 +123,12 @@ export default antfu(
       'no-restricted-imports': 'off',
     },
   },
+  createAutoInsert({
+    imports: [
+      {
+        from: 'vue',
+        name: 'shallowRef',
+      },
+    ],
+  }),
 )

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -139,7 +139,7 @@ export default antfu(
   }),
   createSimplePlugin({
     name: 'no-ref',
-    exclude: ['**/*.md'],
+    exclude: ['**/*.md', '**/*.md/**'],
     create(context) {
       return {
         CallExpression(node) {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "consola": "catalog:",
     "esbuild-register": "catalog:",
     "eslint": "catalog:",
+    "eslint-factory": "^0.1.2",
     "eslint-plugin-format": "catalog:",
     "eslint-plugin-unimport": "^0.1.2",
     "export-size": "catalog:",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "esbuild-register": "catalog:",
     "eslint": "catalog:",
     "eslint-plugin-format": "catalog:",
+    "eslint-plugin-unimport": "^0.1.2",
     "export-size": "catalog:",
     "fake-indexeddb": "catalog:",
     "firebase": "catalog:",

--- a/packages/.test/mount.ts
+++ b/packages/.test/mount.ts
@@ -1,5 +1,5 @@
 import type { InjectionKey, Ref } from 'vue'
-import { createApp, defineComponent, h, provide, ref } from 'vue'
+import { createApp, defineComponent, h, provide, shallowRef } from 'vue'
 
 type InstanceType<V> = V extends { new (...arg: any[]): infer X } ? X : never
 type VM<V> = InstanceType<V> & { unmount: () => void }
@@ -38,7 +38,7 @@ export function useInjectedSetup<V>(setup: () => V) {
   const Provider = defineComponent({
     components: Comp,
     setup() {
-      provide(Key, ref(1))
+      provide(Key, shallowRef(1))
     },
     render() {
       return h('div', [])

--- a/packages/.vitepress/theme/components/DemoContainer.vue
+++ b/packages/.vitepress/theme/components/DemoContainer.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { onErrorCaptured, ref } from 'vue'
+import { ref as deepRef, onErrorCaptured } from 'vue'
 
-const error = ref<Error | null>(null)
+const error = deepRef<Error | null>(null)
 
 onErrorCaptured((err) => {
   error.value = err

--- a/packages/core/_template/index.ts
+++ b/packages/core/_template/index.ts
@@ -1,7 +1,7 @@
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 
 export function useCounter(initialValue = 0) {
-  const count = ref(initialValue)
+  const count = shallowRef(initialValue)
 
   const inc = (delta = 1) => (count.value += delta)
   const dec = (delta = 1) => (count.value -= delta)

--- a/packages/core/computedAsync/index.test.ts
+++ b/packages/core/computedAsync/index.test.ts
@@ -1,6 +1,6 @@
 import type { Ref } from 'vue'
 import { describe, expect, expectTypeOf, it, vi } from 'vitest'
-import { computed, nextTick, ref } from 'vue'
+import { computed, nextTick, ref, shallowRef } from 'vue'
 import { asyncComputed, computedAsync } from './index'
 
 describe('computed', () => {
@@ -84,7 +84,7 @@ describe('computedAsync', () => {
   })
 
   it('re-computes when dependency changes', async () => {
-    const counter = ref(1)
+    const counter = shallowRef(1)
     const double = computedAsync(() => {
       const result = counter.value * 2
       return Promise.resolve(result)
@@ -106,10 +106,10 @@ describe('computedAsync', () => {
   })
 
   it('uses last result', async () => {
-    const evaluating = ref(false)
+    const evaluating = shallowRef(false)
     const resolutions: Array<() => void> = []
 
-    const counter = ref(1)
+    const counter = shallowRef(1)
     const double = computedAsync(() => {
       const result = counter.value * 2
       return new Promise(resolve => (resolutions.push(() => resolve(result))))
@@ -162,7 +162,7 @@ describe('computedAsync', () => {
 
   it('evaluating works', async () => {
     vi.useFakeTimers()
-    const evaluating = ref(false)
+    const evaluating = shallowRef(false)
 
     const data = computedAsync(
       () => new Promise(resolve => setTimeout(() => resolve('data'), 0)),
@@ -181,7 +181,7 @@ describe('computedAsync', () => {
   })
 
   it('triggers', async () => {
-    const counter = ref(1)
+    const counter = shallowRef(1)
     const double = computedAsync(() => {
       const result = counter.value * 2
       return Promise.resolve(result)
@@ -211,9 +211,9 @@ describe('computedAsync', () => {
   it('cancel is called', async () => {
     vi.useFakeTimers()
     const onCancel = vi.fn()
-    const evaluating = ref(false)
+    const evaluating = shallowRef(false)
 
-    const data = ref('initial')
+    const data = shallowRef('initial')
     const uppercase = computedAsync((cancel) => {
       cancel(onCancel)
 
@@ -246,7 +246,7 @@ describe('computedAsync', () => {
   it('cancel is called for lazy', async () => {
     const onCancel = vi.fn()
 
-    const data = ref('initial')
+    const data = shallowRef('initial')
     const uppercase = computedAsync((cancel) => {
       cancel(() => onCancel())
 

--- a/packages/core/computedAsync/index.test.ts
+++ b/packages/core/computedAsync/index.test.ts
@@ -1,6 +1,6 @@
 import type { Ref } from 'vue'
 import { describe, expect, expectTypeOf, it, vi } from 'vitest'
-import { computed, nextTick, ref, shallowRef } from 'vue'
+import { computed, ref as deepRef, nextTick, shallowRef } from 'vue'
 import { asyncComputed, computedAsync } from './index'
 
 describe('computed', () => {
@@ -46,7 +46,7 @@ describe('computedAsync', () => {
   })
 
   it('call onError when error is thrown', async () => {
-    const errorMessage = ref()
+    const errorMessage = deepRef()
     const func = vi.fn(async () => {
       throw new Error('An Error Message')
     })

--- a/packages/core/computedAsync/index.ts
+++ b/packages/core/computedAsync/index.ts
@@ -1,7 +1,7 @@
 import type { Fn } from '@vueuse/shared'
 import type { Ref } from 'vue'
 import { noop } from '@vueuse/shared'
-import { computed, isRef, ref, shallowRef, watchEffect } from 'vue'
+import { computed, ref as deepRef, isRef, shallowRef, watchEffect } from 'vue'
 
 /**
  * Handle overlapping async evaluations.
@@ -77,8 +77,8 @@ export function computedAsync<T>(
     onError = noop,
   } = options
 
-  const started = ref(!lazy)
-  const current = (shallow ? shallowRef(initialState) : ref(initialState)) as Ref<T>
+  const started = deepRef(!lazy)
+  const current = (shallow ? shallowRef(initialState) : deepRef(initialState)) as Ref<T>
   let counter = 0
 
   watchEffect(async (onInvalidate) => {

--- a/packages/core/computedInject/demo.vue
+++ b/packages/core/computedInject/demo.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import { provide, ref } from 'vue'
+import { ref as deepRef, provide } from 'vue'
 import Receiver, { ArrayKey } from './demoReceiver.vue'
 
-const array = ref([{ key: 1, value: '1' }, { key: 2, value: '2' }, { key: 3, value: '3' }])
+const array = deepRef([{ key: 1, value: '1' }, { key: 2, value: '2' }, { key: 3, value: '3' }])
 
 provide(ArrayKey, array)
 </script>

--- a/packages/core/computedInject/demoReceiver.vue
+++ b/packages/core/computedInject/demoReceiver.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import type { InjectionKey, Ref } from 'vue'
-import { defineComponent, ref } from 'vue'
+import { ref as deepRef, defineComponent } from 'vue'
 import { computedInject } from './index'
 
 type OptionsRef = Ref<{ key: number, value: string }[]>
@@ -12,7 +12,7 @@ export default defineComponent({
   setup() {
     const computedArr = computedInject(ArrayKey, (source) => {
       if (!source)
-        return ref([]) as OptionsRef
+        return deepRef([]) as OptionsRef
       const arr = [...source.value]
       arr.unshift({ key: 0, value: 'all' })
       return arr

--- a/packages/core/computedInject/index.test.ts
+++ b/packages/core/computedInject/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 import { Key, useInjectedSetup } from '../../.test'
 import { computedInject } from './index'
 
@@ -17,7 +17,7 @@ describe('computedInject', () => {
       const anotherComputedNum = computedInject(Key, (source) => {
         if (source)
           return source.value + 10
-      }, ref(10))
+      }, shallowRef(10))
 
       expect(computedNum.value).toBe(2)
       expect(anotherComputedNum.value).toBe(11)

--- a/packages/core/createTemplatePromise/index.ts
+++ b/packages/core/createTemplatePromise/index.ts
@@ -1,5 +1,5 @@
 import type { DefineComponent, Ref, TransitionGroupProps } from 'vue'
-import { defineComponent, Fragment, h, ref, shallowReactive, TransitionGroup } from 'vue'
+import { ref as deepRef, defineComponent, Fragment, h, shallowReactive, TransitionGroup } from 'vue'
 
 export interface TemplatePromiseProps<Return, Args extends any[] = []> {
   /**
@@ -66,7 +66,7 @@ export function createTemplatePromise<Return, Args extends any[] = []>(
   options: TemplatePromiseOptions = {},
 ): TemplatePromise<Return, Args> {
   let index = 0
-  const instances = ref([]) as Ref<TemplatePromiseProps<Return, Args>[]>
+  const instances = deepRef([]) as Ref<TemplatePromiseProps<Return, Args>[]>
 
   function create(...args: Args) {
     const props = shallowReactive({

--- a/packages/core/onClickOutside/component.ts
+++ b/packages/core/onClickOutside/component.ts
@@ -1,7 +1,7 @@
 import type { RenderableComponent } from '../types'
 import type { OnClickOutsideOptions } from './index'
 import { onClickOutside } from '@vueuse/core'
-import { defineComponent, h, ref } from 'vue'
+import { ref as deepRef, defineComponent, h } from 'vue'
 
 export interface OnClickOutsideProps extends RenderableComponent {
   options?: Omit<OnClickOutsideOptions, 'controls'>
@@ -12,7 +12,7 @@ export const OnClickOutside = /* #__PURE__ */ defineComponent<OnClickOutsideProp
   props: ['as', 'options'] as unknown as undefined,
   emits: ['trigger'],
   setup(props, { slots, emit }) {
-    const target = ref()
+    const target = deepRef()
     onClickOutside(target, (e) => {
       emit('trigger', e)
     }, props.options)

--- a/packages/core/onClickOutside/demo.vue
+++ b/packages/core/onClickOutside/demo.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import type { OnClickOutsideHandler } from '@vueuse/core'
 import { onClickOutside } from '@vueuse/core'
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 import { vOnClickOutside } from './directive'
 
-const modal = ref(false)
+const modal = shallowRef(false)
 const modalRef = ref(null)
 
 onClickOutside(
@@ -15,7 +15,7 @@ onClickOutside(
   },
 )
 
-const dropdown = ref(false)
+const dropdown = shallowRef(false)
 const dropdownHandler: OnClickOutsideHandler = (event) => {
   console.log(event)
   dropdown.value = false

--- a/packages/core/onClickOutside/demo.vue
+++ b/packages/core/onClickOutside/demo.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import type { OnClickOutsideHandler } from '@vueuse/core'
 import { onClickOutside } from '@vueuse/core'
-import { ref, shallowRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 import { vOnClickOutside } from './directive'
 
 const modal = shallowRef(false)
-const modalRef = ref(null)
+const modalRef = deepRef(null)
 
 onClickOutside(
   modalRef,

--- a/packages/core/onElementRemoval/demo.vue
+++ b/packages/core/onElementRemoval/demo.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import { onElementRemoval } from '@vueuse/core'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 
 // demo1: recreate new element
-const demo1Ref = ref<HTMLElement | null>(null)
-const demo1State = ref(true)
-const demo1Count = ref(0)
+const demo1Ref = shallowRef<HTMLElement | null>(null)
+const demo1State = shallowRef(true)
+const demo1Count = shallowRef(0)
 
 function demo1BtnOnClick() {
   demo1State.value = !demo1State.value
@@ -14,10 +14,10 @@ function demo1BtnOnClick() {
 onElementRemoval(demo1Ref, () => demo1Count.value++)
 
 // demo2: reuse same element
-const demo2ParentRef = ref<HTMLElement | null>(null)
-const demo2Ref = ref<HTMLElement | null>(null)
-const demo2State = ref(true)
-const demo2Count = ref(0)
+const demo2ParentRef = shallowRef<HTMLElement | null>(null)
+const demo2Ref = shallowRef<HTMLElement | null>(null)
+const demo2State = shallowRef(true)
+const demo2Count = shallowRef(0)
 
 function demo2BtnOnClick() {
   demo2State.value = !demo2State.value

--- a/packages/core/onElementRemoval/index.test.ts
+++ b/packages/core/onElementRemoval/index.test.ts
@@ -1,7 +1,7 @@
 import type { AnyFn } from '@vueuse/shared'
 import type { Ref } from 'vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { effectScope, nextTick, ref } from 'vue'
+import { ref as deepRef, effectScope, nextTick, shallowRef } from 'vue'
 import { onElementRemoval } from './index'
 
 describe('onElementRemoval', () => {
@@ -12,9 +12,9 @@ describe('onElementRemoval', () => {
 
   beforeEach(() => {
     callBackFn = vi.fn(m => expect(m[0]).toBeInstanceOf(MutationRecord))
-    grandElement = ref(document.createElement('div'))
-    parentElement = ref(document.createElement('div'))
-    targetElement = ref(document.createElement('div'))
+    grandElement = shallowRef(document.createElement('div'))
+    parentElement = shallowRef(document.createElement('div'))
+    targetElement = shallowRef(document.createElement('div'))
 
     parentElement.value.appendChild(targetElement.value)
     grandElement.value.appendChild(parentElement.value)
@@ -87,7 +87,7 @@ describe('onElementRemoval', () => {
   })
 
   it('should correctly triggered even if the element is assigned a value after initialization', async () => {
-    const targetElement2 = ref()
+    const targetElement2 = deepRef()
     onElementRemoval(targetElement2, callBackFn)
 
     const el = document.createElement('div')

--- a/packages/core/onKeyStroke/demo.vue
+++ b/packages/core/onKeyStroke/demo.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { onKeyStroke } from '@vueuse/core'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 
-const translateX = ref(0)
-const translateY = ref(0)
+const translateX = shallowRef(0)
+const translateY = shallowRef(0)
 
 onKeyStroke(['w', 'W', 'ArrowUp'], (e) => {
   if (e.key === 'ArrowUp') {

--- a/packages/core/onKeyStroke/index.test.ts
+++ b/packages/core/onKeyStroke/index.test.ts
@@ -1,7 +1,7 @@
 import type { Ref } from 'vue'
 import type { KeyStrokeEventName } from './index'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 import { onKeyStroke } from './index'
 
 describe('onKeyStroke', () => {
@@ -9,7 +9,7 @@ describe('onKeyStroke', () => {
   let callBackFn: any
 
   beforeEach(() => {
-    element = ref(document.createElement('div'))
+    element = shallowRef(document.createElement('div'))
     callBackFn = vi.fn()
   })
 

--- a/packages/core/onLongPress/component.ts
+++ b/packages/core/onLongPress/component.ts
@@ -1,6 +1,6 @@
 import type { RenderableComponent } from '../types'
 import type { OnLongPressOptions } from './index'
-import { defineComponent, h, ref } from 'vue'
+import { ref as deepRef, defineComponent, h } from 'vue'
 import { onLongPress } from './index'
 
 export interface OnLongPressProps extends RenderableComponent {
@@ -12,7 +12,7 @@ export const OnLongPress = /* #__PURE__ */ defineComponent<OnLongPressProps>({
   props: ['as', 'options'] as unknown as undefined,
   emits: ['trigger'],
   setup(props, { slots, emit }) {
-    const target = ref()
+    const target = deepRef()
     onLongPress(
       target,
       (e) => {

--- a/packages/core/onLongPress/demo.vue
+++ b/packages/core/onLongPress/demo.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 import { onLongPress } from './'
 
-const htmlRef = ref<HTMLElement | null>(null)
-const htmlRefOptions = ref<HTMLElement | null>(null)
-const htmlRefOnMouseUp = ref<HTMLElement | null>(null)
+const htmlRef = shallowRef<HTMLElement | null>(null)
+const htmlRefOptions = shallowRef<HTMLElement | null>(null)
+const htmlRefOnMouseUp = shallowRef<HTMLElement | null>(null)
 
-const longPressed = ref(false)
-const clicked = ref(false)
+const longPressed = shallowRef(false)
+const clicked = shallowRef(false)
 
 function onLongPressCallback(e: PointerEvent) {
   longPressed.value = true

--- a/packages/core/onLongPress/index.test.ts
+++ b/packages/core/onLongPress/index.test.ts
@@ -1,6 +1,6 @@
 import type { Ref } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 import { useEventListener } from '../useEventListener'
 import { onLongPress } from './index'
 
@@ -203,9 +203,9 @@ describe('onLongPress', () => {
   }
 
   beforeEach(() => {
-    element = ref(document.createElement('div'))
-    parentElement = ref(document.createElement('div'))
-    childElement = ref(document.createElement('div'))
+    element = shallowRef(document.createElement('div'))
+    parentElement = shallowRef(document.createElement('div'))
+    childElement = shallowRef(document.createElement('div'))
     parentElement.value.appendChild(element.value)
     element.value.appendChild(childElement.value)
 

--- a/packages/core/onStartTyping/demo.vue
+++ b/packages/core/onStartTyping/demo.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { onStartTyping } from '@vueuse/core'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 
-const input = ref<HTMLInputElement | null>(null)
+const input = shallowRef<HTMLInputElement | null>(null)
 
 onStartTyping(() => {
   if (input.value !== document.activeElement)

--- a/packages/core/templateRef/index.test.ts
+++ b/packages/core/templateRef/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { defineComponent, h, nextTick, ref } from 'vue'
+import { defineComponent, h, nextTick, shallowRef } from 'vue'
 import { mount } from '../../.test'
 import { templateRef } from './index'
 
@@ -27,7 +27,7 @@ describe('templateRef', () => {
   it('string ref update', async () => {
     const vm = mount(defineComponent({
       setup() {
-        const refKey = ref('foo')
+        const refKey = shallowRef('foo')
         const fooEl = templateRef<HTMLElement | null>('foo', null)
         const barEl = templateRef<HTMLElement | null>('bar', null)
         return {
@@ -54,7 +54,7 @@ describe('templateRef', () => {
   it('string ref unmount', async () => {
     const vm = mount(defineComponent({
       setup() {
-        const toggle = ref(true)
+        const toggle = shallowRef(true)
         const targetEl = templateRef<HTMLElement | null>('target', null)
         return {
           toggle,

--- a/packages/core/useActiveElement/index.ts
+++ b/packages/core/useActiveElement/index.ts
@@ -1,5 +1,5 @@
 import type { ConfigurableDocumentOrShadowRoot, ConfigurableWindow } from '../_configurable'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { onElementRemoval } from '../onElementRemoval'
 import { useEventListener } from '../useEventListener'
@@ -44,7 +44,7 @@ export function useActiveElement<T extends HTMLElement>(
     return element
   }
 
-  const activeElement = ref<T | null | undefined>()
+  const activeElement = deepRef<T | null | undefined>()
   const trigger = () => {
     activeElement.value = getDeepActiveElement() as T | null | undefined
   }

--- a/packages/core/useAsyncQueue/index.ts
+++ b/packages/core/useAsyncQueue/index.ts
@@ -1,6 +1,6 @@
 import type { Ref } from 'vue'
 import { noop } from '@vueuse/shared'
-import { reactive, ref } from 'vue'
+import { ref as deepRef, reactive } from 'vue'
 
 export type UseAsyncQueueTask<T> = (...args: any[]) => T | Promise<T>
 
@@ -75,7 +75,7 @@ export function useAsyncQueue<T extends any[], S = MapQueueTask<T>>(
 
   const result = reactive(initialResult) as { [P in keyof T]: UseAsyncQueueResult<T[P]> }
 
-  const activeIndex = ref<number>(-1)
+  const activeIndex = deepRef<number>(-1)
 
   if (!tasks || tasks.length === 0) {
     onFinished()

--- a/packages/core/useAsyncState/index.ts
+++ b/packages/core/useAsyncState/index.ts
@@ -93,8 +93,8 @@ export function useAsyncState<Data, Params extends any[] = any[], Shallow extend
     throwError,
   } = options ?? {}
   const state = shallow ? shallowRef(initialState) : ref(initialState)
-  const isReady = ref(false)
-  const isLoading = ref(false)
+  const isReady = shallowRef(false)
+  const isLoading = shallowRef(false)
   const error = shallowRef<unknown | undefined>(undefined)
 
   async function execute(delay = 0, ...args: any[]) {

--- a/packages/core/useAsyncState/index.ts
+++ b/packages/core/useAsyncState/index.ts
@@ -1,6 +1,6 @@
 import type { Ref, ShallowRef, UnwrapRef } from 'vue'
 import { noop, promiseTimeout, until } from '@vueuse/shared'
-import { ref, shallowRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 
 export interface UseAsyncStateReturnBase<Data, Params extends any[], Shallow extends boolean> {
   state: Shallow extends true ? Ref<Data> : Ref<UnwrapRef<Data>>
@@ -92,7 +92,7 @@ export function useAsyncState<Data, Params extends any[] = any[], Shallow extend
     shallow = true,
     throwError,
   } = options ?? {}
-  const state = shallow ? shallowRef(initialState) : ref(initialState)
+  const state = shallow ? shallowRef(initialState) : deepRef(initialState)
   const isReady = shallowRef(false)
   const isLoading = shallowRef(false)
   const error = shallowRef<unknown | undefined>(undefined)

--- a/packages/core/useBase64/demo.vue
+++ b/packages/core/useBase64/demo.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import type { Ref } from 'vue'
 import { useBase64 } from '@vueuse/core'
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 
-const text = ref('')
+const text = shallowRef('')
 const file = ref() as Ref<File>
 const image = ref() as Ref<HTMLImageElement>
 

--- a/packages/core/useBase64/demo.vue
+++ b/packages/core/useBase64/demo.vue
@@ -1,11 +1,10 @@
 <script setup lang="ts">
-import type { Ref } from 'vue'
 import { useBase64 } from '@vueuse/core'
-import { ref, shallowRef } from 'vue'
+import { shallowRef } from 'vue'
 
 const text = shallowRef('')
-const file = ref() as Ref<File>
-const image = ref() as Ref<HTMLImageElement>
+const file = shallowRef<File>()
+const image = shallowRef<HTMLImageElement>()
 
 const { base64: textBase64 } = useBase64(text)
 const { base64: fileBase64 } = useBase64(file)

--- a/packages/core/useBase64/index.ts
+++ b/packages/core/useBase64/index.ts
@@ -1,7 +1,7 @@
 import type { MaybeRefOrGetter } from '@vueuse/shared'
 import type { Ref } from 'vue'
 import { isClient } from '@vueuse/shared'
-import { isRef, ref, shallowRef, toValue, watch } from 'vue'
+import { isRef, shallowRef, toValue, watch } from 'vue'
 import { getDefaultSerialization } from './serialization'
 
 export interface UseBase64Options {
@@ -34,11 +34,11 @@ export interface UseBase64Return {
   execute: () => Promise<string>
 }
 
-export function useBase64(target: MaybeRefOrGetter<string>, options?: UseBase64Options): UseBase64Return
-export function useBase64(target: MaybeRefOrGetter<Blob>, options?: UseBase64Options): UseBase64Return
-export function useBase64(target: MaybeRefOrGetter<ArrayBuffer>, options?: UseBase64Options): UseBase64Return
-export function useBase64(target: MaybeRefOrGetter<HTMLCanvasElement>, options?: ToDataURLOptions): UseBase64Return
-export function useBase64(target: MaybeRefOrGetter<HTMLImageElement>, options?: ToDataURLOptions): UseBase64Return
+export function useBase64(target: MaybeRefOrGetter<string | undefined>, options?: UseBase64Options): UseBase64Return
+export function useBase64(target: MaybeRefOrGetter<Blob | undefined>, options?: UseBase64Options): UseBase64Return
+export function useBase64(target: MaybeRefOrGetter<ArrayBuffer | undefined>, options?: UseBase64Options): UseBase64Return
+export function useBase64(target: MaybeRefOrGetter<HTMLCanvasElement | undefined>, options?: ToDataURLOptions): UseBase64Return
+export function useBase64(target: MaybeRefOrGetter<HTMLImageElement | undefined>, options?: ToDataURLOptions): UseBase64Return
 export function useBase64<T extends Record<string, unknown>>(target: MaybeRefOrGetter<T>, options?: UseBase64ObjectOptions<T>): UseBase64Return
 export function useBase64<T extends Map<string, unknown>>(target: MaybeRefOrGetter<T>, options?: UseBase64ObjectOptions<T>): UseBase64Return
 export function useBase64<T extends Set<unknown>>(target: MaybeRefOrGetter<T>, options?: UseBase64ObjectOptions<T>): UseBase64Return
@@ -48,7 +48,7 @@ export function useBase64(
   options?: any,
 ) {
   const base64 = shallowRef('')
-  const promise = ref() as Ref<Promise<string>>
+  const promise = shallowRef<Promise<string>>()
 
   function execute() {
     if (!isClient)

--- a/packages/core/useBase64/index.ts
+++ b/packages/core/useBase64/index.ts
@@ -1,7 +1,7 @@
 import type { MaybeRefOrGetter } from '@vueuse/shared'
 import type { Ref } from 'vue'
 import { isClient } from '@vueuse/shared'
-import { isRef, ref, toValue, watch } from 'vue'
+import { isRef, ref, shallowRef, toValue, watch } from 'vue'
 import { getDefaultSerialization } from './serialization'
 
 export interface UseBase64Options {
@@ -47,7 +47,7 @@ export function useBase64(
   target: any,
   options?: any,
 ) {
-  const base64 = ref('')
+  const base64 = shallowRef('')
   const promise = ref() as Ref<Promise<string>>
 
   function execute() {

--- a/packages/core/useBattery/index.ts
+++ b/packages/core/useBattery/index.ts
@@ -1,7 +1,7 @@
 /* this implementation is original ported from https://github.com/logaretm/vue-use-web by Abdelrahman Awad */
 
 import type { ConfigurableNavigator } from '../_configurable'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 import { defaultNavigator } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 import { useSupported } from '../useSupported'
@@ -28,10 +28,10 @@ export function useBattery(options: ConfigurableNavigator = {}) {
 
   const isSupported = useSupported(() => navigator && 'getBattery' in navigator && typeof navigator.getBattery === 'function')
 
-  const charging = ref(false)
-  const chargingTime = ref(0)
-  const dischargingTime = ref(0)
-  const level = ref(1)
+  const charging = shallowRef(false)
+  const chargingTime = shallowRef(0)
+  const dischargingTime = shallowRef(0)
+  const level = shallowRef(1)
 
   let battery: BatteryManager | null
 

--- a/packages/core/useBreakpoints/demo.vue
+++ b/packages/core/useBreakpoints/demo.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import { breakpointsTailwind, useBreakpoints } from '@vueuse/core'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 
 const breakpoints = useBreakpoints(breakpointsTailwind)
 
 const smWidth = breakpointsTailwind.sm
 
-const reactiveStuff = ref<keyof typeof breakpointsTailwind>('sm')
+const reactiveStuff = deepRef<keyof typeof breakpointsTailwind>('sm')
 const isGreaterThanBreakpoint = breakpoints.greaterOrEqual(() => reactiveStuff.value)
 
 const current = breakpoints.current()

--- a/packages/core/useBreakpoints/index.ts
+++ b/packages/core/useBreakpoints/index.ts
@@ -1,7 +1,7 @@
 import type { MaybeRefOrGetter } from '@vueuse/shared'
 import type { ConfigurableWindow } from '../_configurable'
 import { increaseWithUnit, pxValue, tryOnMounted } from '@vueuse/shared'
-import { computed, ref, toValue } from 'vue'
+import { computed, shallowRef, toValue } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useMediaQuery } from '../useMediaQuery'
 import { useSSRWidth } from '../useSSRWidth'
@@ -47,7 +47,7 @@ export function useBreakpoints<K extends string>(
   const { window = defaultWindow, strategy = 'min-width', ssrWidth = useSSRWidth() } = options
 
   const ssrSupport = typeof ssrWidth === 'number'
-  const mounted = ssrSupport ? ref(false) : { value: true }
+  const mounted = ssrSupport ? shallowRef(false) : { value: true }
   if (ssrSupport) {
     tryOnMounted(() => mounted.value = !!window)
   }

--- a/packages/core/useBroadcastChannel/demo.vue
+++ b/packages/core/useBroadcastChannel/demo.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useBroadcastChannel } from '@vueuse/core'
-import { ref, watch } from 'vue'
+import { shallowRef, watch } from 'vue'
 
 const {
   isSupported,
@@ -9,7 +9,7 @@ const {
   error,
 } = useBroadcastChannel({ name: 'vueuse-demo-channel' })
 
-const message = ref('')
+const message = shallowRef('')
 
 watch(data, () => {
   if (data.value)

--- a/packages/core/useBroadcastChannel/index.ts
+++ b/packages/core/useBroadcastChannel/index.ts
@@ -28,7 +28,7 @@ export function useBroadcastChannel<D, P>(options: UseBroadcastChannelOptions): 
   } = options
 
   const isSupported = useSupported(() => window && 'BroadcastChannel' in window)
-  const isClosed = ref(false)
+  const isClosed = shallowRef(false)
 
   const channel = ref<BroadcastChannel | undefined>()
   const data = ref()

--- a/packages/core/useBroadcastChannel/index.ts
+++ b/packages/core/useBroadcastChannel/index.ts
@@ -1,7 +1,7 @@
 import type { ComputedRef, Ref } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
 import { tryOnMounted, tryOnScopeDispose } from '@vueuse/shared'
-import { ref, shallowRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 import { useSupported } from '../useSupported'
@@ -30,8 +30,8 @@ export function useBroadcastChannel<D, P>(options: UseBroadcastChannelOptions): 
   const isSupported = useSupported(() => window && 'BroadcastChannel' in window)
   const isClosed = shallowRef(false)
 
-  const channel = ref<BroadcastChannel | undefined>()
-  const data = ref()
+  const channel = deepRef<BroadcastChannel | undefined>()
+  const data = deepRef()
   const error = shallowRef<Event | null>(null)
 
   const post = (data: unknown) => {

--- a/packages/core/useBrowserLocation/index.ts
+++ b/packages/core/useBrowserLocation/index.ts
@@ -3,7 +3,7 @@
 import type { Ref } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
 import { objectEntries } from '@vueuse/shared'
-import { reactive, ref, watch } from 'vue'
+import { ref as deepRef, reactive, watch } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 
@@ -41,7 +41,7 @@ export interface BrowserLocationState {
 export function useBrowserLocation(options: ConfigurableWindow = {}) {
   const { window = defaultWindow } = options
   const refs = Object.fromEntries(
-    WRITABLE_PROPERTIES.map(key => [key, ref()]),
+    WRITABLE_PROPERTIES.map(key => [key, deepRef()]),
   ) as Record<typeof WRITABLE_PROPERTIES[number], Ref<string | undefined>>
 
   for (const [key, ref] of objectEntries(refs)) {
@@ -68,7 +68,7 @@ export function useBrowserLocation(options: ConfigurableWindow = {}) {
     })
   }
 
-  const state = ref(buildState('load'))
+  const state = deepRef(buildState('load'))
 
   if (window) {
     const listenerOptions = { passive: true }

--- a/packages/core/useCached/demo.vue
+++ b/packages/core/useCached/demo.vue
@@ -1,20 +1,20 @@
 <script setup lang="ts">
 import { useCached } from '@vueuse/core'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 
 interface Value {
   value: number
   extra: number
 }
 
-const value = ref<Value>({ value: 42, extra: 0 })
+const value = deepRef<Value>({ value: 42, extra: 0 })
 function comparator(a: Value, b: Value) {
   return a.value === b.value
 }
 const cachedValue = useCached(value, comparator)
 
-const inputValue = ref(value.value.value)
-const inputExtra = ref(value.value.extra)
+const inputValue = deepRef(value.value.value)
+const inputExtra = deepRef(value.value.extra)
 
 function onSyncClick() {
   value.value = {

--- a/packages/core/useCached/index.test.ts
+++ b/packages/core/useCached/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 import { nextTwoTick } from '../../.test'
 import { useCached } from './index'
 
@@ -20,7 +20,7 @@ describe('useCached', () => {
   })
 
   it('should work with default comparator', async () => {
-    const booleanRef = ref(true)
+    const booleanRef = shallowRef(true)
 
     const cachedBooleanRef = useCached(booleanRef)
     await nextTwoTick()

--- a/packages/core/useCached/index.test.ts
+++ b/packages/core/useCached/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref, shallowRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 import { nextTwoTick } from '../../.test'
 import { useCached } from './index'
 
@@ -34,7 +34,7 @@ describe('useCached', () => {
   })
 
   it('should work with custom comparator', async () => {
-    const arrayRef = ref([1])
+    const arrayRef = deepRef([1])
     const initialArrayValue = arrayRef.value
 
     const cachedArrayRef = useCached(arrayRef, arrayEquals)

--- a/packages/core/useCached/index.ts
+++ b/packages/core/useCached/index.ts
@@ -1,12 +1,12 @@
 import type { Ref, WatchOptions } from 'vue'
-import { ref, watch } from 'vue'
+import { ref as deepRef, watch } from 'vue'
 
 export function useCached<T>(
   refValue: Ref<T>,
   comparator: (a: T, b: T) => boolean = (a, b) => a === b,
   watchOptions?: WatchOptions,
 ): Ref<T> {
-  const cachedValue = ref(refValue.value) as Ref<T>
+  const cachedValue = deepRef(refValue.value) as Ref<T>
 
   watch(() => refValue.value, (value) => {
     if (!comparator(value, cachedValue.value))

--- a/packages/core/useClipboard/demo.vue
+++ b/packages/core/useClipboard/demo.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { useClipboard, usePermission } from '@vueuse/core'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 
-const input = ref('')
+const input = shallowRef('')
 
 const { text, isSupported, copy } = useClipboard()
 const permissionRead = usePermission('clipboard-read')

--- a/packages/core/useClipboard/index.ts
+++ b/packages/core/useClipboard/index.ts
@@ -4,7 +4,7 @@ import type { MaybeRefOrGetter } from '@vueuse/shared'
 import type { ComputedRef } from 'vue'
 import type { ConfigurableNavigator } from '../_configurable'
 import { useTimeoutFn } from '@vueuse/shared'
-import { computed, ref, toValue } from 'vue'
+import { computed, shallowRef, toValue } from 'vue'
 import { defaultNavigator } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 import { usePermission } from '../usePermission'
@@ -66,8 +66,8 @@ export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<strin
   const permissionRead = usePermission('clipboard-read')
   const permissionWrite = usePermission('clipboard-write')
   const isSupported = computed(() => isClipboardApiSupported.value || legacy)
-  const text = ref('')
-  const copied = ref(false)
+  const text = shallowRef('')
+  const copied = shallowRef(false)
   const timeout = useTimeoutFn(() => copied.value = false, copiedDuring, { immediate: false })
 
   function updateText() {

--- a/packages/core/useClipboardItems/demo.vue
+++ b/packages/core/useClipboardItems/demo.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import { useClipboardItems, usePermission } from '@vueuse/core'
-import { effect, ref } from 'vue'
+import { effect, shallowRef } from 'vue'
 
-const input = ref('')
+const input = shallowRef('')
 
 const { content, isSupported, copy } = useClipboardItems()
-const computedText = ref('')
-const computedMimeType = ref('')
+const computedText = shallowRef('')
+const computedMimeType = shallowRef('')
 effect(() => {
   Promise.all(content.value.map(item => item.getType('text/plain')))
     .then(async (blobs) => {

--- a/packages/core/useClipboardItems/index.ts
+++ b/packages/core/useClipboardItems/index.ts
@@ -2,7 +2,7 @@ import type { MaybeRefOrGetter } from '@vueuse/shared'
 import type { ComputedRef } from 'vue'
 import type { ConfigurableNavigator } from '../_configurable'
 import { useTimeoutFn } from '@vueuse/shared'
-import { ref, toValue } from 'vue'
+import { ref, shallowRef, toValue } from 'vue'
 import { defaultNavigator } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 import { useSupported } from '../useSupported'
@@ -53,7 +53,7 @@ export function useClipboardItems(options: UseClipboardItemsOptions<MaybeRefOrGe
 
   const isSupported = useSupported(() => (navigator && 'clipboard' in navigator))
   const content = ref<ClipboardItems>([])
-  const copied = ref(false)
+  const copied = shallowRef(false)
   const timeout = useTimeoutFn(() => copied.value = false, copiedDuring, { immediate: false })
 
   function updateContent() {

--- a/packages/core/useClipboardItems/index.ts
+++ b/packages/core/useClipboardItems/index.ts
@@ -2,7 +2,7 @@ import type { MaybeRefOrGetter } from '@vueuse/shared'
 import type { ComputedRef } from 'vue'
 import type { ConfigurableNavigator } from '../_configurable'
 import { useTimeoutFn } from '@vueuse/shared'
-import { ref, shallowRef, toValue } from 'vue'
+import { ref as deepRef, shallowRef, toValue } from 'vue'
 import { defaultNavigator } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 import { useSupported } from '../useSupported'
@@ -52,7 +52,7 @@ export function useClipboardItems(options: UseClipboardItemsOptions<MaybeRefOrGe
   } = options
 
   const isSupported = useSupported(() => (navigator && 'clipboard' in navigator))
-  const content = ref<ClipboardItems>([])
+  const content = deepRef<ClipboardItems>([])
   const copied = shallowRef(false)
   const timeout = useTimeoutFn(() => copied.value = false, copiedDuring, { immediate: false })
 

--- a/packages/core/useCloned/index.test.ts
+++ b/packages/core/useCloned/index.test.ts
@@ -1,6 +1,6 @@
 import { useCloned } from '@vueuse/core'
 import { describe, expect, it } from 'vitest'
-import { nextTick, ref } from 'vue'
+import { ref as deepRef, nextTick } from 'vue'
 
 describe('useCloned', () => {
   it('works with simple objects', () => {
@@ -18,7 +18,7 @@ describe('useCloned', () => {
   })
 
   it('works with refs', async () => {
-    const data = ref({ test: 'test' })
+    const data = deepRef({ test: 'test' })
 
     const { cloned } = useCloned(data)
 
@@ -30,7 +30,7 @@ describe('useCloned', () => {
   })
 
   it('works with getter function', async () => {
-    const data = ref({ test: 'test' })
+    const data = deepRef({ test: 'test' })
 
     const { cloned } = useCloned(() => data.value)
 
@@ -42,7 +42,7 @@ describe('useCloned', () => {
   })
 
   it('works with refs and manual sync', async () => {
-    const data = ref({ test: 'test' })
+    const data = deepRef({ test: 'test' })
 
     const { cloned, sync } = useCloned(data, { manual: true })
 
@@ -56,7 +56,7 @@ describe('useCloned', () => {
   })
 
   it('works with custom clone function', async () => {
-    const data = ref<Record<string, any>>({ test: 'test' })
+    const data = deepRef<Record<string, any>>({ test: 'test' })
 
     const { cloned } = useCloned(data, {
       clone: source => ({ ...source, proxyTest: true }),
@@ -71,7 +71,7 @@ describe('useCloned', () => {
   })
 
   it('works with watch options', async () => {
-    const data = ref({ test: 'test' })
+    const data = deepRef({ test: 'test' })
 
     const { cloned } = useCloned(data, { immediate: false, deep: false })
 
@@ -95,7 +95,7 @@ describe('useCloned', () => {
   })
 
   it('works with use isModified', async () => {
-    const data = ref({ test: 'test' })
+    const data = deepRef({ test: 'test' })
 
     const { cloned, isModified, sync } = useCloned(data)
 

--- a/packages/core/useCloned/index.ts
+++ b/packages/core/useCloned/index.ts
@@ -1,6 +1,6 @@
 import type { MaybeRefOrGetter } from '@vueuse/shared'
 import type { Ref, WatchOptions } from 'vue'
-import { isRef, ref, toValue, watch } from 'vue'
+import { ref as deepRef, isRef, toValue, watch } from 'vue'
 
 export interface UseClonedOptions<T = any> extends WatchOptions {
   /**
@@ -43,8 +43,8 @@ export function useCloned<T>(
   source: MaybeRefOrGetter<T>,
   options: UseClonedOptions = {},
 ): UseClonedReturn<T> {
-  const cloned = ref({} as T) as Ref<T>
-  const isModified = ref<boolean>(false)
+  const cloned = deepRef({} as T) as Ref<T>
+  const isModified = deepRef<boolean>(false)
   let _lastSync = false
 
   const {

--- a/packages/core/useColorMode/index.test.ts
+++ b/packages/core/useColorMode/index.test.ts
@@ -1,6 +1,6 @@
 import type { Ref } from 'vue'
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick, ref } from 'vue'
+import { nextTick, shallowRef } from 'vue'
 import { nextTwoTick } from '../../.test'
 import { usePreferredDark } from '../usePreferredDark'
 import { useColorMode } from './index'
@@ -10,7 +10,7 @@ describe('useColorMode', () => {
   const htmlEl = document.querySelector('html')
 
   vi.mock('../usePreferredDark', () => {
-    const mockPreferredDark = ref(false)
+    const mockPreferredDark = shallowRef(false)
     return {
       usePreferredDark: () => mockPreferredDark,
     }

--- a/packages/core/useConfirmDialog/demo.vue
+++ b/packages/core/useConfirmDialog/demo.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { useConfirmDialog } from '@vueuse/core'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 
-const message = ref('')
-const revaled1 = ref(false)
-const revaled2 = ref(false)
+const message = shallowRef('')
+const revaled1 = shallowRef(false)
+const revaled2 = shallowRef(false)
 
 const dialog1 = useConfirmDialog(revaled1)
 const dialog2 = useConfirmDialog(revaled2)

--- a/packages/core/useConfirmDialog/index.test.ts
+++ b/packages/core/useConfirmDialog/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { nextTick, ref } from 'vue'
+import { nextTick, shallowRef } from 'vue'
 import { useConfirmDialog } from './index'
 
 describe('useConfirmDialog', () => {
@@ -8,7 +8,7 @@ describe('useConfirmDialog', () => {
   })
 
   it('should open the dialog and close on confirm', () => {
-    const show = ref(false)
+    const show = shallowRef(false)
 
     const {
       reveal,
@@ -23,7 +23,7 @@ describe('useConfirmDialog', () => {
   })
 
   it('should close on cancel', () => {
-    const show = ref(false)
+    const show = shallowRef(false)
 
     const {
       reveal,
@@ -38,8 +38,8 @@ describe('useConfirmDialog', () => {
   })
 
   it('should execute `onReveal` fn on open dialog', () => {
-    const show = ref(false)
-    const message = ref('initial')
+    const show = shallowRef(false)
+    const message = shallowRef('initial')
 
     const {
       reveal,
@@ -58,8 +58,8 @@ describe('useConfirmDialog', () => {
   })
 
   it('should execute a callback inside `onConfirm` hook only after confirming', () => {
-    const show = ref(false)
-    const message = ref('initial')
+    const show = shallowRef(false)
+    const message = shallowRef('initial')
 
     const {
       reveal,
@@ -79,8 +79,8 @@ describe('useConfirmDialog', () => {
   })
 
   it('should execute a callback inside `onCancel` hook only after canceling dialog', () => {
-    const show = ref(false)
-    const message = ref('initial')
+    const show = shallowRef(false)
+    const message = shallowRef('initial')
 
     const {
       reveal,
@@ -100,8 +100,8 @@ describe('useConfirmDialog', () => {
   })
 
   it('should pass data from confirm fn to `onConfirm` hook', () => {
-    const message = ref('initial')
-    const show = ref(false)
+    const message = shallowRef('initial')
+    const show = shallowRef(false)
     const data = { value: 'confirm' }
 
     const {
@@ -121,8 +121,8 @@ describe('useConfirmDialog', () => {
   })
 
   it('should pass data from cancel fn to `onCancel` hook', async () => {
-    const message = ref('initial')
-    const show = ref(false)
+    const message = shallowRef('initial')
+    const show = shallowRef(false)
     const data = { value: 'confirm' }
 
     const {
@@ -142,7 +142,7 @@ describe('useConfirmDialog', () => {
   })
 
   it('should return promise that will be resolved on `confirm()`', async () => {
-    const show = ref(false)
+    const show = shallowRef(false)
 
     const {
       reveal,
@@ -162,7 +162,7 @@ describe('useConfirmDialog', () => {
   })
 
   it('should return promise that will be resolved on `cancel()`', async () => {
-    const show = ref(false)
+    const show = shallowRef(false)
 
     const {
       reveal,

--- a/packages/core/useConfirmDialog/index.ts
+++ b/packages/core/useConfirmDialog/index.ts
@@ -1,7 +1,7 @@
 import type { EventHook, EventHookOn } from '@vueuse/shared'
 import type { ComputedRef, Ref } from 'vue'
 import { createEventHook, noop } from '@vueuse/shared'
-import { computed, ref } from 'vue'
+import { computed, shallowRef } from 'vue'
 
 export type UseConfirmDialogRevealResult<C, D>
   = {
@@ -67,7 +67,7 @@ export function useConfirmDialog<
   ConfirmData = any,
   CancelData = any,
 >(
-  revealed: Ref<boolean> = ref(false),
+  revealed: Ref<boolean> = shallowRef(false),
 ): UseConfirmDialogReturn<RevealData, ConfirmData, CancelData> {
   const confirmHook: EventHook = createEventHook<ConfirmData>()
   const cancelHook: EventHook = createEventHook<CancelData>()

--- a/packages/core/useCountdown/demo.vue
+++ b/packages/core/useCountdown/demo.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { useEventListener } from '@vueuse/core'
-import { ref, shallowRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 import { useCountdown } from './index'
 
 const countdownSeconds = shallowRef(5)
-const rocketRef = ref<HTMLDivElement>()
+const rocketRef = deepRef<HTMLDivElement>()
 const { remaining, start, stop, pause, resume } = useCountdown(countdownSeconds, {
   onComplete() {
     rocketRef.value!.classList.add('launching')

--- a/packages/core/useCountdown/demo.vue
+++ b/packages/core/useCountdown/demo.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { useEventListener } from '@vueuse/core'
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 import { useCountdown } from './index'
 
-const countdownSeconds = ref(5)
+const countdownSeconds = shallowRef(5)
 const rocketRef = ref<HTMLDivElement>()
 const { remaining, start, stop, pause, resume } = useCountdown(countdownSeconds, {
   onComplete() {

--- a/packages/core/useCountdown/index.test.ts
+++ b/packages/core/useCountdown/index.test.ts
@@ -1,7 +1,7 @@
 import type { Pausable } from '@vueuse/shared'
 import type { UseCountdownOptions } from './index'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { effectScope, ref } from 'vue'
+import { effectScope, shallowRef } from 'vue'
 import { useCountdown } from './index'
 
 describe('useCountdown', () => {
@@ -112,7 +112,7 @@ describe('useCountdown', () => {
   })
 
   it('initial interval can be changed', async () => {
-    const countdown = ref(3)
+    const countdown = shallowRef(3)
 
     const { start } = useCountdown(countdown, { ...options, immediate: false })
 

--- a/packages/core/useCountdown/index.ts
+++ b/packages/core/useCountdown/index.ts
@@ -1,7 +1,7 @@
 import type { MaybeRefOrGetter, Pausable } from '@vueuse/shared'
 import type { Ref } from 'vue'
 import { useIntervalFn } from '@vueuse/shared'
-import { ref, toValue } from 'vue'
+import { ref as deepRef, toValue } from 'vue'
 
 export interface UseCountdownOptions {
   /**
@@ -52,7 +52,7 @@ export interface UseCountdownReturn extends Pausable {
  * @see https://vueuse.org/useCountdown
  */
 export function useCountdown(initialCountdown: MaybeRefOrGetter<number>, options?: UseCountdownOptions): UseCountdownReturn {
-  const remaining = ref(toValue(initialCountdown))
+  const remaining = deepRef(toValue(initialCountdown))
 
   const intervalController = useIntervalFn(() => {
     const value = remaining.value - 1

--- a/packages/core/useCssVar/demo.vue
+++ b/packages/core/useCssVar/demo.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useCssVar } from '@vueuse/core'
-import { ref, useTemplateRef } from 'vue'
+import { shallowRef, useTemplateRef } from 'vue'
 
 const el = useTemplateRef('el')
 const color = useCssVar('--color', el)
@@ -13,7 +13,7 @@ function switchColor() {
 }
 
 const elv = useTemplateRef('elv')
-const key = ref('--color')
+const key = shallowRef('--color')
 const colorVal = useCssVar(key, elv)
 function changeVar() {
   if (key.value === '--color')

--- a/packages/core/useCssVar/index.test.ts
+++ b/packages/core/useCssVar/index.test.ts
@@ -1,6 +1,6 @@
 import { defaultWindow } from '@vueuse/core'
 import { describe, expect, it } from 'vitest'
-import { defineComponent, h, nextTick, onMounted, ref, shallowRef, useTemplateRef } from 'vue'
+import { defineComponent, h, nextTick, onMounted, shallowRef, useTemplateRef } from 'vue'
 import { mount } from '../../.test'
 import { useCssVar } from './index'
 
@@ -173,7 +173,7 @@ describe('useCssVar', () => {
     const vm = mount(defineComponent({
       setup() {
         const el = useTemplateRef<HTMLDivElement>('el')
-        const key = ref('--color')
+        const key = shallowRef('--color')
         const variable = useCssVar(key, el)
 
         function changeVar() {

--- a/packages/core/useCssVar/index.ts
+++ b/packages/core/useCssVar/index.ts
@@ -1,7 +1,7 @@
 import type { MaybeRefOrGetter } from '@vueuse/shared'
 import type { ConfigurableWindow } from '../_configurable'
 import type { MaybeElementRef } from '../unrefElement'
-import { computed, ref, toValue, watch } from 'vue'
+import { computed, ref as deepRef, toValue, watch } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { unrefElement } from '../unrefElement'
 import { useMutationObserver } from '../useMutationObserver'
@@ -29,7 +29,7 @@ export function useCssVar(
   options: UseCssVarOptions = {},
 ) {
   const { window = defaultWindow, initialValue, observe = false } = options
-  const variable = ref(initialValue)
+  const variable = deepRef(initialValue)
   const elRef = computed(() => unrefElement(target) || window?.document?.documentElement)
 
   function updateCssVar() {

--- a/packages/core/useCycleList/demo.vue
+++ b/packages/core/useCycleList/demo.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { useCycleList } from '@vueuse/core'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 
-const list = ref([
+const list = deepRef([
   'Dog',
   'Cat',
   'Lizard',

--- a/packages/core/useCycleList/index.test.ts
+++ b/packages/core/useCycleList/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 import { useCycleList } from './index'
 
 describe('useCycleList', () => {
@@ -31,7 +31,7 @@ describe('useCycleList', () => {
   })
 
   it('should work with ref', () => {
-    const list = ref(['foo', 'bar', 'fooBar'])
+    const list = deepRef(['foo', 'bar', 'fooBar'])
 
     const { state, next, prev, index, go } = useCycleList(list)
 
@@ -71,7 +71,7 @@ describe('useCycleList', () => {
 
   describe('when list empty', () => {
     it('returns the correctly data', () => {
-      const list = ref(['foo', 'bar', 'fooBar'])
+      const list = deepRef(['foo', 'bar', 'fooBar'])
 
       const { state, index } = useCycleList(list)
 

--- a/packages/core/useDebouncedRefHistory/demo.vue
+++ b/packages/core/useDebouncedRefHistory/demo.vue
@@ -2,13 +2,12 @@
 import type { Ref } from 'vue'
 import { formatDate, useDebouncedRefHistory } from '@vueuse/core'
 import { useCounter } from '@vueuse/shared'
-
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 
 function format(ts: number) {
   return formatDate(new Date(ts), 'YYYY-MM-DD HH:mm:ss')
 }
-const delay: Ref<number> = ref(1000)
+const delay: Ref<number> = shallowRef(1000)
 
 const { count, inc, dec } = useCounter()
 const { history, undo, redo, canUndo, canRedo } = useDebouncedRefHistory(

--- a/packages/core/useDebouncedRefHistory/index.test.ts
+++ b/packages/core/useDebouncedRefHistory/index.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
-import { nextTick, ref } from 'vue'
+import { nextTick, shallowRef } from 'vue'
 import { useDebouncedRefHistory } from './index'
 
 describe('useDebouncedRefHistory', () => {
   it('once the ref\'s value has changed and some time has passed, ensure the snapshot is updated', async () => {
-    const v = ref(0)
+    const v = shallowRef(0)
 
     const { history } = useDebouncedRefHistory(v, { debounce: 10 })
     v.value = 100
@@ -18,7 +18,7 @@ describe('useDebouncedRefHistory', () => {
   })
 
   it('when debounce is undefined', async () => {
-    const v = ref(0)
+    const v = shallowRef(0)
 
     const { history } = useDebouncedRefHistory(v, { deep: false })
 

--- a/packages/core/useDeviceMotion/index.ts
+++ b/packages/core/useDeviceMotion/index.ts
@@ -4,7 +4,7 @@ import type { ConfigurableEventFilter } from '@vueuse/shared'
 import type { Ref } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
 import { bypassFilter, createFilterWrapper } from '@vueuse/shared'
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 import { useSupported } from '../useSupported'
@@ -38,10 +38,10 @@ export function useDeviceMotion(options: DeviceMotionOptions = {}) {
 
   const isSupported = useSupported(() => typeof DeviceMotionEvent !== 'undefined')
   const requirePermissions = useSupported(() => isSupported.value && 'requestPermission' in DeviceMotionEvent && typeof DeviceMotionEvent.requestPermission === 'function')
-  const permissionGranted = ref(false)
+  const permissionGranted = shallowRef(false)
   const acceleration: Ref<DeviceMotionEvent['acceleration']> = ref({ x: null, y: null, z: null })
   const rotationRate: Ref<DeviceMotionEvent['rotationRate']> = ref({ alpha: null, beta: null, gamma: null })
-  const interval = ref(0)
+  const interval = shallowRef(0)
   const accelerationIncludingGravity: Ref<DeviceMotionEvent['accelerationIncludingGravity']> = ref({
     x: null,
     y: null,

--- a/packages/core/useDeviceMotion/index.ts
+++ b/packages/core/useDeviceMotion/index.ts
@@ -4,7 +4,7 @@ import type { ConfigurableEventFilter } from '@vueuse/shared'
 import type { Ref } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
 import { bypassFilter, createFilterWrapper } from '@vueuse/shared'
-import { ref, shallowRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 import { useSupported } from '../useSupported'
@@ -39,10 +39,10 @@ export function useDeviceMotion(options: DeviceMotionOptions = {}) {
   const isSupported = useSupported(() => typeof DeviceMotionEvent !== 'undefined')
   const requirePermissions = useSupported(() => isSupported.value && 'requestPermission' in DeviceMotionEvent && typeof DeviceMotionEvent.requestPermission === 'function')
   const permissionGranted = shallowRef(false)
-  const acceleration: Ref<DeviceMotionEvent['acceleration']> = ref({ x: null, y: null, z: null })
-  const rotationRate: Ref<DeviceMotionEvent['rotationRate']> = ref({ alpha: null, beta: null, gamma: null })
+  const acceleration: Ref<DeviceMotionEvent['acceleration']> = deepRef({ x: null, y: null, z: null })
+  const rotationRate: Ref<DeviceMotionEvent['rotationRate']> = deepRef({ alpha: null, beta: null, gamma: null })
   const interval = shallowRef(0)
-  const accelerationIncludingGravity: Ref<DeviceMotionEvent['accelerationIncludingGravity']> = ref({
+  const accelerationIncludingGravity: Ref<DeviceMotionEvent['accelerationIncludingGravity']> = deepRef({
     x: null,
     y: null,
     z: null,

--- a/packages/core/useDeviceOrientation/index.ts
+++ b/packages/core/useDeviceOrientation/index.ts
@@ -2,7 +2,7 @@
 
 import type { Ref } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 import { useSupported } from '../useSupported'
@@ -17,7 +17,7 @@ export function useDeviceOrientation(options: ConfigurableWindow = {}) {
   const { window = defaultWindow } = options
   const isSupported = useSupported(() => window && 'DeviceOrientationEvent' in window)
 
-  const isAbsolute = ref(false)
+  const isAbsolute = shallowRef(false)
   const alpha: Ref<number | null> = ref(null)
   const beta: Ref<number | null> = ref(null)
   const gamma: Ref<number | null> = ref(null)

--- a/packages/core/useDeviceOrientation/index.ts
+++ b/packages/core/useDeviceOrientation/index.ts
@@ -2,7 +2,7 @@
 
 import type { Ref } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
-import { ref, shallowRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 import { useSupported } from '../useSupported'
@@ -18,9 +18,9 @@ export function useDeviceOrientation(options: ConfigurableWindow = {}) {
   const isSupported = useSupported(() => window && 'DeviceOrientationEvent' in window)
 
   const isAbsolute = shallowRef(false)
-  const alpha: Ref<number | null> = ref(null)
-  const beta: Ref<number | null> = ref(null)
-  const gamma: Ref<number | null> = ref(null)
+  const alpha: Ref<number | null> = deepRef(null)
+  const beta: Ref<number | null> = deepRef(null)
+  const gamma: Ref<number | null> = deepRef(null)
 
   if (window && isSupported.value) {
     useEventListener(window, 'deviceorientation', (event) => {

--- a/packages/core/useDevicePixelRatio/index.ts
+++ b/packages/core/useDevicePixelRatio/index.ts
@@ -1,6 +1,6 @@
 import type { ConfigurableWindow } from '../_configurable'
 import { noop, watchImmediate } from '@vueuse/shared'
-import { readonly, ref } from 'vue'
+import { readonly, shallowRef } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useMediaQuery } from '../useMediaQuery'
 
@@ -14,7 +14,7 @@ export function useDevicePixelRatio(options: ConfigurableWindow = {}) {
     window = defaultWindow,
   } = options
 
-  const pixelRatio = ref(1)
+  const pixelRatio = shallowRef(1)
   const query = useMediaQuery(() => `(resolution: ${pixelRatio.value}dppx)`, options)
   let stop = noop
 

--- a/packages/core/useDevicesList/index.ts
+++ b/packages/core/useDevicesList/index.ts
@@ -2,7 +2,7 @@
 
 import type { ComputedRef, Ref } from 'vue'
 import type { ConfigurableNavigator } from '../_configurable'
-import { computed, ref } from 'vue'
+import { computed, ref, shallowRef } from 'vue'
 import { defaultNavigator } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 import { usePermission } from '../usePermission'
@@ -57,7 +57,7 @@ export function useDevicesList(options: UseDevicesListOptions = {}): UseDevicesL
   const audioInputs = computed(() => devices.value.filter(i => i.kind === 'audioinput'))
   const audioOutputs = computed(() => devices.value.filter(i => i.kind === 'audiooutput'))
   const isSupported = useSupported(() => navigator && navigator.mediaDevices && navigator.mediaDevices.enumerateDevices)
-  const permissionGranted = ref(false)
+  const permissionGranted = shallowRef(false)
   let stream: MediaStream | null
 
   async function update() {

--- a/packages/core/useDevicesList/index.ts
+++ b/packages/core/useDevicesList/index.ts
@@ -2,7 +2,7 @@
 
 import type { ComputedRef, Ref } from 'vue'
 import type { ConfigurableNavigator } from '../_configurable'
-import { computed, ref, shallowRef } from 'vue'
+import { computed, ref as deepRef, shallowRef } from 'vue'
 import { defaultNavigator } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 import { usePermission } from '../usePermission'
@@ -52,7 +52,7 @@ export function useDevicesList(options: UseDevicesListOptions = {}): UseDevicesL
     onUpdated,
   } = options
 
-  const devices = ref([]) as Ref<MediaDeviceInfo[]>
+  const devices = deepRef([]) as Ref<MediaDeviceInfo[]>
   const videoInputs = computed(() => devices.value.filter(i => i.kind === 'videoinput'))
   const audioInputs = computed(() => devices.value.filter(i => i.kind === 'audioinput'))
   const audioOutputs = computed(() => devices.value.filter(i => i.kind === 'audiooutput'))

--- a/packages/core/useDisplayMedia/demo.vue
+++ b/packages/core/useDisplayMedia/demo.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { useDisplayMedia } from '@vueuse/core'
-import { ref, watchEffect } from 'vue'
+import { ref as deepRef, watchEffect } from 'vue'
 
-const video = ref<HTMLVideoElement>()
+const video = deepRef<HTMLVideoElement>()
 const { stream, enabled } = useDisplayMedia()
 
 watchEffect(() => {

--- a/packages/core/useDisplayMedia/index.ts
+++ b/packages/core/useDisplayMedia/index.ts
@@ -1,7 +1,7 @@
 import type { MaybeRef } from '@vueuse/shared'
 import type { Ref } from 'vue'
 import type { ConfigurableNavigator } from '../_configurable'
-import { ref, shallowRef, watch } from 'vue'
+import { ref as deepRef, shallowRef, watch } from 'vue'
 import { defaultNavigator } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 import { useSupported } from '../useSupported'
@@ -30,7 +30,7 @@ export interface UseDisplayMediaOptions extends ConfigurableNavigator {
  * @param options
  */
 export function useDisplayMedia(options: UseDisplayMediaOptions = {}) {
-  const enabled = ref(options.enabled ?? false)
+  const enabled = deepRef(options.enabled ?? false)
   const video = options.video
   const audio = options.audio
   const { navigator = defaultNavigator } = options

--- a/packages/core/useDocumentVisibility/demo.vue
+++ b/packages/core/useDocumentVisibility/demo.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { useDocumentVisibility } from '@vueuse/core'
 import { useTimeoutFn } from '@vueuse/shared'
-import { ref, watch } from 'vue'
+import { ref as deepRef, watch } from 'vue'
 
 const startMessage = '💡 Minimize the page or switch tab then return'
-const message = ref(startMessage)
+const message = deepRef(startMessage)
 const visibility = useDocumentVisibility()
 
 const timeout = useTimeoutFn(() => {

--- a/packages/core/useDocumentVisibility/index.ts
+++ b/packages/core/useDocumentVisibility/index.ts
@@ -1,6 +1,6 @@
 import type { Ref } from 'vue'
 import type { ConfigurableDocument } from '../_configurable'
-import { ref, shallowRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 import { defaultDocument } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 
@@ -14,7 +14,7 @@ export function useDocumentVisibility(options: ConfigurableDocument = {}): Ref<D
   if (!document)
     return shallowRef('visible')
 
-  const visibility = ref(document.visibilityState)
+  const visibility = deepRef(document.visibilityState)
 
   useEventListener(document, 'visibilitychange', () => {
     visibility.value = document.visibilityState

--- a/packages/core/useDocumentVisibility/index.ts
+++ b/packages/core/useDocumentVisibility/index.ts
@@ -1,6 +1,6 @@
 import type { Ref } from 'vue'
 import type { ConfigurableDocument } from '../_configurable'
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 import { defaultDocument } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 
@@ -12,7 +12,7 @@ import { useEventListener } from '../useEventListener'
 export function useDocumentVisibility(options: ConfigurableDocument = {}): Ref<DocumentVisibilityState> {
   const { document = defaultDocument } = options
   if (!document)
-    return ref('visible')
+    return shallowRef('visible')
 
   const visibility = ref(document.visibilityState)
 

--- a/packages/core/useDraggable/component.ts
+++ b/packages/core/useDraggable/component.ts
@@ -1,7 +1,7 @@
 import type { UseDraggableOptions } from '@vueuse/core'
 import type { Position, RenderableComponent } from '../types'
 import { isClient, useDraggable, useStorage } from '@vueuse/core'
-import { computed, defineComponent, h, reactive, ref, toValue } from 'vue'
+import { computed, ref as deepRef, defineComponent, h, reactive, toValue } from 'vue'
 
 export interface UseDraggableProps extends UseDraggableOptions, RenderableComponent {
   /**
@@ -38,7 +38,7 @@ export const UseDraggable = /* #__PURE__ */ defineComponent<UseDraggableProps>({
     'containerElement',
   ] as unknown as undefined,
   setup(props, { slots }) {
-    const target = ref()
+    const target = deepRef()
     const handle = computed(() => props.handle ?? target.value)
     const containerElement = computed(() => props.containerElement as (HTMLElement | SVGElement | null | undefined) ?? undefined)
     const disabled = computed(() => !!props.disabled)

--- a/packages/core/useDraggable/demo.vue
+++ b/packages/core/useDraggable/demo.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useDraggable } from '@vueuse/core'
 import { isClient } from '@vueuse/shared'
-import { ref, useTemplateRef } from 'vue'
+import { shallowRef, useTemplateRef } from 'vue'
 import { UseDraggable as Draggable } from './component'
 
 const el = useTemplateRef<HTMLElement>('el')
@@ -9,7 +9,7 @@ const handle = useTemplateRef<HTMLElement>('handle')
 
 const innerWidth = isClient ? window.innerWidth : 200
 
-const disabled = ref(false)
+const disabled = shallowRef(false)
 const { x, y, style } = useDraggable(el, {
   initialValue: { x: innerWidth / 4.2, y: 80 },
   preventDefault: true,

--- a/packages/core/useDraggable/index.ts
+++ b/packages/core/useDraggable/index.ts
@@ -1,7 +1,7 @@
 import type { MaybeRefOrGetter } from '@vueuse/shared'
 import type { PointerType, Position } from '../types'
 import { isClient, toRefs } from '@vueuse/shared'
-import { computed, ref, toValue } from 'vue'
+import { computed, ref as deepRef, toValue } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 
@@ -140,11 +140,11 @@ export function useDraggable(
     buttons = [0],
   } = options
 
-  const position = ref<Position>(
+  const position = deepRef<Position>(
     toValue(initialValue) ?? { x: 0, y: 0 },
   )
 
-  const pressedDelta = ref<Position>()
+  const pressedDelta = deepRef<Position>()
 
   const filterEvent = (e: PointerEvent) => {
     if (pointerTypes)

--- a/packages/core/useDropZone/demo.vue
+++ b/packages/core/useDropZone/demo.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { useDropZone } from '@vueuse/core'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 
-const filesData = ref<{ name: string, size: number, type: string, lastModified: number }[]>([])
-const imageFilesData = ref<{ name: string, size: number, type: string, lastModified: number }[]>([])
+const filesData = deepRef<{ name: string, size: number, type: string, lastModified: number }[]>([])
+const imageFilesData = deepRef<{ name: string, size: number, type: string, lastModified: number }[]>([])
 
 function onDrop(files: File[] | null) {
   filesData.value = []
@@ -29,8 +29,8 @@ function onImageDrop(files: File[] | null) {
   }
 }
 
-const dropZoneRef = ref<HTMLElement>()
-const imageDropZoneRef = ref<HTMLElement>()
+const dropZoneRef = deepRef<HTMLElement>()
+const imageDropZoneRef = deepRef<HTMLElement>()
 
 const { isOverDropZone } = useDropZone(dropZoneRef, onDrop)
 

--- a/packages/core/useDropZone/index.ts
+++ b/packages/core/useDropZone/index.ts
@@ -3,7 +3,7 @@ import type { MaybeRef, MaybeRefOrGetter } from '@vueuse/shared'
 import type { Ref } from 'vue'
 import { isClient } from '@vueuse/shared'
 // eslint-disable-next-line no-restricted-imports
-import { ref, shallowRef, unref } from 'vue'
+import { shallowRef, unref } from 'vue'
 
 import { useEventListener } from '../useEventListener'
 
@@ -36,7 +36,7 @@ export function useDropZone(
   target: MaybeRefOrGetter<HTMLElement | null | undefined>,
   options: UseDropZoneOptions | UseDropZoneOptions['onDrop'] = {},
 ): UseDropZoneReturn {
-  const isOverDropZone = ref(false)
+  const isOverDropZone = shallowRef(false)
   const files = shallowRef<File[] | null>(null)
   let counter = 0
   let isValid = true

--- a/packages/core/useElementBounding/component.ts
+++ b/packages/core/useElementBounding/component.ts
@@ -1,13 +1,13 @@
 import type { RenderableComponent } from '../types'
 import type { UseResizeObserverOptions } from '../useResizeObserver'
 import { useElementBounding } from '@vueuse/core'
-import { defineComponent, h, reactive, ref } from 'vue'
+import { ref as deepRef, defineComponent, h, reactive } from 'vue'
 
 export const UseElementBounding = /* #__PURE__ */ defineComponent<UseResizeObserverOptions & RenderableComponent>({
   name: 'UseElementBounding',
   props: ['box', 'as'] as unknown as undefined,
   setup(props, { slots }) {
-    const target = ref()
+    const target = deepRef()
     const data = reactive(useElementBounding(target))
 
     return () => {

--- a/packages/core/useElementBounding/index.ts
+++ b/packages/core/useElementBounding/index.ts
@@ -1,6 +1,6 @@
 import type { MaybeComputedElementRef } from '../unrefElement'
 import { tryOnMounted } from '@vueuse/shared'
-import { ref, watch } from 'vue'
+import { shallowRef, watch } from 'vue'
 import { unrefElement } from '../unrefElement'
 import { useEventListener } from '../useEventListener'
 import { useMutationObserver } from '../useMutationObserver'
@@ -63,14 +63,14 @@ export function useElementBounding(
     updateTiming = 'sync',
   } = options
 
-  const height = ref(0)
-  const bottom = ref(0)
-  const left = ref(0)
-  const right = ref(0)
-  const top = ref(0)
-  const width = ref(0)
-  const x = ref(0)
-  const y = ref(0)
+  const height = shallowRef(0)
+  const bottom = shallowRef(0)
+  const left = shallowRef(0)
+  const right = shallowRef(0)
+  const top = shallowRef(0)
+  const width = shallowRef(0)
+  const x = shallowRef(0)
+  const y = shallowRef(0)
 
   function recalculate() {
     const el = unrefElement(target)

--- a/packages/core/useElementByPoint/index.ts
+++ b/packages/core/useElementByPoint/index.ts
@@ -2,7 +2,7 @@ import type { MaybeRefOrGetter, Pausable } from '@vueuse/shared'
 import type { ComputedRef, Ref } from 'vue'
 import type { ConfigurableDocument } from '../_configurable'
 import { useIntervalFn } from '@vueuse/shared'
-import { ref, toValue } from 'vue'
+import { ref as deepRef, toValue } from 'vue'
 import { defaultDocument } from '../_configurable'
 import { useRafFn } from '../useRafFn'
 import { useSupported } from '../useSupported'
@@ -43,7 +43,7 @@ export function useElementByPoint<M extends boolean = false>(options: UseElement
     return document && 'elementFromPoint' in document
   })
 
-  const element = ref<any>(null)
+  const element = deepRef<any>(null)
 
   const cb = () => {
     element.value = toValue(multiple)

--- a/packages/core/useElementHover/demo.vue
+++ b/packages/core/useElementHover/demo.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { useElementHover } from '@vueuse/core'
-import { ref, useTemplateRef } from 'vue'
+import { shallowRef, useTemplateRef } from 'vue'
 import { vElementHover } from './directive'
 
 const el = useTemplateRef<HTMLButtonElement>('el')
-const isDirectiveHovered = ref(false)
+const isDirectiveHovered = shallowRef(false)
 const isHovered = useElementHover(el, { delayEnter: 200, delayLeave: 600 })
 function onHover(hovered: boolean) {
   isDirectiveHovered.value = hovered

--- a/packages/core/useElementHover/index.ts
+++ b/packages/core/useElementHover/index.ts
@@ -2,7 +2,7 @@ import type { MaybeRefOrGetter } from '@vueuse/shared'
 import type { Ref } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
 import type { MaybeComputedElementRef } from '../unrefElement'
-import { computed, ref } from 'vue'
+import { computed, shallowRef } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { onElementRemoval } from '../onElementRemoval'
 import { unrefElement } from '../unrefElement'
@@ -22,7 +22,7 @@ export function useElementHover(el: MaybeRefOrGetter<EventTarget | null | undefi
     window = defaultWindow,
   } = options
 
-  const isHovered = ref(false)
+  const isHovered = shallowRef(false)
   let timer: ReturnType<typeof setTimeout> | undefined
 
   const toggle = (entering: boolean) => {

--- a/packages/core/useElementSize/component.ts
+++ b/packages/core/useElementSize/component.ts
@@ -2,13 +2,13 @@ import type { ElementSize } from '@vueuse/core'
 import type { RenderableComponent } from '../types'
 import type { UseResizeObserverOptions } from '../useResizeObserver'
 import { useElementSize } from '@vueuse/core'
-import { defineComponent, h, reactive, ref } from 'vue'
+import { ref as deepRef, defineComponent, h, reactive } from 'vue'
 
 export const UseElementSize = /* #__PURE__ */ defineComponent<ElementSize & UseResizeObserverOptions & RenderableComponent>({
   name: 'UseElementSize',
   props: ['width', 'height', 'box', 'as'] as unknown as undefined,
   setup(props, { slots }) {
-    const target = ref()
+    const target = deepRef()
     const data = reactive(useElementSize(target, { width: props.width, height: props.height }, { box: props.box }))
 
     return () => {

--- a/packages/core/useElementSize/index.ts
+++ b/packages/core/useElementSize/index.ts
@@ -1,7 +1,7 @@
 import type { MaybeComputedElementRef } from '../unrefElement'
 import type { UseResizeObserverOptions } from '../useResizeObserver'
 import { toArray, tryOnMounted } from '@vueuse/shared'
-import { computed, ref, watch } from 'vue'
+import { computed, ref as deepRef, watch } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { unrefElement } from '../unrefElement'
 import { useResizeObserver } from '../useResizeObserver'
@@ -23,8 +23,8 @@ export function useElementSize(
 ) {
   const { window = defaultWindow, box = 'content-box' } = options
   const isSVG = computed(() => unrefElement(target)?.namespaceURI?.includes('svg'))
-  const width = ref(initialSize.width)
-  const height = ref(initialSize.height)
+  const width = deepRef(initialSize.width)
+  const height = deepRef(initialSize.height)
 
   const { stop: stop1 } = useResizeObserver(
     target,

--- a/packages/core/useElementVisibility/component.ts
+++ b/packages/core/useElementVisibility/component.ts
@@ -1,12 +1,12 @@
 import type { RenderableComponent } from '../types'
 import { useElementVisibility } from '@vueuse/core'
-import { defineComponent, h, reactive, ref } from 'vue'
+import { ref as deepRef, defineComponent, h, reactive } from 'vue'
 
 export const UseElementVisibility = /* #__PURE__ */ defineComponent<RenderableComponent>({
   name: 'UseElementVisibility',
   props: ['as'] as unknown as undefined,
   setup(props, { slots }) {
-    const target = ref()
+    const target = deepRef()
     const data = reactive({
       isVisible: useElementVisibility(target),
     })

--- a/packages/core/useElementVisibility/index.ts
+++ b/packages/core/useElementVisibility/index.ts
@@ -3,7 +3,7 @@ import type { ConfigurableWindow } from '../_configurable'
 import type { MaybeComputedElementRef } from '../unrefElement'
 import type { UseIntersectionObserverOptions } from '../useIntersectionObserver'
 import { watchOnce } from '@vueuse/shared'
-import { ref, toValue } from 'vue'
+import { shallowRef, toValue } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useIntersectionObserver } from '../useIntersectionObserver'
 
@@ -40,7 +40,7 @@ export function useElementVisibility(
     rootMargin,
     once = false,
   } = options
-  const elementIsVisible = ref(false)
+  const elementIsVisible = shallowRef(false)
 
   const { stop } = useIntersectionObserver(
     element,

--- a/packages/core/useEventBus/demo.vue
+++ b/packages/core/useEventBus/demo.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { useEventBus } from '@vueuse/core'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 
 const { on, emit } = useEventBus<string>('vue-use-event-bus')
-const message = ref('')
+const message = shallowRef('')
 const news = [
   'Su Bingtian broke the Asian record and entered the Olympic 100-meter race finals as the first person in China-RTHK',
   'Comprehensive investigation in Zhengzhou to avoid further spread of the epidemic-RTHK',

--- a/packages/core/useEventListener/index.test.ts
+++ b/packages/core/useEventListener/index.test.ts
@@ -2,7 +2,7 @@ import type { Fn } from '@vueuse/shared'
 import type { MockInstance } from 'vitest'
 import type { Ref } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { computed, effectScope, nextTick, ref, shallowRef } from 'vue'
+import { computed, ref as deepRef, effectScope, nextTick, shallowRef } from 'vue'
 import { useEventListener } from './index'
 
 describe('useEventListener', () => {
@@ -153,7 +153,7 @@ describe('useEventListener', () => {
     let listener: () => any
 
     beforeEach(() => {
-      target = ref(document.createElement('div'))
+      target = shallowRef(document.createElement('div'))
       listener = vi.fn()
     })
 
@@ -310,9 +310,9 @@ describe('useEventListener', () => {
       const listener2 = vi.fn()
       const el1 = document.createElement('div')
       const el2 = document.createElement('div')
-      const els = ref([el1])
-      const events = ref(['click'])
-      const listeners = ref([listener1])
+      const els = deepRef([el1])
+      const events = deepRef(['click'])
+      const listeners = deepRef([listener1])
 
       useEventListener(els, events, listeners)
       el1.dispatchEvent(new Event('click'))
@@ -340,9 +340,9 @@ describe('useEventListener', () => {
   })
 
   it('should auto re-register', async () => {
-    const target = ref()
+    const target = deepRef()
     const listener = vi.fn()
-    const options = ref<any>(false)
+    const options = deepRef<any>(false)
     useEventListener(target, 'click', listener, options)
 
     const el = document.createElement('div')

--- a/packages/core/useEventListener/index.test.ts
+++ b/packages/core/useEventListener/index.test.ts
@@ -2,7 +2,7 @@ import type { Fn } from '@vueuse/shared'
 import type { MockInstance } from 'vitest'
 import type { Ref } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { computed, effectScope, nextTick, ref } from 'vue'
+import { computed, effectScope, nextTick, ref, shallowRef } from 'vue'
 import { useEventListener } from './index'
 
 describe('useEventListener', () => {
@@ -245,7 +245,7 @@ describe('useEventListener', () => {
       const listener = vi.fn()
       const el1 = document.createElement('div')
       const el2 = document.createElement('div')
-      const active = ref(true)
+      const active = shallowRef(true)
 
       useEventListener(() => active.value ? [el1, el2] : [], 'mousedown', listener)
       await nextTick()
@@ -283,7 +283,7 @@ describe('useEventListener', () => {
       const listener = vi.fn()
       const el1 = document.createElement('div')
       const el2 = document.createElement('div')
-      const active = ref(true)
+      const active = shallowRef(true)
 
       useEventListener(() => active.value ? [el1, el2] : [], ['mousedown', 'click'], listener)
       await nextTick()

--- a/packages/core/useEventSource/index.ts
+++ b/packages/core/useEventSource/index.ts
@@ -117,7 +117,7 @@ export function useEventSource<Events extends string[]>(
 ): UseEventSourceReturn<Events> {
   const event: Ref<string | null> = ref(null)
   const data: Ref<string | null> = ref(null)
-  const status = ref('CONNECTING') as Ref<EventSourceStatus>
+  const status = shallowRef('CONNECTING') as Ref<EventSourceStatus>
   const eventSource = ref(null) as Ref<EventSource | null>
   const error = shallowRef(null) as Ref<Event | null>
   const urlRef = toRef(url)

--- a/packages/core/useEventSource/index.ts
+++ b/packages/core/useEventSource/index.ts
@@ -1,7 +1,7 @@
 import type { Fn, MaybeRefOrGetter } from '@vueuse/shared'
 import type { Ref } from 'vue'
 import { isClient, toRef, tryOnScopeDispose } from '@vueuse/shared'
-import { ref, shallowRef, watch } from 'vue'
+import { ref as deepRef, shallowRef, watch } from 'vue'
 import { useEventListener } from '../useEventListener'
 
 export type EventSourceStatus = 'CONNECTING' | 'OPEN' | 'CLOSED'
@@ -115,10 +115,10 @@ export function useEventSource<Events extends string[]>(
   events: Events = [] as unknown as Events,
   options: UseEventSourceOptions = {},
 ): UseEventSourceReturn<Events> {
-  const event: Ref<string | null> = ref(null)
-  const data: Ref<string | null> = ref(null)
+  const event: Ref<string | null> = deepRef(null)
+  const data: Ref<string | null> = deepRef(null)
   const status = shallowRef('CONNECTING') as Ref<EventSourceStatus>
-  const eventSource = ref(null) as Ref<EventSource | null>
+  const eventSource = deepRef(null) as Ref<EventSource | null>
   const error = shallowRef(null) as Ref<Event | null>
   const urlRef = toRef(url)
   const lastEventId = shallowRef<string | null>(null)

--- a/packages/core/useEyeDropper/index.ts
+++ b/packages/core/useEyeDropper/index.ts
@@ -1,4 +1,4 @@
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 import { useSupported } from '../useSupported'
 
 export interface EyeDropperOpenOptions {
@@ -32,7 +32,7 @@ export interface UseEyeDropperOptions {
 export function useEyeDropper(options: UseEyeDropperOptions = {}) {
   const { initialValue = '' } = options
   const isSupported = useSupported(() => typeof window !== 'undefined' && 'EyeDropper' in window)
-  const sRGBHex = ref(initialValue)
+  const sRGBHex = deepRef(initialValue)
 
   async function open(openOptions?: EyeDropperOpenOptions) {
     if (!isSupported.value)

--- a/packages/core/useFavicon/demo.vue
+++ b/packages/core/useFavicon/demo.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { useFavicon } from '@vueuse/core'
-import { computed, ref } from 'vue'
+import { computed, shallowRef } from 'vue'
 
-const type = ref('vueuse')
+const type = shallowRef('vueuse')
 
 const favicon = computed(() =>
   type.value === 'vue' ? 'vue.png' : 'favicon-32x32.png')

--- a/packages/core/useFavicon/index.test.ts
+++ b/packages/core/useFavicon/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { computed, ref, shallowRef } from 'vue'
+import { computed, ref as deepRef, shallowRef } from 'vue'
 import { useFavicon } from './index'
 
 describe('useFavicon', () => {
@@ -40,13 +40,13 @@ describe('useFavicon', () => {
   })
 
   it('ref null', () => {
-    const targetRef = ref(null)
+    const targetRef = deepRef(null)
     const favicon = useFavicon(targetRef)
     expect(favicon.value).toEqual(null)
   })
 
   it('ref undefined', () => {
-    const favicon = useFavicon(ref(undefined))
+    const favicon = useFavicon(deepRef(undefined))
     expect(favicon.value).toEqual(undefined)
   })
 

--- a/packages/core/useFavicon/index.test.ts
+++ b/packages/core/useFavicon/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { computed, ref } from 'vue'
+import { computed, ref, shallowRef } from 'vue'
 import { useFavicon } from './index'
 
 describe('useFavicon', () => {
@@ -32,7 +32,7 @@ describe('useFavicon', () => {
   })
 
   it('ref const', () => {
-    const targetRef = ref('v1')
+    const targetRef = shallowRef('v1')
     const favicon = useFavicon(targetRef)
     expect(favicon.value).toEqual('v1')
     targetRef.value = 'v2'
@@ -51,7 +51,7 @@ describe('useFavicon', () => {
   })
 
   it('computed/readonly', () => {
-    const onoff = ref(1)
+    const onoff = shallowRef(1)
     const target = computed(() => onoff.value === 1 ? 'a.jpg' : 'b.jpg')
     const favicon = useFavicon(target)
     expect(favicon.value).toEqual('a.jpg')

--- a/packages/core/useFetch/demo.vue
+++ b/packages/core/useFetch/demo.vue
@@ -2,10 +2,10 @@
 import { useFetch } from '@vueuse/core'
 import { stringify } from '@vueuse/docs-utils'
 import { useToggle } from '@vueuse/shared'
-import { computed, reactive, ref } from 'vue'
+import { computed, reactive, shallowRef } from 'vue'
 
-const url = ref('https://httpbin.org/get')
-const refetch = ref(false)
+const url = shallowRef('https://httpbin.org/get')
+const refetch = shallowRef(false)
 
 const toggleRefetch = useToggle(refetch)
 

--- a/packages/core/useFetch/index.test.ts
+++ b/packages/core/useFetch/index.test.ts
@@ -1,7 +1,7 @@
 import type { AfterFetchContext, OnFetchErrorContext } from './index'
 import { until } from '@vueuse/shared'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick, ref } from 'vue'
+import { nextTick, ref, shallowRef } from 'vue'
 import { isBelowNode18 } from '../../.test'
 import { createFetch, useFetch } from './index'
 import '../../.test/mockServer'
@@ -135,7 +135,7 @@ describe.skipIf(isBelowNode18)('useFetch', () => {
   })
 
   it('should refetch if refetch is set to true', async () => {
-    const url = ref('https://example.com')
+    const url = shallowRef('https://example.com')
     useFetch(url, { refetch: true })
     url.value = 'https://example.com?text'
     await vi.waitFor(() => {
@@ -722,7 +722,7 @@ describe.skipIf(isBelowNode18)('useFetch', () => {
   })
 
   it('should listen url ref change abort previous request', async () => {
-    const url = ref('https://example.com')
+    const url = shallowRef('https://example.com')
     const { onFetchResponse } = useFetch(url, { refetch: true, immediate: false })
 
     onFetchResponse(onFetchResponseSpy)

--- a/packages/core/useFetch/index.test.ts
+++ b/packages/core/useFetch/index.test.ts
@@ -1,7 +1,7 @@
 import type { AfterFetchContext, OnFetchErrorContext } from './index'
 import { until } from '@vueuse/shared'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick, ref, shallowRef } from 'vue'
+import { ref as deepRef, nextTick, shallowRef } from 'vue'
 import { isBelowNode18 } from '../../.test'
 import { createFetch, useFetch } from './index'
 import '../../.test/mockServer'
@@ -144,7 +144,7 @@ describe.skipIf(isBelowNode18)('useFetch', () => {
   })
 
   it('should auto refetch when the refetch is set to true and the payload is a ref', async () => {
-    const param = ref({ num: 1 })
+    const param = deepRef({ num: 1 })
     useFetch('https://example.com', { refetch: true }).post(param)
     param.value.num = 2
     await vi.waitFor(() => {
@@ -739,7 +739,7 @@ describe.skipIf(isBelowNode18)('useFetch', () => {
   })
 
   it('should be generated payloadType on execute', async () => {
-    const form = ref()
+    const form = deepRef()
     const { execute } = useFetch('https://example.com').post(form)
 
     form.value = { x: 1 }
@@ -751,7 +751,7 @@ describe.skipIf(isBelowNode18)('useFetch', () => {
   })
 
   it('should be generated payloadType on execute with formdata', async () => {
-    const form = ref<any>({ x: 1 })
+    const form = deepRef<any>({ x: 1 })
     const { execute } = useFetch('https://example.com').post(form)
 
     form.value = new FormData()

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -1,7 +1,7 @@
 import type { EventHookOn, Fn, MaybeRefOrGetter, Stoppable } from '@vueuse/shared'
 import type { ComputedRef, Ref } from 'vue'
 import { containsProp, createEventHook, toRef, until, useTimeoutFn } from '@vueuse/shared'
-import { computed, isRef, readonly, ref, shallowRef, toValue, watch } from 'vue'
+import { computed, ref as deepRef, isRef, readonly, shallowRef, toValue, watch } from 'vue'
 import { defaultWindow } from '../_configurable'
 
 export interface UseFetchReturn<T> {
@@ -378,7 +378,7 @@ export function useFetch<T>(url: MaybeRefOrGetter<string>, ...args: any[]): UseF
   const isFinished = shallowRef(false)
   const isFetching = shallowRef(false)
   const aborted = shallowRef(false)
-  const statusCode = ref<number | null>(null)
+  const statusCode = deepRef<number | null>(null)
   const response = shallowRef<Response | null>(null)
   const error = shallowRef<any>(null)
   const data = shallowRef<T | null>(initialData || null)

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -375,9 +375,9 @@ export function useFetch<T>(url: MaybeRefOrGetter<string>, ...args: any[]): UseF
   const errorEvent = createEventHook<any>()
   const finallyEvent = createEventHook<any>()
 
-  const isFinished = ref(false)
-  const isFetching = ref(false)
-  const aborted = ref(false)
+  const isFinished = shallowRef(false)
+  const isFetching = shallowRef(false)
+  const aborted = shallowRef(false)
   const statusCode = ref<number | null>(null)
   const response = shallowRef<Response | null>(null)
   const error = shallowRef<any>(null)

--- a/packages/core/useFileDialog/index.ts
+++ b/packages/core/useFileDialog/index.ts
@@ -2,7 +2,7 @@ import type { EventHookOn } from '@vueuse/shared'
 import type { Ref } from 'vue'
 import type { ConfigurableDocument } from '../_configurable'
 import { createEventHook, hasOwn } from '@vueuse/shared'
-import { readonly, ref } from 'vue'
+import { ref as deepRef, readonly } from 'vue'
 import { defaultDocument } from '../_configurable'
 
 export interface UseFileDialogOptions extends ConfigurableDocument {
@@ -79,7 +79,7 @@ export function useFileDialog(options: UseFileDialogOptions = {}): UseFileDialog
     document = defaultDocument,
   } = options
 
-  const files = ref<FileList | null>(prepareInitialFiles(options.initialFiles))
+  const files = deepRef<FileList | null>(prepareInitialFiles(options.initialFiles))
   const { on: onChange, trigger: changeTrigger } = createEventHook()
   const { on: onCancel, trigger: cancelTrigger } = createEventHook()
   let input: HTMLInputElement | undefined

--- a/packages/core/useFileSystemAccess/demo.vue
+++ b/packages/core/useFileSystemAccess/demo.vue
@@ -2,9 +2,9 @@
 import type { Ref } from 'vue'
 import { useFileSystemAccess } from '@vueuse/core'
 import { stringify } from '@vueuse/docs-utils'
-import { reactive, ref } from 'vue'
+import { reactive, shallowRef } from 'vue'
 
-const dataType = ref('Text') as Ref<'Text' | 'ArrayBuffer' | 'Blob'>
+const dataType = shallowRef('Text') as Ref<'Text' | 'ArrayBuffer' | 'Blob'>
 const res = useFileSystemAccess({
   dataType,
   types: [{

--- a/packages/core/useFileSystemAccess/index.ts
+++ b/packages/core/useFileSystemAccess/index.ts
@@ -1,7 +1,7 @@
 import type { Awaitable, MaybeRefOrGetter } from '@vueuse/shared'
 import type { ComputedRef, Ref } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
-import { computed, ref, toValue, watch } from 'vue'
+import { computed, ref as deepRef, toValue, watch } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useSupported } from '../useSupported'
 
@@ -106,10 +106,10 @@ export function useFileSystemAccess(options: UseFileSystemAccessOptions = {}): U
   const window = _window as FileSystemAccessWindow
   const isSupported = useSupported(() => window && 'showSaveFilePicker' in window && 'showOpenFilePicker' in window)
 
-  const fileHandle = ref<FileSystemFileHandle>()
-  const data = ref<string | ArrayBuffer | Blob>()
+  const fileHandle = deepRef<FileSystemFileHandle>()
+  const data = deepRef<string | ArrayBuffer | Blob>()
 
-  const file = ref<File>()
+  const file = deepRef<File>()
   const fileName = computed(() => file.value?.name ?? '')
   const fileMIME = computed(() => file.value?.type ?? '')
   const fileSize = computed(() => file.value?.size ?? 0)

--- a/packages/core/useFocus/demo.vue
+++ b/packages/core/useFocus/demo.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { useFocus } from '@vueuse/core'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 
-const text = ref()
-const input = ref()
-const button = ref()
+const text = deepRef()
+const input = deepRef()
+const button = deepRef()
 
 const { focused: paragraphFocus } = useFocus(text)
 const { focused: inputFocus } = useFocus(input, { initialValue: true })

--- a/packages/core/useFocus/index.test.ts
+++ b/packages/core/useFocus/index.test.ts
@@ -1,13 +1,13 @@
 import type { Ref } from 'vue'
 import { beforeEach, describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 import { useFocus } from './index'
 
 describe('useFocus', () => {
   let target: Ref<HTMLButtonElement>
 
   beforeEach(() => {
-    target = ref(document.createElement('button'))
+    target = shallowRef(document.createElement('button'))
     target.value.tabIndex = 0
     document.body.appendChild(target.value)
   })

--- a/packages/core/useFocus/index.ts
+++ b/packages/core/useFocus/index.ts
@@ -1,7 +1,7 @@
 import type { Ref } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
 import type { MaybeElementRef } from '../unrefElement'
-import { computed, ref, watch } from 'vue'
+import { computed, shallowRef, watch } from 'vue'
 import { unrefElement } from '../unrefElement'
 import { useEventListener } from '../useEventListener'
 
@@ -46,7 +46,7 @@ export interface UseFocusReturn {
 export function useFocus(target: MaybeElementRef, options: UseFocusOptions = {}): UseFocusReturn {
   const { initialValue = false, focusVisible = false, preventScroll = false } = options
 
-  const innerFocused = ref(false)
+  const innerFocused = shallowRef(false)
   const targetElement = computed(() => unrefElement(target))
 
   const listenerOptions = { passive: true }

--- a/packages/core/useFocusWithin/demo.vue
+++ b/packages/core/useFocusWithin/demo.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { useFocusWithin } from '@vueuse/core'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 
-const target = ref()
+const target = deepRef()
 
 const { focused } = useFocusWithin(target)
 </script>

--- a/packages/core/useFocusWithin/index.test.ts
+++ b/packages/core/useFocusWithin/index.test.ts
@@ -1,6 +1,6 @@
 import type { Ref } from 'vue'
 import { beforeEach, describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 import { useFocusWithin } from './index'
 
 describe('useFocusWithin', () => {
@@ -10,19 +10,19 @@ describe('useFocusWithin', () => {
   let grandchild: Ref<HTMLInputElement>
 
   beforeEach(() => {
-    parent = ref(document.createElement('form'))
+    parent = shallowRef(document.createElement('form'))
     parent.value.tabIndex = 0
     document.body.appendChild(parent.value)
 
-    child = ref(document.createElement('div'))
+    child = shallowRef(document.createElement('div'))
     child.value.tabIndex = 0
     parent.value.appendChild(child.value)
 
-    child2 = ref(document.createElement('div'))
+    child2 = shallowRef(document.createElement('div'))
     child2.value.tabIndex = 0
     parent.value.appendChild(child2.value)
 
-    grandchild = ref(document.createElement('input'))
+    grandchild = shallowRef(document.createElement('input'))
     grandchild.value.tabIndex = 0
     child.value.appendChild(grandchild.value)
   })

--- a/packages/core/useFocusWithin/index.ts
+++ b/packages/core/useFocusWithin/index.ts
@@ -1,7 +1,7 @@
 import type { ComputedRef } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
 import type { MaybeElementRef } from '../unrefElement'
-import { computed, ref } from 'vue'
+import { computed, shallowRef } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { unrefElement } from '../unrefElement'
 import { useActiveElement } from '../useActiveElement'
@@ -28,7 +28,7 @@ const PSEUDO_CLASS_FOCUS_WITHIN = ':focus-within'
 export function useFocusWithin(target: MaybeElementRef, options: ConfigurableWindow = {}): UseFocusWithinReturn {
   const { window = defaultWindow } = options
   const targetElement = computed(() => unrefElement(target))
-  const _focused = ref(false)
+  const _focused = shallowRef(false)
   const focused = computed(() => _focused.value)
   const activeElement = useActiveElement(options)
 

--- a/packages/core/useFps/index.ts
+++ b/packages/core/useFps/index.ts
@@ -1,5 +1,5 @@
 import type { Ref } from 'vue'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 import { useRafFn } from '../useRafFn'
 
 export interface UseFpsOptions {
@@ -11,7 +11,7 @@ export interface UseFpsOptions {
 }
 
 export function useFps(options?: UseFpsOptions): Ref<number> {
-  const fps = ref(0)
+  const fps = shallowRef(0)
   if (typeof performance === 'undefined')
     return fps
   const every = options?.every ?? 10

--- a/packages/core/useFullscreen/component.ts
+++ b/packages/core/useFullscreen/component.ts
@@ -1,12 +1,12 @@
 import type { RenderableComponent } from '../types'
 import { useFullscreen } from '@vueuse/core'
-import { defineComponent, h, reactive, ref } from 'vue'
+import { ref as deepRef, defineComponent, h, reactive } from 'vue'
 
 export const UseFullscreen = /* #__PURE__ */ defineComponent<RenderableComponent>({
   name: 'UseFullscreen',
   props: ['as'] as unknown as undefined,
   setup(props, { slots }) {
-    const target = ref()
+    const target = deepRef()
     const data = reactive(useFullscreen(target))
 
     return () => {

--- a/packages/core/useFullscreen/index.ts
+++ b/packages/core/useFullscreen/index.ts
@@ -1,7 +1,7 @@
 import type { ConfigurableDocument } from '../_configurable'
 import type { MaybeElementRef } from '../unrefElement'
 import { tryOnScopeDispose } from '@vueuse/shared'
-import { computed, ref } from 'vue'
+import { computed, shallowRef } from 'vue'
 import { defaultDocument } from '../_configurable'
 import { unrefElement } from '../unrefElement'
 import { useEventListener } from '../useEventListener'
@@ -41,7 +41,7 @@ export function useFullscreen(
   } = options
 
   const targetRef = computed(() => unrefElement(target) ?? document?.documentElement)
-  const isFullscreen = ref(false)
+  const isFullscreen = shallowRef(false)
 
   const requestMethod = computed<'requestFullscreen' | undefined>(() => {
     return [

--- a/packages/core/useGamepad/index.ts
+++ b/packages/core/useGamepad/index.ts
@@ -1,7 +1,7 @@
 import type { Ref } from 'vue'
 import type { ConfigurableNavigator, ConfigurableWindow } from '../_configurable'
 import { createEventHook, tryOnMounted } from '@vueuse/shared'
-import { computed, ref } from 'vue'
+import { computed, ref as deepRef } from 'vue'
 import { defaultNavigator } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 import { useRafFn } from '../useRafFn'
@@ -64,7 +64,7 @@ export function useGamepad(options: UseGamepadOptions = {}) {
     navigator = defaultNavigator,
   } = options
   const isSupported = useSupported(() => navigator && 'getGamepads' in navigator)
-  const gamepads = ref<Gamepad[]>([])
+  const gamepads = deepRef<Gamepad[]>([])
 
   const onConnectedHook = createEventHook<number>()
   const onDisconnectedHook = createEventHook<number>()

--- a/packages/core/useGeolocation/index.ts
+++ b/packages/core/useGeolocation/index.ts
@@ -3,7 +3,7 @@
 import type { Ref } from 'vue'
 import type { ConfigurableNavigator } from '../_configurable'
 import { tryOnScopeDispose } from '@vueuse/shared'
-import { ref, shallowRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 import { defaultNavigator } from '../_configurable'
 import { useSupported } from '../useSupported'
 
@@ -28,9 +28,9 @@ export function useGeolocation(options: UseGeolocationOptions = {}) {
 
   const isSupported = useSupported(() => navigator && 'geolocation' in navigator)
 
-  const locatedAt: Ref<number | null> = ref(null)
+  const locatedAt: Ref<number | null> = deepRef(null)
   const error = shallowRef<GeolocationPositionError | null>(null)
-  const coords: Ref<Omit<GeolocationPosition['coords'], 'toJSON'>> = ref({
+  const coords: Ref<Omit<GeolocationPosition['coords'], 'toJSON'>> = deepRef({
     accuracy: 0,
     latitude: Number.POSITIVE_INFINITY,
     longitude: Number.POSITIVE_INFINITY,

--- a/packages/core/useIdle/index.ts
+++ b/packages/core/useIdle/index.ts
@@ -3,7 +3,7 @@ import type { Ref } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
 import type { WindowEventName } from '../useEventListener'
 import { createFilterWrapper, throttleFilter, timestamp } from '@vueuse/shared'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 
@@ -55,8 +55,8 @@ export function useIdle(
     window = defaultWindow,
     eventFilter = throttleFilter(50),
   } = options
-  const idle = ref(initialState)
-  const lastActive = ref(timestamp())
+  const idle = deepRef(initialState)
+  const lastActive = deepRef(timestamp())
 
   let timer: any
 

--- a/packages/core/useImage/demo.vue
+++ b/packages/core/useImage/demo.vue
@@ -1,8 +1,8 @@
 <script lang="ts" setup>
 import { useImage } from '@vueuse/core'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 
-const imageOptions = ref({ src: 'https://place-hold.it/300x200' })
+const imageOptions = deepRef({ src: 'https://place-hold.it/300x200' })
 const colors = ['fff', '000', '5f0caa']
 const { isLoading, error } = useImage(imageOptions, { delay: 1000 })
 

--- a/packages/core/useInfiniteScroll/demo.vue
+++ b/packages/core/useInfiniteScroll/demo.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { useInfiniteScroll } from '@vueuse/core'
-import { ref, useTemplateRef } from 'vue'
+import { ref as deepRef, useTemplateRef } from 'vue'
 
 const el = useTemplateRef<HTMLElement>('el')
-const data = ref<number[]>([])
+const data = deepRef<number[]>([])
 
 const { reset } = useInfiniteScroll(
   el,

--- a/packages/core/useInfiniteScroll/index.test.ts
+++ b/packages/core/useInfiniteScroll/index.test.ts
@@ -1,6 +1,6 @@
 import { flushPromises } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 import { useElementVisibility } from '../useElementVisibility'
 import { useInfiniteScroll } from './index'
 
@@ -11,7 +11,7 @@ describe('useInfiniteScroll', () => {
   })
 
   it.each([
-    [ref(givenMockElement())],
+    [deepRef(givenMockElement())],
     [givenMockElement()],
     [document],
     [window],
@@ -66,7 +66,7 @@ describe('useInfiniteScroll', () => {
   }
 
   function givenElementVisibilityRefMock(defaultValue: boolean) {
-    const mockVisibilityRef = ref(defaultValue)
+    const mockVisibilityRef = deepRef(defaultValue)
     vi.mocked(useElementVisibility).mockReturnValue(mockVisibilityRef)
     return mockVisibilityRef
   }

--- a/packages/core/useInfiniteScroll/index.ts
+++ b/packages/core/useInfiniteScroll/index.ts
@@ -2,7 +2,7 @@ import type { Awaitable, MaybeRefOrGetter } from '@vueuse/shared'
 import type { UnwrapNestedRefs } from 'vue'
 import type { UseScrollOptions } from '../useScroll'
 import { tryOnUnmounted } from '@vueuse/shared'
-import { computed, nextTick, reactive, ref, toValue, watch } from 'vue'
+import { computed, ref as deepRef, nextTick, reactive, toValue, watch } from 'vue'
 import { resolveElement } from '../_resolve-element'
 import { useElementVisibility } from '../useElementVisibility'
 import { useScroll } from '../useScroll'
@@ -66,7 +66,7 @@ export function useInfiniteScroll<T extends InfiniteScrollElement>(
     },
   ))
 
-  const promise = ref<any>()
+  const promise = deepRef<any>()
   const isLoading = computed(() => !!promise.value)
 
   // Document and Window cannot be observed by IntersectionObserver

--- a/packages/core/useIntersectionObserver/demo.vue
+++ b/packages/core/useIntersectionObserver/demo.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { useIntersectionObserver } from '@vueuse/core'
-import { ref, shallowRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 
-const root = ref(null)
-const target = ref(null)
+const root = deepRef(null)
+const target = deepRef(null)
 const isVisible = shallowRef(false)
 
 const { isActive, pause, resume } = useIntersectionObserver(

--- a/packages/core/useIntersectionObserver/demo.vue
+++ b/packages/core/useIntersectionObserver/demo.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { useIntersectionObserver } from '@vueuse/core'
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 
 const root = ref(null)
 const target = ref(null)
-const isVisible = ref(false)
+const isVisible = shallowRef(false)
 
 const { isActive, pause, resume } = useIntersectionObserver(
   target,

--- a/packages/core/useIntersectionObserver/index.ts
+++ b/packages/core/useIntersectionObserver/index.ts
@@ -3,7 +3,7 @@ import type { ComputedRef } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
 import type { MaybeComputedElementRef, MaybeElement } from '../unrefElement'
 import { noop, notNullish, toArray, tryOnScopeDispose } from '@vueuse/shared'
-import { computed, ref, toValue, watch } from 'vue'
+import { computed, ref as deepRef, toValue, watch } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { unrefElement } from '../unrefElement'
 import { useSupported } from '../useSupported'
@@ -66,7 +66,7 @@ export function useIntersectionObserver(
   })
 
   let cleanup = noop
-  const isActive = ref(immediate)
+  const isActive = deepRef(immediate)
 
   const stopWatch = isSupported.value
     ? watch(

--- a/packages/core/useKeyModifier/index.ts
+++ b/packages/core/useKeyModifier/index.ts
@@ -1,7 +1,7 @@
 import type { Ref } from 'vue'
 import type { ConfigurableDocument } from '../_configurable'
 import type { WindowEventName } from '../useEventListener'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 import { defaultDocument } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 
@@ -34,7 +34,7 @@ export function useKeyModifier<Initial extends boolean | null>(modifier: KeyModi
     initial = null,
   } = options
 
-  const state = ref(initial) as Ref<boolean>
+  const state = deepRef(initial) as Ref<boolean>
 
   if (document) {
     events.forEach((listenerEvent) => {

--- a/packages/core/useMagicKeys/index.ts
+++ b/packages/core/useMagicKeys/index.ts
@@ -1,7 +1,7 @@
 import type { MaybeRefOrGetter } from '@vueuse/shared'
 import type { ComputedRef } from 'vue'
 import { noop } from '@vueuse/shared'
-import { computed, reactive, ref, toValue } from 'vue'
+import { computed, reactive, shallowRef, toValue } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 import { DefaultMagicKeysAliasMap } from './aliasMap'
@@ -168,7 +168,7 @@ export function useMagicKeys(options: UseMagicKeysOptions<boolean> = {}): any {
             refs[prop] = computed(() => keys.map(key => toValue(proxy[key])).every(Boolean))
           }
           else {
-            refs[prop] = ref(false)
+            refs[prop] = shallowRef(false)
           }
         }
         const r = Reflect.get(target, prop, rec)

--- a/packages/core/useManualRefHistory/index.test.ts
+++ b/packages/core/useManualRefHistory/index.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { isReactive, ref } from 'vue'
+import { isReactive, ref, shallowRef } from 'vue'
 import { useManualRefHistory } from './index'
 
 describe('useManualRefHistory', () => {
   it('should record', () => {
-    const v = ref(0)
+    const v = shallowRef(0)
     const { history, commit } = useManualRefHistory(v)
 
     expect(history.value.length).toBe(1)
@@ -19,7 +19,7 @@ describe('useManualRefHistory', () => {
   })
 
   it('should be able to undo and redo', () => {
-    const v = ref(0)
+    const v = shallowRef(0)
     const { commit, undo, redo, clear, canUndo, canRedo, history, last } = useManualRefHistory(v)
 
     expect(canUndo.value).toBe(false)
@@ -136,7 +136,7 @@ describe('useManualRefHistory', () => {
   })
 
   it('reset', () => {
-    const v = ref(0)
+    const v = shallowRef(0)
     const { history, commit, undoStack, redoStack, reset, undo } = useManualRefHistory(v)
 
     expect(history.value.length).toBe(1)
@@ -190,7 +190,7 @@ describe('useManualRefHistory', () => {
   })
 
   it('snapshots should not be reactive', async () => {
-    const v = ref(0)
+    const v = shallowRef(0)
     const { history, commit } = useManualRefHistory(v)
 
     expect(history.value.length).toBe(1)

--- a/packages/core/useManualRefHistory/index.test.ts
+++ b/packages/core/useManualRefHistory/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isReactive, ref, shallowRef } from 'vue'
+import { ref as deepRef, isReactive, shallowRef } from 'vue'
 import { useManualRefHistory } from './index'
 
 describe('useManualRefHistory', () => {
@@ -68,7 +68,7 @@ describe('useManualRefHistory', () => {
   })
 
   it('object with deep', () => {
-    const v = ref({ foo: 'bar' })
+    const v = deepRef({ foo: 'bar' })
     const { commit, undo, history } = useManualRefHistory(v, { clone: true })
 
     expect(history.value.length).toBe(1)
@@ -91,7 +91,7 @@ describe('useManualRefHistory', () => {
   })
 
   it('object with clone function', () => {
-    const v = ref({ foo: 'bar' })
+    const v = deepRef({ foo: 'bar' })
     const { commit, undo, history } = useManualRefHistory(v, { clone: x => JSON.parse(JSON.stringify(x)) })
 
     expect(history.value.length).toBe(1)
@@ -114,7 +114,7 @@ describe('useManualRefHistory', () => {
   })
 
   it('dump + parse', () => {
-    const v = ref({ a: 'bar' })
+    const v = deepRef({ a: 'bar' })
     const { history, commit, undo } = useManualRefHistory(v, {
       dump: v => JSON.stringify(v),
       parse: (v: string) => JSON.parse(v),

--- a/packages/core/useManualRefHistory/index.ts
+++ b/packages/core/useManualRefHistory/index.ts
@@ -1,7 +1,7 @@
 import type { ComputedRef, Ref } from 'vue'
 import type { CloneFn } from '../useCloned'
 import { timestamp } from '@vueuse/shared'
-import { computed, markRaw, ref } from 'vue'
+import { computed, ref as deepRef, markRaw } from 'vue'
 import { cloneFnJSON } from '../useCloned'
 
 export interface UseRefHistoryRecord<T> {
@@ -150,10 +150,10 @@ export function useManualRefHistory<Raw, Serialized = Raw>(
     })
   }
 
-  const last: Ref<UseRefHistoryRecord<Serialized>> = ref(_createHistoryRecord()) as Ref<UseRefHistoryRecord<Serialized>>
+  const last: Ref<UseRefHistoryRecord<Serialized>> = deepRef(_createHistoryRecord()) as Ref<UseRefHistoryRecord<Serialized>>
 
-  const undoStack: Ref<UseRefHistoryRecord<Serialized>[]> = ref([])
-  const redoStack: Ref<UseRefHistoryRecord<Serialized>[]> = ref([])
+  const undoStack: Ref<UseRefHistoryRecord<Serialized>[]> = deepRef([])
+  const redoStack: Ref<UseRefHistoryRecord<Serialized>[]> = deepRef([])
 
   const _setSource = (record: UseRefHistoryRecord<Serialized>) => {
     setSource(source, parse(record.snapshot))

--- a/packages/core/useMediaControls/components/Menu.vue
+++ b/packages/core/useMediaControls/components/Menu.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { onClickOutside, useEventListener } from '@vueuse/core'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 
-const menu = ref()
-const isOpen = ref()
+const menu = deepRef()
+const isOpen = deepRef()
 
 onClickOutside(menu, () => isOpen.value = false)
 useEventListener('keydown', (e) => {

--- a/packages/core/useMediaControls/components/Scrubber.vue
+++ b/packages/core/useMediaControls/components/Scrubber.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useEventListener, useMouseInElement, useVModel } from '@vueuse/core'
-import { ref, shallowRef, watch } from 'vue'
+import { ref as deepRef, shallowRef, watch } from 'vue'
 
 const props = defineProps({
   min: { type: Number, default: 0 },
@@ -11,7 +11,7 @@ const props = defineProps({
 
 const emit = defineEmits(['update:modelValue'])
 
-const scrubber = ref()
+const scrubber = deepRef()
 const scrubbing = shallowRef(false)
 const pendingValue = shallowRef(0)
 

--- a/packages/core/useMediaControls/components/Scrubber.vue
+++ b/packages/core/useMediaControls/components/Scrubber.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useEventListener, useMouseInElement, useVModel } from '@vueuse/core'
-import { ref, watch } from 'vue'
+import { ref, shallowRef, watch } from 'vue'
 
 const props = defineProps({
   min: { type: Number, default: 0 },
@@ -12,8 +12,8 @@ const props = defineProps({
 const emit = defineEmits(['update:modelValue'])
 
 const scrubber = ref()
-const scrubbing = ref(false)
-const pendingValue = ref(0)
+const scrubbing = shallowRef(false)
+const pendingValue = shallowRef(0)
 
 useEventListener('mouseup', () => scrubbing.value = false, { passive: true })
 

--- a/packages/core/useMediaControls/demo.vue
+++ b/packages/core/useMediaControls/demo.vue
@@ -1,14 +1,14 @@
 <script setup lang="ts">
 import { useMediaControls } from '@vueuse/core'
 import { stringify } from '@vueuse/docs-utils'
-import { computed, reactive, ref } from 'vue'
+import { computed, reactive, ref, shallowRef } from 'vue'
 import Menu from './components/Menu.vue'
 import MenuItem from './components/MenuItem.vue'
 import Scrubber from './components/Scrubber.vue'
 import Spinner from './components/Spinner.vue'
 
 const video = ref<HTMLVideoElement>()
-const loop = ref(false)
+const loop = shallowRef(false)
 const poster = 'https://cdn.bitmovin.com/content/assets/sintel/poster.png'
 
 const controls = useMediaControls(video, {

--- a/packages/core/useMediaControls/demo.vue
+++ b/packages/core/useMediaControls/demo.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
 import { useMediaControls } from '@vueuse/core'
 import { stringify } from '@vueuse/docs-utils'
-import { computed, reactive, ref, shallowRef } from 'vue'
+import { computed, ref as deepRef, reactive, shallowRef } from 'vue'
 import Menu from './components/Menu.vue'
 import MenuItem from './components/MenuItem.vue'
 import Scrubber from './components/Scrubber.vue'
 import Spinner from './components/Spinner.vue'
 
-const video = ref<HTMLVideoElement>()
+const video = deepRef<HTMLVideoElement>()
 const loop = shallowRef(false)
 const poster = 'https://cdn.bitmovin.com/content/assets/sintel/poster.png'
 

--- a/packages/core/useMediaControls/index.ts
+++ b/packages/core/useMediaControls/index.ts
@@ -1,7 +1,7 @@
 import type { Fn, MaybeRef, MaybeRefOrGetter } from '@vueuse/shared'
 import type { ConfigurableDocument } from '../_configurable'
 import { createEventHook, isObject, toRef, tryOnScopeDispose, watchIgnorable } from '@vueuse/shared'
-import { ref, toValue, watch, watchEffect } from 'vue'
+import { ref, shallowRef, toValue, watch, watchEffect } from 'vue'
 import { defaultDocument } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 
@@ -161,20 +161,20 @@ export function useMediaControls(target: MaybeRef<HTMLMediaElement | null | unde
 
   const listenerOptions = { passive: true }
 
-  const currentTime = ref(0)
-  const duration = ref(0)
-  const seeking = ref(false)
-  const volume = ref(1)
-  const waiting = ref(false)
-  const ended = ref(false)
-  const playing = ref(false)
-  const rate = ref(1)
-  const stalled = ref(false)
+  const currentTime = shallowRef(0)
+  const duration = shallowRef(0)
+  const seeking = shallowRef(false)
+  const volume = shallowRef(1)
+  const waiting = shallowRef(false)
+  const ended = shallowRef(false)
+  const playing = shallowRef(false)
+  const rate = shallowRef(1)
+  const stalled = shallowRef(false)
   const buffered = ref<[number, number][]>([])
   const tracks = ref<UseMediaTextTrack[]>([])
   const selectedTrack = ref<number>(-1)
-  const isPictureInPicture = ref(false)
-  const muted = ref(false)
+  const isPictureInPicture = shallowRef(false)
+  const muted = shallowRef(false)
 
   const supportsPictureInPicture = document && 'pictureInPictureEnabled' in document
 

--- a/packages/core/useMediaControls/index.ts
+++ b/packages/core/useMediaControls/index.ts
@@ -1,7 +1,7 @@
 import type { Fn, MaybeRef, MaybeRefOrGetter } from '@vueuse/shared'
 import type { ConfigurableDocument } from '../_configurable'
 import { createEventHook, isObject, toRef, tryOnScopeDispose, watchIgnorable } from '@vueuse/shared'
-import { ref, shallowRef, toValue, watch, watchEffect } from 'vue'
+import { ref as deepRef, shallowRef, toValue, watch, watchEffect } from 'vue'
 import { defaultDocument } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 
@@ -170,9 +170,9 @@ export function useMediaControls(target: MaybeRef<HTMLMediaElement | null | unde
   const playing = shallowRef(false)
   const rate = shallowRef(1)
   const stalled = shallowRef(false)
-  const buffered = ref<[number, number][]>([])
-  const tracks = ref<UseMediaTextTrack[]>([])
-  const selectedTrack = ref<number>(-1)
+  const buffered = deepRef<[number, number][]>([])
+  const tracks = deepRef<UseMediaTextTrack[]>([])
+  const selectedTrack = deepRef<number>(-1)
   const isPictureInPicture = shallowRef(false)
   const muted = shallowRef(false)
 

--- a/packages/core/useMediaQuery/index.test.ts
+++ b/packages/core/useMediaQuery/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { createSSRApp, nextTick, ref } from 'vue'
+import { createSSRApp, nextTick, shallowRef } from 'vue'
 import { provideSSRWidth } from '../useSSRWidth'
 import { useMediaQuery } from './index'
 
@@ -13,7 +13,7 @@ describe('useMediaQuery', () => {
   })
 
   it('should support ssr media queries', async () => {
-    const query = ref('(min-width: 500px)')
+    const query = shallowRef('(min-width: 500px)')
     const mediaQuery = useMediaQuery(query, { window: null as unknown as undefined, ssrWidth: 500 })
     expect(mediaQuery.value).toBe(true)
     query.value = '(min-width: 501px)'
@@ -49,7 +49,7 @@ describe('useMediaQuery', () => {
     const app = createSSRApp({ render: () => '' })
     provideSSRWidth(500, app)
     await app.runWithContext(async () => {
-      const query = ref('(min-width: 500px)')
+      const query = shallowRef('(min-width: 500px)')
       const mediaQuery = useMediaQuery(query, { window: null as unknown as undefined })
       expect(mediaQuery.value).toBe(true)
       query.value = '(min-width: 501px)'

--- a/packages/core/useMediaQuery/index.ts
+++ b/packages/core/useMediaQuery/index.ts
@@ -23,7 +23,7 @@ export function useMediaQuery(query: MaybeRefOrGetter<string>, options: Configur
   const ssrSupport = ref(typeof ssrWidth === 'number')
 
   const mediaQuery = shallowRef<MediaQueryList>()
-  const matches = ref(false)
+  const matches = shallowRef(false)
 
   const handler = (event: MediaQueryListEvent) => {
     matches.value = event.matches

--- a/packages/core/useMediaQuery/index.ts
+++ b/packages/core/useMediaQuery/index.ts
@@ -3,7 +3,7 @@
 import type { MaybeRefOrGetter } from '@vueuse/shared'
 import type { ConfigurableWindow } from '../_configurable'
 import { pxValue } from '@vueuse/shared'
-import { computed, ref, shallowRef, toValue, watchEffect } from 'vue'
+import { computed, ref as deepRef, shallowRef, toValue, watchEffect } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 import { useSSRWidth } from '../useSSRWidth'
@@ -20,7 +20,7 @@ export function useMediaQuery(query: MaybeRefOrGetter<string>, options: Configur
   const { window = defaultWindow, ssrWidth = useSSRWidth() } = options
   const isSupported = useSupported(() => window && 'matchMedia' in window && typeof window.matchMedia === 'function')
 
-  const ssrSupport = ref(typeof ssrWidth === 'number')
+  const ssrSupport = deepRef(typeof ssrWidth === 'number')
 
   const mediaQuery = shallowRef<MediaQueryList>()
   const matches = shallowRef(false)

--- a/packages/core/useMemory/index.ts
+++ b/packages/core/useMemory/index.ts
@@ -1,6 +1,6 @@
 import type { UseIntervalFnOptions } from '@vueuse/shared'
 import { useIntervalFn } from '@vueuse/shared'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 import { useSupported } from '../useSupported'
 
 /**
@@ -40,7 +40,7 @@ type PerformanceMemory = Performance & {
  * @param options
  */
 export function useMemory(options: UseMemoryOptions = {}) {
-  const memory = ref<MemoryInfo>()
+  const memory = deepRef<MemoryInfo>()
   const isSupported = useSupported(() => typeof performance !== 'undefined' && 'memory' in performance)
 
   if (isSupported.value) {

--- a/packages/core/useMounted/index.ts
+++ b/packages/core/useMounted/index.ts
@@ -1,5 +1,9 @@
-// eslint-disable-next-line no-restricted-imports
-import { getCurrentInstance, onMounted, ref } from 'vue'
+import {
+  getCurrentInstance,
+  // eslint-disable-next-line no-restricted-imports
+  onMounted,
+  shallowRef,
+} from 'vue'
 
 /**
  * Mounted state in ref.
@@ -7,7 +11,7 @@ import { getCurrentInstance, onMounted, ref } from 'vue'
  * @see https://vueuse.org/useMounted
  */
 export function useMounted() {
-  const isMounted = ref(false)
+  const isMounted = shallowRef(false)
 
   const instance = getCurrentInstance()
   if (instance) {

--- a/packages/core/useMouse/index.ts
+++ b/packages/core/useMouse/index.ts
@@ -1,7 +1,7 @@
 import type { ConfigurableEventFilter, MaybeRefOrGetter } from '@vueuse/shared'
 import type { ConfigurableWindow } from '../_configurable'
 import type { Position } from '../types'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 
@@ -83,9 +83,9 @@ export function useMouse(options: UseMouseOptions = {}) {
   let _prevScrollX = 0
   let _prevScrollY = 0
 
-  const x = ref(initialValue.x)
-  const y = ref(initialValue.y)
-  const sourceType = ref<UseMouseSourceType>(null)
+  const x = deepRef(initialValue.x)
+  const y = deepRef(initialValue.y)
+  const sourceType = deepRef<UseMouseSourceType>(null)
 
   const extractor = typeof type === 'function'
     ? type

--- a/packages/core/useMouseInElement/component.ts
+++ b/packages/core/useMouseInElement/component.ts
@@ -1,13 +1,13 @@
 import type { MouseInElementOptions } from '@vueuse/core'
 import type { RenderableComponent } from '../types'
 import { useMouseInElement } from '@vueuse/core'
-import { defineComponent, h, reactive, ref } from 'vue'
+import { ref as deepRef, defineComponent, h, reactive } from 'vue'
 
 export const UseMouseInElement = /* #__PURE__ */ defineComponent<MouseInElementOptions & RenderableComponent>({
   name: 'UseMouseElement',
   props: ['handleOutside', 'as'] as unknown as undefined,
   setup(props, { slots }) {
-    const target = ref()
+    const target = deepRef()
     const data = reactive(useMouseInElement(target, props))
 
     return () => {

--- a/packages/core/useMouseInElement/demo.vue
+++ b/packages/core/useMouseInElement/demo.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { useMouseInElement } from '@vueuse/core'
 import { stringify } from '@vueuse/docs-utils'
-import { reactive, ref } from 'vue'
+import { ref as deepRef, reactive } from 'vue'
 import Area from './Area.vue'
 
-const target = ref(null)
+const target = deepRef(null)
 const mouse = reactive(useMouseInElement(target))
 const text = stringify(mouse)
 </script>

--- a/packages/core/useMouseInElement/index.ts
+++ b/packages/core/useMouseInElement/index.ts
@@ -1,6 +1,6 @@
 import type { MaybeElementRef } from '../unrefElement'
 import type { UseMouseOptions } from '../useMouse'
-import { ref, shallowRef, watch } from 'vue'
+import { ref as deepRef, shallowRef, watch } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { unrefElement } from '../unrefElement'
 import { useEventListener } from '../useEventListener'
@@ -29,7 +29,7 @@ export function useMouseInElement(
 
   const { x, y, sourceType } = useMouse(options)
 
-  const targetRef = ref(target ?? window?.document.body)
+  const targetRef = deepRef(target ?? window?.document.body)
   const elementX = shallowRef(0)
   const elementY = shallowRef(0)
   const elementPositionX = shallowRef(0)

--- a/packages/core/useMouseInElement/index.ts
+++ b/packages/core/useMouseInElement/index.ts
@@ -1,6 +1,6 @@
 import type { MaybeElementRef } from '../unrefElement'
 import type { UseMouseOptions } from '../useMouse'
-import { ref, watch } from 'vue'
+import { ref, shallowRef, watch } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { unrefElement } from '../unrefElement'
 import { useEventListener } from '../useEventListener'
@@ -30,13 +30,13 @@ export function useMouseInElement(
   const { x, y, sourceType } = useMouse(options)
 
   const targetRef = ref(target ?? window?.document.body)
-  const elementX = ref(0)
-  const elementY = ref(0)
-  const elementPositionX = ref(0)
-  const elementPositionY = ref(0)
-  const elementHeight = ref(0)
-  const elementWidth = ref(0)
-  const isOutside = ref(true)
+  const elementX = shallowRef(0)
+  const elementY = shallowRef(0)
+  const elementPositionX = shallowRef(0)
+  const elementPositionY = shallowRef(0)
+  const elementHeight = shallowRef(0)
+  const elementWidth = shallowRef(0)
+  const isOutside = shallowRef(true)
 
   let stop = () => {}
 

--- a/packages/core/useMousePressed/component.ts
+++ b/packages/core/useMousePressed/component.ts
@@ -1,13 +1,13 @@
 import type { MousePressedOptions } from '@vueuse/core'
 import type { RenderableComponent } from '../types'
 import { useMousePressed } from '@vueuse/core'
-import { defineComponent, h, reactive, ref } from 'vue'
+import { ref as deepRef, defineComponent, h, reactive } from 'vue'
 
 export const UseMousePressed = /* #__PURE__ */ defineComponent<Omit<MousePressedOptions, 'target'> & RenderableComponent>({
   name: 'UseMousePressed',
   props: ['touch', 'initialValue', 'as'] as unknown as undefined,
   setup(props, { slots }) {
-    const target = ref()
+    const target = deepRef()
     const data = reactive(useMousePressed({ ...props, target }))
 
     return () => {

--- a/packages/core/useMousePressed/index.ts
+++ b/packages/core/useMousePressed/index.ts
@@ -1,7 +1,7 @@
 import type { ConfigurableWindow } from '../_configurable'
 import type { MaybeComputedElementRef } from '../unrefElement'
 import type { UseMouseSourceType } from '../useMouse'
-import { computed, ref } from 'vue'
+import { computed, ref as deepRef } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { unrefElement } from '../unrefElement'
 import { useEventListener } from '../useEventListener'
@@ -71,8 +71,8 @@ export function useMousePressed(options: MousePressedOptions = {}) {
     window = defaultWindow,
   } = options
 
-  const pressed = ref(initialValue)
-  const sourceType = ref<UseMouseSourceType>(null)
+  const pressed = deepRef(initialValue)
+  const sourceType = deepRef<UseMouseSourceType>(null)
 
   if (!window) {
     return {

--- a/packages/core/useMutationObserver/demo.vue
+++ b/packages/core/useMutationObserver/demo.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import { useMutationObserver } from '@vueuse/core'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 
-const el = ref(null)
-const messages = ref<string[]>([])
-const className = ref({})
-const style = ref({})
+const el = deepRef(null)
+const messages = deepRef<string[]>([])
+const className = deepRef({})
+const style = deepRef({})
 
 useMutationObserver(
   el,

--- a/packages/core/useMutationObserver/index.test.ts
+++ b/packages/core/useMutationObserver/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { computed, nextTick, ref } from 'vue'
+import { computed, ref as deepRef, nextTick } from 'vue'
 import { useMutationObserver } from './index'
 
 describe('useMutationObserver', () => {
@@ -188,10 +188,10 @@ describe('useMutationObserver', () => {
   })
 
   it('should work with multiple targets', async () => {
-    const headerElement = ref<HTMLDivElement | null>(
+    const headerElement = deepRef<HTMLDivElement | null>(
       document.createElement('div'),
     )
-    const footerElement = ref<HTMLDivElement | null>(
+    const footerElement = deepRef<HTMLDivElement | null>(
       document.createElement('div'),
     )
     const targets = computed(() => [headerElement.value, footerElement.value])

--- a/packages/core/useNavigatorLanguage/index.ts
+++ b/packages/core/useNavigatorLanguage/index.ts
@@ -1,7 +1,7 @@
 import type { ComputedRef, Ref } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
+import { ref as deepRef } from 'vue'
 
-import { ref } from 'vue'
 import { defaultWindow } from '../_configurable'
 
 import { useEventListener } from '../useEventListener'
@@ -43,7 +43,7 @@ export function useNavigatorLanguage(options: ConfigurableWindow = {}): Readonly
 
   const isSupported = useSupported(() => navigator && 'language' in navigator)
 
-  const language = ref<string | undefined>(navigator?.language)
+  const language = deepRef<string | undefined>(navigator?.language)
 
   // Listen to when to user changes language:
   useEventListener(window, 'languagechange', () => {

--- a/packages/core/useNetwork/index.ts
+++ b/packages/core/useNetwork/index.ts
@@ -2,7 +2,7 @@
 
 import type { ComputedRef, Ref } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
-import { readonly, ref, shallowRef } from 'vue'
+import { ref as deepRef, readonly, shallowRef } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 import { useSupported } from '../useSupported'
@@ -64,13 +64,13 @@ export function useNetwork(options: ConfigurableWindow = {}): Readonly<NetworkSt
 
   const isOnline = shallowRef(true)
   const saveData = shallowRef(false)
-  const offlineAt: Ref<number | undefined> = ref(undefined)
-  const onlineAt: Ref<number | undefined> = ref(undefined)
-  const downlink: Ref<number | undefined> = ref(undefined)
-  const downlinkMax: Ref<number | undefined> = ref(undefined)
-  const rtt: Ref<number | undefined> = ref(undefined)
-  const effectiveType: Ref<NetworkEffectiveType> = ref(undefined)
-  const type: Ref<NetworkType> = ref<NetworkType>('unknown')
+  const offlineAt: Ref<number | undefined> = deepRef(undefined)
+  const onlineAt: Ref<number | undefined> = deepRef(undefined)
+  const downlink: Ref<number | undefined> = deepRef(undefined)
+  const downlinkMax: Ref<number | undefined> = deepRef(undefined)
+  const rtt: Ref<number | undefined> = deepRef(undefined)
+  const effectiveType: Ref<NetworkEffectiveType> = deepRef(undefined)
+  const type: Ref<NetworkType> = deepRef<NetworkType>('unknown')
 
   const connection = isSupported.value && (navigator as any).connection
 

--- a/packages/core/useNetwork/index.ts
+++ b/packages/core/useNetwork/index.ts
@@ -2,7 +2,7 @@
 
 import type { ComputedRef, Ref } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
-import { readonly, ref } from 'vue'
+import { readonly, ref, shallowRef } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 import { useSupported } from '../useSupported'
@@ -62,8 +62,8 @@ export function useNetwork(options: ConfigurableWindow = {}): Readonly<NetworkSt
   const navigator = window?.navigator
   const isSupported = useSupported(() => navigator && 'connection' in navigator)
 
-  const isOnline = ref(true)
-  const saveData = ref(false)
+  const isOnline = shallowRef(true)
+  const saveData = shallowRef(false)
   const offlineAt: Ref<number | undefined> = ref(undefined)
   const onlineAt: Ref<number | undefined> = ref(undefined)
   const downlink: Ref<number | undefined> = ref(undefined)

--- a/packages/core/useNow/index.ts
+++ b/packages/core/useNow/index.ts
@@ -1,7 +1,7 @@
 import type { Pausable } from '@vueuse/shared'
 import type { Ref } from 'vue'
 import { useIntervalFn } from '@vueuse/shared'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 import { useRafFn } from '../useRafFn'
 
 export interface UseNowOptions<Controls extends boolean> {
@@ -34,7 +34,7 @@ export function useNow(options: UseNowOptions<boolean> = {}) {
     interval = 'requestAnimationFrame',
   } = options
 
-  const now = ref(new Date())
+  const now = deepRef(new Date())
 
   const update = () => now.value = new Date()
 

--- a/packages/core/useObjectUrl/index.ts
+++ b/packages/core/useObjectUrl/index.ts
@@ -1,6 +1,6 @@
 import type { MaybeRefOrGetter } from '@vueuse/shared'
 import { tryOnScopeDispose } from '@vueuse/shared'
-import { readonly, ref, toValue, watch } from 'vue'
+import { ref as deepRef, readonly, toValue, watch } from 'vue'
 
 /**
  * Reactive URL representing an object.
@@ -9,7 +9,7 @@ import { readonly, ref, toValue, watch } from 'vue'
  * @param object
  */
 export function useObjectUrl(object: MaybeRefOrGetter<Blob | MediaSource | null | undefined>) {
-  const url = ref<string | undefined>()
+  const url = deepRef<string | undefined>()
 
   const release = () => {
     if (url.value)

--- a/packages/core/useOffsetPagination/demo.vue
+++ b/packages/core/useOffsetPagination/demo.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { Ref } from 'vue'
 import { useOffsetPagination } from '@vueuse/core'
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 
 interface User {
   id: number
@@ -24,8 +24,8 @@ function fetch(page: number, pageSize: number) {
 
 const data: Ref<User[]> = ref([])
 
-const page = ref(1)
-const pageSize = ref(10)
+const page = shallowRef(1)
+const pageSize = shallowRef(10)
 
 fetchData({
   currentPage: page.value,

--- a/packages/core/useOffsetPagination/demo.vue
+++ b/packages/core/useOffsetPagination/demo.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
 import type { Ref } from 'vue'
 import { useOffsetPagination } from '@vueuse/core'
-import { ref, shallowRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 
 interface User {
   id: number
   name: string
 }
-const database = ref([]) as Ref<User[]>
+const database = deepRef([]) as Ref<User[]>
 
 for (let i = 0; i < 80; i++)
   database.value.push({ id: i, name: `user ${i}` })
@@ -22,7 +22,7 @@ function fetch(page: number, pageSize: number) {
   })
 }
 
-const data: Ref<User[]> = ref([])
+const data: Ref<User[]> = deepRef([])
 
 const page = shallowRef(1)
 const pageSize = shallowRef(10)

--- a/packages/core/useOffsetPagination/index.test.ts
+++ b/packages/core/useOffsetPagination/index.test.ts
@@ -1,6 +1,6 @@
 import type { UseOffsetPaginationOptions, UseOffsetPaginationReturn } from './index'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { isRef, nextTick, ref } from 'vue'
+import { isRef, nextTick, shallowRef } from 'vue'
 import { useOffsetPagination } from './index'
 
 describe('useOffsetPagination', () => {
@@ -110,7 +110,7 @@ describe('useOffsetPagination', () => {
 
   describe('when the page is outside of the range of possible pages', () => {
     let currentPage: UseOffsetPaginationReturn['currentPage']
-    const page: UseOffsetPaginationOptions['page'] = ref(0)
+    const page: UseOffsetPaginationOptions['page'] = shallowRef(0)
 
     beforeEach(() => {
       ({
@@ -139,7 +139,7 @@ describe('useOffsetPagination', () => {
 
   describe('when the page is a ref', () => {
     let currentPage: UseOffsetPaginationReturn['currentPage']
-    const pageRef = ref(0)
+    const pageRef = shallowRef(0)
 
     beforeEach(() => {
       pageRef.value = 2;
@@ -206,7 +206,7 @@ describe('useOffsetPagination', () => {
 
     describe('when pageSize is given as a ref', () => {
       let currentPageSize: UseOffsetPaginationReturn['currentPageSize']
-      const pageSize = ref(11)
+      const pageSize = shallowRef(11)
 
       beforeEach(() => {
         ({
@@ -308,7 +308,7 @@ describe('useOffsetPagination', () => {
   describe('onPageChange', () => {
     it('is called when the page changes', async () => {
       const onPageChange = vi.fn()
-      const page = ref(1)
+      const page = shallowRef(1)
 
       useOffsetPagination({
         total: 50,
@@ -333,7 +333,7 @@ describe('useOffsetPagination', () => {
 
     it('is called with the correct UseOffsetPaginationReturn values', async () => {
       const onPageChange = vi.fn()
-      const page = ref(1)
+      const page = shallowRef(1)
 
       useOffsetPagination({
         total: 35,
@@ -394,7 +394,7 @@ describe('useOffsetPagination', () => {
   describe('onPageSizeChange', () => {
     it('is called when the page size changes', async () => {
       const onPageSizeChange = vi.fn()
-      const pageSize = ref(5)
+      const pageSize = shallowRef(5)
 
       useOffsetPagination({
         total: 50,
@@ -412,7 +412,7 @@ describe('useOffsetPagination', () => {
     })
 
     it('is called with the correct UseOffsetPaginationReturn values', async () => {
-      const pageSize = ref(5)
+      const pageSize = shallowRef(5)
       const onPageSizeChange = vi.fn()
 
       useOffsetPagination({
@@ -450,7 +450,7 @@ describe('useOffsetPagination', () => {
   describe('onPageCountChange', () => {
     it('is called when the page count changes', async () => {
       const onPageCountChange = vi.fn()
-      const pageSize = ref(5)
+      const pageSize = shallowRef(5)
 
       useOffsetPagination({
         total: 50,
@@ -468,7 +468,7 @@ describe('useOffsetPagination', () => {
     })
 
     it('is called with the correct UseOffsetPaginationReturn values', async () => {
-      const pageSize = ref(5)
+      const pageSize = shallowRef(5)
       const onPageCountChange = vi.fn()
 
       useOffsetPagination({

--- a/packages/core/usePageLeave/index.ts
+++ b/packages/core/usePageLeave/index.ts
@@ -1,5 +1,5 @@
 import type { ConfigurableWindow } from '../_configurable'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 
@@ -11,7 +11,7 @@ import { useEventListener } from '../useEventListener'
  */
 export function usePageLeave(options: ConfigurableWindow = {}) {
   const { window = defaultWindow } = options
-  const isLeft = ref(false)
+  const isLeft = shallowRef(false)
 
   const handler = (event: MouseEvent) => {
     if (!window)

--- a/packages/core/useParallax/demo.vue
+++ b/packages/core/useParallax/demo.vue
@@ -2,9 +2,9 @@
 import type { CSSProperties } from 'vue'
 import { useMediaQuery, useParallax } from '@vueuse/core'
 import YAML from 'js-yaml'
-import { computed, reactive, ref } from 'vue'
+import { computed, ref as deepRef, reactive } from 'vue'
 
-const target = ref(null)
+const target = deepRef(null)
 const isMobile = useMediaQuery('(max-width: 700px)')
 
 const parallax = reactive(useParallax(target))

--- a/packages/core/useParentElement/index.test.ts
+++ b/packages/core/useParentElement/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { defineComponent, h, nextTick, ref } from 'vue'
+import { ref as deepRef, defineComponent, h, nextTick } from 'vue'
 import { mount } from '../../.test'
 import { useParentElement } from './index'
 
@@ -30,7 +30,7 @@ describe('useParentElement', () => {
   })
 
   it('should accept ref', async () => {
-    const liEl = ref()
+    const liEl = deepRef()
     const parentElement = useParentElement(liEl)
 
     mount(defineComponent({

--- a/packages/core/usePerformanceObserver/demo.vue
+++ b/packages/core/usePerformanceObserver/demo.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { usePerformanceObserver } from '@vueuse/core'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 
-const entrys = ref<PerformanceEntry[]>([])
+const entrys = deepRef<PerformanceEntry[]>([])
 usePerformanceObserver({
   entryTypes: ['paint'],
 }, (list) => {

--- a/packages/core/usePointer/component.ts
+++ b/packages/core/usePointer/component.ts
@@ -1,6 +1,6 @@
 import type { UsePointerOptions } from '@vueuse/core'
 import { usePointer } from '@vueuse/core'
-import { defineComponent, reactive, ref } from 'vue'
+import { defineComponent, reactive, shallowRef } from 'vue'
 import { defaultWindow } from '../_configurable'
 
 export const UsePointer = /* #__PURE__ */ defineComponent<Omit<UsePointerOptions, 'target'> & { target: 'window' | 'self' }>({
@@ -11,7 +11,7 @@ export const UsePointer = /* #__PURE__ */ defineComponent<Omit<UsePointerOptions
     'target',
   ] as unknown as undefined,
   setup(props, { slots }) {
-    const el = ref<HTMLElement | null>(null)
+    const el = shallowRef<HTMLElement | null>(null)
 
     const data = reactive(usePointer({
       ...props,

--- a/packages/core/usePointer/index.ts
+++ b/packages/core/usePointer/index.ts
@@ -3,7 +3,7 @@ import type { Ref } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
 import type { PointerType, Position } from '../types'
 import { objectPick, toRefs } from '@vueuse/shared'
-import { ref, shallowRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 
@@ -63,7 +63,7 @@ export function usePointer(options: UsePointerOptions = {}) {
   } = options
 
   const isInside = shallowRef(false)
-  const state = ref(options.initialValue || {}) as unknown as Ref<UsePointerState>
+  const state = deepRef(options.initialValue || {}) as unknown as Ref<UsePointerState>
   Object.assign(state.value, defaultState, state.value)
 
   const handler = (event: PointerEvent) => {

--- a/packages/core/usePointer/index.ts
+++ b/packages/core/usePointer/index.ts
@@ -3,7 +3,7 @@ import type { Ref } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
 import type { PointerType, Position } from '../types'
 import { objectPick, toRefs } from '@vueuse/shared'
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 
@@ -62,7 +62,7 @@ export function usePointer(options: UsePointerOptions = {}) {
     target = defaultWindow,
   } = options
 
-  const isInside = ref(false)
+  const isInside = shallowRef(false)
   const state = ref(options.initialValue || {}) as unknown as Ref<UsePointerState>
   Object.assign(state.value, defaultState, state.value)
 

--- a/packages/core/usePointerLock/component.ts
+++ b/packages/core/usePointerLock/component.ts
@@ -1,12 +1,12 @@
 import type { RenderableComponent } from '../types'
 import { usePointerLock } from '@vueuse/core'
-import { defineComponent, h, reactive, ref } from 'vue'
+import { ref as deepRef, defineComponent, h, reactive } from 'vue'
 
 export const UsePointerLock = defineComponent<RenderableComponent>({
   name: 'UsePointerLock',
   props: ['as'] as unknown as undefined,
   setup(props, { slots }) {
-    const target = ref()
+    const target = deepRef()
     const data = reactive(usePointerLock(target))
 
     return () => {

--- a/packages/core/usePointerLock/demo.vue
+++ b/packages/core/usePointerLock/demo.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import { useMouse, usePointerLock } from '@vueuse/core'
-import { ref, watch } from 'vue'
+import { ref, shallowRef, watch } from 'vue'
 
 const { lock, unlock, element } = usePointerLock()
 const { x, y } = useMouse({ type: 'movement' })
 const rotY = ref(-45)
-const rotX = ref(0)
+const rotX = shallowRef(0)
 
 watch([x, y], ([x, y]) => {
   if (!element.value)

--- a/packages/core/usePointerLock/demo.vue
+++ b/packages/core/usePointerLock/demo.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { useMouse, usePointerLock } from '@vueuse/core'
-import { ref, shallowRef, watch } from 'vue'
+import { ref as deepRef, shallowRef, watch } from 'vue'
 
 const { lock, unlock, element } = usePointerLock()
 const { x, y } = useMouse({ type: 'movement' })
-const rotY = ref(-45)
+const rotY = deepRef(-45)
 const rotX = shallowRef(0)
 
 watch([x, y], ([x, y]) => {

--- a/packages/core/usePointerLock/index.ts
+++ b/packages/core/usePointerLock/index.ts
@@ -1,7 +1,7 @@
 import type { ConfigurableDocument } from '../_configurable'
 import type { MaybeElement, MaybeElementRef } from '../unrefElement'
 import { until } from '@vueuse/shared'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 import { defaultDocument } from '../_configurable'
 import { unrefElement } from '../unrefElement'
 import { useEventListener } from '../useEventListener'
@@ -29,9 +29,9 @@ export function usePointerLock(target?: MaybeElementRef, options: UsePointerLock
 
   const isSupported = useSupported(() => document && 'pointerLockElement' in document)
 
-  const element = ref<MaybeElement>()
+  const element = deepRef<MaybeElement>()
 
-  const triggerElement = ref<MaybeElement>()
+  const triggerElement = deepRef<MaybeElement>()
 
   let targetElement: MaybeElement
 

--- a/packages/core/usePointerSwipe/demo.vue
+++ b/packages/core/usePointerSwipe/demo.vue
@@ -1,15 +1,15 @@
 <script setup lang="ts">
 import type { UseSwipeDirection } from '@vueuse/core'
 import { usePointerSwipe } from '@vueuse/core'
-import { computed, ref } from 'vue'
+import { computed, shallowRef } from 'vue'
 
-const target = ref<HTMLElement | null>(null)
-const container = ref<HTMLElement | null>(null)
+const target = shallowRef<HTMLElement | null>(null)
+const container = shallowRef<HTMLElement | null>(null)
 
 const containerWidth = computed(() => container.value?.offsetWidth)
 
-const left = ref('0')
-const opacity = ref(1)
+const left = shallowRef('0')
+const opacity = shallowRef(1)
 
 function reset() {
   left.value = '0'

--- a/packages/core/usePointerSwipe/index.ts
+++ b/packages/core/usePointerSwipe/index.ts
@@ -3,7 +3,7 @@ import type { Ref } from 'vue'
 import type { PointerType, Position } from '../types'
 import type { UseSwipeDirection } from '../useSwipe'
 import { toRef, tryOnMounted } from '@vueuse/shared'
-import { computed, reactive, readonly, ref } from 'vue'
+import { computed, reactive, readonly, shallowRef } from 'vue'
 import { useEventListener } from '../useEventListener'
 
 export interface UsePointerSwipeOptions {
@@ -90,8 +90,8 @@ export function usePointerSwipe(
 
   const { max, abs } = Math
   const isThresholdExceeded = computed(() => max(abs(distanceX.value), abs(distanceY.value)) >= threshold)
-  const isSwiping = ref(false)
-  const isPointerDown = ref(false)
+  const isSwiping = shallowRef(false)
+  const isPointerDown = shallowRef(false)
 
   const direction = computed(() => {
     if (!isThresholdExceeded.value)

--- a/packages/core/usePreferredLanguages/index.ts
+++ b/packages/core/usePreferredLanguages/index.ts
@@ -1,6 +1,6 @@
 import type { Ref } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 
@@ -13,10 +13,10 @@ import { useEventListener } from '../useEventListener'
 export function usePreferredLanguages(options: ConfigurableWindow = {}): Ref<readonly string[]> {
   const { window = defaultWindow } = options
   if (!window)
-    return ref(['en'])
+    return deepRef(['en'])
 
   const navigator = window.navigator
-  const value = ref<readonly string[]>(navigator.languages)
+  const value = deepRef<readonly string[]>(navigator.languages)
 
   useEventListener(window, 'languagechange', () => {
     value.value = navigator.languages

--- a/packages/core/usePrevious/index.test.ts
+++ b/packages/core/usePrevious/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref, shallowRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 import { usePrevious } from './index'
 
 describe('usePrevious', () => {
@@ -30,7 +30,7 @@ describe('usePrevious', () => {
   })
 
   it('works with object', () => {
-    const target = ref<any>({ a: 1 })
+    const target = deepRef<any>({ a: 1 })
     const previous = usePrevious(target)
 
     expect(previous.value).toEqual(undefined)

--- a/packages/core/usePrevious/index.test.ts
+++ b/packages/core/usePrevious/index.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 import { usePrevious } from './index'
 
 describe('usePrevious', () => {
   it('works for literals', () => {
-    const target = ref(1)
+    const target = shallowRef(1)
     const previous = usePrevious(target)
 
     expect(previous.value).toBe(undefined)
@@ -19,7 +19,7 @@ describe('usePrevious', () => {
   })
 
   it('works with initial value', () => {
-    const target = ref('Hello')
+    const target = shallowRef('Hello')
     const previous = usePrevious(() => target.value, 'initial')
 
     expect(previous.value).toBe('initial')

--- a/packages/core/useRafFn/demo.vue
+++ b/packages/core/useRafFn/demo.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 import { useRafFn } from './index'
 
 const fpsLimit = 60
-const count = ref(0)
-const deltaMs = ref(0)
+const count = shallowRef(0)
+const deltaMs = shallowRef(0)
 const { pause, resume } = useRafFn(({ delta }) => {
   deltaMs.value = delta
   count.value += 1

--- a/packages/core/useRafFn/index.test.ts
+++ b/packages/core/useRafFn/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 import { useRafFn } from './index'
 
 describe('useRafFn', () => {
@@ -72,7 +72,7 @@ describe('useRafFn', () => {
 
   it('should handle a framerate change', { retry: 3 }, async () => {
     const initialFramerate = 60
-    const fr = ref(initialFramerate)
+    const fr = deepRef(initialFramerate)
     const fn1 = vi.fn()
     const fn2 = vi.fn()
     useRafFn(fn1, { fpsLimit: fr })

--- a/packages/core/useRafFn/index.ts
+++ b/packages/core/useRafFn/index.ts
@@ -2,7 +2,7 @@ import type { Pausable } from '@vueuse/shared'
 import type { MaybeRefOrGetter } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
 import { tryOnScopeDispose } from '@vueuse/shared'
-import { computed, readonly, ref, toValue } from 'vue'
+import { computed, readonly, shallowRef, toValue } from 'vue'
 import { defaultWindow } from '../_configurable'
 
 export interface UseRafFnCallbackArguments {
@@ -47,7 +47,7 @@ export function useRafFn(fn: (args: UseRafFnCallbackArguments) => void, options:
     window = defaultWindow,
   } = options
 
-  const isActive = ref(false)
+  const isActive = shallowRef(false)
   const intervalLimit = computed(() => {
     return fpsLimit ? 1000 / toValue(fpsLimit) : null
   })

--- a/packages/core/useRefHistory/index.test.ts
+++ b/packages/core/useRefHistory/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { nextTick, ref, shallowRef } from 'vue'
+import { ref as deepRef, nextTick, shallowRef } from 'vue'
 import { useRefHistory } from './index'
 
 describe('useRefHistory - sync', () => {
@@ -64,7 +64,7 @@ describe('useRefHistory - sync', () => {
   })
 
   it('sync: object with deep', () => {
-    const v = ref({ foo: 'bar' })
+    const v = deepRef({ foo: 'bar' })
     const { history, undo } = useRefHistory(v, { flush: 'sync', deep: true })
 
     expect(history.value.length).toBe(1)
@@ -86,7 +86,7 @@ describe('useRefHistory - sync', () => {
   })
 
   it('sync: shallow watch with clone', () => {
-    const v = ref({ foo: 'bar' })
+    const v = deepRef({ foo: 'bar' })
     const { history, undo } = useRefHistory(v, { flush: 'sync', clone: true })
 
     expect(history.value.length).toBe(1)
@@ -113,7 +113,7 @@ describe('useRefHistory - sync', () => {
   })
 
   it('sync: dump + parse', () => {
-    const v = ref({ a: 'bar' })
+    const v = deepRef({ a: 'bar' })
     const { history, undo } = useRefHistory(v, {
       flush: 'sync',
       deep: true,
@@ -150,7 +150,7 @@ describe('useRefHistory - sync', () => {
   })
 
   it('sync: without batch', () => {
-    const v = ref({ foo: 1, bar: 'one' })
+    const v = deepRef({ foo: 1, bar: 'one' })
     const { history } = useRefHistory(v, { flush: 'sync', deep: true })
 
     expect(history.value.length).toBe(1)
@@ -166,7 +166,7 @@ describe('useRefHistory - sync', () => {
   })
 
   it('sync: with batch', () => {
-    const v = ref({ foo: 1, bar: 'one' })
+    const v = deepRef({ foo: 1, bar: 'one' })
     const { history, batch } = useRefHistory(v, { flush: 'sync', deep: true })
 
     expect(history.value.length).toBe(1)
@@ -367,7 +367,7 @@ describe('useRefHistory - pre', () => {
   })
 
   it('pre: object with deep', async () => {
-    const v = ref({ foo: 'bar' })
+    const v = deepRef({ foo: 'bar' })
     const { history } = useRefHistory(v, { deep: true })
 
     expect(history.value.length).toBe(1)
@@ -385,7 +385,7 @@ describe('useRefHistory - pre', () => {
   })
 
   it('pre: dump + parse', async () => {
-    const v = ref({ a: 'bar' })
+    const v = deepRef({ a: 'bar' })
     const { history, undo } = useRefHistory(v, {
       deep: true,
       dump: v => JSON.stringify(v),

--- a/packages/core/useRefHistory/index.test.ts
+++ b/packages/core/useRefHistory/index.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { nextTick, ref } from 'vue'
+import { nextTick, ref, shallowRef } from 'vue'
 import { useRefHistory } from './index'
 
 describe('useRefHistory - sync', () => {
   it('sync: should record', () => {
-    const v = ref(0)
+    const v = shallowRef(0)
     const { history } = useRefHistory(v, { flush: 'sync' })
 
     expect(history.value.length).toBe(1)
@@ -18,7 +18,7 @@ describe('useRefHistory - sync', () => {
   })
 
   it('sync: should be able to undo and redo', () => {
-    const v = ref(0)
+    const v = shallowRef(0)
     const { undo, redo, clear, canUndo, canRedo, history, last } = useRefHistory(v, { flush: 'sync' })
 
     expect(canUndo.value).toBe(false)
@@ -136,7 +136,7 @@ describe('useRefHistory - sync', () => {
   })
 
   it('sync: commit', () => {
-    const v = ref(0)
+    const v = shallowRef(0)
     const { commit, history } = useRefHistory(v, { flush: 'sync' })
 
     expect(history.value.length).toBe(1)
@@ -193,7 +193,7 @@ describe('useRefHistory - sync', () => {
   })
 
   it('sync: pause and resume', () => {
-    const v = ref(1)
+    const v = shallowRef(1)
     const { history, pause, resume, last } = useRefHistory(v, { flush: 'sync' })
 
     expect(history.value.length).toBe(1)
@@ -229,7 +229,7 @@ describe('useRefHistory - sync', () => {
   })
 
   it('sync: reset', () => {
-    const v = ref(0)
+    const v = shallowRef(0)
     const { history, commit, undoStack, redoStack, pause, reset, undo } = useRefHistory(v, { flush: 'sync' })
 
     expect(history.value.length).toBe(1)
@@ -284,7 +284,7 @@ describe('useRefHistory - sync', () => {
   })
 
   it('sync: dispose', () => {
-    const v = ref(0)
+    const v = shallowRef(0)
     const { history, dispose, last } = useRefHistory(v, { flush: 'sync' })
 
     v.value = 1
@@ -302,7 +302,7 @@ describe('useRefHistory - sync', () => {
 
 describe('useRefHistory - pre', () => {
   it('pre: should record', async () => {
-    const v = ref(0)
+    const v = shallowRef(0)
     const { history } = useRefHistory(v)
 
     expect(history.value.length).toBe(1)
@@ -317,7 +317,7 @@ describe('useRefHistory - pre', () => {
   })
 
   it('pre: should be able to undo and redo', async () => {
-    const v = ref(0)
+    const v = shallowRef(0)
     const { undo, redo, clear, canUndo, canRedo, history, last } = useRefHistory(v)
 
     expect(canUndo.value).toBe(false)
@@ -409,7 +409,7 @@ describe('useRefHistory - pre', () => {
   })
 
   it('pre: commit', async () => {
-    const v = ref(0)
+    const v = shallowRef(0)
     const { commit, history, undo } = useRefHistory(v)
 
     expect(history.value.length).toBe(1)
@@ -432,7 +432,7 @@ describe('useRefHistory - pre', () => {
   })
 
   it('pre: pause and resume', async () => {
-    const v = ref(1)
+    const v = shallowRef(1)
     const { history, pause, resume, last } = useRefHistory(v)
 
     expect(history.value.length).toBe(1)
@@ -473,7 +473,7 @@ describe('useRefHistory - pre', () => {
   })
 
   it('pre: reset', async () => {
-    const v = ref(0)
+    const v = shallowRef(0)
     const { history, commit, undoStack, redoStack, pause, reset, undo } = useRefHistory(v)
 
     expect(history.value.length).toBe(1)
@@ -533,7 +533,7 @@ describe('useRefHistory - pre', () => {
   })
 
   it('pre: auto batching', async () => {
-    const v = ref(0)
+    const v = shallowRef(0)
     const { history } = useRefHistory(v)
 
     expect(history.value.length).toBe(1)
@@ -559,7 +559,7 @@ describe('useRefHistory - pre', () => {
   })
 
   it('pre: dispose', async () => {
-    const v = ref(0)
+    const v = shallowRef(0)
     const { history, dispose, last } = useRefHistory(v)
 
     v.value = 1

--- a/packages/core/useResizeObserver/demo.vue
+++ b/packages/core/useResizeObserver/demo.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { useResizeObserver } from '@vueuse/core'
-import { ref, useTemplateRef } from 'vue'
+import { shallowRef, useTemplateRef } from 'vue'
 
 const el = useTemplateRef('el')
-const text = ref('')
+const text = shallowRef('')
 
 useResizeObserver(el, (entries) => {
   const [entry] = entries

--- a/packages/core/useScreenOrientation/index.ts
+++ b/packages/core/useScreenOrientation/index.ts
@@ -1,5 +1,5 @@
 import type { ConfigurableWindow } from '../_configurable'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 import { useSupported } from '../useSupported'
@@ -32,8 +32,8 @@ export function useScreenOrientation(options: ConfigurableWindow = {}) {
 
   const screenOrientation = (isSupported.value ? window!.screen.orientation : {}) as ScreenOrientation
 
-  const orientation = ref<OrientationType | undefined>(screenOrientation.type)
-  const angle = ref(screenOrientation.angle || 0)
+  const orientation = deepRef<OrientationType | undefined>(screenOrientation.type)
+  const angle = deepRef(screenOrientation.angle || 0)
 
   if (isSupported.value) {
     useEventListener(window, 'orientationchange', () => {

--- a/packages/core/useScreenSafeArea/index.ts
+++ b/packages/core/useScreenSafeArea/index.ts
@@ -1,5 +1,5 @@
 import { isClient, useDebounceFn } from '@vueuse/shared'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 import { useCssVar } from '../useCssVar'
 import { useEventListener } from '../useEventListener'
 
@@ -14,10 +14,10 @@ const leftVarName = '--vueuse-safe-area-left'
  * @see https://vueuse.org/useScreenSafeArea
  */
 export function useScreenSafeArea() {
-  const top = ref('')
-  const right = ref('')
-  const bottom = ref('')
-  const left = ref('')
+  const top = shallowRef('')
+  const right = shallowRef('')
+  const bottom = shallowRef('')
+  const left = shallowRef('')
 
   if (isClient) {
     const topCssVar = useCssVar(topVarName)

--- a/packages/core/useScriptTag/index.ts
+++ b/packages/core/useScriptTag/index.ts
@@ -1,7 +1,7 @@
 import type { MaybeRefOrGetter } from '@vueuse/shared'
 import type { ConfigurableDocument } from '../_configurable'
 import { noop, tryOnMounted, tryOnUnmounted } from '@vueuse/shared'
-import { ref, toValue } from 'vue'
+import { ref as deepRef, toValue } from 'vue'
 import { defaultDocument } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 
@@ -72,7 +72,7 @@ export function useScriptTag(
     document = defaultDocument,
     attrs = {},
   } = options
-  const scriptTag = ref<HTMLScriptElement | null>(null)
+  const scriptTag = deepRef<HTMLScriptElement | null>(null)
 
   let _promise: Promise<HTMLScriptElement | boolean> | null = null
 

--- a/packages/core/useScroll/demo.vue
+++ b/packages/core/useScroll/demo.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { useScroll } from '@vueuse/core'
-import { computed, ref, toRefs, useTemplateRef } from 'vue'
+import { computed, shallowRef, toRefs, useTemplateRef } from 'vue'
 
 const el = useTemplateRef<HTMLElement>('el')
-const smooth = ref(false)
+const smooth = shallowRef(false)
 const behavior = computed(() => smooth.value ? 'smooth' : 'auto')
 const { x, y, isScrolling, arrivedState, directions } = useScroll(el, { behavior })
 const { left, right, top, bottom } = toRefs(arrivedState)

--- a/packages/core/useScroll/index.ts
+++ b/packages/core/useScroll/index.ts
@@ -1,7 +1,7 @@
 import type { MaybeRefOrGetter } from '@vueuse/shared'
 import type { ConfigurableWindow } from '../_configurable'
 import { noop, tryOnMounted, useDebounceFn, useThrottleFn } from '@vueuse/shared'
-import { computed, reactive, ref, toValue } from 'vue'
+import { computed, reactive, shallowRef, toValue } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { unrefElement } from '../unrefElement'
 import { useEventListener } from '../useEventListener'
@@ -107,8 +107,8 @@ export function useScroll(
     onError = (e) => { console.error(e) },
   } = options
 
-  const internalX = ref(0)
-  const internalY = ref(0)
+  const internalX = shallowRef(0)
+  const internalY = shallowRef(0)
 
   // Use a computed for x and y because we want to write the value to the refs
   // during a `scrollTo()` without firing additional `scrollTo()`s in the process.
@@ -153,7 +153,7 @@ export function useScroll(
       internalY.value = scrollContainer.scrollTop
   }
 
-  const isScrolling = ref(false)
+  const isScrolling = shallowRef(false)
   const arrivedState = reactive({
     left: true,
     right: false,

--- a/packages/core/useScrollLock/directive.ts
+++ b/packages/core/useScrollLock/directive.ts
@@ -1,5 +1,5 @@
 import type { FunctionDirective } from 'vue'
-import { ref, watch } from 'vue'
+import { shallowRef, watch } from 'vue'
 import { useScrollLock } from './index'
 
 function onScrollLock(): FunctionDirective<
@@ -7,7 +7,7 @@ function onScrollLock(): FunctionDirective<
   boolean
 > {
   let isMounted = false
-  const state = ref(false)
+  const state = shallowRef(false)
   return (el, binding) => {
     state.value = binding.value
     if (isMounted)

--- a/packages/core/useScrollLock/index.ts
+++ b/packages/core/useScrollLock/index.ts
@@ -1,6 +1,6 @@
 import type { Fn, MaybeRefOrGetter } from '@vueuse/shared'
 import { isIOS, toRef, tryOnScopeDispose } from '@vueuse/shared'
-import { computed, ref, toValue, watch } from 'vue'
+import { computed, ref as deepRef, toValue, watch } from 'vue'
 
 import { resolveElement } from '../_resolve-element'
 import { useEventListener } from '../useEventListener'
@@ -56,7 +56,7 @@ export function useScrollLock(
   element: MaybeRefOrGetter<HTMLElement | SVGElement | Window | Document | null | undefined>,
   initialState = false,
 ) {
-  const isLocked = ref(initialState)
+  const isLocked = deepRef(initialState)
   let stopTouchMoveListener: Fn | null = null
   let initialOverflow: CSSStyleDeclaration['overflow'] = ''
 

--- a/packages/core/useShare/demo.client.vue
+++ b/packages/core/useShare/demo.client.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { useShare } from '@vueuse/core'
 import { isClient } from '@vueuse/shared'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 
-const options = ref({
+const options = deepRef({
   title: 'VueUse',
   text: 'Collection of essential Vue Composition Utilities!',
   url: isClient ? location.href : '',

--- a/packages/core/useSorted/demo.vue
+++ b/packages/core/useSorted/demo.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { rand } from '@vueuse/shared'
-import { computed, ref } from 'vue'
+import { computed, shallowRef } from 'vue'
 import { useSorted } from './index'
 
 const objArr = [{
@@ -18,7 +18,7 @@ const objArr = [{
 }]
 const result2 = useSorted(objArr, (a, b) => a.age - b.age)
 
-const arrText = ref('')
+const arrText = shallowRef('')
 const inputArr = computed(() => arrText.value.split(','))
 const inputOut = useSorted(inputArr)
 

--- a/packages/core/useSpeechRecognition/demo.vue
+++ b/packages/core/useSpeechRecognition/demo.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useSpeechRecognition } from '@vueuse/core'
-import { ref, shallowRef, watch } from 'vue'
+import { ref as deepRef, shallowRef, watch } from 'vue'
 
 const lang = shallowRef('en-US')
 
@@ -45,7 +45,7 @@ if (speech.isSupported.value) {
   })
 }
 
-const sampled = ref<string[]>([])
+const sampled = deepRef<string[]>([])
 
 function start() {
   color.value = 'transparent'
@@ -56,7 +56,7 @@ function start() {
 
 const { isListening, isSupported, stop, result } = speech
 
-const selectedLanguage = ref(lang.value)
+const selectedLanguage = deepRef(lang.value)
 watch(lang, lang => isListening.value ? null : selectedLanguage.value = lang)
 watch(isListening, isListening => isListening ? null : selectedLanguage.value = lang.value)
 </script>

--- a/packages/core/useSpeechRecognition/demo.vue
+++ b/packages/core/useSpeechRecognition/demo.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { useSpeechRecognition } from '@vueuse/core'
-import { ref, watch } from 'vue'
+import { ref, shallowRef, watch } from 'vue'
 
-const lang = ref('en-US')
+const lang = shallowRef('en-US')
 
 function sample<T>(arr: T[], size: number) {
   const shuffled = arr.slice(0)
@@ -26,7 +26,7 @@ const speech = useSpeechRecognition({
   continuous: true,
 })
 
-const color = ref('transparent')
+const color = shallowRef('transparent')
 
 if (speech.isSupported.value) {
   // @ts-expect-error missing types

--- a/packages/core/useSpeechRecognition/index.ts
+++ b/packages/core/useSpeechRecognition/index.ts
@@ -6,7 +6,7 @@ import type { Ref } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
 import type { SpeechRecognition, SpeechRecognitionErrorEvent } from './types'
 import { toRef, tryOnScopeDispose } from '@vueuse/shared'
-import { ref, shallowRef, toValue, watch } from 'vue'
+import { shallowRef, toValue, watch } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useSupported } from '../useSupported'
 
@@ -54,9 +54,9 @@ export function useSpeechRecognition(options: UseSpeechRecognitionOptions = {}) 
   } = options
 
   const lang = toRef(options.lang || 'en-US')
-  const isListening = ref(false)
-  const isFinal = ref(false)
-  const result = ref('')
+  const isListening = shallowRef(false)
+  const isFinal = shallowRef(false)
+  const result = shallowRef('')
   const error = shallowRef(undefined) as Ref<SpeechRecognitionErrorEvent | undefined>
 
   let recognition: SpeechRecognition | undefined

--- a/packages/core/useSpeechSynthesis/demo.vue
+++ b/packages/core/useSpeechSynthesis/demo.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { useSpeechSynthesis } from '@vueuse/core'
-import { onMounted, ref, shallowRef } from 'vue'
+import { ref as deepRef, onMounted, shallowRef } from 'vue'
 
-const voice = ref<SpeechSynthesisVoice>(undefined as unknown as SpeechSynthesisVoice)
+const voice = deepRef<SpeechSynthesisVoice>(undefined as unknown as SpeechSynthesisVoice)
 const text = shallowRef('Hello, everyone! Good morning!')
 const pitch = shallowRef(1)
 const rate = shallowRef(1)
@@ -15,7 +15,7 @@ const speech = useSpeechSynthesis(text, {
 
 let synth: SpeechSynthesis
 
-const voices = ref<SpeechSynthesisVoice[]>([])
+const voices = deepRef<SpeechSynthesisVoice[]>([])
 
 onMounted(() => {
   if (speech.isSupported.value) {

--- a/packages/core/useSpeechSynthesis/demo.vue
+++ b/packages/core/useSpeechSynthesis/demo.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import { useSpeechSynthesis } from '@vueuse/core'
-import { onMounted, ref } from 'vue'
+import { onMounted, ref, shallowRef } from 'vue'
 
 const voice = ref<SpeechSynthesisVoice>(undefined as unknown as SpeechSynthesisVoice)
-const text = ref('Hello, everyone! Good morning!')
-const pitch = ref(1)
-const rate = ref(1)
+const text = shallowRef('Hello, everyone! Good morning!')
+const pitch = shallowRef(1)
+const rate = shallowRef(1)
 
 const speech = useSpeechSynthesis(text, {
   voice,

--- a/packages/core/useSpeechSynthesis/index.ts
+++ b/packages/core/useSpeechSynthesis/index.ts
@@ -59,7 +59,7 @@ export function useSpeechSynthesis(
   const synth = window && (window as any).speechSynthesis as SpeechSynthesis
   const isSupported = useSupported(() => synth)
 
-  const isPlaying = ref(false)
+  const isPlaying = shallowRef(false)
   const status = ref<UseSpeechSynthesisStatus>('init')
 
   const spokenText = toRef(text || '')

--- a/packages/core/useSpeechSynthesis/index.ts
+++ b/packages/core/useSpeechSynthesis/index.ts
@@ -2,7 +2,7 @@ import type { MaybeRef, MaybeRefOrGetter } from '@vueuse/shared'
 import type { Ref } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
 import { toRef, tryOnScopeDispose } from '@vueuse/shared'
-import { computed, ref, shallowRef, toValue, watch } from 'vue'
+import { computed, ref as deepRef, shallowRef, toValue, watch } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useSupported } from '../useSupported'
 
@@ -60,7 +60,7 @@ export function useSpeechSynthesis(
   const isSupported = useSupported(() => synth)
 
   const isPlaying = shallowRef(false)
-  const status = ref<UseSpeechSynthesisStatus>('init')
+  const status = deepRef<UseSpeechSynthesisStatus>('init')
 
   const spokenText = toRef(text || '')
   const lang = toRef(options.lang || 'en-US')

--- a/packages/core/useStepper/index.test.ts
+++ b/packages/core/useStepper/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { reactive, ref } from 'vue'
+import { reactive, shallowRef } from 'vue'
 import { useStepper } from './index'
 
 describe('useStepper', () => {
@@ -9,7 +9,7 @@ describe('useStepper', () => {
 
   describe('common', () => {
     it('steps are reactive', () => {
-      const flag = ref(true)
+      const flag = shallowRef(true)
       const steps = reactive({
         first: {
           title: 'First',

--- a/packages/core/useStepper/index.ts
+++ b/packages/core/useStepper/index.ts
@@ -1,6 +1,6 @@
 import type { MaybeRef } from '@vueuse/shared'
 import type { ComputedRef, Ref } from 'vue'
-import { computed, ref } from 'vue'
+import { computed, ref as deepRef } from 'vue'
 
 export interface UseStepperReturn<StepName, Steps, Step> {
   /** List of steps. */
@@ -46,9 +46,9 @@ export interface UseStepperReturn<StepName, Steps, Step> {
 export function useStepper<T extends string | number>(steps: MaybeRef<T[]>, initialStep?: T): UseStepperReturn<T, T[], T>
 export function useStepper<T extends Record<string, any>>(steps: MaybeRef<T>, initialStep?: keyof T): UseStepperReturn<Exclude<keyof T, symbol>, T, T[keyof T]>
 export function useStepper(steps: any, initialStep?: any): UseStepperReturn<any, any, any> {
-  const stepsRef = ref<any[]>(steps)
+  const stepsRef = deepRef<any[]>(steps)
   const stepNames = computed<any[]>(() => Array.isArray(stepsRef.value) ? stepsRef.value : Object.keys(stepsRef.value))
-  const index = ref(stepNames.value.indexOf(initialStep ?? stepNames.value[0]))
+  const index = deepRef(stepNames.value.indexOf(initialStep ?? stepNames.value[0]))
   const current = computed(() => at(index.value))
   const isFirst = computed(() => index.value === 0)
   const isLast = computed(() => index.value === stepNames.value.length - 1)

--- a/packages/core/useStorage/index.test.ts
+++ b/packages/core/useStorage/index.test.ts
@@ -1,6 +1,6 @@
 import { debounceFilter } from '@vueuse/shared'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { defineComponent, nextTick, ref, toRaw } from 'vue'
+import { ref as deepRef, defineComponent, nextTick, toRaw } from 'vue'
 import { mount, nextTwoTick, useSetup } from '../../.test'
 import { customStorageEventName, StorageSerializers, useStorage } from './index'
 
@@ -245,7 +245,7 @@ describe('useStorage', () => {
   it('pass ref as initialValue', async () => {
     expect(storage.getItem(KEY)).toEqual(undefined)
 
-    const init = ref({
+    const init = deepRef({
       name: 'a',
       data: 123,
     })
@@ -548,7 +548,7 @@ describe('useStorage', () => {
 
   it('updates on key change when thew new storage value is presented', async () => {
     storage.setItem(ANOTHER_KEY, '1')
-    const key = ref(KEY)
+    const key = deepRef(KEY)
     const data = useStorage(key, 0, storage)
 
     data.value = 2
@@ -567,7 +567,7 @@ describe('useStorage', () => {
   })
 
   it('changes to defaults on key change when the new storage value is undefined', async () => {
-    const key = ref(KEY)
+    const key = deepRef(KEY)
     const data = useStorage(key, 0, storage)
 
     data.value = 1
@@ -587,7 +587,7 @@ describe('useStorage', () => {
   })
 
   it('listens to new storage value changes after key change', async () => {
-    const key = ref(KEY)
+    const key = deepRef(KEY)
     const data = useStorage(key, 0, localStorage)
 
     key.value = ANOTHER_KEY

--- a/packages/core/useStorageAsync/index.ts
+++ b/packages/core/useStorageAsync/index.ts
@@ -2,7 +2,7 @@ import type { MaybeRefOrGetter, RemovableRef } from '@vueuse/shared'
 import type { StorageLikeAsync } from '../ssr-handlers'
 import type { SerializerAsync, UseStorageOptions } from '../useStorage'
 import { watchWithFilter } from '@vueuse/shared'
-import { ref, shallowRef, toValue } from 'vue'
+import { ref as deepRef, shallowRef, toValue } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { getSSRHandler } from '../ssr-handlers'
 import { useEventListener } from '../useEventListener'
@@ -54,7 +54,7 @@ export function useStorageAsync<T extends(string | number | boolean | object | n
   const rawInit: T = toValue(initialValue)
   const type = guessSerializerType<T>(rawInit)
 
-  const data = (shallow ? shallowRef : ref)(toValue(initialValue)) as RemovableRef<T>
+  const data = (shallow ? shallowRef : deepRef)(toValue(initialValue)) as RemovableRef<T>
   const serializer = options.serializer ?? StorageSerializers[type]
 
   if (!storage) {

--- a/packages/core/useStyleTag/index.ts
+++ b/packages/core/useStyleTag/index.ts
@@ -2,7 +2,7 @@ import type { MaybeRef } from '@vueuse/shared'
 import type { Ref } from 'vue'
 import type { ConfigurableDocument } from '../_configurable'
 import { tryOnMounted, tryOnScopeDispose } from '@vueuse/shared'
-import { readonly, ref, watch } from 'vue'
+import { readonly, ref, shallowRef, watch } from 'vue'
 import { defaultDocument } from '../_configurable'
 
 export interface UseStyleTagOptions extends ConfigurableDocument {
@@ -56,7 +56,7 @@ export function useStyleTag(
   css: MaybeRef<string>,
   options: UseStyleTagOptions = {},
 ): UseStyleTagReturn {
-  const isLoaded = ref(false)
+  const isLoaded = shallowRef(false)
 
   const {
     document = defaultDocument,

--- a/packages/core/useStyleTag/index.ts
+++ b/packages/core/useStyleTag/index.ts
@@ -2,7 +2,7 @@ import type { MaybeRef } from '@vueuse/shared'
 import type { Ref } from 'vue'
 import type { ConfigurableDocument } from '../_configurable'
 import { tryOnMounted, tryOnScopeDispose } from '@vueuse/shared'
-import { readonly, ref, shallowRef, watch } from 'vue'
+import { ref as deepRef, readonly, shallowRef, watch } from 'vue'
 import { defaultDocument } from '../_configurable'
 
 export interface UseStyleTagOptions extends ConfigurableDocument {
@@ -65,7 +65,7 @@ export function useStyleTag(
     id = `vueuse_styletag_${++_id}`,
   } = options
 
-  const cssRef = ref(css)
+  const cssRef = deepRef(css)
 
   let stop = () => { }
   const load = () => {

--- a/packages/core/useSwipe/demo.vue
+++ b/packages/core/useSwipe/demo.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
 import type { UseSwipeDirection } from '@vueuse/core'
 import { useSwipe } from '@vueuse/core'
-import { computed, ref } from 'vue'
+import { computed, shallowRef } from 'vue'
 
-const target = ref<HTMLElement | null>(null)
-const container = ref<HTMLElement | null>(null)
+const target = shallowRef<HTMLElement | null>(null)
+const container = shallowRef<HTMLElement | null>(null)
 const containerWidth = computed(() => container.value?.offsetWidth)
-const left = ref('0')
-const opacity = ref(1)
+const left = shallowRef('0')
+const opacity = shallowRef(1)
 
 function reset() {
   left.value = '0'

--- a/packages/core/useSwipe/index.ts
+++ b/packages/core/useSwipe/index.ts
@@ -2,7 +2,7 @@ import type { MaybeRefOrGetter } from '@vueuse/shared'
 import type { ComputedRef, Ref } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
 import type { Position } from '../types'
-import { computed, reactive, ref } from 'vue'
+import { computed, reactive, shallowRef } from 'vue'
 import { useEventListener } from '../useEventListener'
 
 export type UseSwipeDirection = 'up' | 'down' | 'left' | 'right' | 'none'
@@ -80,7 +80,7 @@ export function useSwipe(
   const { max, abs } = Math
   const isThresholdExceeded = computed(() => max(abs(diffX.value), abs(diffY.value)) >= threshold)
 
-  const isSwiping = ref(false)
+  const isSwiping = shallowRef(false)
 
   const direction = computed((): UseSwipeDirection => {
     if (!isThresholdExceeded.value)

--- a/packages/core/useTemplateRefsList/demo.vue
+++ b/packages/core/useTemplateRefsList/demo.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { useTemplateRefsList } from '@vueuse/core'
-import { nextTick, ref, watch } from 'vue'
+import { nextTick, shallowRef, watch } from 'vue'
 
-const count = ref(5)
+const count = shallowRef(5)
 const refs = useTemplateRefsList<HTMLDivElement>()
 
 watch(refs, async () => {

--- a/packages/core/useTemplateRefsList/index.test.ts
+++ b/packages/core/useTemplateRefsList/index.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { defineComponent, h, nextTick, ref, toRefs } from 'vue'
+import { ref as deepRef, defineComponent, h, nextTick, toRefs } from 'vue'
 import { mount } from '../../.test'
 import { useTemplateRefsList } from './index'
 
 const Component1 = defineComponent({
   setup() {
-    const list = ref([1, 2, 3])
+    const list = deepRef([1, 2, 3])
     const refs = useTemplateRefsList()
     return { list, refs }
   },
@@ -45,7 +45,7 @@ const Child = defineComponent({
 
 const testCom2 = defineComponent({
   setup() {
-    const list = ref([1, 2, 3])
+    const list = deepRef([1, 2, 3])
     const refs = useTemplateRefsList<ChildAPI>()
     return { list, refs }
   },

--- a/packages/core/useTemplateRefsList/index.ts
+++ b/packages/core/useTemplateRefsList/index.ts
@@ -1,12 +1,12 @@
 import type { Ref } from 'vue'
-import { onBeforeUpdate, ref } from 'vue'
+import { ref as deepRef, onBeforeUpdate } from 'vue'
 
 export type TemplateRefsList<T> = T[] & {
   set: (el: object | null) => void
 }
 
 export function useTemplateRefsList<T = Element>(): Readonly<Ref<Readonly<TemplateRefsList<T>>>> {
-  const refs = ref<unknown>([]) as Ref<TemplateRefsList<T>>
+  const refs = deepRef<unknown>([]) as Ref<TemplateRefsList<T>>
   refs.value.set = (el: object | null) => {
     if (el)
       refs.value.push(el as T)

--- a/packages/core/useTextDirection/index.ts
+++ b/packages/core/useTextDirection/index.ts
@@ -1,8 +1,8 @@
 import type { ConfigurableDocument } from '../_configurable'
 import type { MaybeElement } from '../unrefElement'
-
 import { tryOnMounted } from '@vueuse/shared'
-import { computed, ref } from 'vue'
+
+import { computed, ref as deepRef } from 'vue'
 import { defaultDocument } from '../_configurable'
 import { useMutationObserver } from '../useMutationObserver'
 
@@ -46,7 +46,7 @@ export function useTextDirection(options: UseTextDirectionOptions = {}) {
     return document?.querySelector(selector)?.getAttribute('dir') as UseTextDirectionValue ?? initialValue
   }
 
-  const dir = ref<UseTextDirectionValue>(getValue())
+  const dir = deepRef<UseTextDirectionValue>(getValue())
 
   tryOnMounted(() => dir.value = getValue())
 

--- a/packages/core/useTextSelection/demo.vue
+++ b/packages/core/useTextSelection/demo.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { useTextSelection } from '@vueuse/core'
-import { computed, ref } from 'vue'
+import { computed, ref as deepRef } from 'vue'
 
-const demo = ref()
+const demo = deepRef()
 const { rects, text } = useTextSelection()
 const selectedStyle = computed(() => text.value ? 'text-primary' : 'text-gray-400')
 </script>

--- a/packages/core/useTextSelection/index.ts
+++ b/packages/core/useTextSelection/index.ts
@@ -1,5 +1,5 @@
 import type { ConfigurableWindow } from '../_configurable'
-import { computed, ref } from 'vue'
+import { computed, ref as deepRef } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 
@@ -18,7 +18,7 @@ export function useTextSelection(options: ConfigurableWindow = {}) {
     window = defaultWindow,
   } = options
 
-  const selection = ref<Selection | null>(null)
+  const selection = deepRef<Selection | null>(null)
   const text = computed(() => selection.value?.toString() ?? '')
   const ranges = computed<Range[]>(() => selection.value ? getRangesFromSelection(selection.value) : [])
   const rects = computed(() => ranges.value.map(range => range.getBoundingClientRect()))

--- a/packages/core/useTextareaAutosize/index.ts
+++ b/packages/core/useTextareaAutosize/index.ts
@@ -1,7 +1,7 @@
 import type { MaybeRef } from '@vueuse/shared'
 import type { WatchSource } from 'vue'
 import { toRef } from '@vueuse/shared'
-import { nextTick, ref, toValue, watch } from 'vue'
+import { nextTick, shallowRef, toValue, watch } from 'vue'
 import { useResizeObserver } from '../useResizeObserver'
 
 export interface UseTextareaAutosizeOptions {
@@ -23,8 +23,8 @@ export function useTextareaAutosize(options?: UseTextareaAutosizeOptions) {
   const textarea = toRef(options?.element)
   const input = toRef(options?.input ?? '')
   const styleProp = options?.styleProp ?? 'height'
-  const textareaScrollHeight = ref(1)
-  const textareaOldWidth = ref(0)
+  const textareaScrollHeight = shallowRef(1)
+  const textareaOldWidth = shallowRef(0)
 
   function triggerResize() {
     if (!textarea.value)

--- a/packages/core/useThrottledRefHistory/demo.vue
+++ b/packages/core/useThrottledRefHistory/demo.vue
@@ -2,12 +2,12 @@
 import type { Ref } from 'vue'
 import { formatDate, useThrottledRefHistory } from '@vueuse/core'
 import { useCounter } from '@vueuse/shared'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 
 function format(ts: number) {
   return formatDate(new Date(ts), 'YYYY-MM-DD HH:mm:ss')
 }
-const delay: Ref<number> = ref(1000)
+const delay: Ref<number> = shallowRef(1000)
 
 const { count, inc, dec } = useCounter()
 const { history, undo, redo, canUndo, canRedo } = useThrottledRefHistory(

--- a/packages/core/useThrottledRefHistory/index.test.ts
+++ b/packages/core/useThrottledRefHistory/index.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 import { useThrottledRefHistory } from './index'
 
 describe('useThrottledRefHistory - sync', () => {
   it('take first snapshot right after data was changed and second after given time', async () => {
     vi.useFakeTimers()
     const ms = 10
-    const v = ref(0)
+    const v = shallowRef(0)
 
     const { history } = useThrottledRefHistory(v, { throttle: ms })
 

--- a/packages/core/useTimeAgo/demo.vue
+++ b/packages/core/useTimeAgo/demo.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { useTimeAgo } from '@vueuse/core'
 import { timestamp } from '@vueuse/shared'
-import { computed, ref } from 'vue'
+import { computed, shallowRef } from 'vue'
 
-const slider = ref(0)
+const slider = shallowRef(0)
 const value = computed(() => timestamp() + slider.value ** 3)
 const timeAgo = useTimeAgo(value)
 </script>

--- a/packages/core/useTimeAgo/index.test.ts
+++ b/packages/core/useTimeAgo/index.test.ts
@@ -1,7 +1,7 @@
 import type { ComputedRef } from 'vue'
 import { timestamp } from '@vueuse/shared'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { computed, ref } from 'vue'
+import { computed, shallowRef } from 'vue'
 import { useTimeAgo } from './index'
 
 type TimeUnit = 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year'
@@ -27,7 +27,7 @@ function getNeededTimeChange(type: TimeUnit, count: number, adjustSecond?: numbe
 
 describe('useTimeAgo', () => {
   let baseTime: number
-  const changeValue = ref(0)
+  const changeValue = shallowRef(0)
   let changeTime: ComputedRef<number>
 
   function reset() {

--- a/packages/core/useTimeoutPoll/demo.vue
+++ b/packages/core/useTimeoutPoll/demo.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { useTimeoutPoll } from '@vueuse/core'
 import { promiseTimeout } from '@vueuse/shared'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 
-const count = ref(0)
+const count = shallowRef(0)
 
 async function fetchData() {
   await promiseTimeout(1000)

--- a/packages/core/useTimeoutPoll/index.test.ts
+++ b/packages/core/useTimeoutPoll/index.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { effectScope, ref } from 'vue'
+import { effectScope, shallowRef } from 'vue'
 import { useTimeoutPoll } from './index'
 
 describe('useTimeoutPoll', () => {
@@ -9,7 +9,7 @@ describe('useTimeoutPoll', () => {
 
   it('basic pause/resume', async () => {
     const callback = vi.fn()
-    const interval = ref(0)
+    const interval = shallowRef(0)
     const { pause, resume } = useTimeoutPoll(callback, interval)
 
     await vi.advanceTimersByTimeAsync(1)
@@ -37,7 +37,7 @@ describe('useTimeoutPoll', () => {
 
   it('pause/resume in scope', async () => {
     const callback = vi.fn()
-    const interval = ref(0)
+    const interval = shallowRef(0)
     const scope = effectScope()
     await scope.run(async () => {
       useTimeoutPoll(callback, interval)

--- a/packages/core/useTimeoutPoll/index.ts
+++ b/packages/core/useTimeoutPoll/index.ts
@@ -1,6 +1,6 @@
 import type { Awaitable, MaybeRefOrGetter, Pausable, UseTimeoutFnOptions } from '@vueuse/shared'
 import { isClient, tryOnScopeDispose, useTimeoutFn } from '@vueuse/shared'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 
 export interface UseTimeoutPollOptions {
   /**
@@ -30,7 +30,7 @@ export function useTimeoutPoll(
 
   const { start } = useTimeoutFn(loop, interval, { immediate })
 
-  const isActive = ref(false)
+  const isActive = shallowRef(false)
 
   async function loop() {
     if (!isActive.value)

--- a/packages/core/useTimestamp/index.test.ts
+++ b/packages/core/useTimestamp/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 import { useTimestamp } from './index'
 
 describe('useTimestamp', () => {
@@ -13,7 +13,7 @@ describe('useTimestamp', () => {
   })
 
   it('allows for a delayed start using requestAnimationFrame', async () => {
-    const now = ref()
+    const now = deepRef()
     const callback = vi.fn((time) => {
       now.value = time
     })

--- a/packages/core/useTimestamp/index.ts
+++ b/packages/core/useTimestamp/index.ts
@@ -1,7 +1,7 @@
 import type { Pausable } from '@vueuse/shared'
 import type { Ref } from 'vue'
 import { timestamp, useIntervalFn } from '@vueuse/shared'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 import { useRafFn } from '../useRafFn'
 
 export interface UseTimestampOptions<Controls extends boolean> {
@@ -55,7 +55,7 @@ export function useTimestamp(options: UseTimestampOptions<boolean> = {}) {
     callback,
   } = options
 
-  const ts = ref(timestamp() + offset)
+  const ts = deepRef(timestamp() + offset)
 
   const update = () => ts.value = timestamp() + offset
   const cb = callback

--- a/packages/core/useTitle/index.test.ts
+++ b/packages/core/useTitle/index.test.ts
@@ -1,6 +1,6 @@
 import type { ComputedRef, Ref } from 'vue'
 import { beforeEach, describe, expect, expectTypeOf, it } from 'vitest'
-import { computed, isReadonly, ref, shallowRef } from 'vue'
+import { computed, ref as deepRef, isReadonly, shallowRef } from 'vue'
 import { useTitle } from './index'
 
 const defaultTitle = 'VueUse testing'
@@ -51,7 +51,7 @@ describe('useTitle', () => {
       })
 
       it('null', () => {
-        const targetRef = ref<null | string>(null)
+        const targetRef = deepRef<null | string>(null)
         const title = useTitle(targetRef)
         expect(title.value).toEqual(null)
         targetRef.value = 'new title'
@@ -61,7 +61,7 @@ describe('useTitle', () => {
       })
 
       it('undefined', () => {
-        const targetRef = ref<undefined | string>(undefined)
+        const targetRef = deepRef<undefined | string>(undefined)
         const title = useTitle(targetRef)
         expect(title.value).toEqual(undefined)
         targetRef.value = 'new title'

--- a/packages/core/useTitle/index.test.ts
+++ b/packages/core/useTitle/index.test.ts
@@ -1,6 +1,6 @@
 import type { ComputedRef, Ref } from 'vue'
 import { beforeEach, describe, expect, expectTypeOf, it } from 'vitest'
-import { computed, isReadonly, ref } from 'vue'
+import { computed, isReadonly, ref, shallowRef } from 'vue'
 import { useTitle } from './index'
 
 const defaultTitle = 'VueUse testing'
@@ -41,7 +41,7 @@ describe('useTitle', () => {
 
     describe('ref param', () => {
       it('string', () => {
-        const targetRef = ref('old title')
+        const targetRef = shallowRef('old title')
         const title = useTitle(targetRef)
         expect(title.value).toEqual('old title')
         targetRef.value = 'new title'
@@ -74,7 +74,7 @@ describe('useTitle', () => {
 
   describe('with readonly param', () => {
     it('computed', () => {
-      const condition = ref(false)
+      const condition = shallowRef(false)
       const target = computed(() => condition.value ? 'new title' : 'old title')
       const title = useTitle(target)
       expect(title.value).toEqual('old title')
@@ -105,7 +105,7 @@ describe('useTitle', () => {
     })
 
     it('should return a ref if initial value is ref', () => {
-      const title = useTitle(ref(''))
+      const title = useTitle(shallowRef(''))
       expect(isReadonly(title)).toBeFalsy()
       expectTypeOf(title).toEqualTypeOf<Ref<string | null | undefined>>()
     })

--- a/packages/core/useTransition/demo.vue
+++ b/packages/core/useTransition/demo.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
 import { TransitionPresets, useTransition } from '@vueuse/core'
 import { rand } from '@vueuse/shared'
-import { ref, shallowRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 
 const duration = 1500
 
 const baseNumber = shallowRef(0)
 
-const baseVector = ref([0, 0])
+const baseVector = deepRef([0, 0])
 
 function easeOutElastic(n: number) {
   return n === 0

--- a/packages/core/useTransition/demo.vue
+++ b/packages/core/useTransition/demo.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import { TransitionPresets, useTransition } from '@vueuse/core'
 import { rand } from '@vueuse/shared'
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 
 const duration = 1500
 
-const baseNumber = ref(0)
+const baseNumber = shallowRef(0)
 
 const baseVector = ref([0, 0])
 

--- a/packages/core/useTransition/index.test.ts
+++ b/packages/core/useTransition/index.test.ts
@@ -1,6 +1,6 @@
 import { promiseTimeout } from '@vueuse/shared'
 import { describe, expect, it, vi } from 'vitest'
-import { ref, shallowRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 import { executeTransition, useTransition } from './index'
 
 function expectBetween(val: number, floor: number, ceiling: number) {
@@ -24,7 +24,7 @@ describe('executeTransition', () => {
   })
 
   it('transitions between vectors', async () => {
-    const source = ref([0, 0, 0])
+    const source = deepRef([0, 0, 0])
 
     const trans = executeTransition(source, [0, 1, 2], [1, 2, 3], { duration: 50 })
 
@@ -78,7 +78,7 @@ describe('useTransition', () => {
   })
 
   it('transitions between vectors', async () => {
-    const source = ref([0, 0])
+    const source = deepRef([0, 0])
     const transition = useTransition(source, { duration: 100 })
 
     expect(transition.value).toEqual([0, 0])
@@ -200,7 +200,7 @@ describe('useTransition', () => {
     const source = shallowRef(0)
     const first = vi.fn(n => n)
     const second = vi.fn(n => n)
-    const easingFn = ref(first)
+    const easingFn = deepRef(first)
 
     useTransition(source, {
       duration: 100,

--- a/packages/core/useTransition/index.test.ts
+++ b/packages/core/useTransition/index.test.ts
@@ -1,6 +1,6 @@
 import { promiseTimeout } from '@vueuse/shared'
 import { describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 import { executeTransition, useTransition } from './index'
 
 function expectBetween(val: number, floor: number, ceiling: number) {
@@ -10,7 +10,7 @@ function expectBetween(val: number, floor: number, ceiling: number) {
 
 describe('executeTransition', () => {
   it('transitions between numbers', async () => {
-    const source = ref(0)
+    const source = shallowRef(0)
 
     const trans = executeTransition(source, 0, 1, { duration: 50 })
 
@@ -44,7 +44,7 @@ describe('executeTransition', () => {
   it('transitions can be aborted', async () => {
     let abort = false
 
-    const source = ref(0)
+    const source = shallowRef(0)
 
     const trans = executeTransition(source, 0, 1, {
       abort: () => abort,
@@ -63,7 +63,7 @@ describe('executeTransition', () => {
 
 describe('useTransition', () => {
   it('transitions between numbers', async () => {
-    const source = ref(0)
+    const source = shallowRef(0)
     const transition = useTransition(source, { duration: 100 })
 
     expect(transition.value).toBe(0)
@@ -95,8 +95,8 @@ describe('useTransition', () => {
   })
 
   it('transitions between refs', async () => {
-    const source1 = ref(0)
-    const source2 = ref(0)
+    const source1 = shallowRef(0)
+    const source2 = shallowRef(0)
     const transition = useTransition([source1, source2], { duration: 100 })
 
     expect(transition.value).toEqual([0, 0])
@@ -114,7 +114,7 @@ describe('useTransition', () => {
   })
 
   it('supports cubic bezier curves', async () => {
-    const source = ref(0)
+    const source = shallowRef(0)
 
     // https://cubic-bezier.com/#0,2,0,1
     const easeOutBack = useTransition(source, {
@@ -140,7 +140,7 @@ describe('useTransition', () => {
   })
 
   it('supports custom easing functions', async () => {
-    const source = ref(0)
+    const source = shallowRef(0)
     const linear = vi.fn(n => n)
     const transition = useTransition(source, {
       duration: 100,
@@ -160,7 +160,7 @@ describe('useTransition', () => {
   })
 
   it('supports non-linear custom easing functions', async () => {
-    const source = ref(0)
+    const source = shallowRef(0)
     const easeInQuad = vi.fn(n => n * n)
     const transition = useTransition(source, {
       duration: 100,
@@ -180,7 +180,7 @@ describe('useTransition', () => {
   })
 
   it('supports delayed transitions', async () => {
-    const source = ref(0)
+    const source = shallowRef(0)
 
     const transition = useTransition(source, {
       delay: 100,
@@ -197,7 +197,7 @@ describe('useTransition', () => {
   })
 
   it('supports dynamic transitions', async () => {
-    const source = ref(0)
+    const source = shallowRef(0)
     const first = vi.fn(n => n)
     const second = vi.fn(n => n)
     const easingFn = ref(first)
@@ -228,8 +228,8 @@ describe('useTransition', () => {
   })
 
   it('supports dynamic durations', async () => {
-    const source = ref(0)
-    const duration = ref(100)
+    const source = shallowRef(0)
+    const duration = shallowRef(100)
     const transition = useTransition(source, { duration })
 
     source.value = 1
@@ -251,7 +251,7 @@ describe('useTransition', () => {
   })
 
   it('fires onStarted and onFinished callbacks', async () => {
-    const source = ref(0)
+    const source = shallowRef(0)
     const onStarted = vi.fn()
     const onFinished = vi.fn()
 
@@ -279,7 +279,7 @@ describe('useTransition', () => {
   })
 
   it('clears pending transitions before starting a new one', async () => {
-    const source = ref(0)
+    const source = shallowRef(0)
     const onStarted = vi.fn()
     const onFinished = vi.fn()
 
@@ -302,8 +302,8 @@ describe('useTransition', () => {
 
   it('can be disabled for sychronous changes', async () => {
     const onStarted = vi.fn()
-    const disabled = ref(false)
-    const source = ref(0)
+    const disabled = shallowRef(false)
+    const source = shallowRef(0)
 
     const transition = useTransition(source, {
       disabled,
@@ -322,7 +322,7 @@ describe('useTransition', () => {
   })
 
   it('begins transition from where previous transition was interrupted', async () => {
-    const source = ref(0)
+    const source = shallowRef(0)
 
     const transition = useTransition(source, {
       duration: 100,

--- a/packages/core/useTransition/index.ts
+++ b/packages/core/useTransition/index.ts
@@ -1,7 +1,7 @@
 import type { MaybeRef, MaybeRefOrGetter } from '@vueuse/shared'
 import type { ComputedRef, Ref } from 'vue'
 import { identity as linear, promiseTimeout, tryOnScopeDispose } from '@vueuse/shared'
-import { computed, ref, toValue, watch } from 'vue'
+import { computed, ref as deepRef, toValue, watch } from 'vue'
 
 /**
  * Cubic bezier points
@@ -219,7 +219,7 @@ export function useTransition(
       : v.map(toValue<number>)
   }
 
-  const outputRef = ref(sourceVal())
+  const outputRef = deepRef(sourceVal())
 
   watch(sourceVal, async (to) => {
     if (toValue(options.disabled))

--- a/packages/core/useUserMedia/demo.vue
+++ b/packages/core/useUserMedia/demo.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { useDevicesList, useUserMedia } from '@vueuse/core'
-import { reactive, ref, watchEffect } from 'vue'
+import { ref as deepRef, reactive, watchEffect } from 'vue'
 
-const currentCamera = ref<string>()
+const currentCamera = deepRef<string>()
 const { videoInputs: cameras } = useDevicesList({
   requestPermissions: true,
   onUpdated() {
@@ -11,7 +11,7 @@ const { videoInputs: cameras } = useDevicesList({
   },
 })
 
-const video = ref<HTMLVideoElement>()
+const video = deepRef<HTMLVideoElement>()
 const { stream, enabled } = useUserMedia({
   constraints: reactive({ video: { deviceId: currentCamera } }),
 })

--- a/packages/core/useUserMedia/index.ts
+++ b/packages/core/useUserMedia/index.ts
@@ -4,7 +4,7 @@ import type { MaybeRef } from '@vueuse/shared'
 import type { Ref } from 'vue'
 import type { ConfigurableNavigator } from '../_configurable'
 import { tryOnScopeDispose } from '@vueuse/shared'
-import { ref, shallowRef, watch } from 'vue'
+import { ref as deepRef, shallowRef, watch } from 'vue'
 import { defaultNavigator } from '../_configurable'
 import { useSupported } from '../useSupported'
 
@@ -36,9 +36,9 @@ export interface UseUserMediaOptions extends ConfigurableNavigator {
  * @param options
  */
 export function useUserMedia(options: UseUserMediaOptions = {}) {
-  const enabled = ref(options.enabled ?? false)
-  const autoSwitch = ref(options.autoSwitch ?? true)
-  const constraints = ref(options.constraints)
+  const enabled = deepRef(options.enabled ?? false)
+  const autoSwitch = deepRef(options.autoSwitch ?? true)
+  const constraints = deepRef(options.constraints)
   const { navigator = defaultNavigator } = options
   const isSupported = useSupported(() => navigator?.mediaDevices?.getUserMedia)
 

--- a/packages/core/useVModel/index.ts
+++ b/packages/core/useVModel/index.ts
@@ -1,7 +1,7 @@
 import type { Ref, UnwrapRef, WritableComputedRef } from 'vue'
 import type { CloneFn } from '../useCloned'
 import { isDef } from '@vueuse/shared'
-import { computed, getCurrentInstance, nextTick, ref, watch } from 'vue'
+import { computed, ref as deepRef, getCurrentInstance, nextTick, watch } from 'vue'
 import { cloneFnJSON } from '../useCloned'
 
 export interface UseVModelOptions<T, Passive extends boolean = false> {
@@ -118,7 +118,7 @@ export function useVModel<P extends object, K extends keyof P, Name extends stri
 
   if (passive) {
     const initialValue = getValue()
-    const proxy = ref<P[K]>(initialValue!)
+    const proxy = deepRef<P[K]>(initialValue!)
     let isUpdating = false
 
     watch(

--- a/packages/core/useVirtualList/demo.vue
+++ b/packages/core/useVirtualList/demo.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import type { Ref } from 'vue'
 import { useVirtualList } from '@vueuse/core'
-import { computed, ref, shallowRef } from 'vue'
+import { computed, ref as deepRef, shallowRef } from 'vue'
 
-const index: Ref = ref()
+const index: Ref = deepRef()
 const search = shallowRef('')
 
 const allItems = Array.from(Array.from({ length: 99999 }).keys())

--- a/packages/core/useVirtualList/demo.vue
+++ b/packages/core/useVirtualList/demo.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import type { Ref } from 'vue'
 import { useVirtualList } from '@vueuse/core'
-import { computed, ref } from 'vue'
+import { computed, ref, shallowRef } from 'vue'
 
 const index: Ref = ref()
-const search = ref('')
+const search = shallowRef('')
 
 const allItems = Array.from(Array.from({ length: 99999 }).keys())
   .map(i => ({

--- a/packages/core/useVirtualList/index.test.ts
+++ b/packages/core/useVirtualList/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 import { useVirtualList } from './index'
 
 describe('useVirtualList', () => {
@@ -14,7 +14,7 @@ describe('useVirtualList, vertical', () => {
       list,
       containerProps: { ref: containerRef },
       scrollTo,
-    } = useVirtualList(ref(['a', 'b', 'c', 'd', 'e', 'f']), { itemHeight: () => 50, overscan: 1 })
+    } = useVirtualList(deepRef(['a', 'b', 'c', 'd', 'e', 'f']), { itemHeight: () => 50, overscan: 1 })
     const div = { ...document.createElement('div'), clientHeight: 50 }
 
     containerRef.value = div
@@ -33,7 +33,7 @@ describe('useVirtualList, vertical', () => {
       list,
       containerProps: { ref: containerRef },
       scrollTo,
-    } = useVirtualList(ref(['a', 'b', 'c', 'd', 'e', 'f', 'g']), { itemHeight: () => 50, overscan: 1 })
+    } = useVirtualList(deepRef(['a', 'b', 'c', 'd', 'e', 'f', 'g']), { itemHeight: () => 50, overscan: 1 })
     const div = { ...document.createElement('div'), clientHeight: 50 }
 
     containerRef.value = div
@@ -67,7 +67,7 @@ describe('useVirtualList, horizontal', () => {
       list,
       containerProps: { ref: containerRef },
       scrollTo,
-    } = useVirtualList(ref(['a', 'b', 'c', 'd', 'e', 'f']), { itemWidth: () => 50, overscan: 1 })
+    } = useVirtualList(deepRef(['a', 'b', 'c', 'd', 'e', 'f']), { itemWidth: () => 50, overscan: 1 })
     const div = { ...document.createElement('div'), clientWidth: 50 }
 
     containerRef.value = div
@@ -86,7 +86,7 @@ describe('useVirtualList, horizontal', () => {
       list,
       containerProps: { ref: containerRef },
       scrollTo,
-    } = useVirtualList(ref(['a', 'b', 'c', 'd', 'e', 'f', 'g']), { itemWidth: () => 50, overscan: 1 })
+    } = useVirtualList(deepRef(['a', 'b', 'c', 'd', 'e', 'f', 'g']), { itemWidth: () => 50, overscan: 1 })
     const div = { ...document.createElement('div'), clientWidth: 50 }
 
     containerRef.value = div
@@ -119,10 +119,10 @@ describe('useVirtualList, horizontal', () => {
 
     const {
       list: readonlyList,
-    } = useVirtualList(ref(readonlyInput), { itemHeight: () => 50, overscan: 1 })
+    } = useVirtualList(deepRef(readonlyInput), { itemHeight: () => 50, overscan: 1 })
     const {
       list: mutableList,
-    } = useVirtualList(ref(mutableInput), { itemHeight: () => 50, overscan: 1 })
+    } = useVirtualList(deepRef(mutableInput), { itemHeight: () => 50, overscan: 1 })
 
     expect(readonlyList.value).toBeDefined()
     expect(mutableList.value).toBeDefined()

--- a/packages/core/useVirtualList/index.ts
+++ b/packages/core/useVirtualList/index.ts
@@ -111,7 +111,7 @@ interface UseVirtualListResources<T> {
 }
 
 function useVirtualListResources<T>(list: MaybeRef<readonly T[]>): UseVirtualListResources<T> {
-  const containerRef = ref<HTMLElement | null>(null)
+  const containerRef = shallowRef<HTMLElement | null>(null)
   const size = useElementSize(containerRef)
 
   const currentList: Ref<UseVirtualListItem<T>[]> = ref([])

--- a/packages/core/useVirtualList/index.ts
+++ b/packages/core/useVirtualList/index.ts
@@ -1,6 +1,6 @@
 import type { MaybeRef } from '@vueuse/shared'
 import type { ComputedRef, Ref, ShallowRef, StyleValue } from 'vue'
-import { computed, ref, shallowRef, watch } from 'vue'
+import { computed, ref as deepRef, shallowRef, watch } from 'vue'
 import { useElementSize } from '../useElementSize'
 
 type UseVirtualListItemSize = number | ((index: number) => number)
@@ -114,10 +114,10 @@ function useVirtualListResources<T>(list: MaybeRef<readonly T[]>): UseVirtualLis
   const containerRef = shallowRef<HTMLElement | null>(null)
   const size = useElementSize(containerRef)
 
-  const currentList: Ref<UseVirtualListItem<T>[]> = ref([])
+  const currentList: Ref<UseVirtualListItem<T>[]> = deepRef([])
   const source = shallowRef(list)
 
-  const state: Ref<{ start: number, end: number }> = ref({ start: 0, end: 10 })
+  const state: Ref<{ start: number, end: number }> = deepRef({ start: 0, end: 10 })
 
   return { state, source, currentList, size, containerRef }
 }

--- a/packages/core/useWakeLock/index.ts
+++ b/packages/core/useWakeLock/index.ts
@@ -1,6 +1,6 @@
 import type { ConfigurableDocument, ConfigurableNavigator } from '../_configurable'
 import { whenever } from '@vueuse/shared'
-import { computed, ref, shallowRef } from 'vue'
+import { computed, ref as deepRef, shallowRef } from 'vue'
 import { defaultDocument, defaultNavigator } from '../_configurable'
 import { useDocumentVisibility } from '../useDocumentVisibility'
 import { useEventListener } from '../useEventListener'
@@ -31,7 +31,7 @@ export function useWakeLock(options: UseWakeLockOptions = {}) {
     navigator = defaultNavigator,
     document = defaultDocument,
   } = options
-  const requestedType = ref<WakeLockType | false>(false)
+  const requestedType = deepRef<WakeLockType | false>(false)
   const sentinel = shallowRef<WakeLockSentinel | null>(null)
   const documentVisibility = useDocumentVisibility({ document })
   const isSupported = useSupported(() => navigator && 'wakeLock' in navigator)

--- a/packages/core/useWebNotification/index.ts
+++ b/packages/core/useWebNotification/index.ts
@@ -2,7 +2,7 @@ import type { EventHook } from '@vueuse/shared'
 import type { Ref } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
 import { createEventHook, tryOnMounted, tryOnScopeDispose } from '@vueuse/shared'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 import { useSupported } from '../useSupported'
@@ -131,9 +131,9 @@ export function useWebNotification(
     return true
   })
 
-  const permissionGranted = ref(isSupported.value && 'permission' in Notification && Notification.permission === 'granted')
+  const permissionGranted = deepRef(isSupported.value && 'permission' in Notification && Notification.permission === 'granted')
 
-  const notification: Ref<Notification | null> = ref(null)
+  const notification: Ref<Notification | null> = deepRef(null)
 
   const ensurePermissions = async () => {
     if (!isSupported.value)

--- a/packages/core/useWebSocket/index.test.ts
+++ b/packages/core/useWebSocket/index.test.ts
@@ -1,6 +1,6 @@
 import type { UseWebSocketReturn } from './index'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick, ref } from 'vue'
+import { nextTick, shallowRef } from 'vue'
 import { useSetup } from '../../.test'
 import { useWebSocket } from './index'
 
@@ -43,7 +43,7 @@ describe('useWebSocket', () => {
   })
 
   it('should reconnect if URL changes', async () => {
-    const url = ref('ws://localhost')
+    const url = shallowRef('ws://localhost')
     vm = useSetup(() => {
       const ref = useWebSocket(url)
 
@@ -61,7 +61,7 @@ describe('useWebSocket', () => {
   })
 
   it('should not reconnect on URL change if immediate and autoConnect are false', async () => {
-    const url = ref('ws://localhost')
+    const url = shallowRef('ws://localhost')
     vm = useSetup(() => {
       const ref = useWebSocket(url, {
         immediate: false,

--- a/packages/core/useWebSocket/index.ts
+++ b/packages/core/useWebSocket/index.ts
@@ -1,7 +1,7 @@
 import type { Fn, MaybeRefOrGetter } from '@vueuse/shared'
 import type { Ref } from 'vue'
 import { isClient, isWorker, toRef, tryOnScopeDispose, useIntervalFn } from '@vueuse/shared'
-import { ref, toValue, watch } from 'vue'
+import { ref as deepRef, toValue, watch } from 'vue'
 import { useEventListener } from '../useEventListener'
 
 export type WebSocketStatus = 'OPEN' | 'CONNECTING' | 'CLOSED'
@@ -170,9 +170,9 @@ export function useWebSocket<Data = any>(
     protocols = [],
   } = options
 
-  const data: Ref<Data | null> = ref(null)
-  const status = ref<WebSocketStatus>('CLOSED')
-  const wsRef = ref<WebSocket | undefined>()
+  const data: Ref<Data | null> = deepRef(null)
+  const status = deepRef<WebSocketStatus>('CLOSED')
+  const wsRef = deepRef<WebSocket | undefined>()
   const urlRef = toRef(url)
 
   let heartbeatPause: Fn | undefined

--- a/packages/core/useWebWorker/index.ts
+++ b/packages/core/useWebWorker/index.ts
@@ -3,7 +3,7 @@
 import type { Ref, ShallowRef } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
 import { tryOnScopeDispose } from '@vueuse/shared'
-import { ref, shallowRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 import { defaultWindow } from '../_configurable'
 
 type PostMessage = typeof Worker.prototype['postMessage']
@@ -50,7 +50,7 @@ export function useWebWorker<Data = any>(
     window = defaultWindow,
   } = options ?? {}
 
-  const data: Ref<any> = ref(null)
+  const data: Ref<any> = deepRef(null)
   const worker = shallowRef<Worker>()
 
   const post: PostMessage = (...args) => {

--- a/packages/core/useWebWorkerFn/demo.vue
+++ b/packages/core/useWebWorkerFn/demo.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useDateFormat, useTimestamp, useWebWorkerFn } from '@vueuse/core'
-import { computed, nextTick, ref, shallowRef } from 'vue'
+import { computed, ref as deepRef, nextTick, shallowRef } from 'vue'
 
 function heavyTask() {
   const randomNumber = () => Math.trunc(Math.random() * 5_000_00)
@@ -14,7 +14,7 @@ const time = useTimestamp()
 const computedTime = useDateFormat(time, 'YYYY-MM-DD HH:mm:ss SSS')
 const running = computed(() => workerStatus.value === 'RUNNING')
 
-const data = ref<number[] | null>(null)
+const data = deepRef<number[] | null>(null)
 const runner = shallowRef('')
 
 async function baseSort() {

--- a/packages/core/useWebWorkerFn/demo.vue
+++ b/packages/core/useWebWorkerFn/demo.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useDateFormat, useTimestamp, useWebWorkerFn } from '@vueuse/core'
-import { computed, nextTick, ref } from 'vue'
+import { computed, nextTick, ref, shallowRef } from 'vue'
 
 function heavyTask() {
   const randomNumber = () => Math.trunc(Math.random() * 5_000_00)
@@ -15,7 +15,7 @@ const computedTime = useDateFormat(time, 'YYYY-MM-DD HH:mm:ss SSS')
 const running = computed(() => workerStatus.value === 'RUNNING')
 
 const data = ref<number[] | null>(null)
-const runner = ref('')
+const runner = shallowRef('')
 
 async function baseSort() {
   data.value = null

--- a/packages/core/useWebWorkerFn/index.ts
+++ b/packages/core/useWebWorkerFn/index.ts
@@ -2,7 +2,7 @@
 
 import type { ConfigurableWindow } from '../_configurable'
 import { tryOnScopeDispose } from '@vueuse/shared'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 import { defaultWindow } from '../_configurable'
 import createWorkerBlobUrl from './lib/createWorkerBlobUrl'
 
@@ -45,10 +45,10 @@ export function useWebWorkerFn<T extends (...fnArgs: any[]) => any>(fn: T, optio
     window = defaultWindow,
   } = options
 
-  const worker = ref<(Worker & { _url?: string }) | undefined>()
-  const workerStatus = ref<WebWorkerStatus>('PENDING')
-  const promise = ref<({ reject?: (result: ReturnType<T> | ErrorEvent) => void, resolve?: (result: ReturnType<T>) => void })>({})
-  const timeoutId = ref<number>()
+  const worker = deepRef<(Worker & { _url?: string }) | undefined>()
+  const workerStatus = deepRef<WebWorkerStatus>('PENDING')
+  const promise = deepRef<({ reject?: (result: ReturnType<T> | ErrorEvent) => void, resolve?: (result: ReturnType<T>) => void })>({})
+  const timeoutId = deepRef<number>()
 
   const workerTerminate = (status: WebWorkerStatus = 'PENDING') => {
     if (worker.value && worker.value._url && window) {

--- a/packages/core/useWindowFocus/demo.vue
+++ b/packages/core/useWindowFocus/demo.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { useWindowFocus } from '@vueuse/core'
-import { ref, watch } from 'vue'
+import { ref as deepRef, watch } from 'vue'
 
 const startMessage = '💡 Click somewhere outside of the document to unfocus.'
-const message = ref(startMessage)
+const message = deepRef(startMessage)
 const focused = useWindowFocus()
 
 watch(focused, (isFocused) => {

--- a/packages/core/useWindowFocus/index.ts
+++ b/packages/core/useWindowFocus/index.ts
@@ -1,6 +1,6 @@
 import type { Ref } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
-import { ref, shallowRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 
@@ -14,7 +14,7 @@ export function useWindowFocus(options: ConfigurableWindow = {}): Ref<boolean> {
   if (!window)
     return shallowRef(false)
 
-  const focused = ref(window.document.hasFocus())
+  const focused = deepRef(window.document.hasFocus())
 
   const listenerOptions = { passive: true }
 

--- a/packages/core/useWindowFocus/index.ts
+++ b/packages/core/useWindowFocus/index.ts
@@ -1,6 +1,6 @@
 import type { Ref } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 
@@ -12,7 +12,7 @@ import { useEventListener } from '../useEventListener'
 export function useWindowFocus(options: ConfigurableWindow = {}): Ref<boolean> {
   const { window = defaultWindow } = options
   if (!window)
-    return ref(false)
+    return shallowRef(false)
 
   const focused = ref(window.document.hasFocus())
 

--- a/packages/core/useWindowSize/index.ts
+++ b/packages/core/useWindowSize/index.ts
@@ -1,6 +1,6 @@
 import type { ConfigurableWindow } from '../_configurable'
 import { tryOnMounted } from '@vueuse/shared'
-import { ref, watch } from 'vue'
+import { ref as deepRef, watch } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 import { useMediaQuery } from '../useMediaQuery'
@@ -47,8 +47,8 @@ export function useWindowSize(options: UseWindowSizeOptions = {}) {
     type = 'inner',
   } = options
 
-  const width = ref(initialWidth)
-  const height = ref(initialHeight)
+  const width = deepRef(initialWidth)
+  const height = deepRef(initialHeight)
 
   const update = () => {
     if (window) {

--- a/packages/electron/useZoomFactor/index.ts
+++ b/packages/electron/useZoomFactor/index.ts
@@ -1,7 +1,7 @@
 import type { MaybeRef } from '@vueuse/shared'
 import type { WebFrame } from 'electron'
 import type { Ref } from 'vue'
-import { isRef, ref, watch } from 'vue'
+import { ref as deepRef, isRef, watch } from 'vue'
 
 export function useZoomFactor(factor: MaybeRef<number>): Ref<number>
 export function useZoomFactor(webFrame: WebFrame, factor: MaybeRef<number>): Ref<number>
@@ -24,11 +24,11 @@ export function useZoomFactor(...args: any[]): Ref<number> {
     || typeof args[0] === 'number'
   ) {
     webFrame = window.require ? window.require('electron').webFrame : undefined
-    newFactor = args.length > 0 ? ref(args[0]) : null
+    newFactor = args.length > 0 ? deepRef(args[0]) : null
   }
   else {
     webFrame = args[0]
-    newFactor = args.length > 1 ? ref(args[1]) : null
+    newFactor = args.length > 1 ? deepRef(args[1]) : null
   }
 
   if (!webFrame)
@@ -37,7 +37,7 @@ export function useZoomFactor(...args: any[]): Ref<number> {
   if (newFactor && newFactor.value === 0)
     throw new Error('the factor must be greater than 0.0.')
 
-  const factor = ref(newFactor ?? webFrame.getZoomFactor())
+  const factor = deepRef(newFactor ?? webFrame.getZoomFactor())
 
   watch(
     factor,

--- a/packages/electron/useZoomLevel/index.ts
+++ b/packages/electron/useZoomLevel/index.ts
@@ -1,7 +1,7 @@
 import type { MaybeRef } from '@vueuse/shared'
 import type { WebFrame } from 'electron'
 import type { Ref } from 'vue'
-import { isRef, ref, watch } from 'vue'
+import { ref as deepRef, isRef, watch } from 'vue'
 
 export function useZoomLevel(level: MaybeRef<number>): Ref<number>
 export function useZoomLevel(webFrame: WebFrame, level: MaybeRef<number>): Ref<number>
@@ -24,17 +24,17 @@ export function useZoomLevel(...args: any[]): Ref<number> {
     || typeof args[0] === 'number'
   ) {
     webFrame = window.require ? window.require('electron').webFrame : undefined
-    newLevel = args.length > 0 ? ref(args[0]) : null
+    newLevel = args.length > 0 ? deepRef(args[0]) : null
   }
   else {
     webFrame = args[0]
-    newLevel = args.length > 1 ? ref(args[1]) : null
+    newLevel = args.length > 1 ? deepRef(args[1]) : null
   }
 
   if (!webFrame)
     throw new Error('provide WebFrame module or enable nodeIntegration')
 
-  const level = ref(newLevel ?? webFrame.getZoomLevel())
+  const level = deepRef(newLevel ?? webFrame.getZoomLevel())
 
   watch(
     level,

--- a/packages/firebase/useAuth/index.ts
+++ b/packages/firebase/useAuth/index.ts
@@ -1,6 +1,6 @@
 import type { Auth, User } from 'firebase/auth'
 import type { ComputedRef, Ref } from 'vue'
-import { computed, ref } from 'vue'
+import { computed, ref as deepRef } from 'vue'
 
 export interface UseFirebaseAuthOptions {
   isAuthenticated: ComputedRef<boolean>
@@ -13,7 +13,7 @@ export interface UseFirebaseAuthOptions {
  * @see https://vueuse.org/useAuth
  */
 export function useAuth(auth: Auth) {
-  const user = ref<User | null>(auth.currentUser)
+  const user = deepRef<User | null>(auth.currentUser)
   const isAuthenticated = computed(() => !!user.value)
 
   auth.onIdTokenChanged(authUser => user.value = authUser)

--- a/packages/firebase/useFirestore/index.test.ts
+++ b/packages/firebase/useFirestore/index.test.ts
@@ -1,7 +1,7 @@
 import type { Firestore } from 'firebase/firestore'
 import { collection, doc } from 'firebase/firestore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { computed, effectScope, nextTick, ref, shallowRef } from 'vue'
+import { computed, ref as deepRef, effectScope, nextTick, shallowRef } from 'vue'
 import { useFirestore } from './index'
 
 const dummyFirestore = {} as Firestore
@@ -95,7 +95,7 @@ describe('useFirestore', () => {
 
   it('should get reactive query data & unsubscribe previous query when re-querying', async () => {
     const queryRef = collection(dummyFirestore, 'posts')
-    const reactiveQueryRef = ref(queryRef)
+    const reactiveQueryRef = deepRef(queryRef)
     const data = useFirestore(reactiveQueryRef)
     expect(data.value).toEqual([getData(getMockSnapFromRef(reactiveQueryRef.value))])
     reactiveQueryRef.value = collection(dummyFirestore, 'todos')

--- a/packages/firebase/useFirestore/index.test.ts
+++ b/packages/firebase/useFirestore/index.test.ts
@@ -1,7 +1,7 @@
 import type { Firestore } from 'firebase/firestore'
 import { collection, doc } from 'firebase/firestore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { computed, effectScope, nextTick, ref } from 'vue'
+import { computed, effectScope, nextTick, ref, shallowRef } from 'vue'
 import { useFirestore } from './index'
 
 const dummyFirestore = {} as Firestore
@@ -105,7 +105,7 @@ describe('useFirestore', () => {
   })
 
   it('should get user data only when user id exists', async () => {
-    const userId = ref('')
+    const userId = shallowRef('')
     const queryRef = computed(() => !!userId.value && collection(dummyFirestore, `users/${userId.value}/posts`))
     const data = useFirestore(queryRef, [{ id: 'default' }])
     expect(data.value).toEqual([{ id: 'default' }])
@@ -128,7 +128,7 @@ describe('useFirestore', () => {
   it('should close when scope dispose', async () => {
     const scope = effectScope()
     let data: any
-    const userId = ref('')
+    const userId = shallowRef('')
     const queryRef = computed(() => !!userId.value && collection(dummyFirestore, `users/${userId.value}/posts`))
 
     scope.run(() => {

--- a/packages/firebase/useFirestore/index.ts
+++ b/packages/firebase/useFirestore/index.ts
@@ -3,7 +3,7 @@ import type { DocumentData, DocumentReference, DocumentSnapshot, Query, QueryDoc
 import type { Ref } from 'vue'
 import { isDef, tryOnScopeDispose, useTimeoutFn } from '@vueuse/shared'
 import { onSnapshot } from 'firebase/firestore'
-import { computed, isRef, ref, watch } from 'vue'
+import { computed, ref as deepRef, isRef, watch } from 'vue'
 
 export interface UseFirestoreOptions {
   errorHandler?: (err: Error) => void
@@ -79,7 +79,7 @@ export function useFirestore<T extends DocumentData>(
     : computed(() => maybeDocRef)
 
   let close = () => { }
-  const data = ref(initialValue) as Ref<T | T[] | null | undefined>
+  const data = deepRef(initialValue) as Ref<T | T[] | null | undefined>
 
   watch(refOfDocRef, (docRef) => {
     close()

--- a/packages/firebase/useRTDB/index.ts
+++ b/packages/firebase/useRTDB/index.ts
@@ -2,7 +2,7 @@ import type { DatabaseReference, DataSnapshot } from 'firebase/database'
 import type { Ref } from 'vue'
 import { tryOnScopeDispose } from '@vueuse/shared'
 import { onValue } from 'firebase/database'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 
 export interface UseRTDBOptions {
   errorHandler?: (err: Error) => void
@@ -22,7 +22,7 @@ export function useRTDB<T = any>(
     errorHandler = (err: Error) => console.error(err),
     autoDispose = true,
   } = options
-  const data = ref(undefined) as Ref<T | undefined>
+  const data = deepRef(undefined) as Ref<T | undefined>
 
   function update(snapshot: DataSnapshot) {
     data.value = snapshot.val()

--- a/packages/guidelines.md
+++ b/packages/guidelines.md
@@ -12,7 +12,8 @@ You can also find some reasons for those design decisions and also some tips for
 - Import all Vue APIs from `"vue"`
 - Use `ref` instead of `reactive` whenever possible
 - Use options object as arguments whenever possible to be more flexible for future extensions.
-- Use `shallowRef` instead of `ref` when wrapping large amounts of data.
+- Prefer `shallowRef` over `ref` whenever possible
+- In case of deep reactivity, prefer explicitly named `deepRef` instead of `ref`
 - Use `configurableWindow` (etc.) when using global variables like `window` to be flexible when working with multi-windows, testing mocks, and SSR.
 - When involved with Web APIs that are not yet implemented by the browser widely, also outputs `isSupported` flag
 - When using `watch` or `watchEffect` internally, also make the `immediate` and `flush` options configurable whenever possible

--- a/packages/integrations/useAsyncValidator/index.test.ts
+++ b/packages/integrations/useAsyncValidator/index.test.ts
@@ -1,7 +1,7 @@
 import type { Rules } from 'async-validator'
 import type { Ref } from 'vue'
 import { beforeEach, describe, expect, it } from 'vitest'
-import { nextTick, ref } from 'vue'
+import { ref as deepRef, nextTick } from 'vue'
 import { useAsyncValidator } from './index'
 
 describe('useAsyncValidator', () => {
@@ -177,12 +177,12 @@ describe('useAsyncValidator', () => {
   })
 
   it('should reactive', async () => {
-    const form = ref({
+    const form = deepRef({
       name: 'jelf',
       age: 24,
     })
 
-    const rules = ref({
+    const rules = deepRef({
       name: {
         type: 'string',
         min: 5,
@@ -274,12 +274,12 @@ describe('set manual true', () => {
   })
 
   it('manual trigger validator', async () => {
-    const form = ref({
+    const form = deepRef({
       name: 'jelf',
       age: 24,
     })
 
-    const rules = ref({
+    const rules = deepRef({
       name: {
         type: 'string',
         min: 5,

--- a/packages/integrations/useAsyncValidator/index.ts
+++ b/packages/integrations/useAsyncValidator/index.ts
@@ -67,7 +67,7 @@ export function useAsyncValidator(
   const valueRef = toRef(value)
 
   const errorInfo = shallowRef<AsyncValidatorError | null>(null)
-  const isFinished = ref(true)
+  const isFinished = shallowRef(true)
   const pass = ref(!immediate || manual)
   const errors = computed(() => errorInfo.value?.errors || [])
   const errorFields = computed(() => errorInfo.value?.fields || {})

--- a/packages/integrations/useAsyncValidator/index.ts
+++ b/packages/integrations/useAsyncValidator/index.ts
@@ -3,7 +3,7 @@ import type { Rules, ValidateError, ValidateOption } from 'async-validator'
 import type { Ref } from 'vue'
 import { toRef, until } from '@vueuse/shared'
 import Schema from 'async-validator'
-import { computed, ref, shallowRef, toValue, watch } from 'vue'
+import { computed, ref as deepRef, shallowRef, toValue, watch } from 'vue'
 
 // @ts-expect-error Schema.default is exist in ssr mode
 const AsyncValidatorSchema = Schema.default || Schema
@@ -68,7 +68,7 @@ export function useAsyncValidator(
 
   const errorInfo = shallowRef<AsyncValidatorError | null>(null)
   const isFinished = shallowRef(true)
-  const pass = ref(!immediate || manual)
+  const pass = deepRef(!immediate || manual)
   const errors = computed(() => errorInfo.value?.errors || [])
   const errorFields = computed(() => errorInfo.value?.fields || {})
 

--- a/packages/integrations/useAxios/index.ts
+++ b/packages/integrations/useAxios/index.ts
@@ -2,7 +2,7 @@ import type { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios'
 import type { Ref, ShallowRef } from 'vue'
 import { noop, until } from '@vueuse/shared'
 import axios, { AxiosError } from 'axios'
-import { ref, shallowRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 
 export interface UseAxiosReturn<T, R = AxiosResponse<T>, _D = any, O extends UseAxiosOptions = UseAxiosOptions<T>> {
   /**
@@ -177,7 +177,7 @@ export function useAxios<T = any, R = AxiosResponse<T>, D = any>(...args: any[])
 
   const initialData = (options as UseAxiosOptionsWithInitialData<T>).initialData
   const response = shallowRef<AxiosResponse<T>>()
-  const data = (shallow ? shallowRef : ref)<T>(initialData!) as Ref<T>
+  const data = (shallow ? shallowRef : deepRef)<T>(initialData!) as Ref<T>
   const isFinished = shallowRef(false)
   const isLoading = shallowRef(false)
   const isAborted = shallowRef(false)

--- a/packages/integrations/useAxios/index.ts
+++ b/packages/integrations/useAxios/index.ts
@@ -178,9 +178,9 @@ export function useAxios<T = any, R = AxiosResponse<T>, D = any>(...args: any[])
   const initialData = (options as UseAxiosOptionsWithInitialData<T>).initialData
   const response = shallowRef<AxiosResponse<T>>()
   const data = (shallow ? shallowRef : ref)<T>(initialData!) as Ref<T>
-  const isFinished = ref(false)
-  const isLoading = ref(false)
-  const isAborted = ref(false)
+  const isFinished = shallowRef(false)
+  const isLoading = shallowRef(false)
+  const isAborted = shallowRef(false)
   const error = shallowRef<unknown>()
 
   let abortController: AbortController = new AbortController()

--- a/packages/integrations/useChangeCase/demo.vue
+++ b/packages/integrations/useChangeCase/demo.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import type { ChangeCaseType } from './index'
 import * as ChangeCase from 'change-case'
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 import { useChangeCase } from './index'
 
 const transforms: any = Object.keys(ChangeCase).filter(v => v.endsWith('Case'))
-const input = ref('helloWorld')
+const input = shallowRef('helloWorld')
 const type = ref<ChangeCaseType>(transforms[0])
 const changeCase = useChangeCase(input, type)
 </script>

--- a/packages/integrations/useChangeCase/demo.vue
+++ b/packages/integrations/useChangeCase/demo.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import type { ChangeCaseType } from './index'
 import * as ChangeCase from 'change-case'
-import { ref, shallowRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 import { useChangeCase } from './index'
 
 const transforms: any = Object.keys(ChangeCase).filter(v => v.endsWith('Case'))
 const input = shallowRef('helloWorld')
-const type = ref<ChangeCaseType>(transforms[0])
+const type = deepRef<ChangeCaseType>(transforms[0])
 const changeCase = useChangeCase(input, type)
 </script>
 

--- a/packages/integrations/useChangeCase/index.test.ts
+++ b/packages/integrations/useChangeCase/index.test.ts
@@ -1,7 +1,7 @@
 import type { Options } from 'change-case'
 import type { ChangeCaseType } from './index'
 import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 import { useChangeCase } from './index'
 
 describe('useChangeCase', () => {
@@ -92,7 +92,7 @@ describe('useChangeCase', () => {
     })
 
     it(`ref ${key}`, () => {
-      const input = ref(helloWorld)
+      const input = deepRef(helloWorld)
       const changeCase = useChangeCase(input, key)
       expect(changeCase.value).toBe(obj[key].helloWorld)
       changeCase.value = vueuse

--- a/packages/integrations/useChangeCase/index.ts
+++ b/packages/integrations/useChangeCase/index.ts
@@ -2,7 +2,7 @@ import type { MaybeRef, MaybeRefOrGetter } from '@vueuse/shared'
 import type { Options } from 'change-case'
 import type { ComputedRef, WritableComputedRef } from 'vue'
 import * as changeCase from 'change-case'
-import { computed, ref, toValue } from 'vue'
+import { computed, ref as deepRef, toValue } from 'vue'
 
 type EndsWithCase<T> = T extends `${infer _}Case` ? T : never
 type FilterKeys<T> = { [K in keyof T as K extends string ? K : never]: EndsWithCase<K> }
@@ -36,7 +36,7 @@ export function useChangeCase(input: MaybeRefOrGetter<string>, type: MaybeRefOrG
   if (typeof input === 'function')
     return computed(() => changeCaseTransforms[typeRef.value](toValue(input), toValue(options)))
 
-  const text = ref(input)
+  const text = deepRef(input)
   return computed<string>({
     get() {
       return changeCaseTransforms[typeRef.value](text.value, toValue(options))

--- a/packages/integrations/useCookies/index.ts
+++ b/packages/integrations/useCookies/index.ts
@@ -1,7 +1,7 @@
 import type { IncomingMessage } from 'node:http'
 import { tryOnScopeDispose } from '@vueuse/shared'
 import Cookie from 'universal-cookie'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 
 type RawCookies = Record<string, string>
 
@@ -40,7 +40,7 @@ export function useCookies(
   /**
    * Adds reactivity to get/getAll methods
    */
-  const touches = ref(0)
+  const touches = shallowRef(0)
 
   const onChange = () => {
     const newCookies = cookies.getAll({ doNotParse: true })

--- a/packages/integrations/useDrauu/demo.client.vue
+++ b/packages/integrations/useDrauu/demo.client.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import { toRefs } from '@vueuse/shared'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 import Scrubber from '../../core/useMediaControls/components/Scrubber.vue'
 import { useDrauu } from './index'
 
-const colors = ref(['black', '#ef4444', '#22c55e', '#3b82f6'])
-const target = ref()
+const colors = deepRef(['black', '#ef4444', '#22c55e', '#3b82f6'])
+const target = deepRef()
 const { undo, redo, canUndo, canRedo, clear, brush } = useDrauu(target, {
   brush: {
     color: 'black',

--- a/packages/integrations/useDrauu/index.ts
+++ b/packages/integrations/useDrauu/index.ts
@@ -5,7 +5,7 @@ import type { Ref } from 'vue'
 import { createEventHook, unrefElement } from '@vueuse/core'
 import { tryOnScopeDispose } from '@vueuse/shared'
 import { createDrauu } from 'drauu'
-import { ref, watch } from 'vue'
+import { ref, shallowRef, watch } from 'vue'
 
 export type UseDrauuOptions = Omit<Options, 'el'>
 
@@ -48,10 +48,10 @@ export function useDrauu(
   const onCommittedHook = createEventHook<SVGElement | undefined>()
   const onStartHook = createEventHook<void>()
   const onEndHook = createEventHook<void>()
-  const canUndo = ref(false)
-  const canRedo = ref(false)
-  const altPressed = ref(false)
-  const shiftPressed = ref(false)
+  const canUndo = shallowRef(false)
+  const canRedo = shallowRef(false)
+  const altPressed = shallowRef(false)
+  const shiftPressed = shallowRef(false)
 
   const brush = ref<Brush>({
     color: 'black',

--- a/packages/integrations/useDrauu/index.ts
+++ b/packages/integrations/useDrauu/index.ts
@@ -5,7 +5,7 @@ import type { Ref } from 'vue'
 import { createEventHook, unrefElement } from '@vueuse/core'
 import { tryOnScopeDispose } from '@vueuse/shared'
 import { createDrauu } from 'drauu'
-import { ref, shallowRef, watch } from 'vue'
+import { ref as deepRef, shallowRef, watch } from 'vue'
 
 export type UseDrauuOptions = Omit<Options, 'el'>
 
@@ -39,7 +39,7 @@ export function useDrauu(
   target: MaybeComputedElementRef,
   options?: UseDrauuOptions,
 ): UseDrauuReturn {
-  const drauuInstance = ref<Drauu>()
+  const drauuInstance = deepRef<Drauu>()
 
   let disposables: Fn[] = []
 
@@ -53,7 +53,7 @@ export function useDrauu(
   const altPressed = shallowRef(false)
   const shiftPressed = shallowRef(false)
 
-  const brush = ref<Brush>({
+  const brush = deepRef<Brush>({
     color: 'black',
     size: 3,
     arrowEnd: false,

--- a/packages/integrations/useFocusTrap/component.ts
+++ b/packages/integrations/useFocusTrap/component.ts
@@ -3,7 +3,7 @@ import type { FocusTrap } from 'focus-trap'
 import type { UseFocusTrapOptions } from './index'
 import { unrefElement } from '@vueuse/core'
 import { createFocusTrap } from 'focus-trap'
-import { defineComponent, h, onScopeDispose, ref, watch } from 'vue'
+import { ref as deepRef, defineComponent, h, onScopeDispose, watch } from 'vue'
 
 export interface ComponentUseFocusTrapOptions extends RenderableComponent {
   options?: UseFocusTrapOptions
@@ -14,7 +14,7 @@ export const UseFocusTrap = /* #__PURE__ */ defineComponent <ComponentUseFocusTr
   props: ['as', 'options'] as unknown as undefined,
   setup(props, { slots }) {
     let trap: undefined | FocusTrap
-    const target = ref()
+    const target = deepRef()
 
     const activate = () => trap && trap.activate()
     const deactivate = () => trap && trap.deactivate()

--- a/packages/integrations/useFocusTrap/demo.vue
+++ b/packages/integrations/useFocusTrap/demo.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 import { useFocusTrap } from './index'
 
-const target = ref()
+const target = deepRef()
 const { hasFocus, activate, deactivate } = useFocusTrap(target)
 </script>
 

--- a/packages/integrations/useFocusTrap/index.ts
+++ b/packages/integrations/useFocusTrap/index.ts
@@ -5,7 +5,7 @@ import type { Ref } from 'vue'
 import { toArray, tryOnScopeDispose, unrefElement } from '@vueuse/core'
 import { notNullish } from '@vueuse/shared'
 import { createFocusTrap } from 'focus-trap'
-import { computed, ref, toValue, watch } from 'vue'
+import { computed, shallowRef, toValue, watch } from 'vue'
 
 export interface UseFocusTrapOptions extends Options {
   /**
@@ -68,8 +68,8 @@ export function useFocusTrap(
   let trap: undefined | FocusTrap
 
   const { immediate, ...focusTrapOptions } = options
-  const hasFocus = ref(false)
-  const isPaused = ref(false)
+  const hasFocus = shallowRef(false)
+  const isPaused = shallowRef(false)
 
   const activate = (opts?: ActivateOptions) => trap && trap.activate(opts)
   const deactivate = (opts?: DeactivateOptions) => trap && trap.deactivate(opts)

--- a/packages/integrations/useFuse/demo.vue
+++ b/packages/integrations/useFuse/demo.vue
@@ -1,6 +1,6 @@
 <script setup lang='ts'>
 import type { UseFuseOptions } from './index'
-import { computed, ref, watch } from 'vue'
+import { computed, ref, shallowRef, watch } from 'vue'
 import { useFuse } from './index'
 
 interface DataItem {
@@ -91,8 +91,8 @@ const data = ref<DataItem[]>([
   },
 ])
 
-const search = ref('')
-const filterBy = ref('both')
+const search = shallowRef('')
+const filterBy = shallowRef('both')
 const keys = computed(() => {
   if (filterBy.value === 'first')
     return ['firstName']
@@ -116,9 +116,9 @@ watch(resultLimitString, () => {
   }
 })
 
-const exactMatch = ref(false)
-const isCaseSensitive = ref(false)
-const matchAllWhenSearchEmpty = ref(true)
+const exactMatch = shallowRef(false)
+const isCaseSensitive = shallowRef(false)
+const matchAllWhenSearchEmpty = shallowRef(true)
 
 const options = computed<UseFuseOptions<DataItem>>(() => ({
   fuseOptions: {

--- a/packages/integrations/useFuse/demo.vue
+++ b/packages/integrations/useFuse/demo.vue
@@ -1,6 +1,6 @@
 <script setup lang='ts'>
 import type { UseFuseOptions } from './index'
-import { computed, ref, shallowRef, watch } from 'vue'
+import { computed, ref as deepRef, shallowRef, watch } from 'vue'
 import { useFuse } from './index'
 
 interface DataItem {
@@ -8,7 +8,7 @@ interface DataItem {
   lastName: string
 }
 
-const data = ref<DataItem[]>([
+const data = deepRef<DataItem[]>([
   {
     firstName: 'Roslyn',
     lastName: 'Mitchell',
@@ -101,8 +101,8 @@ const keys = computed(() => {
   else return ['firstName', 'lastName']
 })
 
-const resultLimit = ref<number | undefined>(undefined)
-const resultLimitString = ref<string>('')
+const resultLimit = shallowRef<number | undefined>(undefined)
+const resultLimitString = shallowRef<string>('')
 watch(resultLimitString, () => {
   if (resultLimitString.value === '') {
     resultLimit.value = undefined

--- a/packages/integrations/useFuse/index.ts
+++ b/packages/integrations/useFuse/index.ts
@@ -2,7 +2,7 @@ import type { MaybeRefOrGetter } from '@vueuse/shared'
 import type { FuseResult, IFuseOptions } from 'fuse.js'
 import type { ComputedRef } from 'vue'
 import Fuse from 'fuse.js'
-import { computed, ref, toValue, watch } from 'vue'
+import { computed, ref as deepRef, toValue, watch } from 'vue'
 
 export type FuseOptions<T> = IFuseOptions<T>
 export interface UseFuseOptions<T> {
@@ -23,7 +23,7 @@ export function useFuse<DataItem>(
     )
   }
 
-  const fuse = ref(createFuse())
+  const fuse = deepRef(createFuse())
 
   watch(
     () => toValue(options)?.fuseOptions,

--- a/packages/integrations/useIDBKeyval/index.ts
+++ b/packages/integrations/useIDBKeyval/index.ts
@@ -2,7 +2,7 @@ import type { ConfigurableFlush, MaybeRefOrGetter, RemovableRef } from '@vueuse/
 import type { Ref } from 'vue'
 import { watchPausable } from '@vueuse/core'
 import { del, get, set, update } from 'idb-keyval'
-import { ref, shallowRef, toRaw, toValue } from 'vue'
+import { ref as deepRef, shallowRef, toRaw, toValue } from 'vue'
 
 export interface UseIDBOptions extends ConfigurableFlush {
   /**
@@ -61,7 +61,7 @@ export function useIDBKeyval<T>(
   } = options
 
   const isFinished = shallowRef(false)
-  const data = (shallow ? shallowRef : ref)(initialValue) as Ref<T>
+  const data = (shallow ? shallowRef : deepRef)(initialValue) as Ref<T>
 
   const rawInit: T = toValue(initialValue)
 

--- a/packages/integrations/useIDBKeyval/index.ts
+++ b/packages/integrations/useIDBKeyval/index.ts
@@ -60,7 +60,7 @@ export function useIDBKeyval<T>(
     writeDefaults = true,
   } = options
 
-  const isFinished = ref(false)
+  const isFinished = shallowRef(false)
   const data = (shallow ? shallowRef : ref)(initialValue) as Ref<T>
 
   const rawInit: T = toValue(initialValue)

--- a/packages/integrations/useJwt/demo.vue
+++ b/packages/integrations/useJwt/demo.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 
 import { useJwt } from './index'
 
-const encodedJwt = ref('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaWF0IjoxNTE2MjM5MDIyfQ.L8i6g3PfcHlioHCCPURC9pmXT7gdJpx3kOoyAfNUwCc')
+const encodedJwt = shallowRef('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaWF0IjoxNTE2MjM5MDIyfQ.L8i6g3PfcHlioHCCPURC9pmXT7gdJpx3kOoyAfNUwCc')
 const { header, payload } = useJwt(encodedJwt)
 </script>
 

--- a/packages/integrations/useJwt/index.test.ts
+++ b/packages/integrations/useJwt/index.test.ts
@@ -1,6 +1,6 @@
 import type { JwtHeader, JwtPayload } from 'jwt-decode'
 import { describe, expect, it, vi } from 'vitest'
-import { ref, shallowRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 import { useJwt } from './index'
 
 interface CustomJwtHeader extends JwtHeader {
@@ -40,7 +40,7 @@ describe('useJwt', () => {
   })
 
   it('reactivity', () => {
-    const jwt = ref(encodedJwt.value)
+    const jwt = deepRef(encodedJwt.value)
     const { header, payload } = useJwt<CustomJwtPayload, CustomJwtHeader>(jwt)
     expect(header.value?.foo).toBeUndefined()
     expect(payload.value?.foo).toBeUndefined()

--- a/packages/integrations/useJwt/index.test.ts
+++ b/packages/integrations/useJwt/index.test.ts
@@ -1,6 +1,6 @@
 import type { JwtHeader, JwtPayload } from 'jwt-decode'
 import { describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 import { useJwt } from './index'
 
 interface CustomJwtHeader extends JwtHeader {
@@ -12,7 +12,7 @@ interface CustomJwtPayload extends JwtPayload {
 }
 
 describe('useJwt', () => {
-  const encodedJwt = ref('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaWF0IjoxNTE2MjM5MDIyfQ.L8i6g3PfcHlioHCCPURC9pmXT7gdJpx3kOoyAfNUwCc')
+  const encodedJwt = shallowRef('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaWF0IjoxNTE2MjM5MDIyfQ.L8i6g3PfcHlioHCCPURC9pmXT7gdJpx3kOoyAfNUwCc')
 
   it('decoded jwt', () => {
     const { header, payload } = useJwt(encodedJwt)
@@ -25,13 +25,13 @@ describe('useJwt', () => {
   it('decode jwt error', () => {
     const onErrorSpy = vi.fn()
 
-    const { header, payload } = useJwt(ref('bad-token'), { onError: onErrorSpy })
+    const { header, payload } = useJwt(shallowRef('bad-token'), { onError: onErrorSpy })
     expect(header.value).toBe(null)
     expect(payload.value).toBe(null)
     expect(onErrorSpy).toHaveBeenCalled()
   })
 
-  const encodedCustomJwt = ref('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImZvbyI6ImJhciJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJmb28iOiJiYXIifQ.S5QwvREUfgEdpB1ljG_xN6NI3HubQ79xx6J1J4dsJmg')
+  const encodedCustomJwt = shallowRef('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImZvbyI6ImJhciJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJmb28iOiJiYXIifQ.S5QwvREUfgEdpB1ljG_xN6NI3HubQ79xx6J1J4dsJmg')
 
   it('decoded jwt with custom fields', () => {
     const { header, payload } = useJwt<CustomJwtPayload, CustomJwtHeader>(encodedCustomJwt)

--- a/packages/integrations/useQRCode/demo.vue
+++ b/packages/integrations/useQRCode/demo.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 import { useQRCode } from './index'
 
-const text = ref('https://vueuse.org')
+const text = shallowRef('https://vueuse.org')
 const qrcode = useQRCode(text, {
   errorCorrectionLevel: 'H',
   margin: 3,

--- a/packages/integrations/useQRCode/index.ts
+++ b/packages/integrations/useQRCode/index.ts
@@ -1,7 +1,7 @@
 import type { MaybeRefOrGetter } from '@vueuse/shared'
 import { isClient, toRef } from '@vueuse/shared'
 import QRCode from 'qrcode'
-import { ref, watch } from 'vue'
+import { shallowRef, watch } from 'vue'
 
 /**
  * Wrapper for qrcode.
@@ -15,7 +15,7 @@ export function useQRCode(
   options?: QRCode.QRCodeToDataURLOptions,
 ) {
   const src = toRef(text)
-  const result = ref('')
+  const result = shallowRef('')
 
   watch(
     src,

--- a/packages/integrations/useSortable/component.ts
+++ b/packages/integrations/useSortable/component.ts
@@ -1,7 +1,7 @@
 import type { PropType } from 'vue'
 import type { UseSortableOptions } from './index'
 import { useVModel } from '@vueuse/core'
-import { defineComponent, h, reactive, ref } from 'vue'
+import { ref as deepRef, defineComponent, h, reactive } from 'vue'
 import { useSortable } from './index'
 
 export const UseSortable = /* #__PURE__ */ defineComponent({
@@ -23,7 +23,7 @@ export const UseSortable = /* #__PURE__ */ defineComponent({
 
   setup(props, { slots }) {
     const list = useVModel(props, 'modelValue')
-    const target = ref()
+    const target = deepRef()
     const data = reactive(useSortable(target, list, props.options))
     return () => {
       if (slots.default)

--- a/packages/integrations/useSortable/demo.vue
+++ b/packages/integrations/useSortable/demo.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import { ref, useTemplateRef } from 'vue'
+import { ref as deepRef, useTemplateRef } from 'vue'
 import { useSortable } from './index'
 
 const el = useTemplateRef<HTMLElement>('el')
-const list = ref([{ id: 1, name: 'a' }, { id: 2, name: 'b' }, { id: 3, name: 'c' }])
+const list = deepRef([{ id: 1, name: 'a' }, { id: 2, name: 'b' }, { id: 3, name: 'c' }])
 
 const { option } = useSortable(el, list, {
   animation: 150,

--- a/packages/math/createProjection/index.test.ts
+++ b/packages/math/createProjection/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 import { createProjection } from './index'
 
 describe('createProjection', () => {
@@ -8,15 +8,15 @@ describe('createProjection', () => {
   })
 
   it('should work with projector', () => {
-    const fromStart = ref(0)
-    const fromEnd = ref(10)
+    const fromStart = shallowRef(0)
+    const fromEnd = shallowRef(10)
     const toRange = ref<[number, number]>([50, 100])
 
     const useProjector = createProjection(
       () => [fromStart.value, fromEnd.value],
       toRange,
     )
-    const input = ref(0)
+    const input = shallowRef(0)
     const output = useProjector(input)
 
     expect(output.value).toBe(50)

--- a/packages/math/createProjection/index.test.ts
+++ b/packages/math/createProjection/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref, shallowRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 import { createProjection } from './index'
 
 describe('createProjection', () => {
@@ -10,7 +10,7 @@ describe('createProjection', () => {
   it('should work with projector', () => {
     const fromStart = shallowRef(0)
     const fromEnd = shallowRef(10)
-    const toRange = ref<[number, number]>([50, 100])
+    const toRange = deepRef<[number, number]>([50, 100])
 
     const useProjector = createProjection(
       () => [fromStart.value, fromEnd.value],

--- a/packages/math/logicAnd/index.test.ts
+++ b/packages/math/logicAnd/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref, toValue } from 'vue'
+import { shallowRef, toValue } from 'vue'
 import { logicAnd } from './index'
 
 describe('logicAnd', () => {
@@ -12,12 +12,12 @@ describe('logicAnd', () => {
   })
 
   it('returns true only when all arguments are truthy', () => {
-    expect(toValue(logicAnd(ref(true), ref(true)))).toBe(true)
-    expect(toValue(logicAnd(ref('foo'), ref(true)))).toBe(true)
-    expect(toValue(logicAnd(ref('foo'), ref(1)))).toBe(true)
+    expect(toValue(logicAnd(shallowRef(true), shallowRef(true)))).toBe(true)
+    expect(toValue(logicAnd(shallowRef('foo'), shallowRef(true)))).toBe(true)
+    expect(toValue(logicAnd(shallowRef('foo'), shallowRef(1)))).toBe(true)
 
-    expect(toValue(logicAnd(ref(true), ref(false)))).toBe(false)
-    expect(toValue(logicAnd(ref('foo'), ref(0)))).toBe(false)
+    expect(toValue(logicAnd(shallowRef(true), shallowRef(false)))).toBe(false)
+    expect(toValue(logicAnd(shallowRef('foo'), shallowRef(0)))).toBe(false)
   })
 
   it('works with values', () => {

--- a/packages/math/logicNot/index.test.ts
+++ b/packages/math/logicNot/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref, toValue } from 'vue'
+import { shallowRef, toValue } from 'vue'
 import { logicNot } from './index'
 
 describe('logicNot', () => {
@@ -8,13 +8,13 @@ describe('logicNot', () => {
   })
 
   it('returns the logical complement of the given ref', () => {
-    expect(toValue(logicNot(ref(true)))).toBe(false)
-    expect(toValue(logicNot(ref('foo')))).toBe(false)
-    expect(toValue(logicNot(ref(1)))).toBe(false)
+    expect(toValue(logicNot(shallowRef(true)))).toBe(false)
+    expect(toValue(logicNot(shallowRef('foo')))).toBe(false)
+    expect(toValue(logicNot(shallowRef(1)))).toBe(false)
 
-    expect(toValue(logicNot(ref(false)))).toBe(true)
-    expect(toValue(logicNot(ref('')))).toBe(true)
-    expect(toValue(logicNot(ref(0)))).toBe(true)
+    expect(toValue(logicNot(shallowRef(false)))).toBe(true)
+    expect(toValue(logicNot(shallowRef('')))).toBe(true)
+    expect(toValue(logicNot(shallowRef(0)))).toBe(true)
   })
 
   it('returns the logical complement of the given value', () => {

--- a/packages/math/logicOr/index.test.ts
+++ b/packages/math/logicOr/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref, toValue } from 'vue'
+import { shallowRef, toValue } from 'vue'
 import { logicOr } from './index'
 
 describe('logicOr', () => {
@@ -12,12 +12,12 @@ describe('logicOr', () => {
   })
 
   it('returns true only when any arguments are truthy', () => {
-    expect(toValue(logicOr(ref(true), ref(true)))).toBe(true)
-    expect(toValue(logicOr(ref('foo'), ref(false)))).toBe(true)
-    expect(toValue(logicOr(ref('foo'), ref(1), ref(false)))).toBe(true)
+    expect(toValue(logicOr(shallowRef(true), shallowRef(true)))).toBe(true)
+    expect(toValue(logicOr(shallowRef('foo'), shallowRef(false)))).toBe(true)
+    expect(toValue(logicOr(shallowRef('foo'), shallowRef(1), shallowRef(false)))).toBe(true)
 
-    expect(toValue(logicOr(ref(false), ref(false)))).toBe(false)
-    expect(toValue(logicOr(ref(''), ref(0)))).toBe(false)
+    expect(toValue(logicOr(shallowRef(false), shallowRef(false)))).toBe(false)
+    expect(toValue(logicOr(shallowRef(''), shallowRef(0)))).toBe(false)
   })
 
   it('works with values', () => {

--- a/packages/math/useAbs/index.test.ts
+++ b/packages/math/useAbs/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 import { useAbs } from './index'
 
 describe('useAbs', () => {
@@ -8,7 +8,7 @@ describe('useAbs', () => {
   })
 
   it('this should work', () => {
-    const original = ref(-1)
+    const original = deepRef(-1)
     const abs = useAbs(original)
 
     expect(abs.value).toBe(1)
@@ -24,7 +24,7 @@ describe('useAbs', () => {
   })
 
   it('getter', () => {
-    const original = ref(-1)
+    const original = deepRef(-1)
     const abs = useAbs(() => original.value)
 
     expect(abs.value).toBe(1)

--- a/packages/math/useAverage/index.test.ts
+++ b/packages/math/useAverage/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 import { useAverage } from './index'
 
 describe('useAverage', () => {
@@ -19,7 +19,7 @@ describe('useAverage', () => {
   })
 
   it('should be the average when some are ref', () => {
-    const a = ref(2)
+    const a = shallowRef(2)
     const arr = ref([1, a, 9])
 
     const v = useAverage(arr)
@@ -31,7 +31,7 @@ describe('useAverage', () => {
   })
 
   it('should be the average when some items are getter', () => {
-    const a = ref(1)
+    const a = shallowRef(1)
     const arr = ref([1, () => a.value + 1, 9])
 
     const v = useAverage(arr)
@@ -44,7 +44,7 @@ describe('useAverage', () => {
 
   it('should be the average when the array is a getter', () => {
     const arr = ref([1, 2, 3])
-    const last = ref(0)
+    const last = shallowRef(0)
 
     const v = useAverage(() => arr.value.concat(last.value))
 
@@ -55,8 +55,8 @@ describe('useAverage', () => {
   })
 
   it('should work with rest', () => {
-    const a = ref(1)
-    const b = ref(2)
+    const a = shallowRef(1)
+    const b = shallowRef(2)
     const sum = useAverage(a, () => b.value, 3)
     expect(sum.value).toBe(2)
     b.value = 11

--- a/packages/math/useAverage/index.test.ts
+++ b/packages/math/useAverage/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref, shallowRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 import { useAverage } from './index'
 
 describe('useAverage', () => {
@@ -8,7 +8,7 @@ describe('useAverage', () => {
   })
 
   it('should be the average', () => {
-    const arr = ref([1, 2, 3])
+    const arr = deepRef([1, 2, 3])
 
     const v = useAverage(arr)
 
@@ -20,7 +20,7 @@ describe('useAverage', () => {
 
   it('should be the average when some are ref', () => {
     const a = shallowRef(2)
-    const arr = ref([1, a, 9])
+    const arr = deepRef([1, a, 9])
 
     const v = useAverage(arr)
 
@@ -32,7 +32,7 @@ describe('useAverage', () => {
 
   it('should be the average when some items are getter', () => {
     const a = shallowRef(1)
-    const arr = ref([1, () => a.value + 1, 9])
+    const arr = deepRef([1, () => a.value + 1, 9])
 
     const v = useAverage(arr)
 
@@ -43,7 +43,7 @@ describe('useAverage', () => {
   })
 
   it('should be the average when the array is a getter', () => {
-    const arr = ref([1, 2, 3])
+    const arr = deepRef([1, 2, 3])
     const last = shallowRef(0)
 
     const v = useAverage(() => arr.value.concat(last.value))

--- a/packages/math/useCeil/index.test.ts
+++ b/packages/math/useCeil/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 import { useCeil } from './index'
 
 describe('useCeil', () => {
@@ -7,7 +7,7 @@ describe('useCeil', () => {
     expect(useCeil).toBeDefined()
   })
   it('should work', () => {
-    const base = ref(0.95)
+    const base = deepRef(0.95)
     const result = useCeil(base)
     expect(result.value).toBe(1)
     base.value = -7.004

--- a/packages/math/useClamp/demo.vue
+++ b/packages/math/useClamp/demo.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { useClamp } from '@vueuse/math'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 
-const min = ref(0)
-const max = ref(10)
+const min = shallowRef(0)
+const max = shallowRef(10)
 
 const value = useClamp(0, min, max)
 </script>

--- a/packages/math/useClamp/index.test.ts
+++ b/packages/math/useClamp/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { computed, isReadonly, ref } from 'vue'
+import { computed, isReadonly, shallowRef } from 'vue'
 import { useClamp } from './index'
 
 describe('useClamp', () => {
@@ -13,9 +13,9 @@ describe('useClamp', () => {
   })
 
   it('should be max', () => {
-    const value = ref(10)
-    const min = ref(0)
-    const max = ref(100)
+    const value = shallowRef(10)
+    const min = shallowRef(0)
+    const max = shallowRef(100)
 
     const v = useClamp(value, min, max)
 
@@ -32,9 +32,9 @@ describe('useClamp', () => {
   })
 
   it('should be min', () => {
-    const value = ref(10)
-    const min = ref(0)
-    const max = ref(100)
+    const value = shallowRef(10)
+    const min = shallowRef(0)
+    const max = shallowRef(100)
 
     const v = useClamp(value, min, max)
 
@@ -52,10 +52,10 @@ describe('useClamp', () => {
   })
 
   it('should work with computed', () => {
-    const baseRef = ref(10)
+    const baseRef = shallowRef(10)
     const value = computed(() => baseRef.value)
-    const min = ref(0)
-    const max = ref(100)
+    const min = shallowRef(0)
+    const max = shallowRef(100)
 
     const v = useClamp(value, min, max)
 
@@ -71,10 +71,10 @@ describe('useClamp', () => {
   })
 
   it('should work with function', () => {
-    const baseRef = ref(10)
+    const baseRef = shallowRef(10)
     const value = () => baseRef.value
-    const min = ref(0)
-    const max = ref(100)
+    const min = shallowRef(0)
+    const max = shallowRef(100)
 
     const v = useClamp(value, min, max)
 

--- a/packages/math/useClamp/index.ts
+++ b/packages/math/useClamp/index.ts
@@ -1,7 +1,7 @@
 import type { MaybeRefOrGetter, ReadonlyRefOrGetter } from '@vueuse/shared'
 import type { ComputedRef, Ref } from 'vue'
 import { clamp } from '@vueuse/shared'
-import { computed, isReadonly, ref, toValue } from 'vue'
+import { computed, ref as deepRef, isReadonly, toValue } from 'vue'
 
 export function useClamp(
   value: ReadonlyRefOrGetter<number>,
@@ -27,7 +27,7 @@ export function useClamp(value: MaybeRefOrGetter<number>, min: MaybeRefOrGetter<
   if (typeof value === 'function' || isReadonly(value))
     return computed(() => clamp(toValue(value), toValue(min), toValue(max)))
 
-  const _value = ref(value)
+  const _value = deepRef(value)
   return computed<number>({
     get() {
       return _value.value = clamp(_value.value, toValue(min), toValue(max))

--- a/packages/math/useFloor/index.test.ts
+++ b/packages/math/useFloor/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 import { useFloor } from './index'
 
 describe('useFloor', () => {
@@ -7,7 +7,7 @@ describe('useFloor', () => {
     expect(useFloor).toBeDefined()
   })
   it('should work', () => {
-    const base = ref(45.95)
+    const base = deepRef(45.95)
     const result = useFloor(base)
     expect(result.value).toBe(45)
     base.value = -45.05

--- a/packages/math/useMath/index.test.ts
+++ b/packages/math/useMath/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 import { useMath } from './index'
 
 describe('useMath', () => {
@@ -13,13 +13,13 @@ describe('useMath', () => {
   })
 
   it('should accept refs', () => {
-    const base = ref(2)
-    const exponent = ref(3)
+    const base = shallowRef(2)
+    const exponent = shallowRef(3)
     const result = useMath('pow', base, exponent)
 
     expect(result.value).toBe(8)
 
-    const num = ref(4)
+    const num = shallowRef(4)
     const root = useMath('sqrt', num)
 
     expect(root.value).toBe(2)

--- a/packages/math/useMax/index.test.ts
+++ b/packages/math/useMax/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 import { useMax } from './index'
 
 describe('useMax', () => {
@@ -13,9 +13,9 @@ describe('useMax', () => {
   })
 
   it('should accept refs', () => {
-    const value1 = ref(10)
-    const value2 = ref(100)
-    const value3 = ref(1000)
+    const value1 = shallowRef(10)
+    const value2 = shallowRef(100)
+    const value3 = shallowRef(1000)
 
     const v = useMax(value1, value2, value3)
     expect(v.value).toBe(1000)
@@ -32,7 +32,7 @@ describe('useMax', () => {
 
   it('should accept numbers and refs', () => {
     const value1 = 10
-    const value2 = ref(100)
+    const value2 = shallowRef(100)
 
     const v = useMax(50, value1, value2)
 

--- a/packages/math/useMin/index.test.ts
+++ b/packages/math/useMin/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 import { useMin } from './index'
 
 describe('useMin', () => {
@@ -13,9 +13,9 @@ describe('useMin', () => {
   })
 
   it('should accept refs', () => {
-    const value1 = ref(10)
-    const value2 = ref(100)
-    const value3 = ref(1000)
+    const value1 = shallowRef(10)
+    const value2 = shallowRef(100)
+    const value3 = shallowRef(1000)
 
     const v = useMin(value1, value2, value3)
     expect(v.value).toBe(10)
@@ -32,7 +32,7 @@ describe('useMin', () => {
 
   it('should accept numbers and refs', () => {
     const value1 = 10
-    const value2 = ref(100)
+    const value2 = shallowRef(100)
 
     const v = useMin(50, value1, value2)
 

--- a/packages/math/usePrecision/index.test.ts
+++ b/packages/math/usePrecision/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 import { usePrecision } from './index'
 
 describe('usePrecision', () => {
@@ -7,21 +7,21 @@ describe('usePrecision', () => {
     expect(usePrecision).toBeDefined()
   })
   it('should work', () => {
-    const base = ref(45.125)
+    const base = deepRef(45.125)
     const result = usePrecision(base, 2)
     expect(result.value).toBe(45.13)
     base.value = -45.155
     expect(result.value).toBe(-45.15)
   })
   it('out ceil should work', () => {
-    const base = ref(45.125)
+    const base = deepRef(45.125)
     const result = usePrecision(base, 2, { math: 'ceil' })
     expect(result.value).toMatchInlineSnapshot('45.13')
     base.value = -45.151
     expect(result.value).toMatchInlineSnapshot('-45.15')
   })
   it('out floor should work', () => {
-    const base = ref(45.129)
+    const base = deepRef(45.129)
     const result = usePrecision(base, 2, { math: 'floor' })
     expect(result.value).toMatchInlineSnapshot('45.12')
     base.value = -45.159

--- a/packages/math/useProjection/demo.vue
+++ b/packages/math/useProjection/demo.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 import { useProjection } from './index'
 
 const from = ref<[number, number]>([0, 10])
 const to = ref<[number, number]>([10, 100])
-const input = ref(0)
+const input = shallowRef(0)
 
 const output = useProjection(input, from, to)
 </script>

--- a/packages/math/useProjection/demo.vue
+++ b/packages/math/useProjection/demo.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import { ref, shallowRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 import { useProjection } from './index'
 
-const from = ref<[number, number]>([0, 10])
-const to = ref<[number, number]>([10, 100])
+const from = deepRef<[number, number]>([0, 10])
+const to = deepRef<[number, number]>([10, 100])
 const input = shallowRef(0)
 
 const output = useProjection(input, from, to)

--- a/packages/math/useProjection/index.test.ts
+++ b/packages/math/useProjection/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isRef, ref } from 'vue'
+import { isRef, shallowRef } from 'vue'
 import { useProjection } from './index'
 
 describe('useProjection', () => {
@@ -8,7 +8,7 @@ describe('useProjection', () => {
   })
 
   it('returns a ref', () => {
-    expect(isRef(useProjection(ref(5), [0, 10], [0, 100]))).toBe(true)
+    expect(isRef(useProjection(shallowRef(5), [0, 10], [0, 100]))).toBe(true)
   })
 
   it('projects correctly', () => {
@@ -18,7 +18,7 @@ describe('useProjection', () => {
   })
 
   it('is reactive', () => {
-    const inputRef = ref(5)
+    const inputRef = shallowRef(5)
     const projection = useProjection(inputRef, [0, 10], [0, 100])
     expect(isRef(projection)).toBe(true)
 

--- a/packages/math/useRound/index.test.ts
+++ b/packages/math/useRound/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 import { useRound } from './index'
 
 describe('useRound', () => {
@@ -7,7 +7,7 @@ describe('useRound', () => {
     expect(useRound).toBeDefined()
   })
   it('should work', () => {
-    const base = ref(20.49)
+    const base = deepRef(20.49)
     const result = useRound(base)
     expect(result.value).toBe(20)
     base.value = -20.51

--- a/packages/math/useSum/index.test.ts
+++ b/packages/math/useSum/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref, shallowRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 import { useSum } from './index'
 
 describe('useSum', () => {
@@ -8,7 +8,7 @@ describe('useSum', () => {
   })
 
   it('array usage', () => {
-    const array = ref([1, 2, 3, 4])
+    const array = deepRef([1, 2, 3, 4])
     const sum = useSum(array)
     expect(sum.value).toBe(10)
     array.value = [-1, -2, 3, 4]

--- a/packages/math/useSum/index.test.ts
+++ b/packages/math/useSum/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 import { useSum } from './index'
 
 describe('useSum', () => {
@@ -16,8 +16,8 @@ describe('useSum', () => {
   })
 
   it('rest usage', () => {
-    const a = ref(1)
-    const b = ref(2)
+    const a = shallowRef(1)
+    const b = shallowRef(2)
     const sum = useSum(a, () => b.value, 3)
     expect(sum.value).toBe(6)
     b.value = 3

--- a/packages/math/useTrunc/index.test.ts
+++ b/packages/math/useTrunc/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 import { useTrunc } from './index'
 
 // Returns:
@@ -19,7 +19,7 @@ describe('useTrunk', () => {
     expect(useTrunc).toBeDefined()
   })
   it('should work', () => {
-    const base = ref(1.95)
+    const base = deepRef(1.95)
     const result = useTrunc(base)
     expect(result.value).toBe(1)
     base.value = -7.004

--- a/packages/router/useRouteHash/index.test.ts
+++ b/packages/router/useRouteHash/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { computed, nextTick, reactive, ref, watch } from 'vue'
+import { computed, nextTick, reactive, shallowRef, watch } from 'vue'
 import { useRouteHash } from './index'
 
 describe('useRouteHash', () => {
@@ -100,7 +100,7 @@ describe('useRouteHash', () => {
     let route = getRoute()
     const router = { replace: (r: any) => route = r } as any
 
-    const defaultTarget = ref('foo')
+    const defaultTarget = shallowRef('foo')
 
     const target = useRouteHash(defaultTarget, { route, router })
 

--- a/packages/router/useRouteParams/index.test.ts
+++ b/packages/router/useRouteParams/index.test.ts
@@ -1,6 +1,6 @@
 import type { Ref } from 'vue'
 import { describe, expect, it, vi } from 'vitest'
-import { computed, effectScope, nextTick, reactive, ref, shallowRef, watch } from 'vue'
+import { computed, ref as deepRef, effectScope, nextTick, reactive, shallowRef, watch } from 'vue'
 import { useRouteParams } from './index'
 
 describe('useRouteParams', () => {
@@ -169,10 +169,10 @@ describe('useRouteParams', () => {
     const scopeA = effectScope()
     const scopeB = effectScope()
 
-    let page: Ref<any> = ref(null)
-    let lang: Ref<any> = ref(null)
-    let code: Ref<any> = ref(null)
-    let slug: Ref<any> = ref(null)
+    let page: Ref<any> = deepRef(null)
+    let lang: Ref<any> = deepRef(null)
+    let code: Ref<any> = deepRef(null)
+    let slug: Ref<any> = deepRef(null)
 
     await scopeA.run(async () => {
       page = useRouteParams('page', null, { route, router })
@@ -228,12 +228,12 @@ describe('useRouteParams', () => {
     route.params.page = 2
 
     const defaultPage = 'DEFAULT_PAGE'
-    let page1: Ref<any> = ref(null)
+    let page1: Ref<any> = deepRef(null)
     await scopeA.run(async () => {
       page1 = useRouteParams('page', defaultPage, { route, router })
     })
 
-    let page2: Ref<any> = ref(null)
+    let page2: Ref<any> = deepRef(null)
     await scopeB.run(async () => {
       page2 = useRouteParams('page', defaultPage, { route, router })
     })

--- a/packages/router/useRouteParams/index.test.ts
+++ b/packages/router/useRouteParams/index.test.ts
@@ -1,6 +1,6 @@
 import type { Ref } from 'vue'
 import { describe, expect, it, vi } from 'vitest'
-import { computed, effectScope, nextTick, reactive, ref, watch } from 'vue'
+import { computed, effectScope, nextTick, reactive, ref, shallowRef, watch } from 'vue'
 import { useRouteParams } from './index'
 
 describe('useRouteParams', () => {
@@ -344,7 +344,7 @@ describe('useRouteParams', () => {
     let route = getRoute()
     const router = { replace: (r: any) => route = r } as any
 
-    const defaultPage = ref(1)
+    const defaultPage = shallowRef(1)
     const defaultLang = () => 'pt-BR'
 
     const page: Ref<any> = useRouteParams('page', defaultPage, { route, router })

--- a/packages/router/useRouteQuery/index.test.ts
+++ b/packages/router/useRouteQuery/index.test.ts
@@ -1,6 +1,6 @@
 import type { Ref } from 'vue'
 import { describe, expect, it, vi } from 'vitest'
-import { computed, effectScope, nextTick, reactive, ref, shallowRef, toValue, watch } from 'vue'
+import { computed, ref as deepRef, effectScope, nextTick, reactive, shallowRef, toValue, watch } from 'vue'
 import { useRouteQuery } from './index'
 
 describe('useRouteQuery', () => {
@@ -157,10 +157,10 @@ describe('useRouteQuery', () => {
     const scopeA = effectScope()
     const scopeB = effectScope()
 
-    let page: Ref<any> = ref(null)
-    let lang: Ref<any> = ref(null)
-    let code: Ref<any> = ref(null)
-    let search: Ref<any> = ref(null)
+    let page: Ref<any> = deepRef(null)
+    let lang: Ref<any> = deepRef(null)
+    let code: Ref<any> = deepRef(null)
+    let search: Ref<any> = deepRef(null)
 
     await scopeA.run(async () => {
       page = useRouteQuery('page', null, { route, router })
@@ -215,12 +215,12 @@ describe('useRouteQuery', () => {
     route.query.page = 2
 
     const defaultPage = 'DEFAULT_PAGE'
-    let page1: Ref<any> = ref(null)
+    let page1: Ref<any> = deepRef(null)
     await scopeA.run(async () => {
       page1 = useRouteQuery('page', defaultPage, { route, router })
     })
 
-    let page2: Ref<any> = ref(null)
+    let page2: Ref<any> = deepRef(null)
     await scopeB.run(async () => {
       page2 = useRouteQuery('page', defaultPage, { route, router })
     })

--- a/packages/router/useRouteQuery/index.test.ts
+++ b/packages/router/useRouteQuery/index.test.ts
@@ -1,6 +1,6 @@
 import type { Ref } from 'vue'
 import { describe, expect, it, vi } from 'vitest'
-import { computed, effectScope, nextTick, reactive, ref, toValue, watch } from 'vue'
+import { computed, effectScope, nextTick, reactive, ref, shallowRef, toValue, watch } from 'vue'
 import { useRouteQuery } from './index'
 
 describe('useRouteQuery', () => {
@@ -374,7 +374,7 @@ describe('useRouteQuery', () => {
     let route = getRoute()
     const router = { replace: (r: any) => route = r } as any
 
-    const defaultPage = ref(1)
+    const defaultPage = shallowRef(1)
     const defaultLang = () => 'pt-BR'
 
     const page: Ref<any> = useRouteQuery('page', defaultPage, { route, router })

--- a/packages/rxjs/from/_demo.vue
+++ b/packages/rxjs/from/_demo.vue
@@ -7,12 +7,12 @@ import {
   takeUntil,
   withLatestFrom,
 } from 'rxjs/operators'
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 import { toObserver } from '../toObserver'
 import { useSubscription } from '../useSubscription'
 import { from, fromEvent } from './index'
 
-const count = ref(0)
+const count = shallowRef(0)
 const button = ref<HTMLButtonElement | null>(null)
 
 useSubscription(

--- a/packages/rxjs/from/_demo.vue
+++ b/packages/rxjs/from/_demo.vue
@@ -7,13 +7,13 @@ import {
   takeUntil,
   withLatestFrom,
 } from 'rxjs/operators'
-import { ref, shallowRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 import { toObserver } from '../toObserver'
 import { useSubscription } from '../useSubscription'
 import { from, fromEvent } from './index'
 
 const count = shallowRef(0)
-const button = ref<HTMLButtonElement | null>(null)
+const button = deepRef<HTMLButtonElement | null>(null)
 
 useSubscription(
   interval(1000)

--- a/packages/rxjs/toObserver/_demo.vue
+++ b/packages/rxjs/toObserver/_demo.vue
@@ -8,13 +8,13 @@ import {
   takeUntil,
   withLatestFrom,
 } from 'rxjs/operators'
-import { ref, shallowRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 import { from, fromEvent } from '../from'
 import { useSubscription } from '../useSubscription'
 import { toObserver } from './index'
 
 const count = shallowRef(0)
-const button = ref<HTMLButtonElement | null>(null)
+const button = deepRef<HTMLButtonElement | null>(null)
 
 useSubscription(
   interval(1000)

--- a/packages/rxjs/toObserver/_demo.vue
+++ b/packages/rxjs/toObserver/_demo.vue
@@ -8,12 +8,12 @@ import {
   takeUntil,
   withLatestFrom,
 } from 'rxjs/operators'
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 import { from, fromEvent } from '../from'
 import { useSubscription } from '../useSubscription'
 import { toObserver } from './index'
 
-const count = ref(0)
+const count = shallowRef(0)
 const button = ref<HTMLButtonElement | null>(null)
 
 useSubscription(

--- a/packages/rxjs/useExtractedObservable/_demo.vue
+++ b/packages/rxjs/useExtractedObservable/_demo.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { interval } from 'rxjs'
 import { mapTo, scan, startWith } from 'rxjs/operators'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 import { useExtractedObservable } from './index'
 
-const start = ref(0)
+const start = shallowRef(0)
 
 const count = useExtractedObservable(
   start,

--- a/packages/rxjs/useExtractedObservable/index.test.ts
+++ b/packages/rxjs/useExtractedObservable/index.test.ts
@@ -1,7 +1,7 @@
 import { BehaviorSubject, of, Subject } from 'rxjs'
 import { delay, endWith, tap } from 'rxjs/operators'
 import { describe, expect, it, vi } from 'vitest'
-import { nextTick, reactive, ref } from 'vue'
+import { nextTick, reactive, ref, shallowRef } from 'vue'
 import { useExtractedObservable } from './index'
 
 describe('useExtractedObservable', () => {
@@ -9,7 +9,7 @@ describe('useExtractedObservable', () => {
     it('should call the extractor immediately', () => {
       const obs = new Subject<number>()
 
-      const last = ref(42)
+      const last = shallowRef(42)
 
       const extractor = vi.fn((lastValue: number) => obs.pipe(endWith(lastValue)))
 
@@ -25,7 +25,7 @@ describe('useExtractedObservable', () => {
       expect.hasAssertions()
       const obs = new Subject<number>()
 
-      const last = ref(42)
+      const last = shallowRef(42)
 
       const refObs = useExtractedObservable(last, lastValue => obs.pipe(endWith(lastValue)))
 
@@ -44,7 +44,7 @@ describe('useExtractedObservable', () => {
       expect.hasAssertions()
       const obs = new Subject<number>()
 
-      const last = ref(42)
+      const last = shallowRef(42)
 
       const refObs = useExtractedObservable(last, lastValue => obs.pipe(endWith(lastValue)), {
         initialValue: 13,
@@ -63,7 +63,7 @@ describe('useExtractedObservable', () => {
       expect.hasAssertions()
       const obs = new BehaviorSubject(16)
 
-      const last = ref(42)
+      const last = shallowRef(42)
 
       const refObs = useExtractedObservable(last, () => obs, {
         initialValue: 13,
@@ -76,7 +76,7 @@ describe('useExtractedObservable', () => {
   describe('when onError is provided', () => {
     it('calls onError when an observable emits an error', async () => {
       expect.hasAssertions()
-      const re = ref(0)
+      const re = shallowRef(0)
       const error = new Error('Odd number')
 
       const extractor = (num: number) => of(num).pipe(
@@ -176,7 +176,7 @@ describe('useExtractedObservable', () => {
       xyz: 'abc',
     })
 
-    const re = ref('def')
+    const re = shallowRef('def')
 
     const extractor = ([abc, def]: [string, string]) => of(`${abc}${def}`)
 

--- a/packages/rxjs/useExtractedObservable/index.test.ts
+++ b/packages/rxjs/useExtractedObservable/index.test.ts
@@ -1,7 +1,7 @@
 import { BehaviorSubject, of, Subject } from 'rxjs'
 import { delay, endWith, tap } from 'rxjs/operators'
 import { describe, expect, it, vi } from 'vitest'
-import { nextTick, reactive, ref, shallowRef } from 'vue'
+import { ref as deepRef, nextTick, reactive, shallowRef } from 'vue'
 import { useExtractedObservable } from './index'
 
 describe('useExtractedObservable', () => {
@@ -105,7 +105,7 @@ describe('useExtractedObservable', () => {
     it('doesn\'t call onError when the observable doesn\'t emit an error', async () => {
       expect.hasAssertions()
 
-      const re = ref([1, 2])
+      const re = deepRef([1, 2])
       const onError = vi.fn()
 
       /* const obsRef = */ useExtractedObservable(re, (arr: unknown[]) => of(...arr), {
@@ -126,7 +126,7 @@ describe('useExtractedObservable', () => {
     it('calls onComplete when an observable completes', async () => {
       expect.hasAssertions()
 
-      const re = ref()
+      const re = deepRef()
       const extractor = (args: unknown[]) => of(...args)
       const onComplete = vi.fn()
 
@@ -151,7 +151,7 @@ describe('useExtractedObservable', () => {
       vi.useFakeTimers()
       expect.hasAssertions()
 
-      const re = ref([13, 23, 420])
+      const re = deepRef([13, 23, 420])
       const extractor = (arr: unknown[]) => of(...arr).pipe(
         delay(1000),
       )

--- a/packages/rxjs/useObservable/index.ts
+++ b/packages/rxjs/useObservable/index.ts
@@ -1,7 +1,7 @@
 import type { Observable } from 'rxjs'
 import type { Ref, UnwrapRef } from 'vue'
 import { tryOnScopeDispose } from '@vueuse/shared'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 
 export interface UseObservableOptions<I> {
   onError?: (err: any) => void
@@ -15,7 +15,7 @@ export function useObservable<H, I = undefined>(
   observable: Observable<H>,
   options?: UseObservableOptions<I | undefined>,
 ): Readonly<Ref<H | I>> {
-  const value = ref<H | I | undefined>(options?.initialValue)
+  const value = deepRef<H | I | undefined>(options?.initialValue)
   const subscription = observable.subscribe({
     next: val => (value.value = (val as UnwrapRef<H>)),
     error: options?.onError,

--- a/packages/rxjs/useSubject/index.ts
+++ b/packages/rxjs/useSubject/index.ts
@@ -3,7 +3,7 @@ import type { Ref } from 'vue'
 import type { UseObservableOptions } from '../useObservable'
 import { tryOnScopeDispose } from '@vueuse/shared'
 import { BehaviorSubject } from 'rxjs'
-import { ref, watch } from 'vue'
+import { ref as deepRef, watch } from 'vue'
 
 export interface UseSubjectOptions<I = undefined> extends Omit<UseObservableOptions<I>, 'initialValue'> {
 }
@@ -11,7 +11,7 @@ export interface UseSubjectOptions<I = undefined> extends Omit<UseObservableOpti
 export function useSubject<H>(subject: BehaviorSubject<H>, options?: UseSubjectOptions): Ref<H>
 export function useSubject<H>(subject: Subject<H>, options?: UseSubjectOptions): Ref<H | undefined>
 export function useSubject<H>(subject: Subject<H>, options?: UseSubjectOptions) {
-  const value = ref(
+  const value = deepRef(
     subject instanceof BehaviorSubject
       ? subject.value
       : undefined,

--- a/packages/rxjs/useSubscription/_demo.vue
+++ b/packages/rxjs/useSubscription/_demo.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { interval } from 'rxjs'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 import { useSubscription } from './index'
 
-const count = ref(0)
+const count = shallowRef(0)
 useSubscription(
   interval(1000)
     .subscribe(() => {

--- a/packages/rxjs/watchExtractedObservable/_demo.vue
+++ b/packages/rxjs/watchExtractedObservable/_demo.vue
@@ -2,7 +2,7 @@
 import type { Observable } from 'rxjs'
 import { fromEvent } from 'rxjs'
 import { map, skip, tap } from 'rxjs/operators'
-import { computed, reactive, ref } from 'vue'
+import { computed, ref as deepRef, reactive } from 'vue'
 import { watchExtractedObservable } from './index'
 
 class AudioPlayer {
@@ -61,7 +61,7 @@ class AudioPlayer {
   }
 }
 
-const audio = ref<HTMLAudioElement>()
+const audio = deepRef<HTMLAudioElement>()
 const player = computed(() => audio.value ? new AudioPlayer(audio.value) : null)
 
 const state = reactive({

--- a/packages/rxjs/watchExtractedObservable/index.test.ts
+++ b/packages/rxjs/watchExtractedObservable/index.test.ts
@@ -4,7 +4,7 @@ import type { ComputedRef, Ref } from 'vue'
 import { BehaviorSubject, of } from 'rxjs'
 import { delay, map, tap } from 'rxjs/operators'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { computed, nextTick, reactive, ref, shallowRef } from 'vue'
+import { computed, ref as deepRef, nextTick, reactive, shallowRef } from 'vue'
 import { watchExtractedObservable } from './index'
 
 class TestWrapper {
@@ -27,7 +27,7 @@ describe('watchExtractedObservable', () => {
     let callback: MockedFunction<(num: number) => void>
 
     beforeEach(() => {
-      numRef = ref<number>()
+      numRef = deepRef<number>()
       obj = computed(() => typeof numRef.value == 'number' ? new TestWrapper(numRef.value) : null)
       extractor = vi.fn().mockImplementation((wrapper: TestWrapper) => wrapper.obs$)
       callback = vi.fn()
@@ -100,7 +100,7 @@ describe('watchExtractedObservable', () => {
     it('doesn\'t call onError when the observable doesn\'t emit an error', async () => {
       expect.hasAssertions()
 
-      const re = ref([1, 2])
+      const re = deepRef([1, 2])
       const callback = vi.fn()
       const onError = vi.fn()
 
@@ -129,7 +129,7 @@ describe('watchExtractedObservable', () => {
 
   describe('when onComplete is provided', () => {
     it('calls onComplete when an observable completes', async () => {
-      const re = ref([1, 2])
+      const re = deepRef([1, 2])
       const extractor = (args: unknown[]) => of(...args)
       const callback = vi.fn()
       const onComplete = vi.fn()
@@ -162,7 +162,7 @@ describe('watchExtractedObservable', () => {
       vi.useFakeTimers()
       expect.hasAssertions()
 
-      const re = ref([42, 23, 420])
+      const re = deepRef([42, 23, 420])
       const extractor = (arr: unknown[]) => of(...arr).pipe(
         delay(1000),
         map(() => 42),

--- a/packages/rxjs/watchExtractedObservable/index.test.ts
+++ b/packages/rxjs/watchExtractedObservable/index.test.ts
@@ -4,7 +4,7 @@ import type { ComputedRef, Ref } from 'vue'
 import { BehaviorSubject, of } from 'rxjs'
 import { delay, map, tap } from 'rxjs/operators'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { computed, nextTick, reactive, ref } from 'vue'
+import { computed, nextTick, reactive, ref, shallowRef } from 'vue'
 import { watchExtractedObservable } from './index'
 
 class TestWrapper {
@@ -64,7 +64,7 @@ describe('watchExtractedObservable', () => {
     it('calls onError when an observable emits an error', async () => {
       expect.hasAssertions()
 
-      const re = ref(0)
+      const re = shallowRef(0)
       const error = new Error('Odd number')
 
       const extractor = (num: number) => of(num).pipe(
@@ -191,7 +191,7 @@ describe('watchExtractedObservable', () => {
       xyz: 'abc',
     })
 
-    const re = ref('def')
+    const re = shallowRef('def')
 
     const extractor = ([abc, def]: [string, string]) => of([abc, def])
     const callback = vi.fn(() => {})

--- a/packages/shared/computedEager/demo.vue
+++ b/packages/shared/computedEager/demo.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 import EagerDemo from './demo/EagerDemo.vue'
 import LazyDemo from './demo/LazyDemo.vue'
 import { count } from './demo/state'
 
-const lazyRenders = ref(0)
-const eagerRenders = ref(0)
+const lazyRenders = shallowRef(0)
+const eagerRenders = shallowRef(0)
 </script>
 
 <template>

--- a/packages/shared/computedEager/demo/state.ts
+++ b/packages/shared/computedEager/demo/state.ts
@@ -1,3 +1,3 @@
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 
-export const count = ref(0)
+export const count = shallowRef(0)

--- a/packages/shared/computedEager/index.test.ts
+++ b/packages/shared/computedEager/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { computed, ref, watch } from 'vue'
+import { computed, shallowRef, watch } from 'vue'
 import { nextTwoTick } from '../../.test'
 import { computedEager } from './index'
 
@@ -9,7 +9,7 @@ describe('computedEager', () => {
   })
 
   it('should work', async () => {
-    const foo = ref(0)
+    const foo = shallowRef(0)
 
     const plusOneComputed = computed(() => {
       return foo.value + 1
@@ -46,7 +46,7 @@ describe('computedEager', () => {
   })
 
   it('should not trigger collect change if result is not changed', async () => {
-    const foo = ref(1)
+    const foo = shallowRef(1)
 
     const isOddComputed = computed(() => {
       return foo.value % 2 === 0

--- a/packages/shared/computedWithControl/index.test.ts
+++ b/packages/shared/computedWithControl/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 import { computedWithControl, controlledComputed } from './index'
 
 describe('computedWithControl', () => {
@@ -9,8 +9,8 @@ describe('computedWithControl', () => {
   })
 
   it('should work', () => {
-    const trigger = ref(0)
-    const data = ref('foo')
+    const trigger = shallowRef(0)
+    const data = shallowRef('foo')
 
     const computed = computedWithControl(trigger, () => data.value.toUpperCase())
 
@@ -26,7 +26,7 @@ describe('computedWithControl', () => {
   })
 
   it('optional old value', () => {
-    const trigger = ref(0)
+    const trigger = shallowRef(0)
 
     const computed = computedWithControl(trigger, (oldValue?: number) =>
       oldValue ? oldValue * 2 : 1)
@@ -58,8 +58,8 @@ describe('computedWithControl', () => {
   })
 
   it('getter and setter', () => {
-    const trigger = ref(0)
-    const data = ref('foo')
+    const trigger = shallowRef(0)
+    const data = shallowRef('foo')
 
     const computed = computedWithControl(trigger, {
       get() {

--- a/packages/shared/computedWithControl/index.ts
+++ b/packages/shared/computedWithControl/index.ts
@@ -1,6 +1,6 @@
 import type { ComputedGetter, ComputedRef, WatchSource, WritableComputedOptions, WritableComputedRef } from 'vue'
 import type { Fn } from '../utils'
-import { customRef, ref, watch } from 'vue'
+import { customRef, shallowRef, watch } from 'vue'
 
 export interface ComputedWithControlRefExtra {
   /**
@@ -35,7 +35,7 @@ export function computedWithControl<T, S>(
   let v: T = undefined!
   let track: Fn
   let trigger: Fn
-  const dirty = ref(true)
+  const dirty = shallowRef(true)
 
   const update = () => {
     dirty.value = true

--- a/packages/shared/createGlobalState/index.test.ts
+++ b/packages/shared/createGlobalState/index.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import { computed, ref } from 'vue'
+import { computed, shallowRef } from 'vue'
 import { useSetup } from '../../.test'
 import { createGlobalState } from './index'
 
 describe('createGlobalState', () => {
   it('should work after dispose 1', async () => {
     const useGlobalState = createGlobalState(() => {
-      const counter = ref(1)
+      const counter = shallowRef(1)
       const doubled = computed(() => counter.value * 2)
 
       return {

--- a/packages/shared/createInjectionState/demo/CountComponent.vue
+++ b/packages/shared/createInjectionState/demo/CountComponent.vue
@@ -4,7 +4,7 @@ import { useCounterStore } from './useCounterStore'
 // use non-null assertion operator to ignore the case that store is not provided.
 const { count, double } = useCounterStore()!
 // if you want to allow component to working without providing store, you can use follow code instead:
-// const { count, double } = useCounterStore() ?? { count: ref(0), double: ref(0) }
+// const { count, double } = useCounterStore() ?? { count: shallowRef(0), double: shallowRef(0) }
 // also, you can use another hook to provide default value
 // const { count, double } = useCounterStoreWithDefaultValue()
 // or throw error

--- a/packages/shared/createInjectionState/demo/useCounterStore.ts
+++ b/packages/shared/createInjectionState/demo/useCounterStore.ts
@@ -1,4 +1,4 @@
-import { computed, ref } from 'vue'
+import { computed, ref, shallowRef } from 'vue'
 import { createInjectionState } from '../../createInjectionState'
 
 const [useProvideCounterStore, useCounterStore] = createInjectionState((initialValue: number) => {
@@ -22,8 +22,8 @@ export { useCounterStore }
 
 export function useCounterStoreWithDefaultValue() {
   return useCounterStore() ?? {
-    count: ref(0),
-    double: ref(0),
+    count: shallowRef(0),
+    double: shallowRef(0),
     increment: () => {},
   }
 }

--- a/packages/shared/createInjectionState/demo/useCounterStore.ts
+++ b/packages/shared/createInjectionState/demo/useCounterStore.ts
@@ -1,9 +1,9 @@
-import { computed, ref, shallowRef } from 'vue'
+import { computed, ref as deepRef, shallowRef } from 'vue'
 import { createInjectionState } from '../../createInjectionState'
 
 const [useProvideCounterStore, useCounterStore] = createInjectionState((initialValue: number) => {
   // state
-  const count = ref(initialValue)
+  const count = deepRef(initialValue)
 
   // getters
   const double = computed(() => count.value * 2)

--- a/packages/shared/createInjectionState/index.test.ts
+++ b/packages/shared/createInjectionState/index.test.ts
@@ -1,13 +1,13 @@
 import type { InjectionKey, Ref } from 'vue'
 import { createInjectionState, injectLocal } from '@vueuse/shared'
 import { describe, expect, it } from 'vitest'
-import { defineComponent, h, inject, nextTick, ref } from 'vue'
+import { ref as deepRef, defineComponent, h, inject, nextTick } from 'vue'
 import { mount, useSetup } from '../../.test'
 
 describe('createInjectionState', () => {
   it('should work for simple nested component', async () => {
     const [useProvideCountState, useCountState] = createInjectionState((initialValue: number) => {
-      const count = ref(initialValue)
+      const count = deepRef(initialValue)
       return count
     })
 
@@ -40,7 +40,7 @@ describe('createInjectionState', () => {
     const KEY: InjectionKey<Ref<number>> = Symbol('count-state')
 
     const [useProvideCountState, useCountState] = createInjectionState((initialValue: number) => {
-      const count = ref(initialValue)
+      const count = deepRef(initialValue)
       return count
     }, { injectionKey: KEY })
 
@@ -72,7 +72,7 @@ describe('createInjectionState', () => {
 
   it('allow call useProvidingState and useInjectedState in same component', async () => {
     const [useProvideCountState, useCountState] = createInjectionState((initialValue: number) => {
-      const count = ref(initialValue)
+      const count = deepRef(initialValue)
       return count
     })
     const vm = useSetup(() => {
@@ -89,7 +89,7 @@ describe('createInjectionState', () => {
   it('allow call useProvidingState and injectLocal in same component', async () => {
     const KEY: InjectionKey<Ref<number>> | string = Symbol('count-state')
     const [useProvideCountState] = createInjectionState((initialValue: number) => {
-      const count = ref(initialValue)
+      const count = deepRef(initialValue)
       return count
     }, { injectionKey: KEY })
     const vm = useSetup(() => {

--- a/packages/shared/get/index.test.ts
+++ b/packages/shared/get/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref, shallowRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 import { get } from './index'
 
 describe('get', () => {
@@ -11,7 +11,7 @@ describe('get', () => {
   })
 
   it('ref object', () => {
-    const reactive = ref({ foo: 'bar' })
+    const reactive = deepRef({ foo: 'bar' })
     const plain = { foo: 'bar' }
 
     expect(get(reactive, 'foo')).toBe('bar')
@@ -24,7 +24,7 @@ describe('get', () => {
   })
 
   it('ref array', () => {
-    const reactive = ref([1, 2, 3])
+    const reactive = deepRef([1, 2, 3])
     const plain = [1, 2, 3]
 
     expect(get(reactive, 2)).toBe(3)

--- a/packages/shared/get/index.test.ts
+++ b/packages/shared/get/index.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 import { get } from './index'
 
 describe('get', () => {
   it('unref', () => {
-    const a = ref(42)
+    const a = shallowRef(42)
 
     expect(get(a)).toBe(42)
     expect(get(42)).toBe(42)

--- a/packages/shared/isDefined/index.test.ts
+++ b/packages/shared/isDefined/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { computed, ref, shallowRef } from 'vue'
+import { computed, ref as deepRef, shallowRef } from 'vue'
 import { isDefined } from './index'
 
 describe('isDefined', () => {
@@ -9,8 +9,8 @@ describe('isDefined', () => {
 
   it('should support refs', () => {
     const definedRef = shallowRef('test')
-    const undefinedRef = ref(undefined)
-    const nullRef = ref(null)
+    const undefinedRef = deepRef(undefined)
+    const nullRef = deepRef(null)
 
     expect(isDefined(definedRef)).toBe(true)
     expect(isDefined(undefinedRef)).toBe(false)

--- a/packages/shared/isDefined/index.test.ts
+++ b/packages/shared/isDefined/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { computed, ref } from 'vue'
+import { computed, ref, shallowRef } from 'vue'
 import { isDefined } from './index'
 
 describe('isDefined', () => {
@@ -8,7 +8,7 @@ describe('isDefined', () => {
   })
 
   it('should support refs', () => {
-    const definedRef = ref('test')
+    const definedRef = shallowRef('test')
     const undefinedRef = ref(undefined)
     const nullRef = ref(null)
 

--- a/packages/shared/reactify/index.test.ts
+++ b/packages/shared/reactify/index.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { ref, shallowRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 import { reactify } from './index'
 
 describe('reactify', () => {
   it('one arg', () => {
-    const base = ref(1.5)
+    const base = deepRef(1.5)
     const floor = reactify(Math.floor)
     const result = floor(base)
 
@@ -53,7 +53,7 @@ describe('reactify', () => {
   })
 
   it('jSON.stringify', () => {
-    const base = ref<any>(0)
+    const base = deepRef<any>(0)
     const stringify = reactify(JSON.stringify)
     const result = stringify(base, null, 2)
 

--- a/packages/shared/reactify/index.test.ts
+++ b/packages/shared/reactify/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 import { reactify } from './index'
 
 describe('reactify', () => {
@@ -16,8 +16,8 @@ describe('reactify', () => {
   })
 
   it('two args', () => {
-    const base = ref(0)
-    const exponent = ref(0)
+    const base = shallowRef(0)
+    const exponent = shallowRef(0)
 
     const pow = reactify(Math.pow)
     const result = pow(base, exponent)
@@ -40,7 +40,7 @@ describe('reactify', () => {
   })
 
   it('mixed with literal', () => {
-    const base = ref(0)
+    const base = shallowRef(0)
 
     const pow = reactify(Math.pow)
     const result = pow(base, 2)
@@ -69,8 +69,8 @@ describe('reactify', () => {
     const sqrt = reactify(Math.sqrt)
     const add = reactify((a: number, b: number) => a + b)
 
-    const a = ref(3)
-    const b = ref(4)
+    const a = shallowRef(3)
+    const b = shallowRef(4)
 
     const c = sqrt(add(pow(a, 2), pow(b, 2)))
 
@@ -85,8 +85,8 @@ describe('reactify', () => {
   it('computed getter', () => {
     const add = reactify((a: number, b: number) => a + b)
 
-    const a = ref(3)
-    const b = ref(4)
+    const a = shallowRef(3)
+    const b = shallowRef(4)
 
     const c = add(a, () => b.value)
 

--- a/packages/shared/reactifyObject/index.test.ts
+++ b/packages/shared/reactifyObject/index.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 import { reactifyObject } from './index'
 
 describe('reactifyObject', () => {
   it('math', () => {
     const { pow } = reactifyObject(Math, { includeOwnProperties: true })
 
-    const base = ref(0)
-    const exponent = ref(0)
+    const base = shallowRef(0)
+    const exponent = shallowRef(0)
     const result = pow(base, exponent)
 
     expect(base.value).toBe(0)
@@ -30,7 +30,7 @@ describe('reactifyObject', () => {
   it('jSON', () => {
     const { stringify, parse } = reactifyObject(JSON)
 
-    const base = ref('{"foo":"bar"}')
+    const base = shallowRef('{"foo":"bar"}')
     const result = stringify(parse(base))
 
     expect(result.value).toBe(base.value)

--- a/packages/shared/reactiveComputed/index.test.ts
+++ b/packages/shared/reactiveComputed/index.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, expectTypeOf, it } from 'vitest'
-import { nextTick, ref, watch, watchEffect } from 'vue'
+import { nextTick, shallowRef, watch, watchEffect } from 'vue'
 import { reactiveComputed } from './index'
 
 describe('reactiveComputed', () => {
   it('should work', () => {
-    const count = ref(0)
+    const count = shallowRef(0)
 
     const state = reactiveComputed(() => {
       return {
@@ -21,7 +21,7 @@ describe('reactiveComputed', () => {
   })
 
   it('should work with dynamic props', async () => {
-    const foo = ref(false)
+    const foo = shallowRef(false)
 
     const state = reactiveComputed(() => {
       return foo.value
@@ -55,7 +55,7 @@ describe('reactiveComputed', () => {
   })
 
   it('should allow for previous value access (for vue 3.4+)', () => {
-    const test = ref(0)
+    const test = shallowRef(0)
 
     const obj = reactiveComputed<{ test: number, num: number }>(
       prev => ({ test: test.value, num: (prev?.num ?? 2) }),

--- a/packages/shared/refAutoReset/index.test.ts
+++ b/packages/shared/refAutoReset/index.test.ts
@@ -1,6 +1,6 @@
 import type { Ref } from 'vue'
 import { describe, expect, it, vi } from 'vitest'
-import { effectScope, ref } from 'vue'
+import { effectScope, shallowRef } from 'vue'
 import { autoResetRef, refAutoReset } from './index'
 
 describe('refAutoReset', () => {
@@ -39,7 +39,7 @@ describe('refAutoReset', () => {
   })
 
   it('should change afterMs', async () => {
-    const afterMs = ref(150)
+    const afterMs = shallowRef(150)
     const val = refAutoReset('default', afterMs)
     val.value = 'update'
     afterMs.value = 100
@@ -57,7 +57,7 @@ describe('refAutoReset', () => {
   })
 
   it('should not reset when scope dispose', async () => {
-    let val: Ref<string> = ref('')
+    let val: Ref<string> = shallowRef('')
     const scope = effectScope()
 
     scope.run(() => {

--- a/packages/shared/refDebounced/demo.vue
+++ b/packages/shared/refDebounced/demo.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { refDebounced } from '@vueuse/core'
-import { ref, watch } from 'vue'
+import { shallowRef, watch } from 'vue'
 
-const input = ref('')
+const input = shallowRef('')
 const debounced = refDebounced(input, 1000)
-const updated = ref(0)
+const updated = shallowRef(0)
 
 watch(debounced, () => (updated.value += 1))
 </script>

--- a/packages/shared/refDebounced/index.ts
+++ b/packages/shared/refDebounced/index.ts
@@ -1,6 +1,6 @@
 import type { Ref } from 'vue'
 import type { DebounceFilterOptions, MaybeRefOrGetter } from '../utils'
-import { ref, watch } from 'vue'
+import { ref as deepRef, watch } from 'vue'
 import { useDebounceFn } from '../useDebounceFn'
 
 /**
@@ -9,7 +9,7 @@ import { useDebounceFn } from '../useDebounceFn'
  * @return A new debounced ref.
  */
 export function refDebounced<T>(value: Ref<T>, ms: MaybeRefOrGetter<number> = 200, options: DebounceFilterOptions = {}): Readonly<Ref<T>> {
-  const debounced = ref(value.value as T) as Ref<T>
+  const debounced = deepRef(value.value as T) as Ref<T>
 
   const updater = useDebounceFn(() => {
     debounced.value = value.value

--- a/packages/shared/refThrottled/demo.vue
+++ b/packages/shared/refThrottled/demo.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import { refThrottled } from '@vueuse/core'
-import { ref, watch } from 'vue'
+import { shallowRef, watch } from 'vue'
 
-const trailing = ref(true)
-const leading = ref(false)
-const input = ref('')
+const trailing = shallowRef(true)
+const leading = shallowRef(false)
+const input = shallowRef('')
 const throttled = refThrottled(input, 1000, trailing.value, leading.value)
-const updated = ref(0)
+const updated = shallowRef(0)
 
 watch(throttled, () => {
   updated.value += 1

--- a/packages/shared/refThrottled/index.ts
+++ b/packages/shared/refThrottled/index.ts
@@ -1,5 +1,5 @@
 import type { Ref } from 'vue'
-import { ref, watch } from 'vue'
+import { ref as deepRef, watch } from 'vue'
 import { useThrottleFn } from '../useThrottleFn'
 
 /**
@@ -15,7 +15,7 @@ export function refThrottled<T>(value: Ref<T>, delay = 200, trailing = true, lea
   if (delay <= 0)
     return value
 
-  const throttled: Ref<T> = ref(value.value as T) as Ref<T>
+  const throttled: Ref<T> = deepRef(value.value as T) as Ref<T>
 
   const updater = useThrottleFn(() => {
     throttled.value = value.value

--- a/packages/shared/set/index.test.ts
+++ b/packages/shared/set/index.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { reactive, ref, watch } from 'vue'
+import { reactive, shallowRef, watch } from 'vue'
 import { set } from './index'
 
 describe('set', () => {
   it('set ref', () => {
-    const source = ref('foo')
+    const source = shallowRef('foo')
 
     expect(source.value).toBe('foo')
 

--- a/packages/shared/syncRef/demo.vue
+++ b/packages/shared/syncRef/demo.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { syncRef } from '@vueuse/core'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 
-const a = ref('')
-const b = ref('')
+const a = shallowRef('')
+const b = shallowRef('')
 
 syncRef(a, b)
 </script>

--- a/packages/shared/syncRef/index.test.ts
+++ b/packages/shared/syncRef/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref, shallowRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 import { syncRef } from './index'
 
 describe('syncRef', () => {
@@ -103,8 +103,8 @@ describe('syncRef', () => {
     const ref1 = shallowRef(1)
     const refString = shallowRef('1')
     const refNumber = shallowRef(1)
-    const refNumString = ref<number | string>(1)
-    const refNumBoolean = ref<number | boolean>(1)
+    const refNumString = deepRef<number | string>(1)
+    const refNumBoolean = deepRef<number | boolean>(1)
     // L = A && direction === 'both'
     syncRef(ref0, ref1)()
     syncRef(ref0, ref1, {

--- a/packages/shared/syncRef/index.test.ts
+++ b/packages/shared/syncRef/index.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 import { syncRef } from './index'
 
 describe('syncRef', () => {
   it('should work', () => {
-    const a = ref('foo')
-    const b = ref('bar')
+    const a = shallowRef('foo')
+    const b = shallowRef('bar')
 
     const stop = syncRef(a, b)
 
@@ -30,8 +30,8 @@ describe('syncRef', () => {
   })
 
   it('trl', () => {
-    const left = ref('left')
-    const right = ref('right')
+    const left = shallowRef('left')
+    const right = shallowRef('right')
 
     syncRef(left, right, { direction: 'rtl' })
 
@@ -50,8 +50,8 @@ describe('syncRef', () => {
   })
 
   it('works with mutual convertors', () => {
-    const left = ref(10)
-    const right = ref(2)
+    const left = shallowRef(10)
+    const right = shallowRef(2)
 
     syncRef(left, right, {
       transform: {
@@ -74,8 +74,8 @@ describe('syncRef', () => {
   })
 
   it('works with only rtl convertor', () => {
-    const left = ref(10)
-    const right = ref(2)
+    const left = shallowRef(10)
+    const right = shallowRef(2)
 
     syncRef(left, right, {
       direction: 'rtl',
@@ -99,10 +99,10 @@ describe('syncRef', () => {
   })
 
   it('ts works', () => {
-    const ref0 = ref(0)
-    const ref1 = ref(1)
-    const refString = ref('1')
-    const refNumber = ref(1)
+    const ref0 = shallowRef(0)
+    const ref1 = shallowRef(1)
+    const refString = shallowRef('1')
+    const refNumber = shallowRef(1)
     const refNumString = ref<number | string>(1)
     const refNumBoolean = ref<number | boolean>(1)
     // L = A && direction === 'both'
@@ -251,8 +251,8 @@ describe('syncRef', () => {
       direction: 'rtl',
     })
 
-    const bool0 = ref(false)
-    const bool1 = ref(false)
+    const bool0 = shallowRef(false)
+    const bool1 = shallowRef(false)
     syncRef(bool0, bool1)
 
     syncRef(refNumber, refString, {

--- a/packages/shared/syncRefs/demo.vue
+++ b/packages/shared/syncRefs/demo.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { syncRefs } from '@vueuse/core'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 
-const source = ref('')
-const target1 = ref('')
-const target2 = ref('')
+const source = shallowRef('')
+const target1 = shallowRef('')
+const target2 = shallowRef('')
 
 syncRefs(source, [target1, target2])
 </script>

--- a/packages/shared/syncRefs/index.test.ts
+++ b/packages/shared/syncRefs/index.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 import { syncRefs } from './index'
 
 describe('syncRefs', () => {
   it('should work with array', () => {
-    const source = ref('foo')
-    const target1 = ref('bar')
-    const target2 = ref('bar2')
+    const source = shallowRef('foo')
+    const target1 = shallowRef('bar')
+    const target2 = shallowRef('bar2')
 
     const stop = syncRefs(source, [target1, target2])
 
@@ -27,8 +27,8 @@ describe('syncRefs', () => {
   })
 
   it('should work with non-array', () => {
-    const source = ref('foo')
-    const target = ref('bar')
+    const source = shallowRef('foo')
+    const target = shallowRef('bar')
 
     const stop = syncRefs(source, target)
 

--- a/packages/shared/toReactive/index.test.ts
+++ b/packages/shared/toReactive/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isReactive, nextTick, reactive, ref, watchSyncEffect } from 'vue'
+import { ref as deepRef, isReactive, nextTick, reactive, watchSyncEffect } from 'vue'
 import { toRefs } from '../toRefs'
 import { toReactive } from './index'
 
@@ -9,7 +9,7 @@ describe('toReactive', () => {
   })
 
   it('should work', () => {
-    const r = ref({ a: 'a', b: 0 })
+    const r = deepRef({ a: 'a', b: 0 })
     const state = toReactive(r)
     expect(state.a).toBe('a')
     expect(state.b).toBe(0)
@@ -22,7 +22,7 @@ describe('toReactive', () => {
 
   it('should be enumerable', () => {
     const obj = { a: 'a', b: 0 }
-    const r = ref(obj)
+    const r = deepRef(obj)
     const state = toReactive(r)
 
     expect(JSON.stringify(state)).toBe(JSON.stringify(r.value))
@@ -30,7 +30,7 @@ describe('toReactive', () => {
   })
 
   it('should be reactive', async () => {
-    const r = ref({ a: 'a', b: 0 })
+    const r = deepRef({ a: 'a', b: 0 })
     const state = toReactive(r)
     let dummy = 0
 
@@ -55,7 +55,7 @@ describe('toReactive', () => {
   })
 
   it('should be replaceable', async () => {
-    const r = ref<any>({ a: 'a', b: 0 })
+    const r = deepRef<any>({ a: 'a', b: 0 })
     const state = toReactive(r)
     let dummy = 0
 

--- a/packages/shared/toRef/index.ts
+++ b/packages/shared/toRef/index.ts
@@ -1,12 +1,8 @@
 import type { ComputedRef, Ref, ToRef } from 'vue'
 import type { MaybeRefOrGetter } from '../utils'
-import {
-  customRef,
-  readonly,
-  ref,
+import { customRef, ref as deepRef, readonly,
   // eslint-disable-next-line no-restricted-imports
-  toRef as vueToRef,
-} from 'vue'
+  toRef as vueToRef } from 'vue'
 import { noop } from '../utils'
 
 /**
@@ -24,7 +20,7 @@ export function toRef(...args: any[]) {
   const r = args[0]
   return typeof r === 'function'
     ? readonly(customRef(() => ({ get: r as any, set: noop })))
-    : ref(r)
+    : deepRef(r)
 }
 
 /**

--- a/packages/shared/toRefs/index.test.ts
+++ b/packages/shared/toRefs/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { computed, reactive, ref, watchSyncEffect } from 'vue'
+import { computed, ref as deepRef, reactive, watchSyncEffect } from 'vue'
 import { toRefs } from './index'
 
 describe('toRefs', () => {
@@ -32,7 +32,7 @@ describe('toRefs', () => {
   })
 
   it('should return refs when an object ref was passed', () => {
-    const obj = ref({ a: 'a', b: 0 })
+    const obj = deepRef({ a: 'a', b: 0 })
     const refs = toRefs(obj)
     expect(refs.a.value).toBe('a')
     expect(refs.b.value).toBe(0)
@@ -44,7 +44,7 @@ describe('toRefs', () => {
   })
 
   it('should return refs when an array ref was passed', () => {
-    const arr = ref(['a', 0])
+    const arr = deepRef(['a', 0])
     const refs = toRefs(arr)
     expect(refs[0].value).toBe('a')
     expect(refs[1].value).toBe(0)
@@ -99,7 +99,7 @@ describe('toRefs', () => {
 
   it('should trigger unwanted effects with replaceRef = false', () => {
     const spy = vi.fn()
-    const obj = ref({
+    const obj = deepRef({
       a: 'a',
       b: 0,
     })
@@ -118,7 +118,7 @@ describe('toRefs', () => {
 
   it('should not trigger unwanted effects with replaceRef = false', () => {
     const spy = vi.fn()
-    const obj = ref({
+    const obj = deepRef({
       a: 'a',
       b: 0,
     })
@@ -144,7 +144,7 @@ describe('toRefs', () => {
       }
     }
 
-    const obj = ref(new SomeClass())
+    const obj = deepRef(new SomeClass())
 
     const { v } = toRefs(obj)
 

--- a/packages/shared/until/index.test.ts
+++ b/packages/shared/until/index.test.ts
@@ -2,7 +2,7 @@ import type { Equal, Expect } from '@type-challenges/utils'
 import type { Ref } from 'vue'
 import { invoke } from '@vueuse/shared'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 import { until } from './index'
 
 describe('until', () => {
@@ -11,15 +11,15 @@ describe('until', () => {
   })
   it('should toBe', () => {
     return new Promise<void>((resolve, reject) => {
-      const r1 = ref(0)
-      const r2 = ref(0)
+      const r1 = shallowRef(0)
+      const r2 = shallowRef(0)
 
       invoke(async () => {
         expect(r1.value).toBe(0)
         expect(r2.value).toBe(0)
         let x = await until(r1).toBe(1)
         expect(x).toBe(1)
-        x = await until(r2).toBe(ref(2))
+        x = await until(r2).toBe(shallowRef(2))
         expect(x).toBe(2)
         resolve()
       }).catch(reject)
@@ -37,7 +37,7 @@ describe('until', () => {
   })
 
   it('should toBeTruthy', async () => {
-    const r = ref(false)
+    const r = shallowRef(false)
     setTimeout(() => {
       r.value = true
     }, 100)
@@ -57,7 +57,7 @@ describe('until', () => {
   })
 
   it('should toBeNaN', async () => {
-    const r = ref(0)
+    const r = shallowRef(0)
     setTimeout(() => {
       r.value = Number.NaN
     }, 100)
@@ -68,10 +68,10 @@ describe('until', () => {
 
   it('should toBe timeout with ref', async () => {
     vi.useRealTimers()
-    const r = ref(0)
+    const r = shallowRef(0)
     const reject = vi.fn()
     await invoke(async () => {
-      await until(r).toBe(ref(1), { timeout: 200, throwOnTimeout: true })
+      await until(r).toBe(shallowRef(1), { timeout: 200, throwOnTimeout: true })
     }).catch(reject)
 
     expect(reject).toHaveBeenCalledWith('Timeout')
@@ -79,7 +79,7 @@ describe('until', () => {
 
   it('should work for changedTimes', async () => {
     await new Promise<void>((resolve, reject) => {
-      const r = ref(0)
+      const r = shallowRef(0)
 
       invoke(async () => {
         expect(r.value).toBe(0)
@@ -94,7 +94,7 @@ describe('until', () => {
       vi.advanceTimersByTime(100)
     })
     await new Promise<void>((resolve, reject) => {
-      const r = ref(0)
+      const r = shallowRef(0)
 
       invoke(async () => {
         expect(r.value).toBe(0)
@@ -114,7 +114,7 @@ describe('until', () => {
 
   it('should support `not`', () => {
     return new Promise<void>((resolve, reject) => {
-      const r = ref(0)
+      const r = shallowRef(0)
 
       invoke(async () => {
         expect(r.value).toBe(0)
@@ -132,7 +132,7 @@ describe('until', () => {
 
   it('should support `not` as separate instances', () => {
     return new Promise<void>((resolve, reject) => {
-      const r = ref(0)
+      const r = shallowRef(0)
 
       invoke(async () => {
         expect(r.value).toBe(0)
@@ -209,7 +209,7 @@ describe('until', () => {
   it('should immediately timeout', () => {
     vi.useRealTimers()
     return new Promise<void>((resolve, reject) => {
-      const r = ref(0)
+      const r = shallowRef(0)
 
       invoke(async () => {
         expect(r.value).toBe(0)

--- a/packages/shared/until/index.test.ts
+++ b/packages/shared/until/index.test.ts
@@ -2,7 +2,7 @@ import type { Equal, Expect } from '@type-challenges/utils'
 import type { Ref } from 'vue'
 import { invoke } from '@vueuse/shared'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref, shallowRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 import { until } from './index'
 
 describe('until', () => {
@@ -47,7 +47,7 @@ describe('until', () => {
   })
 
   it('should toBeUndefined', async () => {
-    const r = ref<boolean | undefined>(false)
+    const r = deepRef<boolean | undefined>(false)
     setTimeout(() => {
       r.value = undefined
     }, 100)
@@ -153,7 +153,7 @@ describe('until', () => {
 
   it('should support toBeNull()', () => {
     return new Promise<void>((resolve, reject) => {
-      const r = ref<number | null>(null)
+      const r = deepRef<number | null>(null)
 
       invoke(async () => {
         expect(r.value).toBe(null)
@@ -171,7 +171,7 @@ describe('until', () => {
 
   it('should support array', () => {
     return new Promise<void>((resolve, reject) => {
-      const r = ref<number[]>([1, 2, 3])
+      const r = deepRef<number[]>([1, 2, 3])
 
       invoke(async () => {
         expect(r.value).toEqual([1, 2, 3])
@@ -189,7 +189,7 @@ describe('until', () => {
 
   it('should support array with not', () => {
     return new Promise<void>((resolve, reject) => {
-      const r = ref<number[]>([1, 2, 3])
+      const r = deepRef<number[]>([1, 2, 3])
 
       invoke(async () => {
         expect(r.value).toEqual([1, 2, 3])
@@ -226,7 +226,7 @@ describe('until', () => {
   it('should type check', () => {
     // eslint-disable-next-line ts/no-unused-expressions
     async () => {
-      const x = ref<'x'>()
+      const x = deepRef<'x'>()
       // type checks are done this way to prevent unused variable warnings
       // and duplicate name warnings
       'test' as any as Expect<Equal<typeof x, Ref<'x' | undefined>>>
@@ -246,7 +246,7 @@ describe('until', () => {
       const xNotUndef = await until(x).not.toBeUndefined()
       'test' as any as Expect<Equal<typeof xNotUndef, 'x'>>
 
-      const y = ref<'y' | null>(null)
+      const y = deepRef<'y' | null>(null)
       'test' as any as Expect<Equal<typeof y, Ref<'y' | null>>>
 
       const yNull = await until(y).toBeNull()
@@ -255,7 +255,7 @@ describe('until', () => {
       const yNotNull = await until(y).not.toBeNull()
       'test' as any as Expect<Equal<typeof yNotNull, 'y'>>
 
-      const z = ref<1 | 2 | 3>(1)
+      const z = deepRef<1 | 2 | 3>(1)
       'test' as any as Expect<Equal<typeof z, Ref<1 | 2 | 3>>>
 
       const is1 = (x: number): x is 1 => x === 1

--- a/packages/shared/useArrayDifference/index.test.ts
+++ b/packages/shared/useArrayDifference/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 import { useArrayDifference } from './index'
 
 describe('useArrayDifference', () => {
@@ -7,8 +7,8 @@ describe('useArrayDifference', () => {
     expect(useArrayDifference).toBeDefined()
   })
   it('should return the difference of two array', () => {
-    const list1 = ref([1, 2, 3, 4, 5])
-    const list2 = ref([4, 5, 6])
+    const list1 = deepRef([1, 2, 3, 4, 5])
+    const list2 = deepRef([4, 5, 6])
 
     const result = useArrayDifference(list1, list2)
     expect(result.value).toEqual([1, 2, 3])
@@ -21,8 +21,8 @@ describe('useArrayDifference', () => {
   })
 
   it('should return the difference of two array with iteratee', () => {
-    const list1 = ref([{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }])
-    const list2 = ref([{ id: 4 }, { id: 5 }])
+    const list1 = deepRef([{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }])
+    const list2 = deepRef([{ id: 4 }, { id: 5 }])
 
     const result = useArrayDifference(list1, list2, (value, othVal) => value.id === othVal.id)
     expect(result.value).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }])
@@ -36,8 +36,8 @@ describe('useArrayDifference', () => {
 
   // key
   it('should return the difference of two array with key', () => {
-    const list1 = ref([{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }])
-    const list2 = ref([{ id: 3 }, { id: 4 }, { id: 5 }])
+    const list1 = deepRef([{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }])
+    const list2 = deepRef([{ id: 3 }, { id: 4 }, { id: 5 }])
 
     const result = useArrayDifference(list1, list2, 'id')
     expect(result.value).toEqual([{ id: 1 }, { id: 2 }])
@@ -50,8 +50,8 @@ describe('useArrayDifference', () => {
   })
 
   it('symmetric diff case 1', () => {
-    const list1 = ref([{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }])
-    const list2 = ref([{ id: 3 }, { id: 4 }, { id: 5 }, { id: 6 }])
+    const list1 = deepRef([{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }])
+    const list2 = deepRef([{ id: 3 }, { id: 4 }, { id: 5 }, { id: 6 }])
 
     const result = useArrayDifference(list1, list2, 'id', { symmetric: true })
     expect(result.value).toEqual([{ id: 1 }, { id: 2 }, { id: 6 }])
@@ -64,8 +64,8 @@ describe('useArrayDifference', () => {
   })
 
   it('symmetric diff case 2', () => {
-    const list1 = ref([{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }])
-    const list2 = ref([{ id: 3 }, { id: 4 }, { id: 5 }, { id: 6 }])
+    const list1 = deepRef([{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }])
+    const list2 = deepRef([{ id: 3 }, { id: 4 }, { id: 5 }, { id: 6 }])
 
     const result = useArrayDifference(list1, list2, (x, y) => x.id === y.id, { symmetric: true })
     expect(result.value).toEqual([{ id: 1 }, { id: 2 }, { id: 6 }])

--- a/packages/shared/useArrayEvery/index.test.ts
+++ b/packages/shared/useArrayEvery/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref, shallowRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 import { useArrayEvery } from './index'
 
 describe('useArrayEvery', () => {
@@ -21,7 +21,7 @@ describe('useArrayEvery', () => {
   })
 
   it('should work with reactive array', () => {
-    const list = ref([0, 2, 4, 6, 8])
+    const list = deepRef([0, 2, 4, 6, 8])
     const result = useArrayEvery(list, i => i % 2 === 0)
     expect(result.value).toBe(true)
     list.value.push(9)

--- a/packages/shared/useArrayEvery/index.test.ts
+++ b/packages/shared/useArrayEvery/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 import { useArrayEvery } from './index'
 
 describe('useArrayEvery', () => {
@@ -8,11 +8,11 @@ describe('useArrayEvery', () => {
   })
 
   it('should work with array of refs', () => {
-    const item1 = ref(0)
-    const item2 = ref(2)
-    const item3 = ref(4)
-    const item4 = ref(6)
-    const item5 = ref(8)
+    const item1 = shallowRef(0)
+    const item2 = shallowRef(2)
+    const item3 = shallowRef(4)
+    const item4 = shallowRef(6)
+    const item5 = shallowRef(8)
     const list = [item1, item2, item3, item4, item5]
     const result = useArrayEvery(list, i => i % 2 === 0)
     expect(result.value).toBe(true)

--- a/packages/shared/useArrayFilter/index.test.ts
+++ b/packages/shared/useArrayFilter/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref, shallowRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 import { useArrayFilter } from './index'
 
 describe('useArrayFilter', () => {
@@ -21,7 +21,7 @@ describe('useArrayFilter', () => {
   })
 
   it('should work with reactive array', () => {
-    const list = ref([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    const list = deepRef([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
     const result = useArrayFilter(list, i => i % 2 === 0)
     expect(result.value).toStrictEqual([0, 2, 4, 6, 8])
     list.value.shift()
@@ -29,7 +29,7 @@ describe('useArrayFilter', () => {
   })
 
   it('should allow values other than boolean in fn', () => {
-    const list = ref([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    const list = deepRef([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
     const result = useArrayFilter(list, i => i % 2)
     expect(result.value).toStrictEqual([1, 3, 5, 7, 9])
   })

--- a/packages/shared/useArrayFilter/index.test.ts
+++ b/packages/shared/useArrayFilter/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 import { useArrayFilter } from './index'
 
 describe('useArrayFilter', () => {
@@ -8,11 +8,11 @@ describe('useArrayFilter', () => {
   })
 
   it('should work with array of refs', () => {
-    const item1 = ref(0)
-    const item2 = ref(2)
-    const item3 = ref(4)
-    const item4 = ref(6)
-    const item5 = ref(8)
+    const item1 = shallowRef(0)
+    const item2 = shallowRef(2)
+    const item3 = shallowRef(4)
+    const item4 = shallowRef(6)
+    const item5 = shallowRef(8)
     const list = [item1, item2, item3, item4, item5]
     const result = useArrayFilter(list, i => i % 2 === 0)
     expect(result.value).toStrictEqual([0, 2, 4, 6, 8])

--- a/packages/shared/useArrayFind/index.test.ts
+++ b/packages/shared/useArrayFind/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { reactive, ref } from 'vue'
+import { reactive, shallowRef } from 'vue'
 import { useSetup } from '../../.test'
 import { useArrayFind } from './index'
 
@@ -10,9 +10,9 @@ describe('useArrayFind', () => {
 
   it('should find positive', () => {
     useSetup(() => {
-      const item1 = ref(1)
-      const item2 = ref(2)
-      const item3 = ref(3)
+      const item1 = shallowRef(1)
+      const item2 = shallowRef(2)
+      const item3 = shallowRef(3)
       const positive = useArrayFind([item1, item2, item3], val => val > 0)
       expect(positive.value).toBe(1)
       item1.value = -1

--- a/packages/shared/useArrayFindIndex/index.test.ts
+++ b/packages/shared/useArrayFindIndex/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 import { useArrayFindIndex } from './index'
 
 describe('useArrayFindIndex', () => {
@@ -8,11 +8,11 @@ describe('useArrayFindIndex', () => {
   })
 
   it('should work with array of refs', () => {
-    const item1 = ref(0)
-    const item2 = ref(2)
-    const item3 = ref(4)
-    const item4 = ref(6)
-    const item5 = ref(8)
+    const item1 = shallowRef(0)
+    const item2 = shallowRef(2)
+    const item3 = shallowRef(4)
+    const item4 = shallowRef(6)
+    const item5 = shallowRef(8)
     const list = [item1, item2, item3, item4, item5]
     const result = useArrayFindIndex(list, i => i % 2 === 0)
     expect(result.value).toBe(0)

--- a/packages/shared/useArrayFindIndex/index.test.ts
+++ b/packages/shared/useArrayFindIndex/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref, shallowRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 import { useArrayFindIndex } from './index'
 
 describe('useArrayFindIndex', () => {
@@ -29,7 +29,7 @@ describe('useArrayFindIndex', () => {
   })
 
   it('should work with reactive array', () => {
-    const list = ref([0, 2, 4, 6, 8])
+    const list = deepRef([0, 2, 4, 6, 8])
     const result = useArrayFindIndex(list, i => i % 2 === 0)
     expect(result.value).toBe(0)
     list.value.unshift(-1)

--- a/packages/shared/useArrayFindLast/index.test.ts
+++ b/packages/shared/useArrayFindLast/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { reactive, ref } from 'vue'
+import { reactive, shallowRef } from 'vue'
 import { useSetup } from '../../.test'
 import { useArrayFindLast } from './index'
 
@@ -10,9 +10,9 @@ describe('useArrayFindLast', () => {
 
   it('should find positive', () => {
     useSetup(() => {
-      const item1 = ref(1)
-      const item2 = ref(2)
-      const item3 = ref(3)
+      const item1 = shallowRef(1)
+      const item2 = shallowRef(2)
+      const item3 = shallowRef(3)
       const positive = useArrayFindLast([item1, item2, item3], val => val > 0)
       expect(positive.value).toBe(3)
       item3.value = -1

--- a/packages/shared/useArrayIncludes/index.test.ts
+++ b/packages/shared/useArrayIncludes/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 import { useArrayIncludes } from './index'
 
 describe('useArrayIncludes', () => {
@@ -8,7 +8,7 @@ describe('useArrayIncludes', () => {
   })
 
   it('should work with array of refs', () => {
-    const array = ref([0, 2, 4, 6])
+    const array = deepRef([0, 2, 4, 6])
     const result = useArrayIncludes(array, 8)
     expect(result.value).toBeFalsy()
     array.value.push(8)
@@ -18,7 +18,7 @@ describe('useArrayIncludes', () => {
   })
 
   it('should work with array of refs and comparator', () => {
-    const array = ref([{ id: 1 }, { id: 2 }, { id: 3 }])
+    const array = deepRef([{ id: 1 }, { id: 2 }, { id: 3 }])
     const result = useArrayIncludes(array, 3, 'id')
     expect(result.value).toBeTruthy()
     array.value.pop()
@@ -26,7 +26,7 @@ describe('useArrayIncludes', () => {
   })
 
   it('should work with array of refs and comparatorFn', () => {
-    const array = ref([{ id: 1 }, { id: 2 }, { id: 3 }])
+    const array = deepRef([{ id: 1 }, { id: 2 }, { id: 3 }])
     const result = useArrayIncludes(array, { id: 3 }, (element, value) => element.id === value.id)
     expect(result.value).toBeTruthy()
     array.value.pop()
@@ -34,7 +34,7 @@ describe('useArrayIncludes', () => {
   })
 
   it('should work with array of refs and fromIndex', () => {
-    const array = ref([{ id: 1 }, { id: 2 }, { id: 3 }])
+    const array = deepRef([{ id: 1 }, { id: 2 }, { id: 3 }])
     const result = useArrayIncludes(array, { id: 1 }, { fromIndex: 1, comparator: (element, value) => element.id === value.id })
     expect(result.value).toBeFalsy()
   })

--- a/packages/shared/useArrayJoin/index.test.ts
+++ b/packages/shared/useArrayJoin/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 import { useArrayJoin } from './index'
 
 describe('useArrayJoin', () => {
@@ -8,8 +8,8 @@ describe('useArrayJoin', () => {
   })
 
   it('should work with array of refs', () => {
-    const item1 = ref('foo')
-    const item2 = ref(0)
+    const item1 = shallowRef('foo')
+    const item2 = shallowRef(0)
     const item3 = ref({ prop: 'val' })
     const list = [item1, item2, item3]
     const result = useArrayJoin(list)

--- a/packages/shared/useArrayJoin/index.test.ts
+++ b/packages/shared/useArrayJoin/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref, shallowRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 import { useArrayJoin } from './index'
 
 describe('useArrayJoin', () => {
@@ -10,7 +10,7 @@ describe('useArrayJoin', () => {
   it('should work with array of refs', () => {
     const item1 = shallowRef('foo')
     const item2 = shallowRef(0)
-    const item3 = ref({ prop: 'val' })
+    const item3 = deepRef({ prop: 'val' })
     const list = [item1, item2, item3]
     const result = useArrayJoin(list)
     expect(result.value).toBe('foo,0,[object Object]')
@@ -19,7 +19,7 @@ describe('useArrayJoin', () => {
   })
 
   it('should work with reactive array', () => {
-    const list = ref(['string', 0, { prop: 'val' }, false, [1], [[2]], null, undefined, []])
+    const list = deepRef(['string', 0, { prop: 'val' }, false, [1], [[2]], null, undefined, []])
     const result = useArrayJoin(list)
     expect(result.value).toBe('string,0,[object Object],false,1,2,,,')
     list.value.push(true)
@@ -29,8 +29,8 @@ describe('useArrayJoin', () => {
   })
 
   it('should work with reactive separator', () => {
-    const list = ref(['string', 0, { prop: 'val' }, [1], [[2]], null, undefined, []])
-    const separator = ref()
+    const list = deepRef(['string', 0, { prop: 'val' }, [1], [[2]], null, undefined, []])
+    const separator = deepRef()
     const result = useArrayJoin(list, separator)
     expect(result.value).toBe('string,0,[object Object],1,2,,,')
     separator.value = ''

--- a/packages/shared/useArrayMap/index.test.ts
+++ b/packages/shared/useArrayMap/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 import { useArrayMap } from './index'
 
 describe('useArrayMap', () => {
@@ -8,11 +8,11 @@ describe('useArrayMap', () => {
   })
 
   it('should work with array of refs', () => {
-    const item1 = ref(0)
-    const item2 = ref(2)
-    const item3 = ref(4)
-    const item4 = ref(6)
-    const item5 = ref(8)
+    const item1 = shallowRef(0)
+    const item2 = shallowRef(2)
+    const item3 = shallowRef(4)
+    const item4 = shallowRef(6)
+    const item5 = shallowRef(8)
     const list = [item1, item2, item3, item4, item5]
     const result = useArrayMap(list, i => i * 2)
     expect(result.value).toStrictEqual([0, 4, 8, 12, 16])

--- a/packages/shared/useArrayMap/index.test.ts
+++ b/packages/shared/useArrayMap/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref, shallowRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 import { useArrayMap } from './index'
 
 describe('useArrayMap', () => {
@@ -21,7 +21,7 @@ describe('useArrayMap', () => {
   })
 
   it('should work with reactive array', () => {
-    const list = ref([0, 1, 2, 3, 4])
+    const list = deepRef([0, 1, 2, 3, 4])
     const result = useArrayMap(list, i => i * 2)
     expect(result.value).toStrictEqual([0, 2, 4, 6, 8])
     list.value.pop()
@@ -29,7 +29,7 @@ describe('useArrayMap', () => {
   })
 
   it('should match the return type of mapper function', () => {
-    const list = ref([0, 1, 2, 3])
+    const list = deepRef([0, 1, 2, 3])
     const result1 = useArrayMap(list, i => i.toString())
     result1.value.forEach(i => expect(i).toBeTypeOf('string'))
 

--- a/packages/shared/useArrayReduce/index.test.ts
+++ b/packages/shared/useArrayReduce/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { reactive, ref } from 'vue'
+import { reactive, shallowRef } from 'vue'
 import { useArrayReduce } from './index'
 
 describe('useArrayReduce', () => {
@@ -8,8 +8,8 @@ describe('useArrayReduce', () => {
   })
 
   it('should calculate the array sum', () => {
-    const item1 = ref(1)
-    const item2 = ref(2)
+    const item1 = shallowRef(1)
+    const item2 = shallowRef(2)
     const sum = useArrayReduce([item1, item2, 3], (a, b) => a + b)
     expect(sum.value).toBe(6)
 

--- a/packages/shared/useArraySome/index.test.ts
+++ b/packages/shared/useArraySome/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref, shallowRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 import { useArraySome } from './index'
 
 describe('useArraySome', () => {
@@ -21,7 +21,7 @@ describe('useArraySome', () => {
   })
 
   it('should work with reactive array', () => {
-    const list = ref([0, 2, 4, 6, 8])
+    const list = deepRef([0, 2, 4, 6, 8])
     const result = useArraySome(list, i => i > 10)
     expect(result.value).toBe(false)
     list.value.push(11)

--- a/packages/shared/useArraySome/index.test.ts
+++ b/packages/shared/useArraySome/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 import { useArraySome } from './index'
 
 describe('useArraySome', () => {
@@ -8,11 +8,11 @@ describe('useArraySome', () => {
   })
 
   it('should work with array of refs', () => {
-    const item1 = ref(0)
-    const item2 = ref(2)
-    const item3 = ref(4)
-    const item4 = ref(6)
-    const item5 = ref(8)
+    const item1 = shallowRef(0)
+    const item2 = shallowRef(2)
+    const item3 = shallowRef(4)
+    const item4 = shallowRef(6)
+    const item5 = shallowRef(8)
     const list = [item1, item2, item3, item4, item5]
     const result = useArraySome(list, i => i > 10)
     expect(result.value).toBe(false)

--- a/packages/shared/useArrayUnique/index.test.ts
+++ b/packages/shared/useArrayUnique/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { reactive, ref, shallowRef } from 'vue'
+import { ref as deepRef, reactive, shallowRef } from 'vue'
 import { useArrayUnique } from './index'
 
 describe('useArrayUnique', () => {
@@ -21,7 +21,7 @@ describe('useArrayUnique', () => {
   })
 
   it('should work with ref array', () => {
-    const list = ref([1, 2, 2, 3])
+    const list = deepRef([1, 2, 2, 3])
     const result = useArrayUnique(list)
     expect(result.value.length).toBe(3)
     list.value.push(1)

--- a/packages/shared/useArrayUnique/index.test.ts
+++ b/packages/shared/useArrayUnique/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { reactive, ref } from 'vue'
+import { reactive, ref, shallowRef } from 'vue'
 import { useArrayUnique } from './index'
 
 describe('useArrayUnique', () => {
@@ -8,11 +8,11 @@ describe('useArrayUnique', () => {
   })
 
   it('should work with array of refs', () => {
-    const item1 = ref(0)
-    const item2 = ref(1)
-    const item3 = ref(1)
-    const item4 = ref(2)
-    const item5 = ref(3)
+    const item1 = shallowRef(0)
+    const item2 = shallowRef(1)
+    const item3 = shallowRef(1)
+    const item4 = shallowRef(2)
+    const item5 = shallowRef(3)
     const list = [item1, item2, item3, item4, item5]
     const result = useArrayUnique(list)
     expect(result.value.length).toBe(4)

--- a/packages/shared/useCounter/index.test.ts
+++ b/packages/shared/useCounter/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 import { useCounter } from './index'
 
 describe('useCounter', () => {
@@ -45,7 +45,7 @@ describe('useCounter', () => {
   })
 
   it('should be update initial & counter', () => {
-    const initial = ref(0)
+    const initial = shallowRef(0)
     const { count, inc, dec, get, set, reset } = useCounter(initial)
 
     expect(count.value).toBe(0)

--- a/packages/shared/useCounter/index.ts
+++ b/packages/shared/useCounter/index.ts
@@ -1,6 +1,9 @@
 import type { MaybeRef } from '../utils'
-// eslint-disable-next-line no-restricted-imports
-import { ref, unref } from 'vue'
+import {
+  ref as deepRef,
+  // eslint-disable-next-line no-restricted-imports
+  unref,
+} from 'vue'
 
 export interface UseCounterOptions {
   min?: number
@@ -16,7 +19,7 @@ export interface UseCounterOptions {
  */
 export function useCounter(initialValue: MaybeRef<number> = 0, options: UseCounterOptions = {}) {
   let _initialValue = unref(initialValue)
-  const count = ref(initialValue)
+  const count = deepRef(initialValue)
 
   const {
     max = Number.POSITIVE_INFINITY,

--- a/packages/shared/useDateFormat/demo.vue
+++ b/packages/shared/useDateFormat/demo.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { useDateFormat, useNow } from '@vueuse/core'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 
-const formatter = ref('dddd YYYY-MM-DD HH:mm:ss')
-const lang = ref('en-US')
+const formatter = shallowRef('dddd YYYY-MM-DD HH:mm:ss')
+const lang = shallowRef('en-US')
 const formatted = useDateFormat(useNow(), formatter, { locales: lang })
 </script>
 

--- a/packages/shared/useDebounceFn/demo.vue
+++ b/packages/shared/useDebounceFn/demo.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { useDebounceFn } from '@vueuse/core'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 
-const updated = ref(0)
-const clicked = ref(0)
+const updated = shallowRef(0)
+const clicked = shallowRef(0)
 const debouncedFn = useDebounceFn(() => {
   updated.value += 1
 }, 1000, { maxWait: 5000 })

--- a/packages/shared/useInterval/index.ts
+++ b/packages/shared/useInterval/index.ts
@@ -1,6 +1,6 @@
 import type { Ref } from 'vue'
 import type { MaybeRefOrGetter, Pausable } from '../utils'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 import { useIntervalFn } from '../useIntervalFn'
 
 export interface UseIntervalOptions<Controls extends boolean> {
@@ -45,7 +45,7 @@ export function useInterval(interval: MaybeRefOrGetter<number> = 1000, options: 
     callback,
   } = options
 
-  const counter = ref(0)
+  const counter = shallowRef(0)
   const update = () => counter.value += 1
   const reset = () => {
     counter.value = 0

--- a/packages/shared/useIntervalFn/demo.vue
+++ b/packages/shared/useIntervalFn/demo.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import { useIntervalFn } from '@vueuse/core'
 import { rand } from '@vueuse/shared'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 
 const greetings = ['Hello', 'Hi', 'Yo!', 'Hey', 'Hola', 'こんにちは', 'Bonjour', 'Salut!', '你好', 'Привет']
-const word = ref('Hello')
-const interval = ref(500)
+const word = shallowRef('Hello')
+const interval = shallowRef(500)
 
 const { pause, resume, isActive } = useIntervalFn(() => {
   word.value = greetings[rand(0, greetings.length - 1)]

--- a/packages/shared/useIntervalFn/index.test.ts
+++ b/packages/shared/useIntervalFn/index.test.ts
@@ -1,6 +1,6 @@
 import type { Pausable } from '../utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { effectScope, nextTick, ref } from 'vue'
+import { effectScope, nextTick, shallowRef } from 'vue'
 import { useIntervalFn } from './index'
 
 describe('useIntervalFn', () => {
@@ -57,7 +57,7 @@ describe('useIntervalFn', () => {
 
     callback = vi.fn()
 
-    const interval = ref(50)
+    const interval = shallowRef(50)
     await exec(useIntervalFn(callback, interval))
 
     callback.mockClear()
@@ -71,7 +71,7 @@ describe('useIntervalFn', () => {
 
     callback = vi.fn()
 
-    const interval = ref(50)
+    const interval = shallowRef(50)
     await execImmediateCallback(useIntervalFn(callback, interval, { immediateCallback: true }))
 
     callback.mockClear()

--- a/packages/shared/useIntervalFn/index.ts
+++ b/packages/shared/useIntervalFn/index.ts
@@ -1,5 +1,5 @@
 import type { Fn, MaybeRefOrGetter, Pausable } from '../utils'
-import { isRef, ref, toValue, watch } from 'vue'
+import { isRef, shallowRef, toValue, watch } from 'vue'
 import { tryOnScopeDispose } from '../tryOnScopeDispose'
 import { isClient } from '../utils'
 
@@ -33,7 +33,7 @@ export function useIntervalFn(cb: Fn, interval: MaybeRefOrGetter<number> = 1000,
   } = options
 
   let timer: ReturnType<typeof setInterval> | null = null
-  const isActive = ref(false)
+  const isActive = shallowRef(false)
 
   function clean() {
     if (timer) {

--- a/packages/shared/useLastChanged/demo.vue
+++ b/packages/shared/useLastChanged/demo.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { timestamp, useLastChanged, useTimeAgo } from '@vueuse/core'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 
-const input = ref('')
+const input = shallowRef('')
 const ms = useLastChanged(input, { initialValue: timestamp() - 1000 * 60 * 5 })
 const timeago = useTimeAgo(ms)
 </script>

--- a/packages/shared/useLastChanged/index.ts
+++ b/packages/shared/useLastChanged/index.ts
@@ -1,5 +1,5 @@
 import type { Ref, WatchOptions, WatchSource } from 'vue'
-import { ref, watch } from 'vue'
+import { ref as deepRef, watch } from 'vue'
 import { timestamp } from '../utils'
 
 export interface UseLastChangedOptions<
@@ -17,7 +17,7 @@ export interface UseLastChangedOptions<
 export function useLastChanged(source: WatchSource, options?: UseLastChangedOptions<false>): Ref<number | null>
 export function useLastChanged(source: WatchSource, options: UseLastChangedOptions<true> | UseLastChangedOptions<boolean, number>): Ref<number>
 export function useLastChanged(source: WatchSource, options: UseLastChangedOptions<boolean, any> = {}): Ref<number | null> | Ref<number> {
-  const ms = ref<number | null>(options.initialValue ?? null)
+  const ms = deepRef<number | null>(options.initialValue ?? null)
 
   watch(
     source,

--- a/packages/shared/useThrottleFn/demo.vue
+++ b/packages/shared/useThrottleFn/demo.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { useThrottleFn } from '@vueuse/core'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 
-const updated = ref(0)
-const clicked = ref(0)
+const updated = shallowRef(0)
+const clicked = shallowRef(0)
 const throttledFn = useThrottleFn(() => {
   updated.value += 1
 }, 1000)

--- a/packages/shared/useTimeout/index.test.ts
+++ b/packages/shared/useTimeout/index.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 import { useTimeout } from './index'
 
 describe('useTimeout', () => {
@@ -21,7 +21,7 @@ describe('useTimeout', () => {
   })
 
   it('works with ref target', () => {
-    const interval = ref(10)
+    const interval = shallowRef(10)
     const ready = useTimeout(interval)
     expect(ready.value).toEqual(false)
     vi.advanceTimersByTime(10)
@@ -29,7 +29,7 @@ describe('useTimeout', () => {
   })
 
   it('works with controls and ref target', () => {
-    const interval = ref(10)
+    const interval = shallowRef(10)
     const { ready } = useTimeout(interval, { controls: true })
     expect(ready.value).toEqual(false)
     vi.advanceTimersByTime(10)

--- a/packages/shared/useTimeoutFn/demo.vue
+++ b/packages/shared/useTimeoutFn/demo.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { useTimeoutFn } from '@vueuse/core'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 
 const defaultText = 'Please wait for 3 seconds'
-const text = ref(defaultText)
+const text = deepRef(defaultText)
 const { start, isPending } = useTimeoutFn(() => {
   text.value = 'Fired!'
 }, 3000)

--- a/packages/shared/useTimeoutFn/index.test.ts
+++ b/packages/shared/useTimeoutFn/index.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 import { useTimeoutFn } from './index'
 
 describe('useTimeoutFn', () => {
@@ -9,7 +9,7 @@ describe('useTimeoutFn', () => {
 
   it('basic start/stop', async () => {
     const callback = vi.fn()
-    const interval = ref(0)
+    const interval = shallowRef(0)
     const { start } = useTimeoutFn(callback, interval)
 
     vi.advanceTimersByTime(1)

--- a/packages/shared/useTimeoutFn/index.ts
+++ b/packages/shared/useTimeoutFn/index.ts
@@ -1,5 +1,5 @@
 import type { AnyFn, MaybeRefOrGetter, Stoppable } from '../utils'
-import { readonly, ref, toValue } from 'vue'
+import { readonly, shallowRef, toValue } from 'vue'
 import { tryOnScopeDispose } from '../tryOnScopeDispose'
 import { isClient } from '../utils'
 
@@ -36,7 +36,7 @@ export function useTimeoutFn<CallbackFn extends AnyFn>(
     immediateCallback = false,
   } = options
 
-  const isPending = ref(false)
+  const isPending = shallowRef(false)
 
   let timer: ReturnType<typeof setTimeout> | null = null
 

--- a/packages/shared/useToNumber/index.test.ts
+++ b/packages/shared/useToNumber/index.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 import { useToNumber } from './index'
 
 describe('useToNumber', () => {
   it('default', () => {
-    const value = ref<string | number>('123.345')
+    const value = shallowRef<string | number>('123.345')
     const float = useToNumber(value)
     const int = useToNumber(value, { method: 'parseInt' })
 
@@ -28,20 +28,20 @@ describe('useToNumber', () => {
   })
 
   it('radix', () => {
-    const value = ref<string | number>('0xFA')
+    const value = shallowRef<string | number>('0xFA')
     const int = useToNumber(value, { method: 'parseInt', radix: 16 })
 
     expect(int.value).toBe(250)
   })
 
   it('nanToZero', () => {
-    const value = ref<string | number>('Hi')
+    const value = shallowRef<string | number>('Hi')
     const float = useToNumber(value, { nanToZero: true })
     expect(float.value).toBe(0)
   })
 
   it('custom method function', () => {
-    const value = ref<string | number>(`${Number.MAX_SAFE_INTEGER}1`)
+    const value = shallowRef<string | number>(`${Number.MAX_SAFE_INTEGER}1`)
     let warn = ''
     const warnFn = vi.fn(str => warn = str)
     const result = useToNumber(value, { method: (v) => {

--- a/packages/shared/useToString/index.test.ts
+++ b/packages/shared/useToString/index.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { ref as deepRef } from 'vue'
 import { useToString } from './index'
 
 describe('useToString', () => {
   it('default', () => {
-    const value = ref<any>(123.345)
+    const value = deepRef<any>(123.345)
     const str = useToString(value)
 
     expect(str.value).toBe('123.345')

--- a/packages/shared/useToggle/index.test.ts
+++ b/packages/shared/useToggle/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isRef, ref, toValue } from 'vue'
+import { isRef, shallowRef, toValue } from 'vue'
 import { useToggle } from './index'
 
 describe('useToggle', () => {
@@ -54,7 +54,7 @@ describe('useToggle', () => {
   })
 
   it('ref initialValue', () => {
-    const isDark = ref(true)
+    const isDark = shallowRef(true)
     const toggle = useToggle(isDark)
 
     expect(typeof toggle).toBe('function')
@@ -73,7 +73,7 @@ describe('useToggle', () => {
   })
 
   it('should toggle with truthy & falsy', () => {
-    const status = ref('ON')
+    const status = shallowRef('ON')
     const toggle = useToggle(status, {
       truthyValue: 'ON',
       falsyValue: 'OFF',

--- a/packages/shared/useToggle/index.ts
+++ b/packages/shared/useToggle/index.ts
@@ -1,6 +1,6 @@
 import type { Ref } from 'vue'
 import type { MaybeRef, MaybeRefOrGetter } from '../utils'
-import { isRef, ref, toValue } from 'vue'
+import { ref as deepRef, isRef, toValue } from 'vue'
 
 export interface UseToggleOptions<Truthy, Falsy> {
   truthyValue?: MaybeRefOrGetter<Truthy>
@@ -26,7 +26,7 @@ export function useToggle(
   } = options
 
   const valueIsRef = isRef(initialValue)
-  const _value = ref(initialValue) as Ref<boolean>
+  const _value = deepRef(initialValue) as Ref<boolean>
 
   function toggle(value?: boolean) {
     // has arguments

--- a/packages/shared/utils/index.test.ts
+++ b/packages/shared/utils/index.test.ts
@@ -1,6 +1,6 @@
 import type { MockInstance } from 'vitest'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 import {
   assert,
   clamp,
@@ -52,7 +52,7 @@ describe('utils', () => {
 
 describe('promise', () => {
   it('should promiseTimeout work', async () => {
-    const num = ref(0)
+    const num = shallowRef(0)
     setTimeout(() => {
       num.value = 1
     }, 100)
@@ -143,7 +143,7 @@ describe('filters', () => {
 
     it('should debounce with ref', () => {
       const debouncedFilterSpy = vi.fn()
-      const debounceTime = ref(0)
+      const debounceTime = shallowRef(0)
       const filter = createFilterWrapper(debounceFilter(debounceTime), debouncedFilterSpy)
 
       filter()
@@ -190,7 +190,7 @@ describe('filters', () => {
 
     it('should throttle with ref', () => {
       const debouncedFilterSpy = vi.fn()
-      const throttle = ref(0)
+      const throttle = shallowRef(0)
       const filter = createFilterWrapper(throttleFilter(throttle), debouncedFilterSpy)
 
       filter()
@@ -405,7 +405,7 @@ describe('optionsFilters', () => {
 
   it('optionsThrottleFilter should throttle with ref', () => {
     const debouncedFilterSpy = vi.fn()
-    const throttle = ref(0)
+    const throttle = shallowRef(0)
     const filter = createFilterWrapper(throttleFilter(throttle), debouncedFilterSpy)
 
     filter()

--- a/packages/shared/watchArray/index.test.ts
+++ b/packages/shared/watchArray/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { nextTick, reactive, ref } from 'vue'
+import { ref as deepRef, nextTick, reactive } from 'vue'
 import { watchArray } from './index'
 
 describe('watchArray', () => {
@@ -11,7 +11,7 @@ describe('watchArray', () => {
       expect(removed).toEqual([2, 3])
     })
 
-    const num = ref([1, 2, 3])
+    const num = deepRef([1, 2, 3])
     watchArray(num, spy)
     num.value = [1, 1, 4]
     await nextTick()
@@ -26,7 +26,7 @@ describe('watchArray', () => {
       expect(removed).toEqual([])
     })
 
-    const num = ref([1, 2, 3])
+    const num = deepRef([1, 2, 3])
     watchArray(num, spy)
     num.value = [1, 2, 3]
     await nextTick()
@@ -41,7 +41,7 @@ describe('watchArray', () => {
       expect(removed).toEqual([])
     })
 
-    const num = ref([1, 2, 3])
+    const num = deepRef([1, 2, 3])
     watchArray(num, spy, { deep: true })
     num.value.push(4)
     await nextTick()
@@ -56,7 +56,7 @@ describe('watchArray', () => {
       expect(removed).toEqual([2])
     })
 
-    const num = ref([1, 2, 3])
+    const num = deepRef([1, 2, 3])
     watchArray(num, spy, { deep: true })
     num.value.splice(1, 1, 5, 6, 7)
     await nextTick()
@@ -86,7 +86,7 @@ describe('watchArray', () => {
       expect(removed).toEqual([])
     })
 
-    const num = ref([1, 2, 3])
+    const num = deepRef([1, 2, 3])
     watchArray(() => num.value, spy)
     num.value = [...num.value, 4]
     await nextTick()
@@ -96,7 +96,7 @@ describe('watchArray', () => {
   it('should work when immediate is true', async () => {
     const spy = vi.fn()
 
-    const num = ref([1, 2, 3])
+    const num = deepRef([1, 2, 3])
     watchArray(() => num.value, spy, { immediate: true })
     expect(spy).toHaveBeenCalledWith([1, 2, 3], [], [1, 2, 3], [], expect.anything())
     num.value = [1, 2, 3, 4]

--- a/packages/shared/watchAtMost/index.test.ts
+++ b/packages/shared/watchAtMost/index.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
-import { nextTick, ref } from 'vue'
+import { nextTick, shallowRef } from 'vue'
 import { watchAtMost } from './index'
 
 describe('watchAtMost', () => {
   it('should work', async () => {
-    const num = ref(0)
+    const num = shallowRef(0)
     const spy = vi.fn()
 
     const { count } = watchAtMost(num, spy, {

--- a/packages/shared/watchAtMost/index.ts
+++ b/packages/shared/watchAtMost/index.ts
@@ -1,7 +1,7 @@
 import type { Ref, WatchCallback, WatchSource, WatchStopHandle } from 'vue'
 import type { MapOldSources, MapSources, MaybeRefOrGetter } from '../utils'
 import type { WatchWithFilterOptions } from '../watchWithFilter'
-import { nextTick, ref, toValue } from 'vue'
+import { nextTick, shallowRef, toValue } from 'vue'
 import { watchWithFilter } from '../watchWithFilter'
 
 export interface WatchAtMostOptions<Immediate> extends WatchWithFilterOptions<Immediate> {
@@ -29,7 +29,7 @@ export function watchAtMost<Immediate extends Readonly<boolean> = false>(
     ...watchOptions
   } = options
 
-  const current = ref(0)
+  const current = shallowRef(0)
 
   const stop = watchWithFilter(
     source,

--- a/packages/shared/watchDebounced/demo.vue
+++ b/packages/shared/watchDebounced/demo.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { watchDebounced } from '@vueuse/core'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 
-const input = ref('')
-const updated = ref(0)
+const input = shallowRef('')
+const updated = shallowRef(0)
 
 watchDebounced(input, () => {
   updated.value += 1

--- a/packages/shared/watchDebounced/index.test.ts
+++ b/packages/shared/watchDebounced/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { nextTick, ref } from 'vue'
+import { nextTick, shallowRef } from 'vue'
 import { debouncedWatch, watchDebounced } from './index'
 
 describe('watchDebounced', () => {
@@ -9,7 +9,7 @@ describe('watchDebounced', () => {
   })
 
   it('should work by default', async () => {
-    const num = ref(0)
+    const num = shallowRef(0)
     const cb = vi.fn()
     watchDebounced(num, cb)
 
@@ -20,7 +20,7 @@ describe('watchDebounced', () => {
 
   it('should work when set debounce and maxWait', async () => {
     vi.useFakeTimers()
-    const num = ref(0)
+    const num = shallowRef(0)
     const cb = vi.fn()
     watchDebounced(num, cb, { debounce: 100, maxWait: 150 })
 
@@ -47,7 +47,7 @@ describe('watchDebounced', () => {
 
   it('should work with constant changes over multiple maxWaits', async () => {
     vi.useFakeTimers()
-    const num = ref(0)
+    const num = shallowRef(0)
     const cb = vi.fn()
 
     const constantUpdateOverTime = async (ms: number) => {

--- a/packages/shared/watchDeep/index.test.ts
+++ b/packages/shared/watchDeep/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { nextTick, ref } from 'vue'
+import { ref as deepRef, nextTick } from 'vue'
 import { watchDeep } from './index'
 
 describe('watchDeep', () => {
@@ -8,7 +8,7 @@ describe('watchDeep', () => {
       expect(objectUpdate).toEqual({ foo: { bar: { deep: 10 } } })
     })
 
-    const obj = ref({ foo: { bar: { deep: 5 } } })
+    const obj = deepRef({ foo: { bar: { deep: 5 } } })
     watchDeep(obj, spy)
     obj.value.foo.bar.deep = 10
     await nextTick()

--- a/packages/shared/watchIgnorable/demo.vue
+++ b/packages/shared/watchIgnorable/demo.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { watchIgnorable } from '@vueuse/core'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 
-const log = ref('')
-const source = ref(0)
+const log = shallowRef('')
+const source = shallowRef(0)
 
 const { ignoreUpdates } = watchIgnorable(
   source,

--- a/packages/shared/watchIgnorable/index.test.ts
+++ b/packages/shared/watchIgnorable/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { nextTick, ref } from 'vue'
+import { nextTick, shallowRef } from 'vue'
 import { ignorableWatch, watchIgnorable } from './index'
 
 describe('watchIgnorable', () => {
@@ -9,8 +9,8 @@ describe('watchIgnorable', () => {
   })
 
   it('ignore async updates', async () => {
-    const source = ref(0)
-    const target = ref(0)
+    const source = shallowRef(0)
+    const target = shallowRef(0)
     const { ignoreUpdates } = watchIgnorable(source, value => target.value = value)
 
     source.value = 1
@@ -36,8 +36,8 @@ describe('watchIgnorable', () => {
   })
 
   it('ignore prev async updates', async () => {
-    const source = ref(0)
-    const target = ref(0)
+    const source = shallowRef(0)
+    const target = shallowRef(0)
     const { ignorePrevAsyncUpdates } = watchIgnorable(source, value => target.value = value)
 
     source.value = 1
@@ -61,8 +61,8 @@ describe('watchIgnorable', () => {
   })
 
   it('ignore sync updates', () => {
-    const source = ref(0)
-    const target = ref(0)
+    const source = shallowRef(0)
+    const target = shallowRef(0)
     const { ignoreUpdates, ignorePrevAsyncUpdates } = watchIgnorable(source, value => target.value = value, { flush: 'sync' })
 
     source.value = 1
@@ -88,7 +88,7 @@ describe('watchIgnorable', () => {
   })
 
   it('stop watch', async () => {
-    const source = ref(0)
+    const source = shallowRef(0)
     const callback = vi.fn()
     const { stop } = watchIgnorable(source, callback)
 

--- a/packages/shared/watchIgnorable/index.ts
+++ b/packages/shared/watchIgnorable/index.ts
@@ -1,7 +1,7 @@
 import type { WatchCallback, WatchSource, WatchStopHandle } from 'vue'
 import type { Fn, MapOldSources, MapSources } from '../utils'
 import type { WatchWithFilterOptions } from '../watchWithFilter'
-import { ref, watch } from 'vue'
+import { shallowRef, watch } from 'vue'
 import { bypassFilter, createFilterWrapper } from '../utils'
 
 // watchIgnorable(source,callback,options) composable
@@ -40,7 +40,7 @@ export function watchIgnorable<Immediate extends Readonly<boolean> = false>(
   let stop: () => void
 
   if (watchOptions.flush === 'sync') {
-    const ignore = ref(false)
+    const ignore = shallowRef(false)
 
     // no op for flush: sync
     ignorePrevAsyncUpdates = () => {}
@@ -76,8 +76,8 @@ export function watchIgnorable<Immediate extends Readonly<boolean> = false>(
     // are more sync triggers than the ignore count, the we now
     // there are modifications in the source ref value that we
     // need to commit
-    const ignoreCounter = ref(0)
-    const syncCounter = ref(0)
+    const ignoreCounter = shallowRef(0)
+    const syncCounter = shallowRef(0)
 
     ignorePrevAsyncUpdates = () => {
       ignoreCounter.value = syncCounter.value

--- a/packages/shared/watchImmediate/index.test.ts
+++ b/packages/shared/watchImmediate/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { nextTick, ref } from 'vue'
+import { nextTick, shallowRef } from 'vue'
 import { watchImmediate } from './index'
 
 describe('watchImmediate', () => {
@@ -15,7 +15,7 @@ describe('watchImmediate', () => {
       currentRun++
     })
 
-    const obj = ref('vue-use')
+    const obj = shallowRef('vue-use')
     watchImmediate(obj, spy)
     obj.value = 'VueUse'
     await nextTick()

--- a/packages/shared/watchOnce/index.test.ts
+++ b/packages/shared/watchOnce/index.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
-import { nextTick, ref } from 'vue'
+import { nextTick, shallowRef } from 'vue'
 import { watchOnce } from './index'
 
 describe('watchOnce', () => {
   it('should work', async () => {
-    const num = ref(0)
+    const num = shallowRef(0)
     const spy = vi.fn()
 
     watchOnce(num, spy)

--- a/packages/shared/watchPausable/demo.vue
+++ b/packages/shared/watchPausable/demo.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import { onStartTyping, watchPausable } from '@vueuse/core'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 
-const input = ref<HTMLInputElement | null>()
-const log = ref('')
+const input = shallowRef<HTMLInputElement | null>()
+const log = shallowRef('')
 
-const source = ref('')
+const source = shallowRef('')
 
 const watcher = watchPausable(
   source,

--- a/packages/shared/watchPausable/index.test.ts
+++ b/packages/shared/watchPausable/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { nextTick, ref } from 'vue'
+import { nextTick, shallowRef } from 'vue'
 import { pausableWatch, watchPausable } from './index'
 
 describe('watchPausable', () => {
@@ -9,7 +9,7 @@ describe('watchPausable', () => {
   })
 
   it('should work', async () => {
-    const num = ref(0)
+    const num = shallowRef(0)
     const cb = vi.fn()
     const { stop, pause, resume, isActive } = watchPausable(num, cb)
 
@@ -38,7 +38,7 @@ describe('watchPausable', () => {
   })
 
   it('should work with initialState "paused"', async () => {
-    const num = ref(0)
+    const num = shallowRef(0)
     const cb = vi.fn()
     const { resume, isActive } = watchPausable(num, cb, { initialState: 'paused' })
 

--- a/packages/shared/watchThrottled/demo.vue
+++ b/packages/shared/watchThrottled/demo.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { watchThrottled } from '@vueuse/core'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 
-const input = ref('')
-const updated = ref(0)
+const input = shallowRef('')
+const updated = shallowRef(0)
 
 watchThrottled(input, () => {
   updated.value += 1

--- a/packages/shared/watchThrottled/index.test.ts
+++ b/packages/shared/watchThrottled/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { nextTick, ref } from 'vue'
+import { nextTick, shallowRef } from 'vue'
 import { throttledWatch, watchThrottled } from './index'
 
 describe('watchThrottled', () => {
@@ -10,7 +10,7 @@ describe('watchThrottled', () => {
 
   it('should work', async () => {
     vi.useFakeTimers()
-    const num = ref(0)
+    const num = shallowRef(0)
     const cb = vi.fn()
     watchThrottled(num, cb, { throttle: 100 })
 

--- a/packages/shared/watchTriggerable/demo.vue
+++ b/packages/shared/watchTriggerable/demo.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { watchTriggerable } from '@vueuse/core'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 
-const log = ref('')
-const source = ref(0)
+const log = shallowRef('')
+const source = shallowRef(0)
 
 const { trigger, ignoreUpdates } = watchTriggerable(
   source,

--- a/packages/shared/watchTriggerable/index.test.ts
+++ b/packages/shared/watchTriggerable/index.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { nextTick, reactive, ref } from 'vue'
+import { nextTick, reactive, ref, shallowRef } from 'vue'
 import { watchTriggerable } from './index'
 
 describe('watchTriggerable', () => {
   it('this should work', async () => {
-    const source = ref(0)
-    const effect = ref(0)
+    const source = shallowRef(0)
+    const effect = shallowRef(0)
     let cleanupCount = -1
     const { trigger } = watchTriggerable(source, (value, oldValue, onCleanup) => {
       onCleanup(() => {
@@ -36,10 +36,10 @@ describe('watchTriggerable', () => {
   })
 
   it('source array', async () => {
-    const source1 = ref(0)
+    const source1 = shallowRef(0)
     const source2 = reactive({ a: 'a' })
     const effect1 = ref(-1)
-    const effect2 = ref('z')
+    const effect2 = shallowRef('z')
     let cleanupCount = -1
     const { trigger } = watchTriggerable([source1, () => source2.a], ([value1, value2], _, onCleanup) => {
       onCleanup(() => {
@@ -65,7 +65,7 @@ describe('watchTriggerable', () => {
 
   it('source reactive object', async () => {
     const source = reactive({ a: 'a' })
-    const effect = ref('')
+    const effect = shallowRef('')
     let cleanupCount = 0
     const { trigger } = watchTriggerable(source, (value, old, onCleanup) => {
       onCleanup(() => {
@@ -86,8 +86,8 @@ describe('watchTriggerable', () => {
   })
 
   it('trigger should await', async () => {
-    const source = ref(1)
-    const effect = ref(0)
+    const source = shallowRef(1)
+    const effect = shallowRef(0)
     const { trigger } = watchTriggerable(source, async (value) => {
       await new Promise(resolve => setTimeout(resolve, 10))
       effect.value = value

--- a/packages/shared/watchTriggerable/index.test.ts
+++ b/packages/shared/watchTriggerable/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { nextTick, reactive, ref, shallowRef } from 'vue'
+import { ref as deepRef, nextTick, reactive, shallowRef } from 'vue'
 import { watchTriggerable } from './index'
 
 describe('watchTriggerable', () => {
@@ -38,7 +38,7 @@ describe('watchTriggerable', () => {
   it('source array', async () => {
     const source1 = shallowRef(0)
     const source2 = reactive({ a: 'a' })
-    const effect1 = ref(-1)
+    const effect1 = deepRef(-1)
     const effect2 = shallowRef('z')
     let cleanupCount = -1
     const { trigger } = watchTriggerable([source1, () => source2.a], ([value1, value2], _, onCleanup) => {

--- a/packages/shared/whenever/index.test.ts
+++ b/packages/shared/whenever/index.test.ts
@@ -1,6 +1,6 @@
 import type { Ref } from 'vue'
 import { describe, expect, it } from 'vitest'
-import { nextTick, ref, shallowRef, toValue } from 'vue'
+import { ref as deepRef, nextTick, shallowRef, toValue } from 'vue'
 import { useSetup } from '../../.test'
 import { whenever } from './index'
 
@@ -10,10 +10,10 @@ describe('whenever', () => {
   it('ignore falsy state change', async () => {
     // use a component to simulate normal use case
     const vm = useSetup(() => {
-      const number = ref<number | null | undefined>(1)
+      const number = deepRef<number | null | undefined>(1)
       const changeNumber = (v: number) => number.value = v
       const watchCount = shallowRef(0)
-      const watchValue: Ref<number | undefined> = ref()
+      const watchValue: Ref<number | undefined> = deepRef()
 
       whenever(number, (value) => {
         watchCount.value += 1
@@ -59,9 +59,9 @@ describe('whenever', () => {
 
   it('once', async () => {
     const vm = useSetup(() => {
-      const number = ref<number | null | undefined>(1)
+      const number = deepRef<number | null | undefined>(1)
       const watchCount = shallowRef(0)
-      const watchValue: Ref<number | undefined> = ref()
+      const watchValue: Ref<number | undefined> = deepRef()
 
       whenever(number, (value) => {
         watchCount.value += 1

--- a/packages/shared/whenever/index.test.ts
+++ b/packages/shared/whenever/index.test.ts
@@ -1,6 +1,6 @@
 import type { Ref } from 'vue'
 import { describe, expect, it } from 'vitest'
-import { nextTick, ref, toValue } from 'vue'
+import { nextTick, ref, shallowRef, toValue } from 'vue'
 import { useSetup } from '../../.test'
 import { whenever } from './index'
 
@@ -12,7 +12,7 @@ describe('whenever', () => {
     const vm = useSetup(() => {
       const number = ref<number | null | undefined>(1)
       const changeNumber = (v: number) => number.value = v
-      const watchCount = ref(0)
+      const watchCount = shallowRef(0)
       const watchValue: Ref<number | undefined> = ref()
 
       whenever(number, (value) => {
@@ -60,7 +60,7 @@ describe('whenever', () => {
   it('once', async () => {
     const vm = useSetup(() => {
       const number = ref<number | null | undefined>(1)
-      const watchCount = ref(0)
+      const watchCount = shallowRef(0)
       const watchValue: Ref<number | undefined> = ref()
 
       whenever(number, (value) => {

--- a/playgrounds/nuxt/app.vue
+++ b/playgrounds/nuxt/app.vue
@@ -2,7 +2,7 @@
 import { useColorMode, useWindowSize } from '@vueuse/core'
 import { onMounted, reactive, ref } from 'vue'
 
-const mounted = ref(false)
+const mounted = shallowRef(false)
 const { width, height } = useWindowSize()
 const color = useColorMode()
 

--- a/playgrounds/nuxt/app.vue
+++ b/playgrounds/nuxt/app.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useColorMode, useWindowSize } from '@vueuse/core'
-import { onMounted, reactive, ref } from 'vue'
+import { onMounted, reactive, shallowRef } from 'vue'
 
 const mounted = shallowRef(false)
 const { width, height } = useWindowSize()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -378,6 +378,9 @@ importers:
       eslint:
         specifier: ^9.20.1
         version: 9.20.1(jiti@2.4.2)
+      eslint-factory:
+        specifier: ^0.1.2
+        version: 0.1.2(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3)
       eslint-plugin-format:
         specifier: 'catalog:'
         version: 1.0.1(eslint@9.20.1(jiti@2.4.2))
@@ -4404,6 +4407,11 @@ packages:
 
   eslint-config-flat-gitignore@2.0.0:
     resolution: {integrity: sha512-9iH+DZO94uxsw5iFjzqa9GfahA5oK3nA1GoJK/6u8evAtooYJMwuSWiLcGDfrdLoqdQ5/kqFJKKuMY/+SAasvg==}
+    peerDependencies:
+      eslint: ^9.20.1
+
+  eslint-factory@0.1.2:
+    resolution: {integrity: sha512-0APUA89aVVxJ0BnP84Wbg1dx9co9ZixotdKjO0S0jz6uq51ev2JBNXpeu5do9oasEc9dn+v7wywUA2WBbmB/RA==}
     peerDependencies:
       eslint: ^9.20.1
 
@@ -12433,6 +12441,14 @@ snapshots:
     dependencies:
       '@eslint/compat': 1.2.5(eslint@9.20.1(jiti@2.4.2))
       eslint: 9.20.1(jiti@2.4.2)
+
+  eslint-factory@0.1.2(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3):
+    dependencies:
+      '@typescript-eslint/utils': 8.24.0(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3)
+      eslint: 9.20.1(jiti@2.4.2)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   eslint-flat-config-utils@2.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -381,6 +381,9 @@ importers:
       eslint-plugin-format:
         specifier: 'catalog:'
         version: 1.0.1(eslint@9.20.1(jiti@2.4.2))
+      eslint-plugin-unimport:
+        specifier: ^0.1.2
+        version: 0.1.2(eslint@9.20.1(jiti@2.4.2))(rollup@4.34.6)(typescript@5.7.3)
       export-size:
         specifier: 'catalog:'
         version: 0.7.0
@@ -4504,6 +4507,11 @@ packages:
   eslint-plugin-unicorn@56.0.1:
     resolution: {integrity: sha512-FwVV0Uwf8XPfVnKSGpMg7NtlZh0G0gBarCaFcMUOoqPxXryxdYxTRRv4kH6B9TFCVIrjRXG+emcxIk2ayZilog==}
     engines: {node: '>=18.18'}
+    peerDependencies:
+      eslint: ^9.20.1
+
+  eslint-plugin-unimport@0.1.2:
+    resolution: {integrity: sha512-C021i+pdXLZXlXwS9QGyRjxYo4PAB7QiOT89GgwwtvcBOhiQpfZFCCLya7iH1ALBICgrKM7GqRSKhUUNTXWALA==}
     peerDependencies:
       eslint: ^9.20.1
 
@@ -12597,6 +12605,19 @@ snapshots:
       regjsparser: 0.10.0
       semver: 7.7.1
       strip-indent: 3.0.0
+
+  eslint-plugin-unimport@0.1.2(eslint@9.20.1(jiti@2.4.2))(rollup@4.34.6)(typescript@5.7.3):
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.24.0
+      '@typescript-eslint/utils': 8.24.0(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3)
+      debug: 4.4.0(supports-color@9.4.0)
+      eslint: 9.20.1(jiti@2.4.2)
+      pathe: 1.1.2
+      unimport: 3.14.5(rollup@4.34.6)
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
+      - typescript
 
   eslint-plugin-unused-imports@4.1.4(@typescript-eslint/eslint-plugin@8.23.0(@typescript-eslint/parser@8.24.0(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3))(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3))(eslint@9.20.1(jiti@2.4.2)):
     dependencies:


### PR DESCRIPTION
Part of #4575

This PR is a refactor, should not introduce any behavioral change

- change primitive refs like `ref(0)` to `shallowRef(0)`
- rename other `ref()` usage to `deepRef()` (alias from `ref()`) for better explicitness
- local ESLint rule to restrict `ref()` usage