### PR TITLE
chore: switch to yaml for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@rollup/plugin-replace": "catalog:",
     "@shikijs/vitepress-twoslash": "catalog:",
     "@type-challenges/utils": "catalog:",
-    "@types/js-yaml": "catalog:",
     "@types/md5": "catalog:",
     "@types/node": "catalog:",
     "@types/remove-markdown": "catalog:",
@@ -78,7 +77,6 @@
     "fuse.js": "catalog:",
     "google-font-installer": "catalog:",
     "gray-matter": "catalog:",
-    "js-yaml": "catalog:",
     "jsdom": "catalog:",
     "lint-staged": "catalog:",
     "markdown-table": "catalog:",
@@ -116,7 +114,8 @@
     "vitest-browser-vue": "catalog:",
     "vitest-package-exports": "catalog:",
     "vue": "catalog:",
-    "vue-tsc": "catalog:"
+    "vue-tsc": "catalog:",
+    "yaml": "catalog:"
   },
   "pnpm": {
     "neverBuiltDependencies": [

--- a/packages/.vitepress/plugins/utils.ts
+++ b/packages/.vitepress/plugins/utils.ts
@@ -2,7 +2,12 @@ import { reactify } from '@vueuse/shared'
 import YAML from 'yaml'
 
 export const stringify = reactify(
-  (input: any) => YAML.stringify(input, {
+  (input: any) => YAML.stringify(input, (k, v) => {
+    if (typeof v === 'function') {
+      return undefined
+    }
+    return v
+  }, {
     singleQuote: true,
     flowCollectionPadding: false,
   }),

--- a/packages/.vitepress/plugins/utils.ts
+++ b/packages/.vitepress/plugins/utils.ts
@@ -1,12 +1,9 @@
 import { reactify } from '@vueuse/shared'
-import YAML from 'js-yaml'
+import YAML from 'yaml'
 
 export const stringify = reactify(
-  (input: any) => YAML.dump(input, {
-    skipInvalid: true,
-    forceQuotes: true,
-    condenseFlow: true,
-    noCompatMode: true,
-    quotingType: '\'',
+  (input: any) => YAML.stringify(input, {
+    singleQuote: true,
+    flowCollectionPadding: false,
   }),
 )

--- a/packages/.vitepress/vite.config.ts
+++ b/packages/.vitepress/vite.config.ts
@@ -77,7 +77,7 @@ export default defineConfig({
     ],
     include: [
       'axios',
-      'js-yaml',
+      'yaml',
       'nprogress',
       'qrcode',
       'tslib',

--- a/packages/core/useAsyncState/demo.vue
+++ b/packages/core/useAsyncState/demo.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useAsyncState } from '@vueuse/core'
 import axios from 'axios'
-import YAML from 'js-yaml'
+import yaml from 'yaml'
 
 const { isLoading, state, isReady, execute } = useAsyncState(
   (args) => {
@@ -20,7 +20,7 @@ const { isLoading, state, isReady, execute } = useAsyncState(
   <div>
     <note>Ready: {{ isReady.toString() }}</note>
     <note>Loading: {{ isLoading.toString() }}</note>
-    <pre lang="json" class="ml-2">{{ YAML.dump(state) }}</pre>
+    <pre lang="json" class="ml-2">{{ yaml.stringify(state) }}</pre>
     <button @click="() => execute(2000, { id: 2 })">
       Execute
     </button>

--- a/packages/core/useMediaQuery/demo.vue
+++ b/packages/core/useMediaQuery/demo.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import { useMediaQuery } from '@vueuse/core'
-import YAML from 'js-yaml'
 import { computed, reactive } from 'vue'
+import yaml from 'yaml'
 
 const isLargeScreen = useMediaQuery('(min-width: 1024px)')
 const prefersDark = useMediaQuery('(prefers-color-scheme: dark)')
 
-const code = computed(() => YAML.dump(reactive({
+const code = computed(() => yaml.stringify(reactive({
   isLargeScreen,
   prefersDark,
 })))

--- a/packages/core/useParallax/demo.vue
+++ b/packages/core/useParallax/demo.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import type { CSSProperties } from 'vue'
 import { useMediaQuery, useParallax } from '@vueuse/core'
-import YAML from 'js-yaml'
 import { computed, reactive, useTemplateRef } from 'vue'
+import yaml from 'yaml'
 
 const target = useTemplateRef<HTMLElement>('target')
 const isMobile = useMediaQuery('(max-width: 700px)')
@@ -92,7 +92,7 @@ const cardStyle = computed(() => ({
 <template>
   <div>
     <div ref="target" :style="targetStyle">
-      <pre :style="infoStyle">{{ YAML.dump(parallax) }}</pre>
+      <pre :style="infoStyle">{{ yaml.stringify(parallax) }}</pre>
       <div :style="containerStyle">
         <div :style="cardStyle">
           <div :style="cardWindowStyle">

--- a/packages/core/usePermission/demo.vue
+++ b/packages/core/usePermission/demo.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { usePermission } from '@vueuse/core'
-import YAML from 'js-yaml'
 import { computed, reactive } from 'vue'
+import yaml from 'yaml'
 
 const accelerometer = usePermission('accelerometer')
 const accessibilityEvents = usePermission('accessibility-events')
@@ -21,7 +21,7 @@ const push = usePermission('push')
 const speaker = usePermission('speaker')
 const localFonts = usePermission('local-fonts')
 
-const code = computed(() => YAML.dump(reactive({
+const code = computed(() => yaml.stringify(reactive({
   accelerometer,
   accessibilityEvents,
   ambientLightSensor,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,9 +36,6 @@ catalogs:
     '@type-challenges/utils':
       specifier: ^0.1.1
       version: 0.1.1
-    '@types/js-yaml':
-      specifier: ^4.0.9
-      version: 4.0.9
     '@types/md5':
       specifier: ^2.3.5
       version: 2.3.5
@@ -141,9 +138,6 @@ catalogs:
     idb-keyval:
       specifier: ^6.2.1
       version: 6.2.1
-    js-yaml:
-      specifier: ^4.1.0
-      version: 4.1.0
     jsdom:
       specifier: ^26.0.0
       version: 26.0.0
@@ -279,6 +273,9 @@ catalogs:
     vue-tsc:
       specifier: ^2.2.8
       version: 2.2.8
+    yaml:
+      specifier: ^2.7.0
+      version: 2.7.0
 
 overrides:
   '@typescript-eslint/utils': ^8.26.0
@@ -324,9 +321,6 @@ importers:
       '@type-challenges/utils':
         specifier: 'catalog:'
         version: 0.1.1
-      '@types/js-yaml':
-        specifier: 'catalog:'
-        version: 4.0.9
       '@types/md5':
         specifier: 'catalog:'
         version: 2.3.5
@@ -423,9 +417,6 @@ importers:
       gray-matter:
         specifier: 'catalog:'
         version: 4.0.3
-      js-yaml:
-        specifier: 'catalog:'
-        version: 4.1.0
       jsdom:
         specifier: 'catalog:'
         version: 26.0.0
@@ -540,6 +531,9 @@ importers:
       vue-tsc:
         specifier: 'catalog:'
         version: 2.2.8(typescript@5.8.2)
+      yaml:
+        specifier: 'catalog:'
+        version: 2.7.0
 
   packages/components:
     dependencies:
@@ -2974,9 +2968,6 @@ packages:
 
   '@types/http-proxy@1.17.16':
     resolution: {integrity: sha512-sdWoUajOB1cd0A8cRRQ1cfyWNbmFKLAqBB89Y8x5iYyG/mkJHc0YUH8pdWBy2omi9qtCpiIgGjuwO0dQST2l5w==}
-
-  '@types/js-yaml@4.0.9':
-    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -10729,8 +10720,6 @@ snapshots:
   '@types/http-proxy@1.17.16':
     dependencies:
       '@types/node': 22.13.10
-
-  '@types/js-yaml@4.0.9': {}
 
   '@types/json-schema@7.0.15': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,7 +12,6 @@ catalog:
   '@rollup/plugin-replace': ^6.0.2
   '@shikijs/vitepress-twoslash': ^3.1.0
   '@type-challenges/utils': ^0.1.1
-  '@types/js-yaml': ^4.0.9
   '@types/md5': ^2.3.5
   '@types/node': ^22.13.10
   '@types/nprogress': ^0.2.3
@@ -49,7 +48,7 @@ catalog:
   google-font-installer: ^1.2.0
   gray-matter: ^4.0.3
   idb-keyval: ^6.2.1
-  js-yaml: ^4.1.0
+  yaml: ^2.7.0
   jsdom: ^26.0.0
   jwt-decode: ^4.0.0
   lint-staged: ^15.4.3

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -210,10 +210,13 @@ export async function updateFunctionREADME(indexes: PackageIndexes) {
     let readme = await fs.readFile(mdPath, 'utf-8')
 
     const { content, data = {} } = matter(readme)
+    const yamlData = yaml.stringify(data, {
+      singleQuote: true,
+    })
 
     data.category = fn.category || 'Unknown'
 
-    readme = `---\n${yaml.stringify(data)}---\n\n${content.trim()}`.trim().replace(/\r\n/g, '\n')
+    readme = `---\n${yamlData}---\n\n${content.trim()}`.trim().replace(/\r\n/g, '\n')
 
     await fs.writeFile(mdPath, `${readme}\n`, 'utf-8')
   }

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -4,9 +4,9 @@ import * as fs from 'node:fs/promises'
 import { join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import matter from 'gray-matter'
-import YAML from 'js-yaml'
 import { $fetch } from 'ofetch'
 import Git from 'simple-git'
+import yaml from 'yaml'
 import { packages } from '../meta/packages'
 import { getCategories } from '../packages/metadata/utils'
 
@@ -213,7 +213,7 @@ export async function updateFunctionREADME(indexes: PackageIndexes) {
 
     data.category = fn.category || 'Unknown'
 
-    readme = `---\n${YAML.dump(data)}---\n\n${content.trim()}`.trim().replace(/\r\n/g, '\n')
+    readme = `---\n${yaml.stringify(data)}---\n\n${content.trim()}`.trim().replace(/\r\n/g, '\n')
 
     await fs.writeFile(mdPath, `${readme}\n`, 'utf-8')
   }

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -1,7 +1,7 @@
-import yaml from 'js-yaml'
 import { x } from 'tinyexec'
 import { describe, expect, it } from 'vitest'
 import { getPackageExportsManifest } from 'vitest-package-exports'
+import yaml from 'yaml'
 
 describe('exports-snapshot', async () => {
   const packages: { name: string, path: string, private?: boolean }[] = JSON.parse(
@@ -16,7 +16,7 @@ describe('exports-snapshot', async () => {
         importMode: 'src',
         cwd: pkg.path,
       })
-      await expect(yaml.dump(manifest.exports, { sortKeys: (a, b) => a.localeCompare(b) }))
+      await expect(yaml.stringify(manifest.exports, { sortMapEntries: (a, b) => String(a.key).localeCompare(String(b.key)) }))
         .toMatchFileSnapshot(`./exports/${pkg.name.split('/').pop()}.yaml`)
     })
   }


### PR DESCRIPTION
Switches to the `yaml` package for tests, since `js-yaml` is no longer maintained and does not support the latest yaml spec.

Note this is low priority since we only use it in tests, but we may as well do the clean up still.

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
