### PR TITLE
feat(computedAsync): add option to control watcher's flush timing

### DIFF
--- a/packages/core/computedAsync/index.ts
+++ b/packages/core/computedAsync/index.ts
@@ -7,8 +7,6 @@ import {
   isRef,
   shallowRef,
   watchEffect,
-  watchPostEffect,
-  watchSyncEffect,
 } from 'vue'
 
 /**
@@ -100,7 +98,7 @@ export function computedAsync<T>(
   const current = (shallow ? shallowRef(initialState) : deepRef(initialState)) as Ref<T>
   let counter = 0
 
-  const cb = async (onInvalidate: AsyncComputedOnCancel) => {
+  watchEffect(async (onInvalidate) => {
     if (!started.value)
       return
 
@@ -139,17 +137,7 @@ export function computedAsync<T>(
 
       hasFinished = true
     }
-  }
-
-  if (flush === 'sync') {
-    watchSyncEffect(cb)
-  }
-  else if (flush === 'post') {
-    watchPostEffect(cb)
-  }
-  else {
-    watchEffect(cb)
-  }
+  }, { flush })
 
   if (lazy) {
     return computed(() => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Add options to control `computedAsync`'s internal `watchEffect`'s flush timing

### Additional context

If you ask me, we should default to `sync`, because that's the real behaviour of normal computed and it's on par with `computedWithControl`, but that's technically a breaking change (**should that breaking change be part of this PR?**)
