### PR TITLE
feat(watchOnce): use vue's native once behaviour

### DIFF
--- a/packages/shared/watchOnce/index.md
+++ b/packages/shared/watchOnce/index.md
@@ -4,17 +4,12 @@ category: Watch
 
 # watchOnce
 
-`watch` that only triggers once.
-
-::: tip
-
-[Once Watcher](https://vuejs.org/guide/essentials/watchers.html#once-watchers) has been added to Vue [since 3.4](https://github.com/vuejs/core/pull/9034), use `watch(watchSource, callback, { once: true })` instead on supported versions.
-
-:::
+Shorthand for watching value with `{ once: true }`. Once the callback fires once, the watcher will be stopped.
+See [Vue's docs](https://vuejs.org/guide/essentials/watchers.html#once-watchers) for full details.
 
 ## Usage
 
-After the callback function has been triggered once, the watch will be stopped automatically.
+Similar to `watch`, but with `{ once: true }`
 
 ```ts
 import { watchOnce } from '@vueuse/core'

--- a/packages/shared/watchOnce/index.ts
+++ b/packages/shared/watchOnce/index.ts
@@ -1,23 +1,38 @@
 import type { WatchCallback, WatchOptions, WatchSource, WatchStopHandle } from 'vue'
 import type { MapOldSources, MapSources } from '../utils'
-import { nextTick, watch } from 'vue'
+import { watch } from 'vue'
 
 // overloads
-export function watchOnce<T extends Readonly<WatchSource<unknown>[]>, Immediate extends Readonly<boolean> = false>(source: [...T], cb: WatchCallback<MapSources<T>, MapOldSources<T, Immediate>>, options?: WatchOptions<Immediate>): WatchStopHandle
+export function watchOnce<T extends Readonly<WatchSource<unknown>[]>>(
+  source: [...T],
+  cb: WatchCallback<MapSources<T>, MapOldSources<T, true>>,
+  options?: Omit<WatchOptions<true>, 'once'>
+): WatchStopHandle
 
-export function watchOnce<T, Immediate extends Readonly<boolean> = false>(sources: WatchSource<T>, cb: WatchCallback<T, Immediate extends true ? T | undefined : T>, options?: WatchOptions<Immediate>): WatchStopHandle
+export function watchOnce<T>(
+  source: WatchSource<T>,
+  cb: WatchCallback<T, T | undefined>,
+  options?: Omit<WatchOptions<true>, 'once'>
+): WatchStopHandle
 
-// implementation
-export function watchOnce<Immediate extends Readonly<boolean> = false>(
-  source: any,
-  cb: any,
-  options?: WatchOptions<Immediate>,
-): WatchStopHandle {
-  const stop = watch(source, (...args) => {
-    nextTick(() => stop())
+export function watchOnce<T extends object>(
+  source: T,
+  cb: WatchCallback<T, T | undefined>,
+  options?: Omit<WatchOptions<true>, 'once'>
+): WatchStopHandle
 
-    return cb(...args)
-  }, options)
-
-  return stop
+/**
+ * Shorthand for watching value with { once: true }
+ *
+ * @see https://vueuse.org/watchOnce
+ */
+export function watchOnce<T = any>(source: T, cb: any, options?: Omit<WatchOptions, 'once'>) {
+  return watch(
+    source as any,
+    cb,
+    {
+      ...options,
+      once: true,
+    },
+  )
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Updates `watchOnce` logic to match shortcut watchers like `watchImmediate`, so it works as a pure shortcut to Vue's native [once watchers](https://vuejs.org/guide/essentials/watchers.html#once-watchers) feature.

### Additional context

@antfu This requires Vue 3.4, so technically this is a breaking change for users pre-Vue 3.4. Shall we support users staying behind or users are expected to always be in the latest version? According to our semver range, [Vue 3.5](https://github.com/vueuse/vueuse/blob/main/pnpm-workspace.yaml#L43) is the only supported version, but I don't know if this is intended or not.
