### PR TITLE
feat(useAsyncState): add isomorphic destructure

### DIFF
--- a/packages/core/useAsyncState/index.md
+++ b/packages/core/useAsyncState/index.md
@@ -6,13 +6,24 @@ category: State
 
 Reactive async state. Will not block your setup function and will trigger changes once the promise is ready. The state is a `shallowRef` by default.
 
+Also supports isomorphic destructuring via [makeDestructurable](https://vueuse.org/shared/makeDestructurable) utility.
+
 ## Usage
 
 ```ts
 import { useAsyncState } from '@vueuse/core'
 import axios from 'axios'
 
+// Object destructure example
 const { state, isReady, isLoading } = useAsyncState(
+  axios
+    .get('https://jsonplaceholder.typicode.com/todos/1')
+    .then(t => t.data),
+  { id: null },
+)
+
+// Array destructure example (in right order)
+const [state, execute, isLoading, isReady, error] = useAsyncState(
   axios
     .get('https://jsonplaceholder.typicode.com/todos/1')
     .then(t => t.data),

--- a/packages/core/useAsyncState/index.test.ts
+++ b/packages/core/useAsyncState/index.test.ts
@@ -8,7 +8,7 @@ describe('useAsyncState', () => {
   })
 
   const p1 = (num = 1) => {
-    return new Promise((resolve) => {
+    return new Promise<number>((resolve) => {
       setTimeout(() => {
         resolve(num)
       }, 50)
@@ -82,5 +82,21 @@ describe('useAsyncState', () => {
   it('should work with throwError', async () => {
     const { execute } = useAsyncState(p2, '0', { throwError: true, immediate: false })
     await expect(execute()).rejects.toThrowError('error')
+  })
+
+  describe('useAsyncState with array destructing', () => {
+    it('should work', async () => {
+      const [state, execute] = useAsyncState(p1, 0, { immediate: false })
+      expect(state.value).toBe(0)
+      await execute(0, 2)
+      expect(state.value).toBe(2)
+    })
+
+    it('should work with error', async () => {
+      const [_state, execute, _isLoading, _isReady, error] = useAsyncState(p2, '0', { immediate: false })
+      expect(error.value).toBeUndefined()
+      await execute()
+      expect(error.value).toBeInstanceOf(Error)
+    })
   })
 })

--- a/packages/core/useAsyncState/index.ts
+++ b/packages/core/useAsyncState/index.ts
@@ -24,7 +24,7 @@ export type UseAsyncStateReturn<Data, Params extends any[], Shallow extends bool
   UseAsyncStateReturnBase<Data, Params, Shallow>
   & UseAsyncStateReturnArray<Data, Params, Shallow>
 
-export type UseAsyncStateReturnWithThen<Data, Params extends any[], Shallow extends boolean> =
+export type UseAsyncStateReturnWithPromiseLike<Data, Params extends any[], Shallow extends boolean> =
   UseAsyncStateReturn<Data, Params, Shallow>
   & UseAsyncStatePromiseLike<Data, Params, Shallow>
 
@@ -96,7 +96,7 @@ export function useAsyncState<Data, Params extends any[] = any[], Shallow extend
   promise: Promise<Data> | ((...args: Params) => Promise<Data>),
   initialState: Data,
   options?: UseAsyncStateOptions<Shallow, Data>,
-): UseAsyncStateReturnWithThen<Data, Params, Shallow> {
+): UseAsyncStateReturnWithPromiseLike<Data, Params, Shallow> {
   const {
     immediate = true,
     delay = 0,
@@ -180,5 +180,5 @@ export function useAsyncState<Data, Params extends any[] = any[], Shallow extend
     })
   }
 
-  return makeDestructurable({ ...shell, then }, arrayShell) as UseAsyncStateReturnWithThen<Data, Params, Shallow>
+  return makeDestructurable({ ...shell, then }, arrayShell) as UseAsyncStateReturnWithPromiseLike<Data, Params, Shallow>
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following
- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This PR adds a isomorphic destructure possibility for useAsyncState.

Personally, i use multiple `useAsyncState` in components and mostly with the same fields, for example: `{ isLoading, state, execute }`, and have to rename them all. In situations like that, this feature will make code more compact and succinct.
(Order in array based on my personal experience, open to any suggestions!)

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->