### PR TITLE
test(useSortable): implement initial tests

### DIFF
--- a/packages/integrations/useSortable/index.browser.test.ts
+++ b/packages/integrations/useSortable/index.browser.test.ts
@@ -1,0 +1,155 @@
+import { mount } from '@vue/test-utils'
+import { templateRef } from '@vueuse/core'
+import Sortable from 'sortablejs'
+import { describe, expect, it } from 'vitest'
+import { defineComponent, shallowRef } from 'vue'
+import { useSortable } from './index'
+
+describe('useSortable', () => {
+  it('should initialise Sortable', () => {
+    const wrapper = mount(defineComponent({
+      template: '<div ref="el"></div>',
+      setup() {
+        const el = templateRef<HTMLElement>('el')
+        const list = shallowRef<string[]>([])
+        const result = useSortable(el, list, {
+        })
+
+        return { ...result, el }
+      },
+    }))
+    const vm = wrapper.vm
+    try {
+      const sortable = Sortable.get(vm.el)
+      expect(sortable).toBeDefined()
+    }
+    finally {
+      wrapper.unmount()
+    }
+  })
+
+  it('should accept selectors as el', () => {
+    const wrapper = mount(defineComponent({
+      template: '<div ref="el" id="el"></div>',
+      setup() {
+        const el = templateRef<HTMLElement>('el')
+        const list = shallowRef<string[]>([])
+        const result = useSortable('#el', list, {
+        })
+
+        return { ...result, el }
+      },
+    }), {
+      attachTo: document.body,
+    })
+    const vm = wrapper.vm
+    try {
+      const sortable = Sortable.get(vm.el)
+      expect(sortable).toBeDefined()
+    }
+    finally {
+      wrapper.unmount()
+    }
+  })
+
+  describe('stop', () => {
+    it('should destroy instance', () => {
+      const wrapper = mount(defineComponent({
+        template: '<div ref="el"></div>',
+        setup() {
+          const el = templateRef<HTMLElement>('el')
+          const list = shallowRef<string[]>([])
+          const result = useSortable(el, list, {
+          })
+
+          return { ...result, el }
+        },
+      }))
+      const vm = wrapper.vm
+      try {
+        const sortable = Sortable.get(vm.el)
+        expect(sortable).toBeDefined()
+        vm.stop()
+        expect(Sortable.get(vm.el)).toEqual(null)
+      }
+      finally {
+        wrapper.unmount()
+      }
+    })
+  })
+
+  describe('start', () => {
+    it('can recreate sortable after being stopped', () => {
+      const wrapper = mount(defineComponent({
+        template: '<div ref="el"></div>',
+        setup() {
+          const el = templateRef<HTMLElement>('el')
+          const list = shallowRef<string[]>([])
+          const result = useSortable(el, list, {
+          })
+
+          return { ...result, el }
+        },
+      }))
+      const vm = wrapper.vm
+      try {
+        const sortable = Sortable.get(vm.el)
+        expect(sortable).toBeDefined()
+        vm.stop()
+        expect(Sortable.get(vm.el)).toEqual(null)
+        vm.start()
+        expect(Sortable.get(vm.el)).toBeDefined()
+      }
+      finally {
+        wrapper.unmount()
+      }
+    })
+  })
+
+  describe('option', () => {
+    it('should set option in sortable', () => {
+      const wrapper = mount(defineComponent({
+        template: '<div ref="el"></div>',
+        setup() {
+          const el = templateRef<HTMLElement>('el')
+          const list = shallowRef<string[]>([])
+          const result = useSortable(el, list, {
+          })
+
+          return { ...result, el }
+        },
+      }))
+      const vm = wrapper.vm
+      try {
+        const sortable = Sortable.get(vm.el)
+        expect(sortable?.option('disabled')).toEqual(false)
+        vm.option('disabled', true)
+        expect(sortable?.option('disabled')).toEqual(true)
+      }
+      finally {
+        wrapper.unmount()
+      }
+    })
+
+    it('should get option in sortable', () => {
+      const wrapper = mount(defineComponent({
+        template: '<div ref="el"></div>',
+        setup() {
+          const el = templateRef<HTMLElement>('el')
+          const list = shallowRef<string[]>([])
+          const result = useSortable(el, list, {
+          })
+
+          return { ...result, el }
+        },
+      }))
+      const vm = wrapper.vm
+      try {
+        expect(vm.option('disabled')).toEqual(false)
+      }
+      finally {
+        wrapper.unmount()
+      }
+    })
+  })
+})


### PR DESCRIPTION
Adds a bunch of browser tests for `useSortable`.

Maybe this will help with #4684 if we merge this first.

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
