### PR TITLE
docs(useCached): add missing `type="number"` for correct demo styling

### DIFF
--- a/packages/core/useCached/demo.vue
+++ b/packages/core/useCached/demo.vue
@@ -34,11 +34,11 @@ function onSyncClick() {
 
       <div>
         <label for="localValue">Temp Value: </label>
-        <input id="localValue" v-model.number="inputValue">
+        <input id="localValue" v-model.number="inputValue" type="number">
       </div>
       <div>
         <label for="localExtra">Local Extra: </label>
-        <input id="localExtra" v-model.number="inputExtra">
+        <input id="localExtra" v-model.number="inputExtra" type="number">
       </div>
       <div>
         <button @click="onSyncClick">


### PR DESCRIPTION
This PR adds the missing type="number" to the input fields in the useCached demo, ensuring they receive the intended styles from @demo.css and improving visual consistency.