### PR TITLE
fix: `useDevicesList` in firefox

### DIFF
--- a/packages/core/useDevicesList/index.ts
+++ b/packages/core/useDevicesList/index.ts
@@ -93,26 +93,22 @@ export function useDevicesList(options: UseDevicesListOptions = {}): UseDevicesL
         stream = null
         granted = false
       }
+      update()
       permissionGranted.value = granted
     }
     else {
       permissionGranted.value = true
     }
 
-    update()
-
     return permissionGranted.value
   }
 
   if (isSupported.value) {
-    if (requestPermissions) {
+    if (requestPermissions)
       ensurePermissions()
-    }
-    else {
-      update()
-    }
 
     useEventListener(navigator!.mediaDevices, 'devicechange', update, { passive: true })
+    update()
   }
 
   return {

--- a/packages/core/useDevicesList/index.ts
+++ b/packages/core/useDevicesList/index.ts
@@ -44,9 +44,7 @@ export interface UseDevicesListReturn {
  * @see https://vueuse.org/useDevicesList
  * @param options
  */
-export function useDevicesList(
-  options: UseDevicesListOptions = {},
-): UseDevicesListReturn {
+export function useDevicesList(options: UseDevicesListOptions = {}): UseDevicesListReturn {
   const {
     navigator = defaultNavigator,
     requestPermissions = false,
@@ -55,23 +53,12 @@ export function useDevicesList(
   } = options
 
   const devices = deepRef([]) as Ref<MediaDeviceInfo[]>
-  const videoInputs = computed(() =>
-    devices.value.filter(i => i.kind === 'videoinput'),
-  )
-  const audioInputs = computed(() =>
-    devices.value.filter(i => i.kind === 'audioinput'),
-  )
-  const audioOutputs = computed(() =>
-    devices.value.filter(i => i.kind === 'audiooutput'),
-  )
-  const isSupported = useSupported(
-    () =>
-      navigator
-      && navigator.mediaDevices
-      && navigator.mediaDevices.enumerateDevices,
-  )
+  const videoInputs = computed(() => devices.value.filter(i => i.kind === 'videoinput'))
+  const audioInputs = computed(() => devices.value.filter(i => i.kind === 'audioinput'))
+  const audioOutputs = computed(() => devices.value.filter(i => i.kind === 'audiooutput'))
+  const isSupported = useSupported(() => navigator && navigator.mediaDevices && navigator.mediaDevices.enumerateDevices)
   const permissionGranted = shallowRef(false)
-  let stream: MediaStream | null = null
+  let stream: MediaStream | null
 
   async function update() {
     if (!isSupported.value)

--- a/packages/core/useDevicesList/index.ts
+++ b/packages/core/useDevicesList/index.ts
@@ -72,19 +72,22 @@ export function useDevicesList(options: UseDevicesListOptions = {}): UseDevicesL
     }
   }
 
-  async function ensurePermissions() {
+  async function getCurrentPermission() {
     const deviceName = constraints.video ? 'camera' : 'microphone'
+    const { state, query } = usePermission(deviceName, { controls: true })
+    await query()
+    return state.value
+  }
 
+  async function ensurePermissions() {
     if (!isSupported.value)
       return false
 
     if (permissionGranted.value)
       return true
 
-    const { state, query } = usePermission(deviceName, { controls: true })
-    await query()
     const alwaysRequireStreamToEnumerate = navigator!.userAgent.indexOf('Firefox') > 0
-    if (alwaysRequireStreamToEnumerate || state.value !== 'granted') {
+    if (alwaysRequireStreamToEnumerate || (await getCurrentPermission()) !== 'granted') {
       let granted = true
       try {
         stream = await navigator!.mediaDevices.getUserMedia(constraints)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Fixes #4672. In Firefox it's not enough to only check if permission has already been granted before devices can be listed. Listing the devices always requires an active stream. This PR makes sure to always create a new stream in Firefox, even when permissions have already been granted. By doing this, listing devices continues to work in FF after a reload.  

### Additional context

I have refactored some logic into the `getCurrentPermission` function, so that it's only ran when the browser is not Firefox. This does require an `await` call inside an if condition, which does feel a bit dirty.