### PR TITLE
refactor(useElementSize): use `shallowRef` for height and width

### DIFF
--- a/packages/core/useElementSize/index.ts
+++ b/packages/core/useElementSize/index.ts
@@ -1,7 +1,7 @@
 import type { MaybeComputedElementRef } from '../unrefElement'
 import type { UseResizeObserverOptions } from '../useResizeObserver'
 import { toArray, tryOnMounted } from '@vueuse/shared'
-import { computed, ref as deepRef, watch } from 'vue'
+import { computed, shallowRef, watch } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { unrefElement } from '../unrefElement'
 import { useResizeObserver } from '../useResizeObserver'
@@ -23,8 +23,8 @@ export function useElementSize(
 ) {
   const { window = defaultWindow, box = 'content-box' } = options
   const isSVG = computed(() => unrefElement(target)?.namespaceURI?.includes('svg'))
-  const width = deepRef(initialSize.width)
-  const height = deepRef(initialSize.height)
+  const width = shallowRef(initialSize.width)
+  const height = shallowRef(initialSize.height)
 
   const { stop: stop1 } = useResizeObserver(
     target,


### PR DESCRIPTION
Uses `shallowRef` for the element `height` and `width` (numbers).

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
