### PR TITLE
fix: sharedComposable

### DIFF
--- a/packages/shared/createSharedComposable/index.ts
+++ b/packages/shared/createSharedComposable/index.ts
@@ -30,7 +30,9 @@ export function createSharedComposable<Fn extends AnyFn>(composable: Fn): Shared
       scope = effectScope(true)
       state = scope.run(() => composable(...args))
     }
-    tryOnScopeDispose(dispose)
+    if(!tryOnScopeDispose(dispose)) {
+      dispose()
+    }
     return state
   })
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

-   [ ] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
-   [ ] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
-   [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
-   [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
-   [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Fixed the issue where **createSharedComposable** cannot be properly disposed of when executed in a scope without getCurrentScope.

In the original implementation, when **createSharedComposable** is executed in a scope without getCurrentScope, tryOnScopeDispose directly returns false. This causes the dispose function to not be registered correctly, and thus the resources cannot be cleaned up properly. By directly calling dispose when tryOnScopeDispose returns false, we ensure that resources can be cleaned up correctly even in environments without getCurrentScope.

### **Before**

```
...
tryOnScopeDispose(dispose)
...
```

### **After**

```
...
if(!tryOnScopeDispose(dispose)) {
  dispose()
}
...
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
