### PR TITLE
docs(useRefHistory): correct author name and link in recommended readings

### DIFF
--- a/packages/core/useRefHistory/index.md
+++ b/packages/core/useRefHistory/index.md
@@ -184,4 +184,4 @@ Another option is to avoid mutating the original ref value using `arr.value = [.
 
 ## Recommended Readings
 
-- [History and Persistence](https://patak.dev/vue/history-and-persistence.html) - by [@matias-capeletto](https://github.com/patak-dev)
+- [History and Persistence](https://patak.dev/vue/history-and-persistence.html) - by [@patak-dev](https://github.com/patak-dev)


### PR DESCRIPTION
This PR updates the author name and link in the "Recommended Readings" section of the `useRefHistory` documentation to point to the correct GitHub profile.