### PR TITLE
docs(watchOnce): suggest to use Vue's native feature since 3.4

### DIFF
--- a/packages/shared/watchOnce/index.md
+++ b/packages/shared/watchOnce/index.md
@@ -6,6 +6,12 @@ category: Watch
 
 `watch` that only triggers once.
 
+::: tip
+
+[Once Watcher](https://vuejs.org/guide/essentials/watchers.html#once-watchers) has been added to Vue [since 3.4](https://github.com/vuejs/core/pull/9034), use `watch(watchSource, callback, { once: true })` instead on supported versions.
+
+:::
+
 ## Usage
 
 After the callback function has been triggered once, the watch will be stopped automatically.


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR is similar to #4738, suggesting users to use Vue's native Once Watcher instead in the documentation of `watchOnce`.

### Additional context

Once Watchers were introduced to Vue 3.4 whose first stable release was on [Dec. 29, 2023](https://github.com/vuejs/core/blob/main/changelogs/CHANGELOG-3.4.md#340-slam-dunk-2023-12-29), which is 498 days ago at the time of writing. Maybe we can also deprecate `watchOnce` in this PR.
