### PR TITLE
docs(useWebNotification): add permission tip and update example

### DIFF
--- a/packages/core/useWebNotification/index.md
+++ b/packages/core/useWebNotification/index.md
@@ -14,7 +14,6 @@ The Web Notification interface of the Notifications API is used to configure and
 Before an app can send a notification, the user must grant the application the right to do so. The user's OS settings may also prevent expected notification behaviour.
 :::
 
-
 ```ts
 const {
   isSupported,

--- a/packages/core/useWebNotification/index.md
+++ b/packages/core/useWebNotification/index.md
@@ -10,7 +10,10 @@ The Web Notification interface of the Notifications API is used to configure and
 
 ## Usage
 
-::: tip Before an app can send a notification, the user must grant the application the right to do so. The users' OS settings may also prevent expected notification behaviour. :::
+::: tip
+Before an app can send a notification, the user must grant the application the right to do so. The users' OS settings may also prevent expected notification behaviour.
+:::
+
 
 ```ts
 const {

--- a/packages/core/useWebNotification/index.md
+++ b/packages/core/useWebNotification/index.md
@@ -10,10 +10,13 @@ The Web Notification interface of the Notifications API is used to configure and
 
 ## Usage
 
+::: tip Before an app can send a notification, the user must grant the application the right to do so. The users' OS settings may also prevent expected notification behaviour. :::
+
 ```ts
 const {
   isSupported,
   notification,
+  permissionGranted,
   show,
   close,
   onClick,
@@ -28,7 +31,7 @@ const {
   tag: 'test',
 })
 
-if (isSupported.value)
+if (isSupported.value && permissionGranted.value)
   show()
 ```
 

--- a/packages/core/useWebNotification/index.md
+++ b/packages/core/useWebNotification/index.md
@@ -11,7 +11,7 @@ The Web Notification interface of the Notifications API is used to configure and
 ## Usage
 
 ::: tip
-Before an app can send a notification, the user must grant the application the right to do so. The users' OS settings may also prevent expected notification behaviour.
+Before an app can send a notification, the user must grant the application the right to do so. The user's OS settings may also prevent expected notification behaviour.
 :::
 
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

#3997 is being caused by user error. This PR adds a tip to the useWebNotification "Usage" section, making the user aware of factors that might prevent notifications from displaying as expected.

The PR also adds the `permissionGranted` property to the code example.

### Screenshot
<img width="734" alt="Screenshot 2025-03-14 at 20 20 40" src="https://github.com/user-attachments/assets/cfeb4b58-7a78-49ed-a208-eacfde8a53c0" />

