### PR TITLE
refactor(useDocumentVisibility): use `shallowRef` for primitives

### DIFF
--- a/packages/core/useDocumentVisibility/index.ts
+++ b/packages/core/useDocumentVisibility/index.ts
@@ -1,6 +1,6 @@
 import type { Ref } from 'vue'
 import type { ConfigurableDocument } from '../_configurable'
-import { ref as deepRef, shallowRef } from 'vue'
+import { shallowRef } from 'vue'
 import { defaultDocument } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 
@@ -14,7 +14,7 @@ export function useDocumentVisibility(options: ConfigurableDocument = {}): Ref<D
   if (!document)
     return shallowRef('visible')
 
-  const visibility = deepRef(document.visibilityState)
+  const visibility = shallowRef(document.visibilityState)
 
   useEventListener(document, 'visibilitychange', () => {
     visibility.value = document.visibilityState


### PR DESCRIPTION
Uses `shallowRef` for `visibilityState` since it is a string.

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
