### PR TITLE
fix(useDevicesList): Check for device availability before requesting permissions

### DIFF
--- a/packages/core/useDevicesList/index.ts
+++ b/packages/core/useDevicesList/index.ts
@@ -86,6 +86,11 @@ export function useDevicesList(options: UseDevicesListOptions = {}): UseDevicesL
     if (state.value !== 'granted') {
       let granted = true
       try {
+        const allDevices = await navigator!.mediaDevices.enumerateDevices()
+        const hasCamera = allDevices.some(device => device.kind === 'videoinput')
+        const hasMicrophone = allDevices.some(device => device.kind === 'audioinput' || device.kind === 'audiooutput')
+        constraints.video = hasCamera ? constraints.video : false
+        constraints.audio = hasMicrophone ? constraints.audio : false
         stream = await navigator!.mediaDevices.getUserMedia(constraints)
       }
       catch {


### PR DESCRIPTION
resolve: #4811 

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR adds a check for device availability before requesting media permissions in `useDevicesList`.