### PR TITLE
feat: mark useTemplateRefsList as deprecated

### DIFF
--- a/packages/core/useTemplateRefsList/index.md
+++ b/packages/core/useTemplateRefsList/index.md
@@ -2,6 +2,12 @@
 category: Component
 ---
 
+::: tip
+This function will be removed in future version.
+
+Vue 3.5 introduced the `useTemplateRef` API which can effectively replace the functionality of `useTemplateRefsList`, therefore we recommend using the native approach.
+:::
+
 # useTemplateRefsList
 
 Shorthand for binding refs to template elements and components inside `v-for`.

--- a/packages/core/useTemplateRefsList/index.ts
+++ b/packages/core/useTemplateRefsList/index.ts
@@ -5,6 +5,9 @@ export type TemplateRefsList<T> = T[] & {
   set: (el: object | null) => void
 }
 
+/**
+ * @deprecated Use Vue's built-in `useTemplateRef` instead.
+ */
 export function useTemplateRefsList<T = Element>(): Readonly<Ref<Readonly<TemplateRefsList<T>>>> {
   const refs = deepRef<unknown>([]) as Ref<TemplateRefsList<T>>
   refs.value.set = (el: object | null) => {


### PR DESCRIPTION
This PR is part of #4883 and deprecates `useTemplateRefsList` in favor of Vue's native `useTemplateRef`.