### PR TITLE
feat(useAsyncState): add executeImmediate with the same type as the promise fn

### DIFF
--- a/packages/core/useAsyncState/index.md
+++ b/packages/core/useAsyncState/index.md
@@ -28,18 +28,18 @@ You can also trigger it manually. This is useful when you want to control when t
 <script setup lang="ts">
 import { useAsyncState } from '@vueuse/core'
 
-const { state, execute, executeNow } = useAsyncState(logEvent, undefined, { immediate: false })
+const { state, execute, executeImmediate } = useAsyncState(action, '', { immediate: false })
 
-async function logEvent(event) {
-  console.log('Event:', event)
-  await new Promise(resolve => setTimeout(resolve, 50))
+async function action(event) {
+  await new Promise(resolve => setTimeout(resolve, 500))
+  return `${event.target.textContent} clicked!`
 }
 </script>
 
 <template>
   <p>State: {{ state }}</p>
 
-  <button class="button" @click="executeNow">
+  <button class="button" @click="executeImmediate">
     Execute now
   </button>
 

--- a/packages/core/useAsyncState/index.md
+++ b/packages/core/useAsyncState/index.md
@@ -19,3 +19,32 @@ const { state, isReady, isLoading } = useAsyncState(
   { id: null },
 )
 ```
+
+### Manually trigger the async function
+
+You can also trigger it manually. This is useful when you want to control when the async function is executed.
+
+```vue
+<script setup lang="ts">
+import { useAsyncState } from '@vueuse/core'
+
+const { state, execute, executeNow } = useAsyncState(logEvent, undefined, { immediate: false })
+
+async function logEvent(event) {
+  console.log('Event:', event)
+  await new Promise(resolve => setTimeout(resolve, 50))
+}
+</script>
+
+<template>
+  <p>State: {{ state }}</p>
+
+  <button class="button" @click="executeNow">
+    Execute now
+  </button>
+
+  <button class="ml-2 button" @click="event => execute(500, event.target)">
+    Execute with delay
+  </button>
+</template>
+```

--- a/packages/core/useAsyncState/index.test.ts
+++ b/packages/core/useAsyncState/index.test.ts
@@ -27,6 +27,13 @@ describe('useAsyncState', () => {
     expect(state.value).toBe(2)
   })
 
+  it('should executeNow', async () => {
+    const { executeNow, state } = useAsyncState(p1, 0)
+    expect(state.value).toBe(0)
+    await executeNow(2)
+    expect(state.value).toBe(2)
+  })
+
   it('should work with await', async () => {
     const asyncState = useAsyncState(p1, 0, { immediate: true })
     expect(asyncState.isLoading.value).toBeTruthy()

--- a/packages/core/useAsyncState/index.test.ts
+++ b/packages/core/useAsyncState/index.test.ts
@@ -27,10 +27,10 @@ describe('useAsyncState', () => {
     expect(state.value).toBe(2)
   })
 
-  it('should executeNow', async () => {
-    const { executeNow, state } = useAsyncState(p1, 0)
+  it('should executeImmediate', async () => {
+    const { executeImmediate, state } = useAsyncState(p1, 0)
     expect(state.value).toBe(0)
-    await executeNow(2)
+    await executeImmediate(2)
     expect(state.value).toBe(2)
   })
 

--- a/packages/core/useAsyncState/index.ts
+++ b/packages/core/useAsyncState/index.ts
@@ -8,7 +8,7 @@ export interface UseAsyncStateReturnBase<Data, Params extends any[], Shallow ext
   isLoading: Ref<boolean>
   error: Ref<unknown>
   execute: (delay?: number, ...args: Params) => Promise<Data>
-  executeNow: (...args: Params) => Promise<Data>
+  executeImmediate: (...args: Params) => Promise<Data>
 }
 
 export type UseAsyncStateReturn<Data, Params extends any[], Shallow extends boolean> =
@@ -141,7 +141,7 @@ export function useAsyncState<Data, Params extends any[] = any[], Shallow extend
     isLoading,
     error,
     execute,
-    executeNow: (...args: any[]) => execute(0, ...args),
+    executeImmediate: (...args: any[]) => execute(0, ...args),
   }
 
   function waitUntilIsLoaded() {

--- a/packages/core/useAsyncState/index.ts
+++ b/packages/core/useAsyncState/index.ts
@@ -8,6 +8,7 @@ export interface UseAsyncStateReturnBase<Data, Params extends any[], Shallow ext
   isLoading: Ref<boolean>
   error: Ref<unknown>
   execute: (delay?: number, ...args: Params) => Promise<Data>
+  executeNow: (...args: Params) => Promise<Data>
 }
 
 export type UseAsyncStateReturn<Data, Params extends any[], Shallow extends boolean> =
@@ -140,6 +141,7 @@ export function useAsyncState<Data, Params extends any[] = any[], Shallow extend
     isLoading,
     error,
     execute,
+    executeNow: (...args: any[]) => execute(0, ...args),
   }
 
   function waitUntilIsLoaded() {

--- a/packages/core/useAsyncState/index.ts
+++ b/packages/core/useAsyncState/index.ts
@@ -17,7 +17,7 @@ export type UseAsyncStateReturn<Data, Params extends any[], Shallow extends bool
 
 export interface UseAsyncStateOptions<Shallow extends boolean, D = any> {
   /**
-   * Delay for executing the promise. In milliseconds.
+   * Delay for the first execution of the promise when "immediate" is true. In milliseconds.
    *
    * @default 0
    */


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Implements https://github.com/vueuse/vueuse/issues/4580
Closes #4580

This PR adds a `executeNow` method that has the same input function arguments.
Also adds a example of using `execute` vs `executeNow`
And improves the `delay` config description.

```
const { executeNow, state } = useAsyncState(originalFn), null)
// so that: replacing originalFn('some arg') by executeNow('some arg') to have state ref.
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
