### PR TITLE
feat(useAsyncState): cancel previous promise and use latest promise

### DIFF
--- a/packages/core/useAsyncState/index.test.ts
+++ b/packages/core/useAsyncState/index.test.ts
@@ -90,4 +90,34 @@ describe('useAsyncState', () => {
     const { execute } = useAsyncState(p2, '0', { throwError: true, immediate: false })
     await expect(execute()).rejects.toThrowError('error')
   })
+
+  it('should work with cancellable (only latest promise resolves)', async () => {
+    const p = (num = 1) => {
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          resolve(num)
+        }, num * 1000)
+      })
+    }
+    const { execute, state } = useAsyncState(p, 0, { cancellable: true })
+    execute(0, 1)
+    execute(0, 3)
+    await execute(0, 2)
+    expect(state.value).toBe(2)
+  })
+
+  it('should support manual cancel()', async () => {
+    const p = (num = 1) => {
+      return new Promise<number>((resolve) => {
+        setTimeout(() => {
+          resolve(num)
+        }, num * 1000)
+      })
+    }
+    const { execute, state, cancel } = useAsyncState(p, 0, { cancellable: true })
+    execute(0, 3)
+    execute(0, 5)
+    cancel()
+    expect(state.value).toBe(0)
+  })
 })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

cancel previous promise and use latest promise

### Additional context

Replaces #4797 — reopened because the previous branch name conflicted with an existing one.
