### PR TITLE
fix(useNow): set 1000ms default interval (#4708)

### DIFF
--- a/packages/core/useNow/index.ts
+++ b/packages/core/useNow/index.ts
@@ -15,7 +15,7 @@ export interface UseNowOptions<Controls extends boolean> {
   /**
    * Update interval in milliseconds, or use requestAnimationFrame
    *
-   * @default requestAnimationFrame
+   * @default 1000
    */
   interval?: 'requestAnimationFrame' | number
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

As described in issue #4708, `useNow` updates _a lot_, causing a rather significant performance impact for such a (relatively) small utility. This is even moreso the case when actually doing something with the Date value provided, such as converting it to an internationalised string.  
I've resolved this by setting the default interval to 1000 ms rather than `requestAnimationFrame`. For the use cases where a higher update frequency is required, it is still possible, but I reckon that for 99.9% of cases, once a second is more than plenty.

### Additional context

N/A
