### PR TITLE
fix(onClickOutside): workaround for iOS

### DIFF
--- a/packages/core/onClickOutside/index.ts
+++ b/packages/core/onClickOutside/index.ts
@@ -84,9 +84,11 @@ export function onClickOutside(
   if (isIOS && !_iOSWorkaround) {
     _iOSWorkaround = true
     const listenerOptions = { passive: true }
+    // Not using useEventListener because this event handlers must not be disposed.
+    // See previusly linked references and https://github.com/vueuse/vueuse/issues/4724
     Array.from(window.document.body.children)
-      .forEach(el => useEventListener(el, 'click', noop, listenerOptions))
-    useEventListener(window.document.documentElement, 'click', noop, listenerOptions)
+      .forEach(el => el.addEventListener('click', noop, listenerOptions))
+    window.document.documentElement.addEventListener('click', noop, listenerOptions)
   }
 
   let shouldListen = true


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

---

### Description

Fixes https://github.com/vueuse/vueuse/issues/4724

### Additional context

However, it's useful to note that `pointerdown` event doesn't need this workaround. However, [it's supported since Safari 13](https://developer.mozilla.org/en-US/docs/Web/API/Element/pointerdown_event#browser_compatibility) where our baseline (Vue's 3 requirements) are [Safari 10](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy#browser_compatibility)

Perhaps I should add a TODO comment about this so it can be reviewed at a later time if we change our browser support baseline?
