### PR TITLE
refactor: move to `shallowRef` in shared utilities

### DIFF
--- a/packages/shared/createInjectionState/index.test.ts
+++ b/packages/shared/createInjectionState/index.test.ts
@@ -1,13 +1,13 @@
 import type { InjectionKey, Ref } from 'vue'
 import { createInjectionState, injectLocal } from '@vueuse/shared'
 import { describe, expect, it } from 'vitest'
-import { ref as deepRef, defineComponent, h, inject, nextTick } from 'vue'
+import { defineComponent, h, inject, nextTick, shallowRef } from 'vue'
 import { mount, useSetup } from '../../.test'
 
 describe('createInjectionState', () => {
   it('should work for simple nested component', async () => {
     const [useProvideCountState, useCountState] = createInjectionState((initialValue: number) => {
-      const count = deepRef(initialValue)
+      const count = shallowRef(initialValue)
       return count
     })
 
@@ -40,7 +40,7 @@ describe('createInjectionState', () => {
     const KEY: InjectionKey<Ref<number>> = Symbol('count-state')
 
     const [useProvideCountState, useCountState] = createInjectionState((initialValue: number) => {
-      const count = deepRef(initialValue)
+      const count = shallowRef(initialValue)
       return count
     }, { injectionKey: KEY })
 
@@ -72,7 +72,7 @@ describe('createInjectionState', () => {
 
   it('allow call useProvidingState and useInjectedState in same component', async () => {
     const [useProvideCountState, useCountState] = createInjectionState((initialValue: number) => {
-      const count = deepRef(initialValue)
+      const count = shallowRef(initialValue)
       return count
     })
     const vm = useSetup(() => {
@@ -89,7 +89,7 @@ describe('createInjectionState', () => {
   it('allow call useProvidingState and injectLocal in same component', async () => {
     const KEY: InjectionKey<Ref<number>> | string = Symbol('count-state')
     const [useProvideCountState] = createInjectionState((initialValue: number) => {
-      const count = deepRef(initialValue)
+      const count = shallowRef(initialValue)
       return count
     }, { injectionKey: KEY })
     const vm = useSetup(() => {

--- a/packages/shared/isDefined/index.test.ts
+++ b/packages/shared/isDefined/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { computed, ref as deepRef, shallowRef } from 'vue'
+import { computed, shallowRef } from 'vue'
 import { isDefined } from './index'
 
 describe('isDefined', () => {
@@ -9,8 +9,8 @@ describe('isDefined', () => {
 
   it('should support refs', () => {
     const definedRef = shallowRef('test')
-    const undefinedRef = deepRef(undefined)
-    const nullRef = deepRef(null)
+    const undefinedRef = shallowRef(undefined)
+    const nullRef = shallowRef(null)
 
     expect(isDefined(definedRef)).toBe(true)
     expect(isDefined(undefinedRef)).toBe(false)

--- a/packages/shared/reactify/index.test.ts
+++ b/packages/shared/reactify/index.test.ts
@@ -4,7 +4,7 @@ import { reactify } from './index'
 
 describe('reactify', () => {
   it('one arg', () => {
-    const base = deepRef(1.5)
+    const base = shallowRef(1.5)
     const floor = reactify(Math.floor)
     const result = floor(base)
 

--- a/packages/shared/syncRef/index.test.ts
+++ b/packages/shared/syncRef/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref as deepRef, shallowRef } from 'vue'
+import { shallowRef } from 'vue'
 import { syncRef } from './index'
 
 describe('syncRef', () => {
@@ -103,8 +103,8 @@ describe('syncRef', () => {
     const ref1 = shallowRef(1)
     const refString = shallowRef('1')
     const refNumber = shallowRef(1)
-    const refNumString = deepRef<number | string>(1)
-    const refNumBoolean = deepRef<number | boolean>(1)
+    const refNumString = shallowRef<number | string>(1)
+    const refNumBoolean = shallowRef<number | boolean>(1)
     // L = A && direction === 'both'
     syncRef(ref0, ref1)()
     syncRef(ref0, ref1, {

--- a/packages/shared/until/index.test.ts
+++ b/packages/shared/until/index.test.ts
@@ -1,5 +1,5 @@
 import type { Equal, Expect } from '@type-challenges/utils'
-import type { Ref } from 'vue'
+import type { Ref, ShallowRef } from 'vue'
 import { invoke } from '@vueuse/shared'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref as deepRef, shallowRef } from 'vue'
@@ -47,7 +47,7 @@ describe('until', () => {
   })
 
   it('should toBeUndefined', async () => {
-    const r = deepRef<boolean | undefined>(false)
+    const r = shallowRef<boolean | undefined>(false)
     setTimeout(() => {
       r.value = undefined
     }, 100)
@@ -153,7 +153,7 @@ describe('until', () => {
 
   it('should support toBeNull()', () => {
     return new Promise<void>((resolve, reject) => {
-      const r = deepRef<number | null>(null)
+      const r = shallowRef<number | null>(null)
 
       invoke(async () => {
         expect(r.value).toBe(null)
@@ -246,8 +246,8 @@ describe('until', () => {
       const xNotUndef = await until(x).not.toBeUndefined()
       'test' as any as Expect<Equal<typeof xNotUndef, 'x'>>
 
-      const y = deepRef<'y' | null>(null)
-      'test' as any as Expect<Equal<typeof y, Ref<'y' | null>>>
+      const y = shallowRef<'y' | null>(null)
+      'test' as any as Expect<Equal<typeof y, ShallowRef<'y' | null>>>
 
       const yNull = await until(y).toBeNull()
       'test' as any as Expect<Equal<typeof yNull, null>>
@@ -255,8 +255,8 @@ describe('until', () => {
       const yNotNull = await until(y).not.toBeNull()
       'test' as any as Expect<Equal<typeof yNotNull, 'y'>>
 
-      const z = deepRef<1 | 2 | 3>(1)
-      'test' as any as Expect<Equal<typeof z, Ref<1 | 2 | 3>>>
+      const z = shallowRef<1 | 2 | 3>(1)
+      'test' as any as Expect<Equal<typeof z, ShallowRef<1 | 2 | 3>>>
 
       const is1 = (x: number): x is 1 => x === 1
 

--- a/packages/shared/useLastChanged/index.ts
+++ b/packages/shared/useLastChanged/index.ts
@@ -1,5 +1,5 @@
 import type { Ref, WatchOptions, WatchSource } from 'vue'
-import { ref as deepRef, watch } from 'vue'
+import { shallowRef, watch } from 'vue'
 import { timestamp } from '../utils'
 
 export interface UseLastChangedOptions<
@@ -17,7 +17,7 @@ export interface UseLastChangedOptions<
 export function useLastChanged(source: WatchSource, options?: UseLastChangedOptions<false>): Ref<number | null>
 export function useLastChanged(source: WatchSource, options: UseLastChangedOptions<true> | UseLastChangedOptions<boolean, number>): Ref<number>
 export function useLastChanged(source: WatchSource, options: UseLastChangedOptions<boolean, any> = {}): Ref<number | null> | Ref<number> {
-  const ms = deepRef<number | null>(options.initialValue ?? null)
+  const ms = shallowRef<number | null>(options.initialValue ?? null)
 
   watch(
     source,

--- a/packages/shared/watchTriggerable/index.test.ts
+++ b/packages/shared/watchTriggerable/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref as deepRef, nextTick, reactive, shallowRef } from 'vue'
+import { nextTick, reactive, shallowRef } from 'vue'
 import { watchTriggerable } from './index'
 
 describe('watchTriggerable', () => {
@@ -38,7 +38,7 @@ describe('watchTriggerable', () => {
   it('source array', async () => {
     const source1 = shallowRef(0)
     const source2 = reactive({ a: 'a' })
-    const effect1 = deepRef(-1)
+    const effect1 = shallowRef(-1)
     const effect2 = shallowRef('z')
     let cleanupCount = -1
     const { trigger } = watchTriggerable([source1, () => source2.a], ([value1, value2], _, onCleanup) => {

--- a/packages/shared/whenever/index.test.ts
+++ b/packages/shared/whenever/index.test.ts
@@ -10,7 +10,7 @@ describe('whenever', () => {
   it('ignore falsy state change', async () => {
     // use a component to simulate normal use case
     const vm = useSetup(() => {
-      const number = deepRef<number | null | undefined>(1)
+      const number = shallowRef<number | null | undefined>(1)
       const changeNumber = (v: number) => number.value = v
       const watchCount = shallowRef(0)
       const watchValue: Ref<number | undefined> = deepRef()
@@ -59,7 +59,7 @@ describe('whenever', () => {
 
   it('once', async () => {
     const vm = useSetup(() => {
-      const number = deepRef<number | null | undefined>(1)
+      const number = shallowRef<number | null | undefined>(1)
       const watchCount = shallowRef(0)
       const watchValue: Ref<number | undefined> = deepRef()
 


### PR DESCRIPTION
This switches various tests and `useLastChanged` to use a `shallowRef` rather than a `deepRef` on primitive values (such as numbers).

Achieved through `npx eslint --fix packages/shared`, using the `no-primitive-shallow` lint rule (currently on a branch).

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.