### PR TITLE
fix(useScroll): use ResizeObserver to update arrivedState

### DIFF
--- a/packages/core/useScroll/index.ts
+++ b/packages/core/useScroll/index.ts
@@ -5,6 +5,7 @@ import { computed, reactive, shallowRef, toValue } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { unrefElement } from '../unrefElement'
 import { useEventListener } from '../useEventListener'
+import { useResizeObserver } from '../useResizeObserver'
 
 export interface UseScrollOptions extends ConfigurableWindow {
   /**
@@ -273,6 +274,13 @@ export function useScroll(
       if (!_element)
         return
       setArrivedState(_element)
+      if (_element instanceof HTMLElement) {
+        useResizeObserver(_element, () => {
+          const _element = toValue(element)
+          if (_element)
+            setArrivedState(_element)
+        })
+      }
     }
     catch (e) {
       onError(e)


### PR DESCRIPTION
I ran into this when using useScroll inside of a `<dialog>` element: activeState isn't updated when the dialog is being opened. 
This PR uses a ResizeObserver to update the activeState on resize to make sure its properly reacting to changes.
I did not add a test case for this as I didn't know how to best approach writing a test for this.

