### PR TITLE
test: fix types of some mount calls

### DIFF
--- a/packages/core/useAnimate/index.browser.test.ts
+++ b/packages/core/useAnimate/index.browser.test.ts
@@ -1,12 +1,12 @@
 import { mount } from '@vue/test-utils'
 import { useAnimate } from '@vueuse/core'
 import { describe, expect, it, vi } from 'vitest'
-import { shallowRef } from 'vue'
+import { defineComponent, shallowRef } from 'vue'
 // import { useAnimate } from './index'
 
 describe('useAnimate', () => {
   it('browser should support useAnimate', () => {
-    const wrapper = mount({
+    const wrapper = mount(defineComponent({
       template: '<p ref="el">test</p>',
       setup() {
         const el = shallowRef<HTMLElement>()
@@ -14,7 +14,7 @@ describe('useAnimate', () => {
 
         return { ...animate, el }
       },
-    })
+    }))
     const vm = wrapper.vm
 
     expect(vm.isSupported).toBe(true)
@@ -22,7 +22,7 @@ describe('useAnimate', () => {
   })
 
   it('should be running', async () => {
-    const wrapper = mount({
+    const wrapper = mount(defineComponent({
       template: '<p ref="el">test</p>',
       setup() {
         const el = shallowRef<HTMLElement>()
@@ -30,7 +30,7 @@ describe('useAnimate', () => {
 
         return { ...animate, el }
       },
-    })
+    }))
     const vm = wrapper.vm
     await vi.waitFor(() => {
       expect(vm.playState).toBe('running')
@@ -42,7 +42,7 @@ describe('useAnimate', () => {
     const keyframes = shallowRef<PropertyIndexedKeyframes>({
       transform: 'rotate(360deg)',
     })
-    const wrapper = mount({
+    const wrapper = mount(defineComponent({
       template: '<p ref="el">test</p>',
       setup() {
         const el = shallowRef<HTMLElement>()
@@ -50,7 +50,7 @@ describe('useAnimate', () => {
 
         return { ...animate, el }
       },
-    })
+    }))
     const vm = wrapper.vm
     await vi.waitFor(() => {
       expect(vm.playState).toBe('finished')
@@ -58,9 +58,7 @@ describe('useAnimate', () => {
 
     keyframes.value = { transform: 'rotate(180deg)' }
 
-    // TODO (43081j): figure out how to get `mount` to type this properly
-    // in the first place. So we can drop the cast
-    const animation = vm.animate as Animation
+    const animation = vm.animate!
 
     await vi.waitFor(() => {
       const keyframe = animation.effect as KeyframeEffect

--- a/packages/core/useAnimate/index.test.ts
+++ b/packages/core/useAnimate/index.test.ts
@@ -1,6 +1,6 @@
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
-import { shallowRef } from 'vue'
+import { defineComponent, shallowRef } from 'vue'
 import { useAnimate } from './index'
 
 describe('useAnimate', () => {
@@ -9,7 +9,7 @@ describe('useAnimate', () => {
   })
 
   it('the test environment does not support animate', () => {
-    const wrapper = mount({
+    const wrapper = mount(defineComponent({
       template: '<p ref="el">test</p>',
       setup() {
         const el = shallowRef<HTMLElement>()
@@ -17,7 +17,7 @@ describe('useAnimate', () => {
 
         return { ...animate, el }
       },
-    })
+    }))
     const vm = wrapper.vm
 
     expect(vm.isSupported).toBe(false)

--- a/packages/core/useCurrentElement/index.test.ts
+++ b/packages/core/useCurrentElement/index.test.ts
@@ -10,7 +10,7 @@ describe('useCurrentElement', () => {
   })
 
   it('should return the root element from the current component', () => {
-    const wrapper = mount({
+    const wrapper = mount(defineComponent({
       template: '<p ref="el">test</p>',
       setup() {
         const el = shallowRef<HTMLElement>()
@@ -18,7 +18,7 @@ describe('useCurrentElement', () => {
 
         return { el, currentElement }
       },
-    })
+    }))
     const vm = wrapper.vm
 
     expect(vm.currentElement).toBe(vm.el)
@@ -34,7 +34,7 @@ describe('useCurrentElement', () => {
       },
       template: '<div ref="rootEl">Hello world</div>',
     })
-    const wrapper = mount({
+    const wrapper = mount(defineComponent({
       components: {
         TestVueComponent,
       },
@@ -48,7 +48,7 @@ describe('useCurrentElement', () => {
 
         return { el, currentElementEl }
       },
-    })
+    }))
     const vm = wrapper.vm
 
     expect(vm.currentElementEl).toBe((vm.el as typeof TestVueComponent).rootEl)


### PR DESCRIPTION
If you call `mount` with a plain object, the `vm` types are not inferred correctly.

For example:

```ts
const wrapper = mount({
  template: '<div></div>',
  setup() {
    return { foo: 303 };
  }
});

wrapper.vm.foo; // `never`
```

This seems to be solved by using `defineComponent`, so `vm.foo` is now `number`.


### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
