### PR TITLE
docs(pausableWatch): suggest to use Vue's native since 3.5

### DIFF
--- a/packages/shared/watchPausable/index.md
+++ b/packages/shared/watchPausable/index.md
@@ -7,6 +7,12 @@ alias: pausableWatch
 
 Pausable watch
 
+::: tip
+
+[Pausable Watcher](https://vuejs.org/api/reactivity-core.html#watch) has been added to Vue [since 3.5](https://github.com/vuejs/core/pull/9651), use `const { stop, pause, resume } = watch(watchSource, callback)` instead on supported versions.
+
+:::
+
 ## Usage
 
 Use as normal the `watch`, but return extra `pause()` and `resume()` functions to control.


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Since Vue 3.5, it supports the same functionality and API as pausableWatch. The documentation is updated therefore to recommend user to use Vue's builtin feature.  
Maybe we can deprecate it as well? More opinions are welcome.
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
The description of Pausable Watcher in Vue's documentation are in the form of examples, which is not a dedicated section that can be linked. So the first link goes to the section containing relevant examples.