### PR TITLE
docs: add responsive styles for input in small screens

### DIFF
--- a/packages/.vitepress/theme/styles/demo.css
+++ b/packages/.vitepress/theme/styles/demo.css
@@ -122,7 +122,7 @@
     outline: none;
     background: var(--vp-c-bg);
     color: var(--vp-c-text);
-    min-width: 20rem;
+    min-width: min(20rem, 100%);
     margin: 0.5rem 0;
   }
 


### PR DESCRIPTION
In #4692, the textarea min-width was changed to `min(20rem, 100%)` to prevent layout issues on small screens.

This PR applies a similar fix for input fields, ensuring they display correctly on small screens as well.

Before:

![CleanShot 2025-07-06 at 00 51 09@2x](https://github.com/user-attachments/assets/718b1862-f61a-4325-9ac6-4dc2aa507d30)

After:

![CleanShot 2025-07-06 at 00 56 33@2x](https://github.com/user-attachments/assets/1fe5eddf-6d04-4c55-ae23-80120494117e)


