### PR TITLE
test(useAnimate): add test for keyframe reactivity

### DIFF
--- a/packages/core/useAnimate/index.browser.test.ts
+++ b/packages/core/useAnimate/index.browser.test.ts
@@ -37,4 +37,42 @@ describe('useAnimate', () => {
     })
     wrapper.unmount()
   })
+
+  it('should support keyframes refs', async () => {
+    const keyframes = shallowRef<PropertyIndexedKeyframes>({
+      transform: 'rotate(360deg)',
+    })
+    const wrapper = mount({
+      template: '<p ref="el">test</p>',
+      setup() {
+        const el = shallowRef<HTMLElement>()
+        const animate = useAnimate(el, keyframes, 100)
+
+        return { ...animate, el }
+      },
+    })
+    const vm = wrapper.vm
+    await vi.waitFor(() => {
+      expect(vm.playState).toBe('finished')
+    })
+
+    keyframes.value = { transform: 'rotate(180deg)' }
+
+    // TODO (43081j): figure out how to get `mount` to type this properly
+    // in the first place. So we can drop the cast
+    const animation = vm.animate as Animation
+
+    await vi.waitFor(() => {
+      const keyframe = animation.effect as KeyframeEffect
+      expect(keyframe.getKeyframes()).to.deep.equal([{
+        composite: 'auto',
+        computedOffset: 1,
+        easing: 'linear',
+        offset: null,
+        transform: 'rotate(180deg)',
+      }])
+    })
+
+    wrapper.unmount()
+  })
 })


### PR DESCRIPTION
Adds a test for asserting that keyframes can be passed as a ref and will trigger an update when they change.

Depends on #4619 

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
