### PR TITLE
refactor(computedAsync)!: default to `flush: sync`

### DIFF
--- a/packages/core/computedAsync/index.ts
+++ b/packages/core/computedAsync/index.ts
@@ -42,7 +42,7 @@ export interface AsyncComputedOptions {
    * Possible values: `pre`, `post`, `sync`
    *
    * It works in the same way as the flush option in watch and watch effect in vue reactivity
-   * @default 'pre'
+   * @default 'sync'
    */
   flush?: 'pre' | 'post' | 'sync'
 
@@ -98,7 +98,7 @@ export function computedAsync<T>(
 
   const {
     lazy = false,
-    flush = 'pre',
+    flush = 'sync',
     evaluating = undefined,
     shallow = true,
     onError = noop,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

To align the behaviour specified in [our own docs](https://vueuse.org/guide/config.html#reactive-timing) and match the other composables that use watchers internally [1](https://github.com/vueuse/vueuse/blob/main/packages/shared/computedEager/index.ts#L28) [2](https://github.com/vueuse/vueuse/blob/main/packages/shared/computedWithControl/index.ts#L47), the `flush` option of `computedAsync` must be `sync` by default.

### Additional context

I'd even arge this composable should default to being `lazy: true`, so the default behaviour of it is even closer to original Vue's computed.
