### PR TITLE
chore(computedEager): mark for deprecation

### DIFF
--- a/packages/shared/computedEager/index.ts
+++ b/packages/shared/computedEager/index.ts
@@ -14,6 +14,7 @@ export type ComputedEagerReturn<T = any> = Readonly<ShallowRef<T>>
  * computed, effect, watch, watchEffect, render dependencies will not be triggered.
  * refer: https://github.com/vuejs/core/pull/5912
  *
+ * @deprecated
  * @param fn effect function
  * @param options WatchOptionsBase
  * @returns readonly shallowRef


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Marks this composable as deprecated so it can be removed in a future major version.

### Additional context

In my opinion, there is no reason users can't always track latest minor Vue releases. It's been a while since Vue 3.4 has been released and Vue 3.6 is around the corner, so there have been plenty of time for every person to test their `computedEager` usages (plus the introduction in Vue in normal `computed` has hardly been breaking).
Users that stil want to lag behind Vue updates won't also have a problem staying behind in VueUse's
