### PR TITLE
feat(useFetch): add responseType to the beforeFetch context

### DIFF
--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -109,6 +109,11 @@ export interface BeforeFetchContext {
   options: RequestInit
 
   /**
+   * The response type of the current request
+   */
+  responseType: DataType
+
+  /**
    * Cancels the current request
    */
   cancel: Fn
@@ -456,6 +461,7 @@ export function useFetch<T>(url: MaybeRefOrGetter<string>, ...args: any[]): UseF
         ...defaultFetchOptions,
         ...fetchOptions,
       },
+      responseType: config.type,
       cancel: () => { isCanceled = true },
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

在 `BeforeFetchContext` 接口中新增 `responseType`，其值为原代码中的 `config.type`。原因有两个：
1. 用户可以在 `beforeFetch` 和 `afterFetch` 中添加依赖 `responseType` 的业务逻辑
2. 在某种程度上来说，新增的`responseType`属性对齐了 `axios` 库对 `AxiosResponse`接口中的 `request.responseType`

Add `responseType` to the `BeforeFetchContext` interface, and its value is `config.type` in the original code. There are two reasons for this:
1. Users can add business logic dependent on `responseType` in `beforeFetch` and `afterFetch`.
2. To some extent, the newly added `responseType` property aligns with the `request.responseType` in the `AxiosResponse` interface of the `axios` library.
