### PR TITLE
refactor(useEventSource): use `shallowRef` for event & allow any data

### DIFF
--- a/packages/core/useEventSource/index.ts
+++ b/packages/core/useEventSource/index.ts
@@ -1,7 +1,7 @@
 import type { Fn, MaybeRefOrGetter } from '@vueuse/shared'
 import type { Ref, ShallowRef } from 'vue'
 import { isClient, toRef, tryOnScopeDispose } from '@vueuse/shared'
-import { ref as deepRef, shallowRef, watch } from 'vue'
+import { ref as deepRef, shallowReadonly, shallowRef, watch } from 'vue'
 import { useEventListener } from '../useEventListener'
 
 export type EventSourceStatus = 'CONNECTING' | 'OPEN' | 'CLOSED'
@@ -55,23 +55,23 @@ export interface UseEventSourceReturn<Events extends string[], Data = any> {
    * Reference to the latest data received via the EventSource,
    * can be watched to respond to incoming messages
    */
-  readonly data: ShallowRef<Data>
+  readonly data: Readonly<ShallowRef<Data>>
 
   /**
    * The current state of the connection, can be only one of:
    * 'CONNECTING', 'OPEN' 'CLOSED'
    */
-  readonly status: ShallowRef<EventSourceStatus>
+  readonly status: Readonly<ShallowRef<EventSourceStatus>>
 
   /**
    * The latest named event
    */
-  readonly event: ShallowRef<Events[number] | null>
+  readonly event: Readonly<ShallowRef<Events[number] | null>>
 
   /**
    * The current error
    */
-  readonly error: ShallowRef<Event | null>
+  readonly error: Readonly<ShallowRef<Event | null>>
 
   /**
    * Closes the EventSource connection gracefully.
@@ -92,7 +92,7 @@ export interface UseEventSourceReturn<Events extends string[], Data = any> {
    * The last event ID string, for server-sent events.
    * @see https://developer.mozilla.org/en-US/docs/Web/API/MessageEvent/lastEventId
    */
-  readonly lastEventId: ShallowRef<string | null>
+  readonly lastEventId: Readonly<ShallowRef<string | null>>
 }
 
 function resolveNestedOptions<T>(options: T | true): T {
@@ -214,12 +214,12 @@ export function useEventSource<Events extends string[], Data = any>(
 
   return {
     eventSource,
-    event,
-    data,
-    status,
-    error,
+    event: shallowReadonly(event),
+    data: shallowReadonly(data),
+    status: shallowReadonly(status),
+    error: shallowReadonly(error),
     open,
     close,
-    lastEventId,
+    lastEventId: shallowReadonly(lastEventId),
   }
 }

--- a/packages/core/useEventSource/index.ts
+++ b/packages/core/useEventSource/index.ts
@@ -55,23 +55,23 @@ export interface UseEventSourceReturn<Events extends string[], Data = any> {
    * Reference to the latest data received via the EventSource,
    * can be watched to respond to incoming messages
    */
-  data: Ref<Data>
+  readonly data: ShallowRef<Data>
 
   /**
    * The current state of the connection, can be only one of:
    * 'CONNECTING', 'OPEN' 'CLOSED'
    */
-  status: Ref<EventSourceStatus>
+  readonly status: ShallowRef<EventSourceStatus>
 
   /**
    * The latest named event
    */
-  event: Ref<Events[number] | null>
+  readonly event: ShallowRef<Events[number] | null>
 
   /**
    * The current error
    */
-  error: Ref<Event | null>
+  readonly error: ShallowRef<Event | null>
 
   /**
    * Closes the EventSource connection gracefully.
@@ -92,7 +92,7 @@ export interface UseEventSourceReturn<Events extends string[], Data = any> {
    * The last event ID string, for server-sent events.
    * @see https://developer.mozilla.org/en-US/docs/Web/API/MessageEvent/lastEventId
    */
-  lastEventId: Ref<string | null>
+  readonly lastEventId: ShallowRef<string | null>
 }
 
 function resolveNestedOptions<T>(options: T | true): T {

--- a/packages/core/useEventSource/index.ts
+++ b/packages/core/useEventSource/index.ts
@@ -1,5 +1,5 @@
 import type { Fn, MaybeRefOrGetter } from '@vueuse/shared'
-import type { Ref } from 'vue'
+import type { Ref, ShallowRef } from 'vue'
 import { isClient, toRef, tryOnScopeDispose } from '@vueuse/shared'
 import { ref as deepRef, shallowRef, watch } from 'vue'
 import { useEventListener } from '../useEventListener'
@@ -50,12 +50,12 @@ export interface UseEventSourceOptions extends EventSourceInit {
   autoConnect?: boolean
 }
 
-export interface UseEventSourceReturn<Events extends string[]> {
+export interface UseEventSourceReturn<Events extends string[], Data = any> {
   /**
    * Reference to the latest data received via the EventSource,
    * can be watched to respond to incoming messages
    */
-  data: Ref<string | null>
+  data: Ref<Data>
 
   /**
    * The current state of the connection, can be only one of:
@@ -110,16 +110,16 @@ function resolveNestedOptions<T>(options: T | true): T {
  * @param events
  * @param options
  */
-export function useEventSource<Events extends string[]>(
+export function useEventSource<Events extends string[], Data = any>(
   url: MaybeRefOrGetter<string | URL | undefined>,
   events: Events = [] as unknown as Events,
   options: UseEventSourceOptions = {},
 ): UseEventSourceReturn<Events> {
-  const event: Ref<string | null> = deepRef(null)
-  const data: Ref<string | null> = deepRef(null)
-  const status = shallowRef('CONNECTING') as Ref<EventSourceStatus>
-  const eventSource = deepRef(null) as Ref<EventSource | null>
-  const error = shallowRef(null) as Ref<Event | null>
+  const event: ShallowRef<string | null> = shallowRef(null)
+  const data: ShallowRef<Data | null> = shallowRef(null)
+  const status = shallowRef<EventSourceStatus>('CONNECTING')
+  const eventSource = deepRef<EventSource | null>(null)
+  const error = shallowRef<Event | null>(null)
   const urlRef = toRef(url)
   const lastEventId = shallowRef<string | null>(null)
 
@@ -188,7 +188,7 @@ export function useEventSource<Events extends string[]>(
     }
 
     for (const event_name of events) {
-      useEventListener(es, event_name, (e: Event & { data?: string }) => {
+      useEventListener(es, event_name, (e: Event & { data?: Data }) => {
         event.value = event_name
         data.value = e.data || null
       }, { passive: true })


### PR DESCRIPTION
Uses `shallowRef` for the event names as they are always strings.

Uses `deepRef` for the event data as it could be anything.

This also raised that the `data` is currently typed as `string | null`, but event source events can actually pass data of any type. This compiled successfully in the past because a `MessageEvent` defaults to `MessageEvent<any>` (i.e. `{data: any}`).

For now, i have introduced a `Data` type parameter which defaults to `any` to keep backwards compat.

In future, we should default this to `unknown`.

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
