### PR TITLE
fix(useSortable): fix type misalignment

### DIFF
--- a/packages/integrations/useSortable/index.ts
+++ b/packages/integrations/useSortable/index.ts
@@ -25,9 +25,9 @@ export interface UseSortableReturn {
 
 export type UseSortableOptions = Options & ConfigurableDocument
 
-export function useSortable<T>(selector: string, list: MaybeRefOrGetter<T[]>,
+export function useSortable<T>(selector: string, list: MaybeRef<T[]>,
   options?: UseSortableOptions): UseSortableReturn
-export function useSortable<T>(el: MaybeRefOrGetter<MaybeElement>, list: MaybeRefOrGetter<T[]>,
+export function useSortable<T>(el: MaybeRefOrGetter<MaybeElement>, list: MaybeRef<T[]>,
   options?: UseSortableOptions): UseSortableReturn
 
 /**
@@ -38,7 +38,7 @@ export function useSortable<T>(el: MaybeRefOrGetter<MaybeElement>, list: MaybeRe
  */
 export function useSortable<T>(
   el: MaybeRefOrGetter<MaybeElement> | string,
-  list: MaybeRefOrGetter<T[]>,
+  list: MaybeRef<T[]>,
   options: UseSortableOptions = {},
 ): UseSortableReturn {
   let sortable: Sortable | undefined
@@ -108,7 +108,7 @@ export function removeNode(node: Node) {
 }
 
 export function moveArrayElement<T>(
-  list: MaybeRefOrGetter<T[]>,
+  list: MaybeRef<T[]>,
   from: number,
   to: number,
   e: Sortable.SortableEvent | null = null,


### PR DESCRIPTION

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

The list to be passed must be mutable, that is why if we do
```vue
const list = shallowRef([{ id: 1, name: 'a' }, { id: 2, name: 'b' }, { id: 3, name: 'c' }])

const { option } = useSortable(el, () => list.value, {
  animation: 150,
})
```
the list in the html won't change, but the data might contain invalid sorting.
Check the following videos:
The first one is with the code above, the second one is with my codebase with more complex objects and conditions, still using hte getter
https://github.com/user-attachments/assets/d999d501-aa37-4bde-8128-6259ad750aba
https://github.com/user-attachments/assets/3693c0fa-96b4-48e0-adba-da02dd4abae1


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
