### PR TITLE
fix(useStorage): when used inside `effectScope`, should not remove listener on component unmount (#4695)

### DIFF
--- a/packages/core/useStorage/index.ts
+++ b/packages/core/useStorage/index.ts
@@ -182,7 +182,7 @@ export function useStorage<T extends (string | number | boolean | object | null)
   watch(keyComputed, () => update(), { flush })
 
   if (window && listenToStorageChanges) {
-    const useStorageListener = ()=> {
+    const useStorageListener = () => {
       if (storage instanceof Storage)
         useEventListener(window, 'storage', update, { passive: true })
       else
@@ -202,8 +202,9 @@ export function useStorage<T extends (string | number | boolean | object | null)
         useStorageListener()
         update()
       })
-    } else {
-        useStorageListener()
+    }
+    else {
+      useStorageListener()
     }
   }
 


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

When used in `effectScope`, `useStorage` should continue to listen on storage even after the module is unmounted. `tryOnMounted` should only be called when `initOnMounted` is set.

Fix #4695
