### PR TITLE
fix(onStartTyping): Incorrect accepted valid characters

### DIFF
--- a/packages/core/onStartTyping/index.test.ts
+++ b/packages/core/onStartTyping/index.test.ts
@@ -1,0 +1,56 @@
+import type { Ref } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { shallowRef } from 'vue'
+import { onStartTyping } from './index'
+
+describe('onStartTyping', () => {
+  let element: Ref<HTMLInputElement>
+  let callBackFn: any
+
+  beforeEach(() => {
+    element = shallowRef(document.createElement('input'))
+    element.value.tabIndex = 1
+    callBackFn = vi.fn()
+  })
+
+  function createKeyDownEvent(keyCode: number) {
+    const ev = new KeyboardEvent('keydown', { keyCode })
+    document.dispatchEvent(ev)
+  }
+
+  function range(size: number, startAt = 0) {
+    return [...Array.from({ length: size }).keys()].map(i => i + startAt)
+  }
+
+  it('triggers callback with any letter', () => {
+    const letters = range(26, 65)
+
+    onStartTyping(callBackFn)
+
+    letters.forEach((letter) => {
+      document.body.focus()
+      createKeyDownEvent(letter)
+    })
+
+    expect(callBackFn).toBeCalledTimes(letters.length)
+  })
+
+  it('triggers callback with any number', () => {
+    const numbers = range(10, 48)
+    const numpadNumbers = range(10, 96)
+
+    onStartTyping(callBackFn)
+
+    numbers.forEach((number) => {
+      document.body.focus()
+      createKeyDownEvent(number)
+    })
+
+    numpadNumbers.forEach((number) => {
+      document.body.focus()
+      createKeyDownEvent(number)
+    })
+
+    expect(callBackFn).toBeCalledTimes(numbers.length + numpadNumbers.length)
+  })
+})

--- a/packages/core/onStartTyping/index.test.ts
+++ b/packages/core/onStartTyping/index.test.ts
@@ -13,7 +13,7 @@ describe('onStartTyping', () => {
     callBackFn = vi.fn()
   })
 
-  function createKeyDownEvent(keyCode: number) {
+  function dispatchKeyDownEvent(keyCode: number) {
     const ev = new KeyboardEvent('keydown', { keyCode })
     document.dispatchEvent(ev)
   }
@@ -29,7 +29,7 @@ describe('onStartTyping', () => {
 
     letters.forEach((letter) => {
       document.body.focus()
-      createKeyDownEvent(letter)
+      dispatchKeyDownEvent(letter)
     })
 
     expect(callBackFn).toBeCalledTimes(letters.length)
@@ -43,14 +43,33 @@ describe('onStartTyping', () => {
 
     numbers.forEach((number) => {
       document.body.focus()
-      createKeyDownEvent(number)
+      dispatchKeyDownEvent(number)
     })
 
     numpadNumbers.forEach((number) => {
       document.body.focus()
-      createKeyDownEvent(number)
+      dispatchKeyDownEvent(number)
     })
 
     expect(callBackFn).toBeCalledTimes(numbers.length + numpadNumbers.length)
+  })
+
+  it('does not trigger callback with invalid characters', () => {
+    const arrows = range(4, 37)
+    const functionKeys = range(32, 112)
+
+    onStartTyping(callBackFn)
+
+    arrows.forEach((arrow) => {
+      document.body.focus()
+      dispatchKeyDownEvent(arrow)
+    })
+
+    functionKeys.forEach((functionKey) => {
+      document.body.focus()
+      dispatchKeyDownEvent(functionKey)
+    })
+
+    expect(callBackFn).toBeCalledTimes(0)
   })
 })

--- a/packages/core/onStartTyping/index.ts
+++ b/packages/core/onStartTyping/index.ts
@@ -34,15 +34,11 @@ function isTypedCharValid({
     return false
 
   // 0...9
-  if (keyCode >= 48 && keyCode <= 57)
+  if ((keyCode >= 48 && keyCode <= 57) || (keyCode >= 96 && keyCode <= 105))
     return true
 
   // A...Z
   if (keyCode >= 65 && keyCode <= 90)
-    return true
-
-  // a...z
-  if (keyCode >= 97 && keyCode <= 122)
     return true
 
   // All other keys.


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

---

### Description

This PR fixes the characters which are accepted when using onStartTyping. Specifically, it adds back the ability for users to start typing with Numpad0 to focus on the connected element (#4614, related: #2932).

### Additional context

Should more characters be accepted or are just the basic letters and numbers enough?
