### PR TITLE
feat(useMagicKeys): add `onRegisteredEventFired` option

### DIFF
--- a/packages/core/useMagicKeys/index.test.ts
+++ b/packages/core/useMagicKeys/index.test.ts
@@ -15,6 +15,29 @@ describe('useMagicKeys', () => {
 
     expect(A.value).toBe(true)
   })
+  it('registered event for single key', async () => {
+    let registeredKeydown = false
+    let registeredKeyup = false
+    const { A } = useMagicKeys({
+      target,
+      onRegisteredEventFired(e) {
+        if (e.key === 'A' && e.type === 'keydown') {
+          registeredKeydown = true
+        }
+        if (e.key === 'A' && e.type === 'updown') {
+          registeredKeyup = true
+        }
+      },
+    })
+
+    target.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'A',
+    }))
+
+    expect(A.value).toBe(true)
+    expect(registeredKeydown).toBe(true)
+    expect(registeredKeyup).toBe(false)
+  })
   it('multiple keys', async () => {
     const { Ctrl_Shift_Period } = useMagicKeys({ target })
     expect(Ctrl_Shift_Period.value).toBe(false)

--- a/packages/core/useMagicKeys/index.ts
+++ b/packages/core/useMagicKeys/index.ts
@@ -37,6 +37,13 @@ export interface UseMagicKeysOptions<Reactive extends boolean> {
   passive?: boolean
 
   /**
+   * Custom event handler for registered keydown/keyup event.
+   *
+   * When using `e.preventDefault()`, you will need to pass `passive: false` to useMagicKeys().
+   */
+  onRegisteredEventFired?: (e: KeyboardEvent) => void | boolean
+
+  /**
    * Custom event handler for keydown/keyup event.
    * Useful when you want to apply custom logic.
    *
@@ -76,6 +83,7 @@ export function useMagicKeys(options: UseMagicKeysOptions<boolean> = {}): any {
     target = defaultWindow,
     aliasMap = DefaultMagicKeysAliasMap,
     passive = true,
+    onRegisteredEventFired = noop,
     onEventFired = noop,
   } = options
   const current = reactive(new Set<string>())
@@ -117,6 +125,8 @@ export function useMagicKeys(options: UseMagicKeysOptions<boolean> = {}): any {
 
     for (const key of values) {
       usedKeys.add(key)
+      if (value)
+        onRegisteredEventFired(e)
       setRefs(key, value)
     }
 

--- a/packages/core/useMagicKeys/index.ts
+++ b/packages/core/useMagicKeys/index.ts
@@ -41,7 +41,7 @@ export interface UseMagicKeysOptions<Reactive extends boolean> {
    *
    * When using `e.preventDefault()`, you will need to pass `passive: false` to useMagicKeys().
    */
-  onRegisteredEventFired?: (e: KeyboardEvent) => void | boolean
+  onRegisteredEventFired?: (e: KeyboardEvent) => void
 
   /**
    * Custom event handler for keydown/keyup event.


### PR DESCRIPTION
This pull request adds a `onRegisteredEventFired` option to `useMagicKeys`. The `onEventFired` callback is fired for all keydown events, while `onRegisteredEventFired` is only fired for registered key presses.

```ts
const { Ctrl_P, Slash } = useMagicKeys({
	passive: false,
	onRegisteredEventFired(e) {
		e.preventDefault() // only called for Ctrl+P and Slash, without the need for a condition
	},
})
```