### PR TITLE
feat(useObjectVModel): Implement new useObjectVModel composable to allow update of an object passed through v-model in child components

### DIFF
--- a/packages/core/useObjectVModel/index.ts
+++ b/packages/core/useObjectVModel/index.ts
@@ -1,0 +1,23 @@
+import type { ModelRef, WritableComputedRef } from 'vue'
+import { computed } from 'vue'
+
+export function useObjectVModel<T extends object, M extends PropertyKey = string, G = T, S = T>(
+  obj: ModelRef<T, M, G, S>,
+): WritableComputedRef<T> {
+  const o = computed({
+    get: (): T => {
+      return new Proxy(obj.value as unknown as T, {
+        set(target, propertyName, newValue): boolean {
+          o.value = { ...target, [propertyName]: newValue }
+
+          return true
+        },
+      })
+    },
+    set: (newValue: T): void => {
+      obj.value = newValue as unknown as S
+    },
+  })
+
+  return o
+}

--- a/packages/core/useObjectVModel/index.ts
+++ b/packages/core/useObjectVModel/index.ts
@@ -4,14 +4,39 @@ import { computed } from 'vue'
 export function useObjectVModel<T extends object, M extends PropertyKey = string, G = T, S = T>(
   obj: ModelRef<T, M, G, S>,
 ): WritableComputedRef<T> {
+  function createDeepProxy(target: T, update: (newValue: any) => void): T {
+    return new Proxy(target, {
+      get(target: T, p, receiver) {
+        const value = Reflect.get(target, p, receiver)
+
+        if (typeof value === 'object') {
+          return createDeepProxy(value as T, (newChildValue: any) => {
+            const targetCopy = Array.isArray(target) ? [...target] : { ...target }
+
+            targetCopy[p] = newChildValue
+            update(targetCopy)
+
+            return newChildValue
+          })
+        }
+
+        return value
+      },
+      set(target, p, newValue, receiver) {
+        const targetCopy = Array.isArray(target) ? [...target] : { ...target }
+
+        targetCopy[p] = newValue
+        update(targetCopy)
+
+        return Reflect.set(target, p, newValue, receiver)
+      },
+    })
+  }
+
   const o = computed({
     get: (): T => {
-      return new Proxy(obj.value as unknown as T, {
-        set(target, propertyName, newValue): boolean {
-          o.value = { ...target, [propertyName]: newValue }
-
-          return true
-        },
+      return createDeepProxy(obj.value as unknown as T, (newValue: T) => {
+        o.value = newValue
       })
     },
     set: (newValue: T): void => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

At the moment vue does not provide any way to update the property of an object passed through props by using v-model without breaking the parent -> child data flow. even by using defineModel
in the child component as in the following:

```
const obj = defineModel<{propertyA: string; propertyB: string}>({ required: true })
</script>

<template>
    <div>
        <input v-model="obj.propertyB">
    </div>
</template>
```

it would break the data flow. (https://vuejs.org/guide/components/props.html#mutating-object-array-props)

In order to solve this problem i created a composable `useObjectVModel` that takes a `modelRef` as parameter (obtainable thanks to the `defineModel()` macro) and leverages the js proxy to update the whole object with the same data as before plus the changed one for each property by triggering an update on the  `modelRef ` that will automatically trigger an emit to update the data in the parent component.

The idea has been taken from https://skirtles-code.github.io/vue-examples/patterns/computed-v-model
I just made a composable out of it.

Probably the same outcome can be achieved with the `useVModel` but i think it would be more expensive when used with nested properties in big objects as there should be a deep watcher involved.

### Additional context

If the feature gets approved, I will add docs and tests.
