### PR TITLE
feat(useStyleTag): support passing `nonce`

### DIFF
--- a/packages/core/useStyleTag/index.ts
+++ b/packages/core/useStyleTag/index.ts
@@ -30,6 +30,13 @@ export interface UseStyleTagOptions extends ConfigurableDocument {
    * @default auto-incremented
    */
   id?: string
+
+  /**
+   * Nonce value for CSP (Content Security Policy)
+   *
+   * @default ''
+   */
+  nonce?: string
 }
 
 export interface UseStyleTagReturn {
@@ -53,7 +60,7 @@ let _id = 0
  */
 export function useStyleTag(
   css: MaybeRef<string>,
-  options: UseStyleTagOptions & { nonce?: string } = {},
+  options: UseStyleTagOptions = {},
 ): UseStyleTagReturn {
   const isLoaded = shallowRef(false)
 

--- a/packages/core/useStyleTag/index.ts
+++ b/packages/core/useStyleTag/index.ts
@@ -34,7 +34,7 @@ export interface UseStyleTagOptions extends ConfigurableDocument {
   /**
    * Nonce value for CSP (Content Security Policy)
    *
-   * @default ''
+   * @default undefined
    */
   nonce?: string
 }

--- a/packages/core/useStyleTag/index.ts
+++ b/packages/core/useStyleTag/index.ts
@@ -53,7 +53,7 @@ let _id = 0
  */
 export function useStyleTag(
   css: MaybeRef<string>,
-  options: UseStyleTagOptions = {},
+  options: UseStyleTagOptions & { nonce?: string } = {},
 ): UseStyleTagReturn {
   const isLoaded = shallowRef(false)
 
@@ -75,6 +75,8 @@ export function useStyleTag(
 
     if (!el.isConnected) {
       el.id = id
+      if (options.nonce)
+        el.nonce = options.nonce
       if (options.media)
         el.media = options.media
       document.head.appendChild(el)


### PR DESCRIPTION

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description
#4741 Bypass the strict Content Security Policy (CSP) using nonce

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

// Example of CSP header
Content-Security-Policy: style-src 'self' 'nonce-EDNnf03nceIOfn39fn3e9h3sdfa';

// Pass in the nonce when using it
useStyleTag(css, {
nonce: 'EDNnf03nceIOfn39fn3e9h3sdfa'
})

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
