### PR TITLE
fix(watchIgnorable): clear disposables array on stop

### DIFF
--- a/packages/shared/watchIgnorable/index.ts
+++ b/packages/shared/watchIgnorable/index.ts
@@ -122,6 +122,7 @@ export function watchIgnorable<Immediate extends Readonly<boolean> = false>(
 
     stop = () => {
       disposables.forEach(fn => fn())
+      disposables.length = 0
     }
   }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

This PR improves memory management in `watchIgnorable` by clearing the `disposables` array after stopping all watchers.

**What this PR solves:**
- Prevents potential memory leaks by releasing references to stopped watcher functions
- Makes the `stop()` function idempotent and safer for multiple calls
- Follows best practices for resource cleanup in Vue composables

**Changes:**
- Added `disposables.length = 0` after calling all disposable functions in the `stop()` method for async flush modes

This is a small but important improvement that ensures proper cleanup when using `watchIgnorable` in applications.

### Additional context

This change only affects the async flush modes (`'pre'` and `'post'`) where multiple watchers are created and stored in the `disposables` array. The sync mode already uses Vue's native watch stop handle directly.

The change is backwards compatible and doesn't affect the API or behavior of the function - it just ensures better memory management.