### PR TITLE
docs(pwa): fix 404 navigation errors when using search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ packages/**/*.js
 packages/**/*.[cm]js
 packages/**/*.d.ts
 packages/**/*.d.[cm]ts
+!packages/.vitepress/
+!packages/.vitepress/shims.d.ts
 playgrounds/*/pnpm-lock.yaml
 types
 coverage

--- a/packages/.vitepress/config.ts
+++ b/packages/.vitepress/config.ts
@@ -4,6 +4,7 @@ import { withPwa } from '@vite-pwa/vitepress'
 import { defineConfig } from 'vitepress'
 import { currentVersion, versions } from '../../meta/versions'
 import { addonCategoryNames, categoryNames, coreCategoryNames, metadata } from '../metadata/metadata'
+import { PWAVirtual } from './plugins/pwa-virtual'
 import { transformHead } from './transformHead'
 import viteConfig from './vite.config'
 
@@ -248,6 +249,12 @@ export default withPwa(defineConfig({
     injectManifest: {
       globPatterns: ['**/*.{css,js,html,svg,png,ico,txt,woff2}', 'hashmap.json'],
       globIgnores: ['og-*.png'],
+      // for local build + preview
+      // enableWorkboxModulesLogs: true,
+      // minify: false,
+      buildPlugins: {
+        vite: [PWAVirtual()],
+      },
     },
   },
 

--- a/packages/.vitepress/config.ts
+++ b/packages/.vitepress/config.ts
@@ -249,6 +249,8 @@ export default withPwa(defineConfig({
     injectManifest: {
       globPatterns: ['**/*.{css,js,html,svg,png,ico,txt,woff2}', 'hashmap.json'],
       globIgnores: ['og-*.png'],
+      // vue chunk ~5.4MB: won't be precached, and won't work when offline
+      maximumFileSizeToCacheInBytes: 6_000_000,
       // for local build + preview
       // enableWorkboxModulesLogs: true,
       // minify: false,

--- a/packages/.vitepress/plugins/pwa-virtual.ts
+++ b/packages/.vitepress/plugins/pwa-virtual.ts
@@ -1,0 +1,35 @@
+import type { Plugin } from 'vite'
+
+export function PWAVirtual(): Plugin {
+  const name = 'virtual:pwa'
+  const resolved = `\0${name}`
+  const packagesPromises = import('../../metadata')
+  return {
+    name: 'pwa-virtual',
+    enforce: 'pre',
+    resolveId(id) {
+      return id === name ? resolved : null
+    },
+    async load(id) {
+      if (id === resolved) {
+        const { categoryNames, metadata } = await packagesPromises
+        const packages: [path: string, { url: string, hash: string }][] = []
+        for (const name of categoryNames) {
+          if (name[0] === '_' || name[0] === '@') {
+            continue
+          }
+
+          for (const f of metadata.functions) {
+            if (f.external || f.category !== name || f.internal) {
+              continue
+            }
+            const url = `/${f.package}/${f.name}/`
+            packages.push([url.toLowerCase(), { url, hash: f.name }])
+          }
+        }
+
+        return `export const packageNames = ${JSON.stringify(packages)};`
+      }
+    },
+  }
+}

--- a/packages/.vitepress/plugins/pwa-virtual.ts
+++ b/packages/.vitepress/plugins/pwa-virtual.ts
@@ -15,7 +15,7 @@ export function PWAVirtual(): Plugin {
         const { categoryNames, metadata } = await packagesPromises
         const packages: [path: string, { url: string, hash: string }][] = []
         for (const name of categoryNames) {
-          if (name[0] === '_' || name[0] === '@') {
+          if (name[0] === '_') {
             continue
           }
 

--- a/packages/.vitepress/shims.d.ts
+++ b/packages/.vitepress/shims.d.ts
@@ -1,0 +1,7 @@
+declare module 'virtual:pwa' {
+  export interface NormalizedPath {
+    url: string
+    hash: string
+  }
+  export const packageNames: [path: string, NormalizedPath][]
+}

--- a/packages/.vitepress/sw.ts
+++ b/packages/.vitepress/sw.ts
@@ -18,13 +18,15 @@ const normalizedPaths = new Map(packageNames)
 
 const assetMatcher = /^\/assets\/([a-zA-Z]+)_([a-zA-Z]+)_index\.md\.[\w-]+\.(?:lean\.)?js$/
 
+const selfHostname = self.location.hostname
+
 // self.__WB_MANIFEST is the default injection point
 precacheAndRoute(
   entries,
   {
     urlManipulation({ url }) {
       const urls: URL[] = []
-      if (url.pathname.includes('.html') || url.host !== self.location.host) {
+      if (url.hostname !== selfHostname || url.pathname.includes('.html')) {
         return urls
       }
       const pathname = url.pathname

--- a/packages/.vitepress/sw.ts
+++ b/packages/.vitepress/sw.ts
@@ -24,7 +24,7 @@ precacheAndRoute(
   {
     urlManipulation({ url }) {
       const urls: URL[] = []
-      if (url.pathname.includes('.html')) {
+      if (url.pathname.includes('.html') || url.host !== self.location.host) {
         return urls
       }
       const pathname = url.pathname

--- a/packages/.vitepress/sw.ts
+++ b/packages/.vitepress/sw.ts
@@ -3,6 +3,7 @@
 // eslint-disable-next-line spaced-comment
 /// <reference lib="webworker" />
 
+import { packageNames } from 'virtual:pwa'
 import { CacheableResponsePlugin } from 'workbox-cacheable-response'
 import { ExpirationPlugin } from 'workbox-expiration'
 import { cleanupOutdatedCaches, createHandlerBoundToURL, precacheAndRoute } from 'workbox-precaching'
@@ -13,8 +14,48 @@ declare let self: ServiceWorkerGlobalScope
 
 const entries = self.__WB_MANIFEST
 
+const normalizedPaths = new Map(packageNames)
+
+const assetMatcher = /^\/assets\/([a-zA-Z]+)_([a-zA-Z]+)_index\.md\.[\w-]+\.(?:lean\.)?js$/
+
 // self.__WB_MANIFEST is the default injection point
-precacheAndRoute(entries)
+precacheAndRoute(
+  entries,
+  {
+    urlManipulation({ url }) {
+      const urls: URL[] = []
+      if (url.pathname.includes('.html')) {
+        return urls
+      }
+      const pathname = url.pathname
+      let entry = normalizedPaths.get(pathname)
+      if (!entry) {
+        const match = pathname.match(assetMatcher)
+        if (match) {
+          const [full, pkg, name] = match
+          entry = normalizedPaths.get(`/${pkg}/${name}/`.toLowerCase())
+          if (entry) {
+            const newURL = new URL(url.href)
+            newURL.pathname = full.replace(
+              `${pkg}_${name}`,
+              `${entry.url.slice(1).replace(/\/$/, '').replace('/', '_')}`,
+            )
+            urls.push(newURL)
+          }
+        }
+        return urls
+      }
+      const newURL = new URL(url.href)
+      if (newURL.hash) {
+        newURL.hash = entry.hash
+      }
+      newURL.pathname = `${entry.url}index.html`
+      urls.push(newURL)
+
+      return urls
+    },
+  },
+)
 
 // clean old assets
 cleanupOutdatedCaches()

--- a/packages/.vitepress/vite.config.ts
+++ b/packages/.vitepress/vite.config.ts
@@ -12,6 +12,7 @@ import { getChangeLog, getFunctionContributors } from '../../scripts/changelog'
 import { ChangeLog } from './plugins/changelog'
 import { Contributors } from './plugins/contributors'
 import { MarkdownTransform } from './plugins/markdownTransform'
+import { PWAVirtual } from './plugins/pwa-virtual'
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url))
 const require = createRequire(import.meta.url)
@@ -51,6 +52,7 @@ export default defineConfig({
       defaultStyle: 'display: inline-block',
     }),
     UnoCSS(),
+    PWAVirtual(),
     Inspect(),
   ],
   resolve: {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
When using Algolia search, the links are lower case, this PR adds an `urlManipulation` callback to the service worker precache handler to serve the real page/assets.

This PR also adds a new Vite plugin to generate the function names with the package and the search:
- the plugin `packages/.vitepress/plugins/pwa-virtual.ts` for the virtual
- updated Vite configuration file to include the plugin in dev
- updated VitePress configuration to include the plugin at build in the `injectManifest` PWA option
- added `packages/.vitepress/shims.d.ts` for the virtual
- updated `.gitignore` to exclude `packages/.vitepress/shims.d.ts`, we need the module augmentation (not yet here, I'll push it in 1 min. **DONE** ✅ )

resolves #4309

### Additional context

![image](https://github.com/user-attachments/assets/5a3ebcdd-10f2-4f23-9228-3eda4fc9030f)
_workbox precaching serving existing asset_

![image](https://github.com/user-attachments/assets/79aa2c09-9498-4359-b55d-f740a8ebe4ad)
_page resolved correctly_
