### PR TITLE
fix: always mount listeners in useStorage

### DIFF
--- a/packages/core/useStorage/index.ts
+++ b/packages/core/useStorage/index.ts
@@ -197,6 +197,12 @@ export function useStorage<T extends (string | number | boolean | object | null)
     updateFromCustomEvent(ev)
   }
 
+  /**
+   * The custom event is needed for same-document syncing when using custom
+   * storage backends, but it doesn't work across different documents.
+   *
+   * TODO: Consider implementing a BroadcastChannel-based solution that fixes this.
+   */
   if (window && listenToStorageChanges) {
     if (storage instanceof Storage)
       useEventListener(window, 'storage', onStorageEvent, { passive: true })

--- a/packages/core/useStorage/index.ts
+++ b/packages/core/useStorage/index.ts
@@ -181,29 +181,38 @@ export function useStorage<T extends (string | number | boolean | object | null)
 
   watch(keyComputed, () => update(), { flush })
 
-  if (window && listenToStorageChanges) {
-    tryOnMounted(() => {
-      /**
-       * Attaching event listeners here should be fine since we are in a mounted hook
-       *
-       * The custom event is needed for same-document syncing when using custom
-       * storage backends, but it doesn't work across different documents.
-       *
-       * TODO: Consider implementing a BroadcastChannel-based solution that fixes this.
-       */
-      if (storage instanceof Storage)
-        useEventListener(window, 'storage', update, { passive: true })
-      else
-        useEventListener(window, customStorageEventName, updateFromCustomEvent)
+  let firstMounted = false
+  const onStorageEvent = (ev: StorageEvent): void => {
+    if (initOnMounted && !firstMounted) {
+      return
+    }
 
-      if (initOnMounted)
-        update()
-    })
+    update(ev)
+  }
+  const onStorageCustomEvent = (ev: CustomEvent<StorageEventLike>): void => {
+    if (initOnMounted && !firstMounted) {
+      return
+    }
+
+    updateFromCustomEvent(ev)
   }
 
-  // avoid reading immediately to avoid hydration mismatch when doing SSR
-  if (!initOnMounted)
+  if (window && listenToStorageChanges) {
+    if (storage instanceof Storage)
+      useEventListener(window, 'storage', onStorageEvent, { passive: true })
+    else
+      useEventListener(window, customStorageEventName, onStorageCustomEvent)
+  }
+
+  if (initOnMounted) {
+    tryOnMounted(() => {
+      firstMounted = true
+      update()
+    })
+  }
+  else {
     update()
+  }
 
   function dispatchWriteEvent(oldValue: string | null, newValue: string | null) {
     // send custom event to communicate within same page


### PR DESCRIPTION
This is _yet another_ possible fix for the various `useStorage` scope issues.

Basically, `onMounted` will _always_ run in the scope of the _component_. This means the event listener will not be torn down unless the element itself is. When the various effect scopes we use are torn down, the listener will remain and cause various memory leaks.

We can solve this by moving the event listeners _outside_ the `onMounted` callback, as they will then teardown when the scope they're in disposes.

However, this then means the event listener could run before the component has mounted, when `initOnMount` is true. To solve this, we check in the event handler and do nothing if it isn't mounted yet.

We only care about the _first_ mount, since all others will have already gone through at least one `update` call.

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
