### PR TITLE
fix(useMagicKeys): doesn't trigger on releasing and pressing again the second key in a combination

### DIFF
--- a/packages/core/useMagicKeys/index.test.ts
+++ b/packages/core/useMagicKeys/index.test.ts
@@ -63,4 +63,48 @@ describe('useMagicKeys', () => {
     }))
     expect(Ctrl_Shift_Period.value).toBe(true)
   })
+  it('macos command key combinations with double keydown', async () => {
+    // #3026: doesn't trigger on releasing and pressing again the second key in a combination
+    const { Meta_Z } = useMagicKeys({ target })
+    expect(Meta_Z.value).toBe(false)
+
+    // Simulate first keydown of command key
+    target.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'Meta',
+      metaKey: true,
+    }))
+    expect(Meta_Z.value).toBe(false)
+
+    // Simulate first keydown of Z
+    target.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'z',
+      metaKey: true,
+    }))
+    expect(Meta_Z.value).toBe(true) // true because of the first keydown of command key + z
+    await new Promise(resolve => setTimeout(resolve, 1))
+    expect(Meta_Z.value).toBe(true) // after 1ms, it's still true
+
+    // Simulate second keydown of Z without keyup (macOS behavior)
+    target.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'z',
+      metaKey: true,
+    }))
+    expect(Meta_Z.value).toBe(false) // false because it has to manually trigger keyup event
+    await new Promise(resolve => setTimeout(resolve, 1))
+    expect(Meta_Z.value).toBe(true) // after 1ms, it's true again
+
+    // Simulate keyup of Z
+    target.dispatchEvent(new KeyboardEvent('keyup', {
+      key: 'z',
+      metaKey: true,
+    }))
+    expect(Meta_Z.value).toBe(false)
+
+    // Simulate keyup of command key
+    target.dispatchEvent(new KeyboardEvent('keyup', {
+      key: 'Meta',
+      metaKey: false,
+    }))
+    expect(Meta_Z.value).toBe(false)
+  })
 })

--- a/packages/core/useMagicKeys/index.ts
+++ b/packages/core/useMagicKeys/index.ts
@@ -1,6 +1,6 @@
 import type { ComputedRef, MaybeRefOrGetter } from 'vue'
 import { noop } from '@vueuse/shared'
-import { computed, reactive, shallowRef, toValue } from 'vue'
+import { computed, nextTick, reactive, shallowRef, toValue } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 import { DefaultMagicKeysAliasMap } from './aliasMap'
@@ -142,9 +142,9 @@ export function useMagicKeys(options: UseMagicKeysOptions<boolean> = {}): any {
     // Solution: Trigger "keyup" event manually when "keydown" event is fired without "keyup"
     if (key && e.getModifierState('Meta') && current.has(key)) {
       updateRefs(e, false)
-      setTimeout(() => {
+      nextTick(() => {
         updateRefs(e, true)
-      }, 0)
+      })
     }
     else {
       updateRefs(e, true)

--- a/packages/core/useMagicKeys/index.ts
+++ b/packages/core/useMagicKeys/index.ts
@@ -137,7 +137,18 @@ export function useMagicKeys(options: UseMagicKeysOptions<boolean> = {}): any {
   }
 
   useEventListener(target, 'keydown', (e: KeyboardEvent) => {
-    updateRefs(e, true)
+    const key = e.key?.toLowerCase()
+    // #3026: doesn't trigger on releasing and pressing again the second key in a combination
+    // Solution: Trigger "keyup" event manually when "keydown" event is fired without "keyup"
+    if (key && e.getModifierState('Meta') && current.has(key)) {
+      updateRefs(e, false)
+      setTimeout(() => {
+        updateRefs(e, true)
+      }, 0)
+    }
+    else {
+      updateRefs(e, true)
+    }
     return onEventFired(e)
   }, { passive })
   useEventListener(target, 'keyup', (e: KeyboardEvent) => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Fixes #3026


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

This is the explanation of the issue and the solution
1. On MacOS browser
2. Press and hold <kbd>⌘</kbd> 
3. Press <kbd>Z</kbd> twice
4. The keydown event will fire twice, but the ref won't update because it is the same value.
5. So, if a double keydown event is detected, run a manual keyup right before it.
