### PR TITLE
refactor(computedInject): rename ctx param to oldValue

### DIFF
--- a/packages/core/computedInject/index.test.ts
+++ b/packages/core/computedInject/index.test.ts
@@ -23,4 +23,24 @@ describe('computedInject', () => {
       expect(anotherComputedNum.value).toBe(11)
     })
   })
+
+  it('should pass oldValue to computed getter', () => {
+    useInjectedSetup(() => {
+      const curValue = shallowRef(0)
+      const oldValue = shallowRef()
+
+      const computedNum = computedInject(Key, (source, previous) => {
+        oldValue.value = previous
+        return curValue.value + (source?.value ?? 0)
+      })
+
+      expect(computedNum.value).toBe(1)
+      expect(oldValue.value).toBeUndefined()
+
+      curValue.value = 1
+
+      expect(computedNum.value).toBe(2)
+      expect(oldValue.value).toBe(1)
+    })
+  })
 })

--- a/packages/core/computedInject/index.ts
+++ b/packages/core/computedInject/index.ts
@@ -1,8 +1,8 @@
 import type { ComputedRef, InjectionKey } from 'vue'
 import { computed, inject } from 'vue'
 
-export type ComputedInjectGetter<T, K> = (source: T | undefined, ctx?: any) => K
-export type ComputedInjectGetterWithDefault<T, K> = (source: T, ctx?: any) => K
+export type ComputedInjectGetter<T, K> = (source: T | undefined, oldValue?: K) => K
+export type ComputedInjectGetterWithDefault<T, K> = (source: T, oldValue?: K) => K
 export type ComputedInjectSetter<T> = (v: T) => void
 
 export interface WritableComputedInjectOptions<T, K> {
@@ -48,11 +48,11 @@ export function computedInject<T, K = any>(
     source = inject(key, defaultSource, treatDefaultAsFactory) as T
 
   if (typeof options === 'function') {
-    return computed(ctx => options(source, ctx))
+    return computed(oldValue => options(source, oldValue as K | undefined))
   }
   else {
     return computed({
-      get: ctx => options.get(source, ctx),
+      get: oldValue => options.get(source, oldValue as K | undefined),
       set: options.set,
     })
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

In previous versions, the second parameter of the getter was named ctx, which could easily be misunderstood as referring to the Vue component instance.
However, the actual value passed is oldValue, as introduced in Vue 3.4's computed API. This renaming improves clarity and better aligns with Vue’s official behavior.

### Additional context

Related: [vuejs/rfcs#594](https://github.com/vuejs/rfcs/discussions/594)
