### PR TITLE
chore: typo

### DIFF
--- a/packages/core/createTemplatePromise/index.md
+++ b/packages/core/createTemplatePromise/index.md
@@ -149,7 +149,7 @@ Learn more about [Vue Transition](https://vuejs.org/guide/built-ins/transition.h
 
 ## Motivation
 
-The common approach to call a dialog or a model programmatically would be like this:
+The common approach to call a dialog or a modal programmatically would be like this:
 
 ```ts
 const dialog = useDialog()


### PR DESCRIPTION
### Description

Docs: fix minor typo on `core/createTemplatePromise` page

#### Keywords

documentation
docs
typo
