### PR TITLE
fix(useElementVisibility): Resolve possible issue with once watcher inside of callback

### DIFF
--- a/packages/core/useElementVisibility/index.ts
+++ b/packages/core/useElementVisibility/index.ts
@@ -56,12 +56,6 @@ export function useElementVisibility(
         }
       }
       elementIsVisible.value = isIntersecting
-
-      if (once) {
-        watchOnce(elementIsVisible, () => {
-          stop()
-        })
-      }
     },
     {
       root: scrollTarget,
@@ -70,6 +64,12 @@ export function useElementVisibility(
       rootMargin: toValue(rootMargin),
     },
   )
+
+  if (once) {
+    watchOnce(elementIsVisible, () => {
+      stop()
+    })
+  }
 
   return elementIsVisible
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

fix #4704

Problem solved: The watchOnce call in useElementVisibility is happening inside of the intersection callback. 
Solution: I moved the watchOnce call outside of the intersection callback to ensure it is only registered once when the composable is initialized.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
