### PR TITLE
fix(useDropZone): Allow passing `document` as target

### DIFF
--- a/packages/core/useDropZone/index.ts
+++ b/packages/core/useDropZone/index.ts
@@ -31,7 +31,7 @@ export interface UseDropZoneOptions {
 }
 
 export function useDropZone(
-  target: MaybeRefOrGetter<HTMLElement | null | undefined>,
+  target: MaybeRefOrGetter<HTMLElement | Document | null | undefined>,
   options: UseDropZoneOptions | UseDropZoneOptions['onDrop'] = {},
 ): UseDropZoneReturn {
   const isOverDropZone = shallowRef(false)


### PR DESCRIPTION
If one wants to drop files on the entire page, they need to pass ` document` as the target:

```typescript
useDropZone(window.document, {
    onDrop: (files) => console.log('Dropped files:', files),
})
```

This PR fixes the TypeScript type to allow `Document` usage.