### PR TITLE
refactor: Change `primitive` and `element` to `shallowRef`, update some return types.

### DIFF
--- a/packages/core/useAsyncQueue/index.ts
+++ b/packages/core/useAsyncQueue/index.ts
@@ -1,4 +1,4 @@
-import type { Ref } from 'vue'
+import type { ShallowRef } from 'vue'
 import { noop } from '@vueuse/shared'
 import { reactive, shallowRef } from 'vue'
 
@@ -13,7 +13,7 @@ export interface UseAsyncQueueResult<T> {
 }
 
 export interface UseAsyncQueueReturn<T> {
-  activeIndex: Ref<number>
+  activeIndex: ShallowRef<number>
   result: T
 }
 

--- a/packages/core/useBase64/index.ts
+++ b/packages/core/useBase64/index.ts
@@ -1,5 +1,5 @@
 import type { MaybeRefOrGetter } from '@vueuse/shared'
-import type { Ref } from 'vue'
+import type { ShallowRef } from 'vue'
 import { isClient } from '@vueuse/shared'
 import { isRef, shallowRef, toValue, watch } from 'vue'
 import { getDefaultSerialization } from './serialization'
@@ -29,8 +29,8 @@ export interface UseBase64ObjectOptions<T> extends UseBase64Options {
 }
 
 export interface UseBase64Return {
-  base64: Ref<string>
-  promise: Ref<Promise<string>>
+  base64: ShallowRef<string>
+  promise: ShallowRef<Promise<string>>
   execute: () => Promise<string>
 }
 

--- a/packages/core/useBroadcastChannel/index.ts
+++ b/packages/core/useBroadcastChannel/index.ts
@@ -1,4 +1,4 @@
-import type { ComputedRef, Ref } from 'vue'
+import type { ComputedRef, Ref, ShallowRef } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
 import { tryOnMounted, tryOnScopeDispose } from '@vueuse/shared'
 import { ref as deepRef, shallowRef } from 'vue'
@@ -89,6 +89,6 @@ export interface UseBroadcastChannelReturn<D, P> {
   data: Ref<D>
   post: (data: P) => void
   close: () => void
-  error: Ref<Event | null>
-  isClosed: Ref<boolean>
+  error: ShallowRef<Event | null>
+  isClosed: ShallowRef<boolean>
 }

--- a/packages/core/useConfirmDialog/index.ts
+++ b/packages/core/useConfirmDialog/index.ts
@@ -1,5 +1,5 @@
 import type { EventHook, EventHookOn } from '@vueuse/shared'
-import type { ComputedRef, Ref } from 'vue'
+import type { ComputedRef, ShallowRef } from 'vue'
 import { createEventHook, noop } from '@vueuse/shared'
 import { computed, shallowRef } from 'vue'
 
@@ -67,7 +67,7 @@ export function useConfirmDialog<
   ConfirmData = any,
   CancelData = any,
 >(
-  revealed: Ref<boolean> = shallowRef(false),
+  revealed: ShallowRef<boolean> = shallowRef(false),
 ): UseConfirmDialogReturn<RevealData, ConfirmData, CancelData> {
   const confirmHook: EventHook = createEventHook<ConfirmData>()
   const cancelHook: EventHook = createEventHook<CancelData>()

--- a/packages/core/useCountdown/index.ts
+++ b/packages/core/useCountdown/index.ts
@@ -1,5 +1,5 @@
 import type { MaybeRefOrGetter, Pausable } from '@vueuse/shared'
-import type { Ref } from 'vue'
+import type { ShallowRef } from 'vue'
 import { useIntervalFn } from '@vueuse/shared'
 import { shallowRef, toValue } from 'vue'
 
@@ -28,7 +28,7 @@ export interface UseCountdownReturn extends Pausable {
   /**
    * Current countdown value.
    */
-  remaining: Ref<number>
+  remaining: ShallowRef<number>
   /**
    * Resets the countdown and repeatsLeft to their initial values.
    */

--- a/packages/core/useCycleList/index.ts
+++ b/packages/core/useCycleList/index.ts
@@ -1,5 +1,5 @@
 import type { MaybeRef, MaybeRefOrGetter } from '@vueuse/shared'
-import type { ComputedRef, ShallowRef } from 'vue'
+import type { ShallowRef, WritableComputedRef } from 'vue'
 import { toRef } from '@vueuse/shared'
 import { computed, shallowRef, toValue, watch } from 'vue'
 
@@ -86,7 +86,7 @@ export function useCycleList<T>(list: MaybeRefOrGetter<T[]>, options?: UseCycleL
 
 export interface UseCycleListReturn<T> {
   state: ShallowRef<T>
-  index: ComputedRef<number>
+  index: WritableComputedRef<number>
   next: (n?: number) => T
   prev: (n?: number) => T
   /**

--- a/packages/core/useCycleList/index.ts
+++ b/packages/core/useCycleList/index.ts
@@ -1,5 +1,5 @@
 import type { MaybeRef, MaybeRefOrGetter } from '@vueuse/shared'
-import type { Ref } from 'vue'
+import type { ComputedRef, ShallowRef } from 'vue'
 import { toRef } from '@vueuse/shared'
 import { computed, shallowRef, toValue, watch } from 'vue'
 
@@ -27,7 +27,7 @@ export interface UseCycleListOptions<T> {
  * @see https://vueuse.org/useCycleList
  */
 export function useCycleList<T>(list: MaybeRefOrGetter<T[]>, options?: UseCycleListOptions<T>): UseCycleListReturn<T> {
-  const state = shallowRef(getInitialValue()) as Ref<T>
+  const state = shallowRef(getInitialValue()) as ShallowRef<T>
   const listRef = toRef(list)
 
   const index = computed<number>({
@@ -85,8 +85,8 @@ export function useCycleList<T>(list: MaybeRefOrGetter<T[]>, options?: UseCycleL
 }
 
 export interface UseCycleListReturn<T> {
-  state: Ref<T>
-  index: Ref<number>
+  state: ShallowRef<T>
+  index: ComputedRef<number>
   next: (n?: number) => T
   prev: (n?: number) => T
   /**

--- a/packages/core/useDevicesList/index.ts
+++ b/packages/core/useDevicesList/index.ts
@@ -1,6 +1,6 @@
 /* this implementation is original ported from https://github.com/logaretm/vue-use-web by Abdelrahman Awad */
 
-import type { ComputedRef, Ref } from 'vue'
+import type { ComputedRef, Ref, ShallowRef } from 'vue'
 import type { ConfigurableNavigator } from '../_configurable'
 import { computed, ref as deepRef, shallowRef } from 'vue'
 import { defaultNavigator } from '../_configurable'
@@ -33,7 +33,7 @@ export interface UseDevicesListReturn {
   videoInputs: ComputedRef<MediaDeviceInfo[]>
   audioInputs: ComputedRef<MediaDeviceInfo[]>
   audioOutputs: ComputedRef<MediaDeviceInfo[]>
-  permissionGranted: Ref<boolean>
+  permissionGranted: ShallowRef<boolean>
   ensurePermissions: () => Promise<boolean>
   isSupported: ComputedRef<boolean>
 }

--- a/packages/core/useDisplayMedia/index.ts
+++ b/packages/core/useDisplayMedia/index.ts
@@ -1,5 +1,4 @@
 import type { MaybeRef } from '@vueuse/shared'
-import type { Ref } from 'vue'
 import type { ConfigurableNavigator } from '../_configurable'
 import { shallowRef, watch } from 'vue'
 import { defaultNavigator } from '../_configurable'
@@ -38,7 +37,7 @@ export function useDisplayMedia(options: UseDisplayMediaOptions = {}) {
 
   const constraint: MediaStreamConstraints = { audio, video }
 
-  const stream: Ref<MediaStream | undefined> = shallowRef()
+  const stream = shallowRef<MediaStream | undefined>()
 
   async function _start() {
     if (!isSupported.value || stream.value)

--- a/packages/core/useDocumentVisibility/index.ts
+++ b/packages/core/useDocumentVisibility/index.ts
@@ -1,4 +1,4 @@
-import type { Ref } from 'vue'
+import type { ShallowRef } from 'vue'
 import type { ConfigurableDocument } from '../_configurable'
 import { shallowRef } from 'vue'
 import { defaultDocument } from '../_configurable'
@@ -9,7 +9,7 @@ import { useEventListener } from '../useEventListener'
  *
  * @see https://vueuse.org/useDocumentVisibility
  */
-export function useDocumentVisibility(options: ConfigurableDocument = {}): Ref<DocumentVisibilityState> {
+export function useDocumentVisibility(options: ConfigurableDocument = {}): ShallowRef<DocumentVisibilityState> {
   const { document = defaultDocument } = options
   if (!document)
     return shallowRef('visible')

--- a/packages/core/useDropZone/index.ts
+++ b/packages/core/useDropZone/index.ts
@@ -1,6 +1,6 @@
 import type { MaybeRef, MaybeRefOrGetter } from '@vueuse/shared'
 
-import type { Ref } from 'vue'
+import type { ShallowRef } from 'vue'
 import { isClient } from '@vueuse/shared'
 // eslint-disable-next-line no-restricted-imports
 import { shallowRef, unref } from 'vue'
@@ -8,8 +8,8 @@ import { shallowRef, unref } from 'vue'
 import { useEventListener } from '../useEventListener'
 
 export interface UseDropZoneReturn {
-  files: Ref<File[] | null>
-  isOverDropZone: Ref<boolean>
+  files: ShallowRef<File[] | null>
+  isOverDropZone: ShallowRef<boolean>
 }
 
 export interface UseDropZoneOptions {

--- a/packages/core/useElementByPoint/index.ts
+++ b/packages/core/useElementByPoint/index.ts
@@ -1,8 +1,8 @@
 import type { MaybeRefOrGetter, Pausable } from '@vueuse/shared'
-import type { ComputedRef, Ref } from 'vue'
+import type { ComputedRef, ShallowRef } from 'vue'
 import type { ConfigurableDocument } from '../_configurable'
 import { useIntervalFn } from '@vueuse/shared'
-import { ref as deepRef, toValue } from 'vue'
+import { shallowRef, toValue } from 'vue'
 import { defaultDocument } from '../_configurable'
 import { useRafFn } from '../useRafFn'
 import { useSupported } from '../useSupported'
@@ -17,7 +17,7 @@ export interface UseElementByPointOptions<Multiple extends boolean = false> exte
 
 export interface UseElementByPointReturn<Multiple extends boolean = false> extends Pausable {
   isSupported: ComputedRef<boolean>
-  element: Ref<Multiple extends true ? HTMLElement[] : HTMLElement | null>
+  element: ShallowRef<Multiple extends true ? HTMLElement[] : HTMLElement | null>
 }
 
 /**
@@ -43,7 +43,7 @@ export function useElementByPoint<M extends boolean = false>(options: UseElement
     return document && 'elementFromPoint' in document
   })
 
-  const element = deepRef<any>(null)
+  const element = shallowRef<any>(null)
 
   const cb = () => {
     element.value = toValue(multiple)

--- a/packages/core/useElementHover/index.ts
+++ b/packages/core/useElementHover/index.ts
@@ -1,5 +1,5 @@
 import type { MaybeRefOrGetter } from '@vueuse/shared'
-import type { Ref } from 'vue'
+import type { ShallowRef } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
 import type { MaybeComputedElementRef } from '../unrefElement'
 import { computed, shallowRef } from 'vue'
@@ -14,7 +14,7 @@ export interface UseElementHoverOptions extends ConfigurableWindow {
   triggerOnRemoval?: boolean
 }
 
-export function useElementHover(el: MaybeRefOrGetter<EventTarget | null | undefined>, options: UseElementHoverOptions = {}): Ref<boolean> {
+export function useElementHover(el: MaybeRefOrGetter<EventTarget | null | undefined>, options: UseElementHoverOptions = {}): ShallowRef<boolean> {
   const {
     delayEnter = 0,
     delayLeave = 0,

--- a/packages/core/useElementVisibility/index.ts
+++ b/packages/core/useElementVisibility/index.ts
@@ -1,4 +1,5 @@
 import type { MaybeRefOrGetter } from '@vueuse/shared'
+import type { ShallowRef } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
 import type { MaybeComputedElementRef } from '../unrefElement'
 import type { UseIntersectionObserverOptions } from '../useIntersectionObserver'
@@ -32,7 +33,7 @@ export interface UseElementVisibilityOptions extends ConfigurableWindow, Pick<Us
 export function useElementVisibility(
   element: MaybeComputedElementRef,
   options: UseElementVisibilityOptions = {},
-) {
+): ShallowRef<boolean> {
   const {
     window = defaultWindow,
     scrollTarget,

--- a/packages/core/useElementVisibility/index.ts
+++ b/packages/core/useElementVisibility/index.ts
@@ -1,5 +1,4 @@
 import type { MaybeRefOrGetter } from '@vueuse/shared'
-import type { ShallowRef } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
 import type { MaybeComputedElementRef } from '../unrefElement'
 import type { UseIntersectionObserverOptions } from '../useIntersectionObserver'
@@ -33,7 +32,7 @@ export interface UseElementVisibilityOptions extends ConfigurableWindow, Pick<Us
 export function useElementVisibility(
   element: MaybeComputedElementRef,
   options: UseElementVisibilityOptions = {},
-): ShallowRef<boolean> {
+) {
   const {
     window = defaultWindow,
     scrollTarget,

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -1,5 +1,5 @@
 import type { EventHookOn, Fn, MaybeRefOrGetter, Stoppable } from '@vueuse/shared'
-import type { ComputedRef, Ref } from 'vue'
+import type { ComputedRef, ShallowRef } from 'vue'
 import { containsProp, createEventHook, toRef, until, useTimeoutFn } from '@vueuse/shared'
 import { computed, isRef, readonly, shallowRef, toValue, watch } from 'vue'
 import { defaultWindow } from '../_configurable'
@@ -8,32 +8,32 @@ export interface UseFetchReturn<T> {
   /**
    * Indicates if the fetch request has finished
    */
-  isFinished: Readonly<Ref<boolean>>
+  isFinished: Readonly<ShallowRef<boolean>>
 
   /**
    * The statusCode of the HTTP fetch response
    */
-  statusCode: Ref<number | null>
+  statusCode: ShallowRef<number | null>
 
   /**
    * The raw response of the fetch response
    */
-  response: Ref<Response | null>
+  response: ShallowRef<Response | null>
 
   /**
    * Any fetch errors that may have occurred
    */
-  error: Ref<any>
+  error: ShallowRef<any>
 
   /**
    * The fetch response body on success, may either be JSON or text
    */
-  data: Ref<T | null>
+  data: ShallowRef<T | null>
 
   /**
    * Indicates if the request is currently being fetched.
    */
-  isFetching: Readonly<Ref<boolean>>
+  isFetching: Readonly<ShallowRef<boolean>>
 
   /**
    * Indicates if the fetch request is able to be aborted
@@ -43,7 +43,7 @@ export interface UseFetchReturn<T> {
   /**
    * Indicates if the fetch request was aborted
    */
-  aborted: Ref<boolean>
+  aborted: ShallowRef<boolean>
 
   /**
    * Abort the fetch request

--- a/packages/core/useFileSystemAccess/index.ts
+++ b/packages/core/useFileSystemAccess/index.ts
@@ -1,5 +1,5 @@
 import type { Awaitable, MaybeRefOrGetter } from '@vueuse/shared'
-import type { ComputedRef, Ref } from 'vue'
+import type { ComputedRef, ShallowRef } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
 import { computed, shallowRef, toValue, watch } from 'vue'
 import { defaultWindow } from '../_configurable'
@@ -197,12 +197,12 @@ export function useFileSystemAccess(options: UseFileSystemAccessOptions = {}): U
 
 export interface UseFileSystemAccessReturn<T = string> {
   isSupported: ComputedRef<boolean>
-  data: Ref<T | undefined>
-  file: Ref<File | undefined>
-  fileName: Ref<string>
-  fileMIME: Ref<string>
-  fileSize: Ref<number>
-  fileLastModified: Ref<number>
+  data: ShallowRef<T | undefined>
+  file: ShallowRef<File | undefined>
+  fileName: ComputedRef<string>
+  fileMIME: ComputedRef<string>
+  fileSize: ComputedRef<number>
+  fileLastModified: ComputedRef<number>
   open: (_options?: UseFileSystemAccessCommonOptions) => Awaitable<void>
   create: (_options?: UseFileSystemAccessShowSaveFileOptions) => Awaitable<void>
   save: (_options?: UseFileSystemAccessShowSaveFileOptions) => Awaitable<void>

--- a/packages/core/useFocus/index.ts
+++ b/packages/core/useFocus/index.ts
@@ -1,4 +1,4 @@
-import type { Ref } from 'vue'
+import type { ComputedRef } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
 import type { MaybeElementRef } from '../unrefElement'
 import { computed, shallowRef, watch } from 'vue'
@@ -33,7 +33,7 @@ export interface UseFocusReturn {
    * If read as true, then the element has focus. If read as false, then the element does not have focus
    * If set to true, then the element will be focused. If set to false, the element will be blurred.
    */
-  focused: Ref<boolean>
+  focused: ComputedRef<boolean>
 }
 
 /**

--- a/packages/core/useFocus/index.ts
+++ b/packages/core/useFocus/index.ts
@@ -1,4 +1,4 @@
-import type { ComputedRef } from 'vue'
+import type { WritableComputedRef } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
 import type { MaybeElementRef } from '../unrefElement'
 import { computed, shallowRef, watch } from 'vue'
@@ -33,7 +33,7 @@ export interface UseFocusReturn {
    * If read as true, then the element has focus. If read as false, then the element does not have focus
    * If set to true, then the element will be focused. If set to false, the element will be blurred.
    */
-  focused: ComputedRef<boolean>
+  focused: WritableComputedRef<boolean>
 }
 
 /**

--- a/packages/core/useFps/index.ts
+++ b/packages/core/useFps/index.ts
@@ -1,4 +1,4 @@
-import type { Ref } from 'vue'
+import type { ShallowRef } from 'vue'
 import { shallowRef } from 'vue'
 import { useRafFn } from '../useRafFn'
 
@@ -10,7 +10,7 @@ export interface UseFpsOptions {
   every?: number
 }
 
-export function useFps(options?: UseFpsOptions): Ref<number> {
+export function useFps(options?: UseFpsOptions): ShallowRef<number> {
   const fps = shallowRef(0)
   if (typeof performance === 'undefined')
     return fps

--- a/packages/core/useGeolocation/index.ts
+++ b/packages/core/useGeolocation/index.ts
@@ -28,7 +28,7 @@ export function useGeolocation(options: UseGeolocationOptions = {}) {
 
   const isSupported = useSupported(() => navigator && 'geolocation' in navigator)
 
-  const locatedAt: Ref<number | null> = deepRef(null)
+  const locatedAt = shallowRef<number | null>(null)
   const error = shallowRef<GeolocationPositionError | null>(null)
   const coords: Ref<Omit<GeolocationPosition['coords'], 'toJSON'>> = deepRef({
     accuracy: 0,

--- a/packages/core/useGeolocation/index.ts
+++ b/packages/core/useGeolocation/index.ts
@@ -1,6 +1,5 @@
 /* this implementation is original ported from https://github.com/logaretm/vue-use-web by Abdelrahman Awad */
 
-import type { Ref } from 'vue'
 import type { ConfigurableNavigator } from '../_configurable'
 import { tryOnScopeDispose } from '@vueuse/shared'
 import { ref as deepRef, shallowRef } from 'vue'
@@ -30,7 +29,7 @@ export function useGeolocation(options: UseGeolocationOptions = {}) {
 
   const locatedAt = shallowRef<number | null>(null)
   const error = shallowRef<GeolocationPositionError | null>(null)
-  const coords: Ref<Omit<GeolocationPosition['coords'], 'toJSON'>> = deepRef({
+  const coords = deepRef<Omit<GeolocationPosition['coords'], 'toJSON'>>({
     accuracy: 0,
     latitude: Number.POSITIVE_INFINITY,
     longitude: Number.POSITIVE_INFINITY,

--- a/packages/core/useIdle/index.ts
+++ b/packages/core/useIdle/index.ts
@@ -1,5 +1,5 @@
 import type { ConfigurableEventFilter } from '@vueuse/shared'
-import type { Ref } from 'vue'
+import type { ShallowRef } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
 import type { WindowEventName } from '../useEventListener'
 import { createFilterWrapper, throttleFilter, timestamp } from '@vueuse/shared'
@@ -32,8 +32,8 @@ export interface UseIdleOptions extends ConfigurableWindow, ConfigurableEventFil
 }
 
 export interface UseIdleReturn {
-  idle: Ref<boolean>
-  lastActive: Ref<number>
+  idle: ShallowRef<boolean>
+  lastActive: ShallowRef<number>
   reset: () => void
 }
 

--- a/packages/core/useIntersectionObserver/index.ts
+++ b/packages/core/useIntersectionObserver/index.ts
@@ -3,7 +3,7 @@ import type { ComputedRef } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
 import type { MaybeComputedElementRef, MaybeElement } from '../unrefElement'
 import { noop, notNullish, toArray, tryOnScopeDispose } from '@vueuse/shared'
-import { computed, ref as deepRef, toValue, watch } from 'vue'
+import { computed, shallowRef, toValue, watch } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { unrefElement } from '../unrefElement'
 import { useSupported } from '../useSupported'
@@ -66,7 +66,7 @@ export function useIntersectionObserver(
   })
 
   let cleanup = noop
-  const isActive = deepRef(immediate)
+  const isActive = shallowRef(immediate)
 
   const stopWatch = isSupported.value
     ? watch(

--- a/packages/core/useKeyModifier/index.ts
+++ b/packages/core/useKeyModifier/index.ts
@@ -1,7 +1,7 @@
-import type { Ref } from 'vue'
+import type { ShallowRef } from 'vue'
 import type { ConfigurableDocument } from '../_configurable'
 import type { WindowEventName } from '../useEventListener'
-import { ref as deepRef } from 'vue'
+import { shallowRef } from 'vue'
 import { defaultDocument } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 
@@ -25,7 +25,7 @@ export interface UseModifierOptions<Initial> extends ConfigurableDocument {
   initial?: Initial
 }
 
-export type UseKeyModifierReturn<Initial> = Ref<Initial extends boolean ? boolean : boolean | null>
+export type UseKeyModifierReturn<Initial> = ShallowRef<Initial extends boolean ? boolean : boolean | null>
 
 export function useKeyModifier<Initial extends boolean | null>(modifier: KeyModifier, options: UseModifierOptions<Initial> = {}): UseKeyModifierReturn<Initial> {
   const {
@@ -34,7 +34,7 @@ export function useKeyModifier<Initial extends boolean | null>(modifier: KeyModi
     initial = null,
   } = options
 
-  const state = deepRef(initial) as Ref<boolean>
+  const state = shallowRef(initial) as ShallowRef<boolean>
 
   if (document) {
     events.forEach((listenerEvent) => {

--- a/packages/core/useMediaQuery/index.ts
+++ b/packages/core/useMediaQuery/index.ts
@@ -3,7 +3,7 @@
 import type { MaybeRefOrGetter } from '@vueuse/shared'
 import type { ConfigurableWindow } from '../_configurable'
 import { pxValue } from '@vueuse/shared'
-import { computed, ref as deepRef, shallowRef, toValue, watchEffect } from 'vue'
+import { computed, shallowRef, toValue, watchEffect } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 import { useSSRWidth } from '../useSSRWidth'
@@ -20,7 +20,7 @@ export function useMediaQuery(query: MaybeRefOrGetter<string>, options: Configur
   const { window = defaultWindow, ssrWidth = useSSRWidth() } = options
   const isSupported = useSupported(() => window && 'matchMedia' in window && typeof window.matchMedia === 'function')
 
-  const ssrSupport = deepRef(typeof ssrWidth === 'number')
+  const ssrSupport = shallowRef(typeof ssrWidth === 'number')
 
   const mediaQuery = shallowRef<MediaQueryList>()
   const matches = shallowRef(false)

--- a/packages/core/useMouseInElement/index.ts
+++ b/packages/core/useMouseInElement/index.ts
@@ -1,6 +1,6 @@
 import type { MaybeElementRef } from '../unrefElement'
 import type { UseMouseOptions } from '../useMouse'
-import { ref as deepRef, shallowRef, watch } from 'vue'
+import { shallowRef, watch } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { unrefElement } from '../unrefElement'
 import { useEventListener } from '../useEventListener'
@@ -29,7 +29,7 @@ export function useMouseInElement(
 
   const { x, y, sourceType } = useMouse(options)
 
-  const targetRef = deepRef(target ?? window?.document.body)
+  const targetRef = shallowRef(target ?? window?.document.body)
   const elementX = shallowRef(0)
   const elementY = shallowRef(0)
   const elementPositionX = shallowRef(0)

--- a/packages/core/useMousePressed/index.ts
+++ b/packages/core/useMousePressed/index.ts
@@ -1,7 +1,7 @@
 import type { ConfigurableWindow } from '../_configurable'
 import type { MaybeComputedElementRef } from '../unrefElement'
 import type { UseMouseSourceType } from '../useMouse'
-import { computed, ref as deepRef } from 'vue'
+import { computed, shallowRef } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { unrefElement } from '../unrefElement'
 import { useEventListener } from '../useEventListener'
@@ -71,8 +71,8 @@ export function useMousePressed(options: MousePressedOptions = {}) {
     window = defaultWindow,
   } = options
 
-  const pressed = deepRef(initialValue)
-  const sourceType = deepRef<UseMouseSourceType>(null)
+  const pressed = shallowRef(initialValue)
+  const sourceType = shallowRef<UseMouseSourceType>(null)
 
   if (!window) {
     return {

--- a/packages/core/useNavigatorLanguage/index.ts
+++ b/packages/core/useNavigatorLanguage/index.ts
@@ -1,6 +1,6 @@
-import type { ComputedRef, Ref } from 'vue'
+import type { ComputedRef, ShallowRef } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
-import { ref as deepRef } from 'vue'
+import { shallowRef } from 'vue'
 
 import { defaultWindow } from '../_configurable'
 
@@ -25,7 +25,7 @@ export interface NavigatorLanguageState {
    * @see https://www.loc.gov/standards/iso639-2/php/code_list.php
    *
    */
-  language: Ref<string | undefined>
+  language: ShallowRef<string | undefined>
 }
 
 /**
@@ -43,7 +43,7 @@ export function useNavigatorLanguage(options: ConfigurableWindow = {}): Readonly
 
   const isSupported = useSupported(() => navigator && 'language' in navigator)
 
-  const language = deepRef<string | undefined>(navigator?.language)
+  const language = shallowRef<string | undefined>(navigator?.language)
 
   // Listen to when to user changes language:
   useEventListener(window, 'languagechange', () => {

--- a/packages/core/useNetwork/index.ts
+++ b/packages/core/useNetwork/index.ts
@@ -1,8 +1,8 @@
 /* this implementation is original ported from https://github.com/logaretm/vue-use-web by Abdelrahman Awad */
 
-import type { ComputedRef, Ref } from 'vue'
+import type { ComputedRef, ShallowRef } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
-import { ref as deepRef, readonly, shallowRef } from 'vue'
+import { readonly, shallowRef } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 import { useSupported } from '../useSupported'
@@ -16,39 +16,39 @@ export interface NetworkState {
   /**
    * If the user is currently connected.
    */
-  isOnline: Readonly<Ref<boolean>>
+  isOnline: Readonly<ShallowRef<boolean>>
   /**
    * The time since the user was last connected.
    */
-  offlineAt: Readonly<Ref<number | undefined>>
+  offlineAt: Readonly<ShallowRef<number | undefined>>
   /**
    * At this time, if the user is offline and reconnects
    */
-  onlineAt: Readonly<Ref<number | undefined>>
+  onlineAt: Readonly<ShallowRef<number | undefined>>
   /**
    * The download speed in Mbps.
    */
-  downlink: Readonly<Ref<number | undefined>>
+  downlink: Readonly<ShallowRef<number | undefined>>
   /**
    * The max reachable download speed in Mbps.
    */
-  downlinkMax: Readonly<Ref<number | undefined>>
+  downlinkMax: Readonly<ShallowRef<number | undefined>>
   /**
    * The detected effective speed type.
    */
-  effectiveType: Readonly<Ref<NetworkEffectiveType | undefined>>
+  effectiveType: Readonly<ShallowRef<NetworkEffectiveType | undefined>>
   /**
    * The estimated effective round-trip time of the current connection.
    */
-  rtt: Readonly<Ref<number | undefined>>
+  rtt: Readonly<ShallowRef<number | undefined>>
   /**
    * If the user activated data saver mode.
    */
-  saveData: Readonly<Ref<boolean | undefined>>
+  saveData: Readonly<ShallowRef<boolean | undefined>>
   /**
    * The detected connection/network type.
    */
-  type: Readonly<Ref<NetworkType>>
+  type: Readonly<ShallowRef<NetworkType>>
 }
 
 /**
@@ -64,13 +64,13 @@ export function useNetwork(options: ConfigurableWindow = {}): Readonly<NetworkSt
 
   const isOnline = shallowRef(true)
   const saveData = shallowRef(false)
-  const offlineAt: Ref<number | undefined> = deepRef(undefined)
-  const onlineAt: Ref<number | undefined> = deepRef(undefined)
-  const downlink: Ref<number | undefined> = deepRef(undefined)
-  const downlinkMax: Ref<number | undefined> = deepRef(undefined)
-  const rtt: Ref<number | undefined> = deepRef(undefined)
-  const effectiveType: Ref<NetworkEffectiveType> = deepRef(undefined)
-  const type: Ref<NetworkType> = deepRef<NetworkType>('unknown')
+  const offlineAt = shallowRef<number | undefined>(undefined)
+  const onlineAt = shallowRef<number | undefined>(undefined)
+  const downlink = shallowRef<number | undefined>(undefined)
+  const downlinkMax = shallowRef<number | undefined>(undefined)
+  const rtt = shallowRef<number | undefined>(undefined)
+  const effectiveType = shallowRef<NetworkEffectiveType>(undefined)
+  const type = shallowRef<NetworkType>('unknown')
 
   const connection = isSupported.value && (navigator as any).connection
 

--- a/packages/core/useObjectUrl/index.ts
+++ b/packages/core/useObjectUrl/index.ts
@@ -1,6 +1,6 @@
 import type { MaybeRefOrGetter } from '@vueuse/shared'
 import { tryOnScopeDispose } from '@vueuse/shared'
-import { ref as deepRef, readonly, toValue, watch } from 'vue'
+import { readonly, shallowRef, toValue, watch } from 'vue'
 
 /**
  * Reactive URL representing an object.
@@ -9,7 +9,7 @@ import { ref as deepRef, readonly, toValue, watch } from 'vue'
  * @param object
  */
 export function useObjectUrl(object: MaybeRefOrGetter<Blob | MediaSource | null | undefined>) {
-  const url = deepRef<string | undefined>()
+  const url = shallowRef<string | undefined>()
 
   const release = () => {
     if (url.value)

--- a/packages/core/useParentElement/index.ts
+++ b/packages/core/useParentElement/index.ts
@@ -1,5 +1,5 @@
 import type { MaybeRefOrGetter } from '@vueuse/shared'
-import type { Ref } from 'vue'
+import type { ShallowRef } from 'vue'
 import { tryOnMounted } from '@vueuse/shared'
 import { shallowRef, toValue, watch } from 'vue'
 import { unrefElement } from '../unrefElement'
@@ -7,7 +7,7 @@ import { useCurrentElement } from '../useCurrentElement'
 
 export function useParentElement(
   element: MaybeRefOrGetter<HTMLElement | SVGElement | null | undefined> = useCurrentElement<HTMLElement | SVGAElement>(),
-): Readonly<Ref<HTMLElement | SVGElement | null | undefined>> {
+): Readonly<ShallowRef<HTMLElement | SVGElement | null | undefined>> {
   const parentElement = shallowRef<HTMLElement | SVGElement | null | undefined>()
 
   const update = () => {

--- a/packages/core/usePermission/index.ts
+++ b/packages/core/usePermission/index.ts
@@ -1,4 +1,4 @@
-import type { ComputedRef, Ref } from 'vue'
+import type { ComputedRef, ShallowRef } from 'vue'
 import type { ConfigurableNavigator } from '../_configurable'
 import { createSingletonPromise } from '@vueuse/shared'
 import { shallowRef, toRaw } from 'vue'
@@ -37,7 +37,7 @@ export interface UsePermissionOptions<Controls extends boolean> extends Configur
   controls?: Controls
 }
 
-export type UsePermissionReturn = Readonly<Ref<PermissionState | undefined>>
+export type UsePermissionReturn = Readonly<ShallowRef<PermissionState | undefined>>
 export interface UsePermissionReturnWithControls {
   state: UsePermissionReturn
   isSupported: ComputedRef<boolean>

--- a/packages/core/usePointerLock/index.ts
+++ b/packages/core/usePointerLock/index.ts
@@ -1,7 +1,7 @@
 import type { ConfigurableDocument } from '../_configurable'
 import type { MaybeElement, MaybeElementRef } from '../unrefElement'
 import { until } from '@vueuse/shared'
-import { ref as deepRef } from 'vue'
+import { shallowRef } from 'vue'
 import { defaultDocument } from '../_configurable'
 import { unrefElement } from '../unrefElement'
 import { useEventListener } from '../useEventListener'
@@ -29,9 +29,9 @@ export function usePointerLock(target?: MaybeElementRef, options: UsePointerLock
 
   const isSupported = useSupported(() => document && 'pointerLockElement' in document)
 
-  const element = deepRef<MaybeElement>()
+  const element = shallowRef<MaybeElement>()
 
-  const triggerElement = deepRef<MaybeElement>()
+  const triggerElement = shallowRef<MaybeElement>()
 
   let targetElement: MaybeElement
 

--- a/packages/core/usePointerSwipe/index.ts
+++ b/packages/core/usePointerSwipe/index.ts
@@ -1,5 +1,5 @@
 import type { MaybeRefOrGetter } from '@vueuse/shared'
-import type { Ref } from 'vue'
+import type { ComputedRef, ShallowRef } from 'vue'
 import type { PointerType, Position } from '../types'
 import type { UseSwipeDirection } from '../useSwipe'
 import { toRef, tryOnMounted } from '@vueuse/shared'
@@ -43,12 +43,12 @@ export interface UsePointerSwipeOptions {
 }
 
 export interface UsePointerSwipeReturn {
-  readonly isSwiping: Ref<boolean>
-  direction: Readonly<Ref<UseSwipeDirection>>
+  readonly isSwiping: ShallowRef<boolean>
+  direction: Readonly<ShallowRef<UseSwipeDirection>>
   readonly posStart: Position
   readonly posEnd: Position
-  distanceX: Readonly<Ref<number>>
-  distanceY: Readonly<Ref<number>>
+  distanceX: Readonly<ComputedRef<number>>
+  distanceY: Readonly<ComputedRef<number>>
   stop: () => void
 }
 

--- a/packages/core/usePrevious/index.ts
+++ b/packages/core/usePrevious/index.ts
@@ -1,7 +1,7 @@
 /* This implementation is original ported from https://github.com/shorwood/pompaute by Stanley Horwood */
 
 import type { MaybeRefOrGetter } from '@vueuse/shared'
-import type { Ref } from 'vue'
+import type { ShallowRef } from 'vue'
 import { toRef } from '@vueuse/shared'
 import { readonly, shallowRef, watch } from 'vue'
 
@@ -10,8 +10,8 @@ import { readonly, shallowRef, watch } from 'vue'
  *
  * @see   {@link https://vueuse.org/usePrevious}
  */
-export function usePrevious<T>(value: MaybeRefOrGetter<T>): Readonly<Ref<T | undefined>>
-export function usePrevious<T>(value: MaybeRefOrGetter<T>, initialValue: T): Readonly<Ref<T>>
+export function usePrevious<T>(value: MaybeRefOrGetter<T>): Readonly<ShallowRef<T | undefined>>
+export function usePrevious<T>(value: MaybeRefOrGetter<T>, initialValue: T): Readonly<ShallowRef<T>>
 export function usePrevious<T>(value: MaybeRefOrGetter<T>, initialValue?: T) {
   const previous = shallowRef<T | undefined>(initialValue)
 

--- a/packages/core/useScreenOrientation/index.ts
+++ b/packages/core/useScreenOrientation/index.ts
@@ -1,5 +1,5 @@
 import type { ConfigurableWindow } from '../_configurable'
-import { ref as deepRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 import { useSupported } from '../useSupported'
@@ -33,7 +33,7 @@ export function useScreenOrientation(options: ConfigurableWindow = {}) {
   const screenOrientation = (isSupported.value ? window!.screen.orientation : {}) as ScreenOrientation
 
   const orientation = deepRef<OrientationType | undefined>(screenOrientation.type)
-  const angle = deepRef(screenOrientation.angle || 0)
+  const angle = shallowRef(screenOrientation.angle || 0)
 
   if (isSupported.value) {
     useEventListener(window, 'orientationchange', () => {

--- a/packages/core/useScriptTag/index.ts
+++ b/packages/core/useScriptTag/index.ts
@@ -1,7 +1,7 @@
 import type { MaybeRefOrGetter } from '@vueuse/shared'
 import type { ConfigurableDocument } from '../_configurable'
 import { noop, tryOnMounted, tryOnUnmounted } from '@vueuse/shared'
-import { ref as deepRef, toValue } from 'vue'
+import { shallowRef, toValue } from 'vue'
 import { defaultDocument } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 
@@ -72,7 +72,7 @@ export function useScriptTag(
     document = defaultDocument,
     attrs = {},
   } = options
-  const scriptTag = deepRef<HTMLScriptElement | null>(null)
+  const scriptTag = shallowRef<HTMLScriptElement | null>(null)
 
   let _promise: Promise<HTMLScriptElement | boolean> | null = null
 

--- a/packages/core/useScrollLock/index.ts
+++ b/packages/core/useScrollLock/index.ts
@@ -1,6 +1,6 @@
 import type { Fn, MaybeRefOrGetter } from '@vueuse/shared'
 import { isIOS, toRef, tryOnScopeDispose } from '@vueuse/shared'
-import { computed, ref as deepRef, toValue, watch } from 'vue'
+import { computed, shallowRef, toValue, watch } from 'vue'
 
 import { resolveElement } from '../_resolve-element'
 import { useEventListener } from '../useEventListener'
@@ -56,7 +56,7 @@ export function useScrollLock(
   element: MaybeRefOrGetter<HTMLElement | SVGElement | Window | Document | null | undefined>,
   initialState = false,
 ) {
-  const isLocked = deepRef(initialState)
+  const isLocked = shallowRef(initialState)
   let stopTouchMoveListener: Fn | null = null
   let initialOverflow: CSSStyleDeclaration['overflow'] = ''
 

--- a/packages/core/useSpeechRecognition/index.ts
+++ b/packages/core/useSpeechRecognition/index.ts
@@ -2,7 +2,6 @@
 // by https://github.com/wobsoriano
 
 import type { MaybeRefOrGetter } from '@vueuse/shared'
-import type { Ref } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
 import type { SpeechRecognition, SpeechRecognitionErrorEvent } from './types'
 import { toRef, tryOnScopeDispose } from '@vueuse/shared'
@@ -57,7 +56,7 @@ export function useSpeechRecognition(options: UseSpeechRecognitionOptions = {}) 
   const isListening = shallowRef(false)
   const isFinal = shallowRef(false)
   const result = shallowRef('')
-  const error = shallowRef(undefined) as Ref<SpeechRecognitionErrorEvent | undefined>
+  const error = shallowRef<SpeechRecognitionErrorEvent | undefined>(undefined)
 
   let recognition: SpeechRecognition | undefined
 

--- a/packages/core/useSpeechSynthesis/index.ts
+++ b/packages/core/useSpeechSynthesis/index.ts
@@ -1,8 +1,7 @@
 import type { MaybeRef, MaybeRefOrGetter } from '@vueuse/shared'
-import type { Ref } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
 import { toRef, tryOnScopeDispose } from '@vueuse/shared'
-import { computed, ref as deepRef, shallowRef, toValue, watch } from 'vue'
+import { computed, shallowRef, toValue, watch } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useSupported } from '../useSupported'
 
@@ -60,11 +59,11 @@ export function useSpeechSynthesis(
   const isSupported = useSupported(() => synth)
 
   const isPlaying = shallowRef(false)
-  const status = deepRef<UseSpeechSynthesisStatus>('init')
+  const status = shallowRef<UseSpeechSynthesisStatus>('init')
 
   const spokenText = toRef(text || '')
   const lang = toRef(options.lang || 'en-US')
-  const error = shallowRef(undefined) as Ref<SpeechSynthesisErrorEvent | undefined>
+  const error = shallowRef<SpeechSynthesisErrorEvent | undefined>(undefined)
 
   const toggle = (value = !isPlaying.value) => {
     isPlaying.value = value

--- a/packages/core/useStyleTag/index.ts
+++ b/packages/core/useStyleTag/index.ts
@@ -1,5 +1,5 @@
 import type { MaybeRef } from '@vueuse/shared'
-import type { Ref } from 'vue'
+import type { ShallowRef } from 'vue'
 import type { ConfigurableDocument } from '../_configurable'
 import { tryOnMounted, tryOnScopeDispose } from '@vueuse/shared'
 import { readonly, shallowRef, watch } from 'vue'
@@ -35,10 +35,10 @@ export interface UseStyleTagOptions extends ConfigurableDocument {
 
 export interface UseStyleTagReturn {
   id: string
-  css: Ref<string>
+  css: ShallowRef<string>
   load: () => void
   unload: () => void
-  isLoaded: Readonly<Ref<boolean>>
+  isLoaded: Readonly<ShallowRef<boolean>>
 }
 
 let _id = 0

--- a/packages/core/useSwipe/index.ts
+++ b/packages/core/useSwipe/index.ts
@@ -1,5 +1,5 @@
 import type { MaybeRefOrGetter } from '@vueuse/shared'
-import type { ComputedRef, Ref } from 'vue'
+import type { ComputedRef, ShallowRef } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
 import type { Position } from '../types'
 import { computed, reactive, shallowRef } from 'vue'
@@ -43,7 +43,7 @@ export interface UseSwipeReturn {
    * This flag will always return `true` and be removed in the next major version.
    */
   isPassiveEventSupported: boolean
-  isSwiping: Ref<boolean>
+  isSwiping: ShallowRef<boolean>
   direction: ComputedRef<UseSwipeDirection>
   coordsStart: Readonly<Position>
   coordsEnd: Readonly<Position>

--- a/packages/core/useTimestamp/index.ts
+++ b/packages/core/useTimestamp/index.ts
@@ -1,5 +1,5 @@
 import type { Pausable } from '@vueuse/shared'
-import type { Ref } from 'vue'
+import type { ShallowRef } from 'vue'
 import { timestamp, useIntervalFn } from '@vueuse/shared'
 import { shallowRef } from 'vue'
 import { useRafFn } from '../useRafFn'
@@ -44,8 +44,8 @@ export interface UseTimestampOptions<Controls extends boolean> {
  * @see https://vueuse.org/useTimestamp
  * @param options
  */
-export function useTimestamp(options?: UseTimestampOptions<false>): Ref<number>
-export function useTimestamp(options: UseTimestampOptions<true>): { timestamp: Ref<number> } & Pausable
+export function useTimestamp(options?: UseTimestampOptions<false>): ShallowRef<number>
+export function useTimestamp(options: UseTimestampOptions<true>): { timestamp: ShallowRef<number> } & Pausable
 export function useTimestamp(options: UseTimestampOptions<boolean> = {}) {
   const {
     controls: exposeControls = false,

--- a/packages/core/useUserMedia/index.ts
+++ b/packages/core/useUserMedia/index.ts
@@ -36,8 +36,8 @@ export interface UseUserMediaOptions extends ConfigurableNavigator {
  * @param options
  */
 export function useUserMedia(options: UseUserMediaOptions = {}) {
-  const enabled = deepRef(options.enabled ?? false)
-  const autoSwitch = deepRef(options.autoSwitch ?? true)
+  const enabled = shallowRef(options.enabled ?? false)
+  const autoSwitch = shallowRef(options.autoSwitch ?? true)
   const constraints = deepRef(options.constraints)
   const { navigator = defaultNavigator } = options
   const isSupported = useSupported(() => navigator?.mediaDevices?.getUserMedia)

--- a/packages/core/useWakeLock/index.ts
+++ b/packages/core/useWakeLock/index.ts
@@ -1,6 +1,6 @@
 import type { ConfigurableDocument, ConfigurableNavigator } from '../_configurable'
 import { whenever } from '@vueuse/shared'
-import { computed, ref as deepRef, shallowRef } from 'vue'
+import { computed, shallowRef } from 'vue'
 import { defaultDocument, defaultNavigator } from '../_configurable'
 import { useDocumentVisibility } from '../useDocumentVisibility'
 import { useEventListener } from '../useEventListener'
@@ -31,7 +31,7 @@ export function useWakeLock(options: UseWakeLockOptions = {}) {
     navigator = defaultNavigator,
     document = defaultDocument,
   } = options
-  const requestedType = deepRef<WakeLockType | false>(false)
+  const requestedType = shallowRef<WakeLockType | false>(false)
   const sentinel = shallowRef<WakeLockSentinel | null>(null)
   const documentVisibility = useDocumentVisibility({ document })
   const isSupported = useSupported(() => navigator && 'wakeLock' in navigator)

--- a/packages/core/useWebNotification/index.ts
+++ b/packages/core/useWebNotification/index.ts
@@ -2,7 +2,7 @@ import type { EventHook } from '@vueuse/shared'
 import type { Ref } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
 import { createEventHook, tryOnMounted, tryOnScopeDispose } from '@vueuse/shared'
-import { ref as deepRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 import { useSupported } from '../useSupported'
@@ -131,7 +131,7 @@ export function useWebNotification(
     return true
   })
 
-  const permissionGranted = deepRef(isSupported.value && 'permission' in Notification && Notification.permission === 'granted')
+  const permissionGranted = shallowRef(isSupported.value && 'permission' in Notification && Notification.permission === 'granted')
 
   const notification: Ref<Notification | null> = deepRef(null)
 

--- a/packages/core/useWebSocket/index.ts
+++ b/packages/core/useWebSocket/index.ts
@@ -1,7 +1,7 @@
 import type { Fn, MaybeRefOrGetter } from '@vueuse/shared'
-import type { Ref } from 'vue'
+import type { Ref, ShallowRef } from 'vue'
 import { isClient, isWorker, toRef, tryOnScopeDispose, useIntervalFn } from '@vueuse/shared'
-import { ref as deepRef, toValue, watch } from 'vue'
+import { ref as deepRef, shallowRef, toValue, watch } from 'vue'
 import { useEventListener } from '../useEventListener'
 
 export type WebSocketStatus = 'OPEN' | 'CONNECTING' | 'CLOSED'
@@ -116,7 +116,7 @@ export interface UseWebSocketReturn<T> {
    * The current websocket status, can be only one of:
    * 'OPEN', 'CONNECTING', 'CLOSED'
    */
-  status: Ref<WebSocketStatus>
+  status: ShallowRef<WebSocketStatus>
 
   /**
    * Closes the websocket connection gracefully.
@@ -171,7 +171,7 @@ export function useWebSocket<Data = any>(
   } = options
 
   const data: Ref<Data | null> = deepRef(null)
-  const status = deepRef<WebSocketStatus>('CLOSED')
+  const status = shallowRef<WebSocketStatus>('CLOSED')
   const wsRef = deepRef<WebSocket | undefined>()
   const urlRef = toRef(url)
 

--- a/packages/core/useWebWorkerFn/index.ts
+++ b/packages/core/useWebWorkerFn/index.ts
@@ -2,7 +2,7 @@
 
 import type { ConfigurableWindow } from '../_configurable'
 import { tryOnScopeDispose } from '@vueuse/shared'
-import { ref as deepRef } from 'vue'
+import { ref as deepRef, shallowRef } from 'vue'
 import { defaultWindow } from '../_configurable'
 import createWorkerBlobUrl from './lib/createWorkerBlobUrl'
 
@@ -46,9 +46,9 @@ export function useWebWorkerFn<T extends (...fnArgs: any[]) => any>(fn: T, optio
   } = options
 
   const worker = deepRef<(Worker & { _url?: string }) | undefined>()
-  const workerStatus = deepRef<WebWorkerStatus>('PENDING')
+  const workerStatus = shallowRef<WebWorkerStatus>('PENDING')
   const promise = deepRef<({ reject?: (result: ReturnType<T> | ErrorEvent) => void, resolve?: (result: ReturnType<T>) => void })>({})
-  const timeoutId = deepRef<number>()
+  const timeoutId = shallowRef<number>()
 
   const workerTerminate = (status: WebWorkerStatus = 'PENDING') => {
     if (worker.value && worker.value._url && window) {

--- a/packages/core/useWindowFocus/index.ts
+++ b/packages/core/useWindowFocus/index.ts
@@ -1,6 +1,6 @@
-import type { Ref } from 'vue'
+import type { ShallowRef } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
-import { ref as deepRef, shallowRef } from 'vue'
+import { shallowRef } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 
@@ -9,12 +9,12 @@ import { useEventListener } from '../useEventListener'
  *
  * @see https://vueuse.org/useWindowFocus
  */
-export function useWindowFocus(options: ConfigurableWindow = {}): Ref<boolean> {
+export function useWindowFocus(options: ConfigurableWindow = {}): ShallowRef<boolean> {
   const { window = defaultWindow } = options
   if (!window)
     return shallowRef(false)
 
-  const focused = deepRef(window.document.hasFocus())
+  const focused = shallowRef(window.document.hasFocus())
 
   const listenerOptions = { passive: true }
 

--- a/packages/core/useWindowSize/index.ts
+++ b/packages/core/useWindowSize/index.ts
@@ -1,6 +1,6 @@
 import type { ConfigurableWindow } from '../_configurable'
 import { tryOnMounted } from '@vueuse/shared'
-import { ref as deepRef, watch } from 'vue'
+import { shallowRef, watch } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 import { useMediaQuery } from '../useMediaQuery'
@@ -47,8 +47,8 @@ export function useWindowSize(options: UseWindowSizeOptions = {}) {
     type = 'inner',
   } = options
 
-  const width = deepRef(initialWidth)
-  const height = deepRef(initialHeight)
+  const width = shallowRef(initialWidth)
+  const height = shallowRef(initialHeight)
 
   const update = () => {
     if (window) {

--- a/packages/electron/useIpcRenderer/index.ts
+++ b/packages/electron/useIpcRenderer/index.ts
@@ -1,5 +1,5 @@
 import type { IpcRenderer, IpcRendererEvent } from 'electron'
-import type { Ref } from 'vue'
+import type { ShallowRef } from 'vue'
 import type { IpcRendererListener } from '../_types'
 import { shallowRef } from 'vue'
 import { useIpcRendererInvoke } from '../useIpcRendererInvoke'
@@ -54,7 +54,7 @@ export interface UseIpcRendererReturn {
    *
    * @see https://www.electronjs.org/docs/api/ipc-renderer#ipcrendererinvokechannel-args
    */
-  invoke: <T>(channel: string, ...args: any[]) => Ref<T | null>
+  invoke: <T>(channel: string, ...args: any[]) => ShallowRef<T | null>
 
   /**
    * Returns any - The value sent back by the ipcMain handler.
@@ -62,7 +62,7 @@ export interface UseIpcRendererReturn {
    *
    * @see https://www.electronjs.org/docs/api/ipc-renderer#ipcrenderersendsyncchannel-args
    */
-  sendSync: <T>(channel: string, ...args: any[]) => Ref<T | null>
+  sendSync: <T>(channel: string, ...args: any[]) => ShallowRef<T | null>
 
   /**
    * Send a message to the main process, optionally transferring ownership of zero or more MessagePort objects.
@@ -90,8 +90,8 @@ export interface UseIpcRendererReturn {
  * Create a `sendSync` function
  */
 function setSendSync(ipcRenderer: IpcRenderer) {
-  return <T>(channel: string, ...args: any[]): Ref<T | null> => {
-    const result = shallowRef<T | null>(null) as Ref<T | null>
+  return <T>(channel: string, ...args: any[]): ShallowRef<T | null> => {
+    const result = shallowRef<T | null>(null) as ShallowRef<T | null>
     result.value = ipcRenderer.sendSync(channel, ...args)
     return result
   }

--- a/packages/electron/useIpcRendererInvoke/index.ts
+++ b/packages/electron/useIpcRendererInvoke/index.ts
@@ -1,5 +1,5 @@
 import type { IpcRenderer } from 'electron'
-import type { Ref } from 'vue'
+import type { ShallowRef } from 'vue'
 import { shallowRef } from 'vue'
 
 /**
@@ -12,7 +12,7 @@ import { shallowRef } from 'vue'
  * @see https://www.electronjs.org/docs/api/ipc-renderer#ipcrendererinvokechannel-args
  * @see https://vueuse.org/useIpcRendererInvoke
  */
-export function useIpcRendererInvoke<T>(ipcRenderer: IpcRenderer, channel: string, ...args: any[]): Ref<T | null>
+export function useIpcRendererInvoke<T>(ipcRenderer: IpcRenderer, channel: string, ...args: any[]): ShallowRef<T | null>
 
 /**
  * Returns Promise<any> - Resolves with the response from the main process.
@@ -24,9 +24,9 @@ export function useIpcRendererInvoke<T>(ipcRenderer: IpcRenderer, channel: strin
  * @see https://www.electronjs.org/docs/api/ipc-renderer#ipcrendererinvokechannel-args
  * @see https://vueuse.org/useIpcRendererInvoke
  */
-export function useIpcRendererInvoke<T>(channel: string, ...args: any[]): Ref<T | null>
+export function useIpcRendererInvoke<T>(channel: string, ...args: any[]): ShallowRef<T | null>
 
-export function useIpcRendererInvoke<T>(...args: any[]): Ref<T | null> {
+export function useIpcRendererInvoke<T>(...args: any[]): ShallowRef<T | null> {
   let ipcRenderer: IpcRenderer | undefined
   let channel: string
   let invokeArgs: any[]

--- a/packages/integrations/useAsyncValidator/index.ts
+++ b/packages/integrations/useAsyncValidator/index.ts
@@ -1,9 +1,9 @@
 import type { MaybeRefOrGetter } from '@vueuse/shared'
 import type { Rules, ValidateError, ValidateOption } from 'async-validator'
-import type { Ref } from 'vue'
+import type { ComputedRef, ShallowRef } from 'vue'
 import { toRef, until } from '@vueuse/shared'
 import Schema from 'async-validator'
-import { computed, ref as deepRef, shallowRef, toValue, watch } from 'vue'
+import { computed, shallowRef, toValue, watch } from 'vue'
 
 // @ts-expect-error Schema.default is exist in ssr mode
 const AsyncValidatorSchema = Schema.default || Schema
@@ -21,11 +21,11 @@ export interface UseAsyncValidatorExecuteReturn {
 }
 
 export interface UseAsyncValidatorReturn {
-  pass: Ref<boolean>
-  isFinished: Ref<boolean>
-  errors: Ref<AsyncValidatorError['errors'] | undefined>
-  errorInfo: Ref<AsyncValidatorError | null>
-  errorFields: Ref<AsyncValidatorError['fields'] | undefined>
+  pass: ShallowRef<boolean>
+  isFinished: ShallowRef<boolean>
+  errors: ComputedRef<AsyncValidatorError['errors'] | undefined>
+  errorInfo: ShallowRef<AsyncValidatorError | null>
+  errorFields: ComputedRef<AsyncValidatorError['fields'] | undefined>
   execute: () => Promise<UseAsyncValidatorExecuteReturn>
 }
 
@@ -68,7 +68,7 @@ export function useAsyncValidator(
 
   const errorInfo = shallowRef<AsyncValidatorError | null>(null)
   const isFinished = shallowRef(true)
-  const pass = deepRef(!immediate || manual)
+  const pass = shallowRef(!immediate || manual)
   const errors = computed(() => errorInfo.value?.errors || [])
   const errorFields = computed(() => errorInfo.value?.fields || {})
 

--- a/packages/integrations/useDrauu/index.ts
+++ b/packages/integrations/useDrauu/index.ts
@@ -1,7 +1,7 @@
 import type { EventHookOn, MaybeComputedElementRef } from '@vueuse/core'
 import type { Fn } from '@vueuse/shared'
 import type { Brush, Drauu, DrawingMode, Options } from 'drauu'
-import type { Ref } from 'vue'
+import type { Ref, ShallowRef } from 'vue'
 import { createEventHook, unrefElement } from '@vueuse/core'
 import { tryOnScopeDispose } from '@vueuse/shared'
 import { createDrauu } from 'drauu'
@@ -17,8 +17,8 @@ export interface UseDrauuReturn {
   cancel: () => void
   undo: () => boolean | undefined
   redo: () => boolean | undefined
-  canUndo: Ref<boolean>
-  canRedo: Ref<boolean>
+  canUndo: ShallowRef<boolean>
+  canRedo: ShallowRef<boolean>
   brush: Ref<Brush>
 
   onChanged: EventHookOn

--- a/packages/integrations/useFocusTrap/index.ts
+++ b/packages/integrations/useFocusTrap/index.ts
@@ -1,7 +1,7 @@
 import type { Arrayable, Fn, MaybeComputedElementRef } from '@vueuse/core'
 import type { MaybeRefOrGetter } from '@vueuse/shared'
 import type { ActivateOptions, DeactivateOptions, FocusTrap, Options } from 'focus-trap'
-import type { Ref } from 'vue'
+import type { ShallowRef } from 'vue'
 import { toArray, tryOnScopeDispose, unrefElement } from '@vueuse/core'
 import { notNullish } from '@vueuse/shared'
 import { createFocusTrap } from 'focus-trap'
@@ -18,12 +18,12 @@ export interface UseFocusTrapReturn {
   /**
    * Indicates if the focus trap is currently active
    */
-  hasFocus: Ref<boolean>
+  hasFocus: ShallowRef<boolean>
 
   /**
    * Indicates if the focus trap is currently paused
    */
-  isPaused: Ref<boolean>
+  isPaused: ShallowRef<boolean>
 
   /**
    * Activate the focus trap

--- a/packages/integrations/useIDBKeyval/index.ts
+++ b/packages/integrations/useIDBKeyval/index.ts
@@ -1,5 +1,5 @@
 import type { ConfigurableFlush, MaybeRefOrGetter, RemovableRef } from '@vueuse/shared'
-import type { Ref } from 'vue'
+import type { Ref, ShallowRef } from 'vue'
 import { watchPausable } from '@vueuse/core'
 import { del, get, set, update } from 'idb-keyval'
 import { ref as deepRef, shallowRef, toRaw, toValue } from 'vue'
@@ -35,7 +35,7 @@ export interface UseIDBOptions extends ConfigurableFlush {
 
 export interface UseIDBKeyvalReturn<T> {
   data: RemovableRef<T>
-  isFinished: Ref<boolean>
+  isFinished: ShallowRef<boolean>
   set: (value: T) => Promise<void>
 }
 

--- a/packages/rxjs/useExtractedObservable/index.ts
+++ b/packages/rxjs/useExtractedObservable/index.ts
@@ -1,6 +1,6 @@
 import type { MapOldSources, MapSources, MultiWatchSources } from '@vueuse/shared'
 import type { Subscription } from 'rxjs'
-import type { Ref, WatchOptions, WatchSource } from 'vue'
+import type { ShallowRef, WatchOptions, WatchSource } from 'vue'
 import type { UseObservableOptions } from '../useObservable'
 import type { WatchExtractedObservableCallback } from '../watchExtractedObservable'
 import { tryOnScopeDispose } from '@vueuse/shared'
@@ -24,7 +24,7 @@ export function useExtractedObservable<
   >,
   options?: UseExtractedObservableOptions<E>,
   watchOptions?: WatchOptions<Immediate>,
-): Readonly<Ref<E>>
+): Readonly<ShallowRef<E>>
 
 // overload: multiple sources w/ `as const`
 // watch([foo, bar] as const, () => {})
@@ -42,7 +42,7 @@ export function useExtractedObservable<
   >,
   options?: UseExtractedObservableOptions<E>,
   watchOptions?: WatchOptions<Immediate>,
-): Readonly<Ref<E>>
+): Readonly<ShallowRef<E>>
 
 // overload: single source + cb
 export function useExtractedObservable<
@@ -58,7 +58,7 @@ export function useExtractedObservable<
   >,
   options?: UseExtractedObservableOptions<E>,
   watchOptions?: WatchOptions<Immediate>,
-): Readonly<Ref<E>>
+): Readonly<ShallowRef<E>>
 
 // overload: watching reactive object w/ cb
 export function useExtractedObservable<
@@ -74,7 +74,7 @@ export function useExtractedObservable<
   >,
   options?: UseExtractedObservableOptions<E>,
   watchOptions?: WatchOptions<Immediate>,
-): Readonly<Ref<E>>
+): Readonly<ShallowRef<E>>
 
 // implementation
 export function useExtractedObservable<T = any, E = unknown, Immediate extends Readonly<boolean> = false>(
@@ -82,7 +82,7 @@ export function useExtractedObservable<T = any, E = unknown, Immediate extends R
   extractor: WatchExtractedObservableCallback<any, any, E>,
   options?: UseExtractedObservableOptions<E>,
   watchOptions?: WatchOptions<Immediate>,
-): Readonly<Ref<E>> {
+): Readonly<ShallowRef<E>> {
   let subscription: Subscription | undefined
 
   tryOnScopeDispose(() => {
@@ -120,5 +120,5 @@ export function useExtractedObservable<T = any, E = unknown, Immediate extends R
     ...watchOptions,
   })
 
-  return readonly(obsRef) as Readonly<Ref<E>>
+  return readonly(obsRef) as Readonly<ShallowRef<E>>
 }

--- a/packages/shared/computedEager/index.ts
+++ b/packages/shared/computedEager/index.ts
@@ -1,7 +1,7 @@
 // ported from https://dev.to/linusborg/vue-when-a-computed-property-can-be-the-wrong-tool-195j
 // by @linusborg https://github.com/LinusBorg
 
-import type { Ref, WatchOptionsBase } from 'vue'
+import type { ShallowRef, WatchOptionsBase } from 'vue'
 import { readonly, shallowRef, watchEffect } from 'vue'
 
 /**
@@ -12,9 +12,9 @@ import { readonly, shallowRef, watchEffect } from 'vue'
  *
  * @param fn effect function
  * @param options WatchOptionsBase
- * @returns readonly ref
+ * @returns readonly shallowRef
  */
-export function computedEager<T>(fn: () => T, options?: WatchOptionsBase): Readonly<Ref<T>> {
+export function computedEager<T>(fn: () => T, options?: WatchOptionsBase): Readonly<ShallowRef<T>> {
   const result = shallowRef()
 
   watchEffect(() => {

--- a/packages/shared/useCounter/index.ts
+++ b/packages/shared/useCounter/index.ts
@@ -1,6 +1,6 @@
 import type { MaybeRef } from '../utils'
 import {
-  ref as deepRef,
+  shallowRef,
   // eslint-disable-next-line no-restricted-imports
   unref,
 } from 'vue'
@@ -19,7 +19,7 @@ export interface UseCounterOptions {
  */
 export function useCounter(initialValue: MaybeRef<number> = 0, options: UseCounterOptions = {}) {
   let _initialValue = unref(initialValue)
-  const count = deepRef(initialValue)
+  const count = shallowRef(initialValue)
 
   const {
     max = Number.POSITIVE_INFINITY,

--- a/packages/shared/useInterval/index.ts
+++ b/packages/shared/useInterval/index.ts
@@ -1,4 +1,4 @@
-import type { Ref } from 'vue'
+import type { ShallowRef } from 'vue'
 import type { MaybeRefOrGetter, Pausable } from '../utils'
 import { shallowRef } from 'vue'
 import { useIntervalFn } from '../useIntervalFn'
@@ -25,7 +25,7 @@ export interface UseIntervalOptions<Controls extends boolean> {
 }
 
 export interface UseIntervalControls {
-  counter: Ref<number>
+  counter: ShallowRef<number>
   reset: () => void
 }
 
@@ -36,7 +36,7 @@ export interface UseIntervalControls {
  * @param interval
  * @param options
  */
-export function useInterval(interval?: MaybeRefOrGetter<number>, options?: UseIntervalOptions<false>): Ref<number>
+export function useInterval(interval?: MaybeRefOrGetter<number>, options?: UseIntervalOptions<false>): ShallowRef<number>
 export function useInterval(interval: MaybeRefOrGetter<number>, options: UseIntervalOptions<true>): UseIntervalControls & Pausable
 export function useInterval(interval: MaybeRefOrGetter<number> = 1000, options: UseIntervalOptions<boolean> = {}) {
   const {

--- a/packages/shared/useToggle/index.ts
+++ b/packages/shared/useToggle/index.ts
@@ -1,14 +1,14 @@
-import type { Ref } from 'vue'
+import type { ShallowRef } from 'vue'
 import type { MaybeRef, MaybeRefOrGetter } from '../utils'
-import { ref as deepRef, isRef, toValue } from 'vue'
+import { isRef, shallowRef, toValue } from 'vue'
 
 export interface UseToggleOptions<Truthy, Falsy> {
   truthyValue?: MaybeRefOrGetter<Truthy>
   falsyValue?: MaybeRefOrGetter<Falsy>
 }
 
-export function useToggle<Truthy, Falsy, T = Truthy | Falsy>(initialValue: Ref<T>, options?: UseToggleOptions<Truthy, Falsy>): (value?: T) => T
-export function useToggle<Truthy = true, Falsy = false, T = Truthy | Falsy>(initialValue?: T, options?: UseToggleOptions<Truthy, Falsy>): [Ref<T>, (value?: T) => T]
+export function useToggle<Truthy, Falsy, T = Truthy | Falsy>(initialValue: ShallowRef<T>, options?: UseToggleOptions<Truthy, Falsy>): (value?: T) => T
+export function useToggle<Truthy = true, Falsy = false, T = Truthy | Falsy>(initialValue?: T, options?: UseToggleOptions<Truthy, Falsy>): [ShallowRef<T>, (value?: T) => T]
 
 /**
  * A boolean ref with a toggler
@@ -26,7 +26,7 @@ export function useToggle(
   } = options
 
   const valueIsRef = isRef(initialValue)
-  const _value = deepRef(initialValue) as Ref<boolean>
+  const _value = shallowRef(initialValue) as ShallowRef<boolean>
 
   function toggle(value?: boolean) {
     // has arguments

--- a/packages/shared/useToggle/index.ts
+++ b/packages/shared/useToggle/index.ts
@@ -1,4 +1,4 @@
-import type { ShallowRef } from 'vue'
+import type { Ref, ShallowRef } from 'vue'
 import type { MaybeRef, MaybeRefOrGetter } from '../utils'
 import { isRef, shallowRef, toValue } from 'vue'
 
@@ -7,7 +7,7 @@ export interface UseToggleOptions<Truthy, Falsy> {
   falsyValue?: MaybeRefOrGetter<Falsy>
 }
 
-export function useToggle<Truthy, Falsy, T = Truthy | Falsy>(initialValue: ShallowRef<T>, options?: UseToggleOptions<Truthy, Falsy>): (value?: T) => T
+export function useToggle<Truthy, Falsy, T = Truthy | Falsy>(initialValue: Ref<T>, options?: UseToggleOptions<Truthy, Falsy>): (value?: T) => T
 export function useToggle<Truthy = true, Falsy = false, T = Truthy | Falsy>(initialValue?: T, options?: UseToggleOptions<Truthy, Falsy>): [ShallowRef<T>, (value?: T) => T]
 
 /**

--- a/packages/shared/utils/types.ts
+++ b/packages/shared/utils/types.ts
@@ -1,4 +1,4 @@
-import type { ComputedRef, MaybeRef, MaybeRefOrGetter, Ref, WatchOptions, WatchSource } from 'vue'
+import type { ComputedRef, MaybeRef, MaybeRefOrGetter, Ref, ShallowRef, WatchOptions, WatchSource } from 'vue'
 
 export type {
   MaybeRef,
@@ -75,7 +75,7 @@ export interface Pausable {
   /**
    * A ref indicate whether a pausable instance is active
    */
-  isActive: Readonly<Ref<boolean>>
+  isActive: Readonly<ShallowRef<boolean>>
 
   /**
    * Temporary pause the effect from executing

--- a/packages/shared/watchAtMost/index.ts
+++ b/packages/shared/watchAtMost/index.ts
@@ -1,4 +1,4 @@
-import type { Ref, WatchCallback, WatchSource, WatchStopHandle } from 'vue'
+import type { ShallowRef, WatchCallback, WatchSource, WatchStopHandle } from 'vue'
 import type { MapOldSources, MapSources, MaybeRefOrGetter } from '../utils'
 import type { WatchWithFilterOptions } from '../watchWithFilter'
 import { nextTick, shallowRef, toValue } from 'vue'
@@ -10,7 +10,7 @@ export interface WatchAtMostOptions<Immediate> extends WatchWithFilterOptions<Im
 
 export interface WatchAtMostReturn {
   stop: WatchStopHandle
-  count: Ref<number>
+  count: ShallowRef<number>
 }
 
 // overloads


### PR DESCRIPTION
<!-- Thank you for contributing! -->

Part of https://github.com/vueuse/vueuse/issues/4575

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

This PR will modify:

- Ensure every `ref` is renamed to `deepRef`
- Change primitives and `element` to `shallowRef`
- Remove unnecessary `Ref` types

The goal is to separate parts that will not cause `breaking changes` into a single PR.

I skipped `useEventSource` to ensure it does not conflict with #4598.