### PR TITLE
fix(useStorage): Defaults are updated if the storage gets updated when defaults are object like

### DIFF
--- a/packages/core/useStorage/index.test.ts
+++ b/packages/core/useStorage/index.test.ts
@@ -1,6 +1,6 @@
 import { debounceFilter } from '@vueuse/shared'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref as deepRef, defineComponent, nextTick, toRaw } from 'vue'
+import { ref as deepRef, defineComponent, nextTick, toRaw, toValue } from 'vue'
 import { mount, nextTwoTick, useSetup } from '../../.test'
 import { customStorageEventName, StorageSerializers, useStorage } from './index'
 
@@ -253,12 +253,76 @@ describe('useStorage', () => {
 
     expect(storage.setItem).toBeCalledWith(KEY, '{"name":"a","data":123}')
 
-    expect(state).toBe(init)
+    expect(state.value).toEqual(init.value)
 
     init.value.name = 'b'
     await nextTwoTick()
 
     expect(storage.setItem).toBeCalledWith(KEY, '{"name":"b","data":123}')
+  })
+
+  it('pass ref as defaults and storage is updated either when storage changes or the defaults change', async () => {
+    expect(storage.getItem(KEY)).toEqual(undefined)
+
+    const defaults = deepRef({
+      name: 'a',
+      data: 123,
+    })
+    const state = useStorage(KEY, defaults, storage)
+
+    expect(storage.setItem).toBeCalledWith(KEY, '{"name":"a","data":123}')
+
+    expect(state.value).toEqual(defaults.value)
+
+    defaults.value.name = 'b'
+    await nextTwoTick()
+
+    expect(storage.setItem).toBeCalledWith(KEY, '{"name":"b","data":123}')
+
+    state.value.name = 'c'
+    state.value.data = 124
+    await nextTwoTick()
+
+    expect(storage.setItem).toBeCalledWith(KEY, '{"name":"c","data":124}')
+
+    defaults.value.name = 'd'
+    defaults.value.data = 125
+    await nextTwoTick()
+
+    expect(storage.setItem).toBeCalledWith(KEY, '{"name":"d","data":125}')
+
+    defaults.value.data = 126
+    await nextTwoTick()
+
+    expect(storage.setItem).toBeCalledWith(KEY, '{"name":"d","data":126}')
+  })
+
+  it.each([
+    [deepRef({ name: 'a', data: 123 })],
+    [{ name: 'a', data: 123 }],
+    [() => ({ name: 'a', data: 123 })],
+  ])('does not update defaults internally', async (defaults) => {
+    expect(storage.getItem(KEY)).toEqual(undefined)
+
+    const state = useStorage(KEY, defaults, storage)
+
+    expect(storage.setItem).toBeCalledWith(KEY, '{"name":"a","data":123}')
+
+    expect(state.value).toEqual(toValue(defaults))
+
+    state.value.name = 'b'
+    state.value.data = 124
+    await nextTwoTick()
+
+    expect(storage.setItem).toBeCalledWith(KEY, '{"name":"b","data":124}')
+    expect(toValue(defaults)).toEqual({ name: 'a', data: 123 })
+
+    state.value.data = 125
+    await nextTwoTick()
+
+    expect(storage.setItem).toBeCalledWith(KEY, '{"name":"b","data":125}')
+
+    expect(toValue(defaults)).toEqual({ name: 'a', data: 123 })
   })
 
   it('eventFilter', async () => {


### PR DESCRIPTION

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Objects are references and when they are passed as defaults, the defaults are directly passed into a ref, and when the ref changes the defaults also change.
E.G:
```
const global = {a: 1};
const components = {b: 1}

    export const initialConfig = { global, components }

    export const config = useLocalStorage(
        'my-config',
        initialConfig,
        { mergeDefaults: true },
    );

    export const resetConfig = (): void => {
        config.value = initialConfig;
    };
```

somewhere else in the codebase:
```
  config.value.global.a = 88
 resetConfig();
 console.log(initialConfig, config.value) // both are {global: { a: 88} components: { b: 1}}
```

a workaround is to have a clone of the object (even a getter returning a non cloned object will make the object to be mutated internally):
```
const initialConfig = () => {
        return structuredClone({ global, components });
    };
```

I tried to implement the structured clone in the composable itself.
```
const data = (shallow ? shallowRef : deepRef)(
    structuredClone(toRaw(unref(typeof defaults === 'function' ? defaults() : defaults))),
  ) as RemovableRef<T>
```
- unRef removes the ref from defaults if any
- toRaw unproxies the proxy because proxies cannot be cloned

a watch is added to check for defaults changes, even tough I don't see a real use case for this feature because i suppose that even if defaults is reactive i am expecting the defaults to be used only when the storage value does not exist, but it seems, that, according to the original implementation, if the defaults change, the storage must be updated for the changed value.

just one small thing had to be changed in a test because now the composable will not return the defaults object when it is a ref but just a clone of it, I don't think this is a breaking change as the final value does not change. 

### Additional context


https://github.com/user-attachments/assets/58c95f5d-fee8-41bd-af32-581b39228ee8

