### PR TITLE
fix(useClipboard): unhandled rejection on read permission prompt

### DIFF
--- a/packages/core/useClipboard/index.ts
+++ b/packages/core/useClipboard/index.ts
@@ -70,13 +70,11 @@ export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<strin
   const copied = shallowRef(false)
   const timeout = useTimeoutFn(() => copied.value = false, copiedDuring, { immediate: false })
 
-  function updateText() {
+  async function updateText() {
     let useLegacy = !(isClipboardApiSupported.value && isAllowed(permissionRead.value))
     if (!useLegacy) {
       try {
-        navigator!.clipboard.readText().then((value) => {
-          text.value = value
-        })
+        text.value = await navigator!.clipboard.readText()
       }
       catch {
         useLegacy = true


### PR DESCRIPTION
Fallback to document.getSelection() on read permission prompt as intended instead of consuming NotAllowedError

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

When `options.read === true` and the `'clipboard-read'` permission value is `'prompt'`, thus `isAllowed()` returns `true` and an attempt to use the Clipboard API is made, before the user can press either Allow or Deny, the `Promise` returned by `navigator.clipboard.readText()` can be rejected with a `NotAllowedError`. This was covered in #4512, but a wrong syntax combination was used, consequently, the **fallback to `legacyRead()` didn't happen**, and an **unhandled rejection with a NotAllowedError was generated** in the console. This PR handles the rejection by falling back as intended.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

See [reply](https://github.com/vueuse/vueuse/pull/4512/files#r1962169204) to where this was introduced. Async/await is supported by `addEventHandler()` and was preferred to `Promise.catch()` for its [advantages](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function#:~:text=The%20purpose%20of%20async/await%20is%20to%20simplify%20the%20syntax%20necessary%20to%20consume%20promise%2Dbased%20APIs.) and by analogy to [`copy()`](https://github.com/vueuse/vueuse/pull/4512/files#diff-104a20ea8a35b01c36721b36a81d3138312e27a997280d66290ce7e8a9bc466aR93-R103) from the same PR.