### PR TITLE
fix(useFileDialog): fixing issue where custom input passed in was too eager with later initialized template refs

### DIFF
--- a/packages/core/useFileDialog/index.test.ts
+++ b/packages/core/useFileDialog/index.test.ts
@@ -84,6 +84,21 @@ describe('useFileDialog', () => {
     expect(inputEl2.click).toHaveBeenCalledTimes(1)
   })
 
+  it('should work with input element passed as template ref that is initialised late', async () => {
+    const inputEl = document.createElement('input')
+    inputEl.click = vi.fn()
+
+    const inputRef = shallowRef<HTMLInputElement>()
+
+    const { open } = useFileDialog({ input: inputRef })
+    inputRef.value = inputEl
+    await nextTick()
+
+    open()
+    expect(inputEl.type).toBe('file')
+    expect(inputEl.click).toHaveBeenCalled()
+  })
+
   it('should trigger onchange and update files when file is selected', async () => {
     const input = document.createElement('input')
     const file = new File(['dummy content'], 'example.txt', { type: 'text/plain' })


### PR DESCRIPTION


<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

---

### Description

Fixes https://github.com/vueuse/vueuse/issues/4867
