### PR TITLE
feat(useFetch): support for custom abort reason

### DIFF
--- a/packages/core/useFetch/index.test.ts
+++ b/packages/core/useFetch/index.test.ts
@@ -835,4 +835,19 @@ describe.skipIf(isBelowNode18)('useFetch', () => {
       expect(data.value).toEqual(expect.objectContaining({ after: 'Global' }))
     })
   })
+
+  it('should abort with given reason', async () => {
+    const { aborted, abort, execute, onFetchError } = useFetch('https://example.com', { immediate: false })
+    const reason = 'custom abort reason'
+    let error: unknown
+    onFetchError((err) => {
+      error = err
+    })
+    execute()
+    abort(reason)
+    await vi.waitFor(() => {
+      expect(aborted.value).toBe(true)
+      expect(error).toBe(reason)
+    })
+  })
 })

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -48,7 +48,7 @@ export interface UseFetchReturn<T> {
   /**
    * Abort the fetch request
    */
-  abort: Fn
+  abort: (reason?: any) => void
 
   /**
    * Manually call the fetch
@@ -394,9 +394,9 @@ export function useFetch<T>(url: MaybeRefOrGetter<string>, ...args: any[]): UseF
   let controller: AbortController | undefined
   let timer: Stoppable | undefined
 
-  const abort = () => {
+  const abort = (reason?: any) => {
     if (supportsAbort) {
-      controller?.abort()
+      controller?.abort(reason)
       controller = new AbortController()
       controller.signal.onabort = () => aborted.value = true
       fetchOptions = {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
close #4817

This PR adds support for passing a reason parameter to the abort method in useFetch, aligning with the standard [AbortSignal.reason](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/reason) behavior in the Fetch API.

### Example Usage
```ts
const { execute, abort } = useFetch('https://example.com', { immediate: false })
execute()
abort('custom abort reason')
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
