### PR TITLE
fix(useMagicKeys): correctly clear current pressed keys when releasing Shift

### DIFF
--- a/packages/core/useMagicKeys/index.ts
+++ b/packages/core/useMagicKeys/index.ts
@@ -85,6 +85,7 @@ export function useMagicKeys(options: UseMagicKeysOptions<boolean> = {}): any {
   }
   const refs: Record<string, any> = useReactive ? reactive(obj) : obj
   const metaDeps = new Set<string>()
+  const shiftDeps = new Set<string>()
   const usedKeys = new Set<string>()
 
   function setRefs(key: string, value: boolean) {
@@ -119,7 +120,16 @@ export function useMagicKeys(options: UseMagicKeysOptions<boolean> = {}): any {
       usedKeys.add(key)
       setRefs(key, value)
     }
-
+    if (key === 'shift' && !value) {
+      shiftDeps.forEach((key) => {
+        current.delete(key)
+        setRefs(key, false)
+      })
+      shiftDeps.clear()
+    }
+    else if (typeof e.getModifierState === 'function' && e.getModifierState('Shift') && value) {
+      [...values].forEach(key => shiftDeps.add(key))
+    }
     // #1312
     // In macOS, keys won't trigger "keyup" event when Meta key is released
     // We track it's combination and release manually

--- a/packages/core/useMagicKeys/index.ts
+++ b/packages/core/useMagicKeys/index.ts
@@ -128,7 +128,7 @@ export function useMagicKeys(options: UseMagicKeysOptions<boolean> = {}): any {
       shiftDeps.clear()
     }
     else if (typeof e.getModifierState === 'function' && e.getModifierState('Shift') && value) {
-      [...values].forEach(key => shiftDeps.add(key))
+      [...current, ...values].forEach(key => shiftDeps.add(key))
     }
     // #1312
     // In macOS, keys won't trigger "keyup" event when Meta key is released


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Fixed a bug where keys pressed after Shift remained in current even after releasing.
Before:
1. Pressed "Shift, 1, 2"
2. Released Shift - current remained with "!(1)" and "@ (2)" until you press "Shift, 1, 2" again
After:
Now such keys are correctly removed when releasing Shift.

### Additional context

This, of course, almost completely repeats the logic of working with Meta on macOS, and I'm not sure if this change is necessary, but it seems to me to be correct. After all, pressing Shift changes the logic of the keys pressed
