### PR TITLE
fix(onClickOutside): correct return type when controls is undefined and improve handler typing

### DIFF
--- a/packages/core/onClickOutside/index.ts
+++ b/packages/core/onClickOutside/index.ts
@@ -33,7 +33,7 @@ export interface OnClickOutsideOptions<Controls extends boolean = false> extends
 export type OnClickOutsideHandler<
   T extends {
     detectIframe: OnClickOutsideOptions['detectIframe']
-    controls: boolean
+    controls: OnClickOutsideOptions<boolean>['controls']
   } = { detectIframe: false, controls: false },
 > = (
   event: T['controls'] extends true ? Event | (T['detectIframe'] extends true
@@ -53,17 +53,13 @@ let _iOSWorkaround = false
  * @param handler
  * @param options
  */
-export function onClickOutside(
+export function onClickOutside<
+  T extends OnClickOutsideOptions<boolean> = OnClickOutsideOptions,
+>(
   target: MaybeElementRef,
-  handler: OnClickOutsideHandler<{ detectIframe: OnClickOutsideOptions['detectIframe'], controls: true }>,
-  options: OnClickOutsideOptions<true>,
-): { stop: Fn, cancel: Fn, trigger: (event: Event) => void }
-
-export function onClickOutside(
-  target: MaybeElementRef,
-  handler: OnClickOutsideHandler<{ detectIframe: OnClickOutsideOptions['detectIframe'], controls: false }>,
-  options?: OnClickOutsideOptions<false>,
-): Fn
+  handler: OnClickOutsideHandler<{ detectIframe: T['detectIframe'], controls: T['controls'] }>,
+  options?: T,
+): T['controls'] extends true ? { stop: Fn, cancel: Fn, trigger: (event: Event) => void } : Fn
 
 // Implementation
 export function onClickOutside(


### PR DESCRIPTION


<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

fixes the incorrect return type of `onClickOutside` when the `controls` option is undefined or omitted.

**Fixes**

- Return type now correctly resolves to `Fn` when `controls` is not provided or set to false
- Previously returned `{ stop, cancel, trigger }` even if `controls` was undefined

**Improvements**

- Improves handler event type inference based on `controls` and `detectIframe` options
- Event type inference is now more precise based on the combination of `detectIframe` and `controls`
 
### Additional context

fix [#4838](https://github.com/vueuse/vueuse/issues/4838)
