### PR TITLE
fix(useWebSocket): don't call close() on pongTimeout if connection al…

### DIFF
--- a/packages/core/useWebSocket/index.test.ts
+++ b/packages/core/useWebSocket/index.test.ts
@@ -352,4 +352,86 @@ describe('useWebSocket', () => {
       expect(mockWebSocket.prototype.send).toBeCalledWith('bleep bloop')
     })
   })
+
+  describe('heartbeat', () => {
+    vi.useFakeTimers()
+
+    it('should send a heartbeat if heartbeat=true', async () => {
+      vm = useSetup(() => {
+        const ref = useWebSocket('wss://server.example.com', {
+          heartbeat: {
+            interval: 500,
+          },
+        })
+
+        return {
+          ref,
+        }
+      })
+
+      vm.ref.ws.value?.onopen?.(new Event('open'))
+      await vi.advanceTimersByTimeAsync(500)
+      expect(mockWebSocket.prototype.send).toBeCalledWith('ping')
+    })
+    it('shoul not send a heartbeat if heartbeat=false', async () => {
+      vm = useSetup(() => {
+        const ref = useWebSocket('wss://server.example.com', {
+          heartbeat: false,
+        })
+
+        return {
+          ref,
+        }
+      })
+
+      vm.ref.ws.value?.onopen?.(new Event('open'))
+      await vi.advanceTimersByTimeAsync(500)
+      expect(mockWebSocket.prototype.send).not.toHaveBeenCalled()
+    })
+    it('should call close on pongTimeout', async () => {
+      vm = useSetup(() => {
+        const ref = useWebSocket('wss://server.example.com', {
+          heartbeat: {
+            interval: 500,
+            pongTimeout: 1000,
+          },
+        })
+
+        return {
+          ref,
+        }
+      })
+
+      vm.ref.ws.value?.onopen?.(new Event('open'))
+      expect(vm.ref.status.value).toBe('OPEN')
+      mockWebSocket.prototype.close.mockClear()
+      await vi.advanceTimersByTimeAsync(1499)
+      expect(mockWebSocket.prototype.close).not.toHaveBeenCalled()
+      await vi.advanceTimersByTimeAsync(1)
+      expect(mockWebSocket.prototype.close).toHaveBeenCalledOnce()
+    })
+    it('should not call close on pongTimeout if connection already closed', async () => {
+      vm = useSetup(() => {
+        const ref = useWebSocket('wss://server.example.com', {
+          heartbeat: {
+            message: 'ping',
+            interval: 500,
+            pongTimeout: 1000,
+          },
+        })
+
+        return {
+          ref,
+        }
+      })
+      vm.ref.ws.value?.onopen?.(new Event('open'))
+      expect(vm.ref.status.value).toBe('OPEN')
+      const ev = new CloseEvent('close')
+      vm.ref.ws.value?.onclose?.(ev)
+      expect(vm.ref.status.value).toBe('CLOSED')
+      mockWebSocket.prototype.close.mockClear()
+      await vi.advanceTimersByTimeAsync(1500)
+      expect(mockWebSocket.prototype.close).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/packages/core/useWebSocket/index.ts
+++ b/packages/core/useWebSocket/index.ts
@@ -302,9 +302,11 @@ export function useWebSocket<Data = any>(
         if (pongTimeoutWait != null)
           return
         pongTimeoutWait = setTimeout(() => {
-          // auto-reconnect will be trigger with ws.onclose()
-          close()
-          explicitlyClosed = false
+          if (status.value !== 'CLOSED') {
+            // auto-reconnect will be trigger with ws.onclose()
+            close()
+            explicitlyClosed = false
+          }
         }, pongTimeout)
       },
       interval,

--- a/packages/core/useWebSocket/index.ts
+++ b/packages/core/useWebSocket/index.ts
@@ -247,6 +247,8 @@ export function useWebSocket<Data = any>(
 
     ws.onclose = (ev) => {
       status.value = 'CLOSED'
+      resetHeartbeat()
+      heartbeatPause?.()
       onDisconnected?.(ws, ev)
 
       if (!explicitlyClosed && options.autoReconnect && (wsRef.value == null || ws === wsRef.value)) {
@@ -302,11 +304,9 @@ export function useWebSocket<Data = any>(
         if (pongTimeoutWait != null)
           return
         pongTimeoutWait = setTimeout(() => {
-          if (status.value !== 'CLOSED') {
-            // auto-reconnect will be trigger with ws.onclose()
-            close()
-            explicitlyClosed = false
-          }
+          // auto-reconnect will be trigger with ws.onclose()
+          close()
+          explicitlyClosed = false
         }, pongTimeout)
       },
       interval,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Fixes #4607. 
- Only call `close()` in `pongTimeoutWait` is the connection is not `CLOSED`

### Additional context

- I tried to add some tests for the heartbeat
