### PR TITLE
feat(useNow): expose immediate option

### DIFF
--- a/packages/core/useNow/index.test.ts
+++ b/packages/core/useNow/index.test.ts
@@ -9,6 +9,19 @@ describe('useNow', () => {
     expect(+now.value).toBeLessThanOrEqual(+new Date())
   })
 
+  it('show start lazily if immediate is false', () => {
+    const initial = +new Date()
+    const { now, resume } = useNow({ controls: true, immediate: false })
+
+    expect(+now.value).toBe(initial)
+    vi.advanceTimersByTime(50)
+    expect(+now.value).toBe(initial)
+
+    resume()
+    vi.advanceTimersByTime(50)
+    expect(+now.value).toBeGreaterThan(initial)
+  })
+
   function testControl(interval: any) {
     it(`should control now timestamp by ${interval}`, async () => {
       let initial = +new Date()

--- a/packages/core/useNow/index.test.ts
+++ b/packages/core/useNow/index.test.ts
@@ -9,7 +9,7 @@ describe('useNow', () => {
     expect(+now.value).toBeLessThanOrEqual(+new Date())
   })
 
-  it('show start lazily if immediate is false', () => {
+  it('starts lazily if immediate is false', () => {
     const initial = +new Date()
     const { now, resume } = useNow({ controls: true, immediate: false })
 

--- a/packages/core/useNow/index.ts
+++ b/packages/core/useNow/index.ts
@@ -13,6 +13,13 @@ export interface UseNowOptions<Controls extends boolean> {
   controls?: Controls
 
   /**
+   * Start the clock immediately
+   *
+   * @default true
+   */
+  immediate?: boolean
+
+  /**
    * Update interval in milliseconds, or use requestAnimationFrame
    *
    * @default requestAnimationFrame
@@ -32,6 +39,7 @@ export function useNow(options: UseNowOptions<boolean> = {}) {
   const {
     controls: exposeControls = false,
     interval = 'requestAnimationFrame',
+    immediate = true,
   } = options
 
   const now = deepRef(new Date())
@@ -39,8 +47,8 @@ export function useNow(options: UseNowOptions<boolean> = {}) {
   const update = () => now.value = new Date()
 
   const controls: Pausable = interval === 'requestAnimationFrame'
-    ? useRafFn(update, { immediate: true })
-    : useIntervalFn(update, interval, { immediate: true })
+    ? useRafFn(update, { immediate })
+    : useIntervalFn(update, interval, { immediate })
 
   if (exposeControls) {
     return {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR exposes the `immediate` option to `useNow` options, allowing for the creation of reactive dates that are lazily started.

### Additional context

Related advice regarding `immediate`:
https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md#watch-options
