### PR TITLE
refactor(useCloned): use `shallowRef` for primitives

### DIFF
--- a/packages/core/useCloned/index.ts
+++ b/packages/core/useCloned/index.ts
@@ -1,6 +1,6 @@
 import type { MaybeRefOrGetter } from '@vueuse/shared'
 import type { Ref, WatchOptions } from 'vue'
-import { ref as deepRef, isRef, toValue, watch } from 'vue'
+import { ref as deepRef, isRef, shallowRef, toValue, watch } from 'vue'
 
 export interface UseClonedOptions<T = any> extends WatchOptions {
   /**
@@ -44,7 +44,7 @@ export function useCloned<T>(
   options: UseClonedOptions = {},
 ): UseClonedReturn<T> {
   const cloned = deepRef({} as T) as Ref<T>
-  const isModified = deepRef<boolean>(false)
+  const isModified = shallowRef<boolean>(false)
   let _lastSync = false
 
   const {


### PR DESCRIPTION
Switches to `shallowRef` for `isModified`, since it is a boolean.

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
