### PR TITLE
docs: explicit syntax highlighting

### DIFF
--- a/packages/.vitepress/config.ts
+++ b/packages/.vitepress/config.ts
@@ -74,6 +74,7 @@ export default withPwa(defineConfig({
     codeTransformers: [
       transformerTwoslash(),
     ],
+    languages: ['js', 'ts'],
   },
 
   themeConfig: {


### PR DESCRIPTION
This should fix the docs build. For whatever reason, we need to
explicitly define these languages now rather than them being auto
detected.

Probably because loading every known language is a bad idea!
