### PR TITLE
fix(useTransition): prevent runtime error when source is not number o…

### DIFF
--- a/packages/core/useTransition/index.ts
+++ b/packages/core/useTransition/index.ts
@@ -213,9 +213,13 @@ export function useTransition(
   const sourceVal = () => {
     const v = toValue(source)
 
-    return typeof v === 'number'
-      ? v
-      : v.map(toValue<number>)
+    if (typeof v === 'number')
+      return v
+
+    if (Array.isArray(v))
+      return v.map(toValue)
+
+    return 0
   }
 
   const outputRef = deepRef(sourceVal())


### PR DESCRIPTION
…r number[]

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Fixes https://github.com/vueuse/vueuse/issues/4814

This PR fixes a potential runtime error in useTransition when the source is not a number or array of numbers.

Currently, passing a string or other unsupported type as source will result in:

TypeError: v.map is not a function
This can crash the application or prevent rendering when unexpected types are passed in.


### Additional context

The fix introduces a simple type check to ensure the value is either:

- a single number, or

- an array (e.g., number[] or MaybeRef<number>[])

Otherwise, it falls back to a safe default (0), avoiding the .map() call on unsupported types.
