### PR TITLE
refactor: replace `tryOnBeforeUnmount` with `tryOnScopeDispose`

### DIFF
--- a/packages/core/useTitle/index.ts
+++ b/packages/core/useTitle/index.ts
@@ -1,7 +1,7 @@
 import type { MaybeRef, MaybeRefOrGetter, ReadonlyRefOrGetter } from '@vueuse/shared'
 import type { ComputedRef, Ref } from 'vue'
 import type { ConfigurableDocument } from '../_configurable'
-import { toRef, tryOnBeforeUnmount } from '@vueuse/shared'
+import { toRef, tryOnScopeDispose } from '@vueuse/shared'
 import { toValue, watch } from 'vue'
 import { defaultDocument } from '../_configurable'
 import { useMutationObserver } from '../useMutationObserver'
@@ -94,7 +94,7 @@ export function useTitle(
     )
   }
 
-  tryOnBeforeUnmount(() => {
+  tryOnScopeDispose(() => {
     if (restoreOnUnmount) {
       const restoredTitle = restoreOnUnmount(originalTitle, title.value || '')
       if (restoredTitle != null && document)


### PR DESCRIPTION
One of the tasks in #4548:  

This PR replaces [`tryOnBeforeUnmount`](https://vueuse.org/shared/tryOnBeforeUnmount) with [`tryOnScopeDispose`](https://vueuse.org/shared/tryOnScopeDispose).