### PR TITLE
docs(refDebounce,refThrottled): add usage example with object ref

### DIFF
--- a/packages/shared/refDebounced/index.md
+++ b/packages/shared/refDebounced/index.md
@@ -44,7 +44,7 @@ function update() {
 }
 
 console.log(debounced.value) // { name: 'foo', age: 18 }
-
+update()
 await sleep(1100)
 
 console.log(debounced.value) // { name: 'bar', age: 18 }

--- a/packages/shared/refDebounced/index.md
+++ b/packages/shared/refDebounced/index.md
@@ -24,6 +24,32 @@ await sleep(1100)
 console.log(debounced.value) // 'bar'
 ```
 
+An example with object ref.
+
+```js {5}
+import { refDebounced } from '@vueuse/core'
+import { shallowRef } from 'vue';
+
+const data = shallowRef({
+  name: 'foo',
+  age: 18,
+})
+const debounced = refDebounced(data, 1000)
+
+function update() {
+  data.value = {
+    ...data.value,
+    name: 'bar',
+  }
+}
+
+console.log(debounced.value) // { name: 'foo', age: 18 }
+
+await sleep(1100)
+
+console.log(debounced.value) // { name: 'bar', age: 18 }
+```
+
 You can also pass an optional 3rd parameter including maxWait option. See `useDebounceFn` for details.
 
 ## Recommended Reading

--- a/packages/shared/refDebounced/index.md
+++ b/packages/shared/refDebounced/index.md
@@ -26,9 +26,9 @@ console.log(debounced.value) // 'bar'
 
 An example with object ref.
 
-```js {5}
+```js
 import { refDebounced } from '@vueuse/core'
-import { shallowRef } from 'vue';
+import { shallowRef } from 'vue'
 
 const data = shallowRef({
   name: 'foo',

--- a/packages/shared/refThrottled/index.md
+++ b/packages/shared/refThrottled/index.md
@@ -21,7 +21,7 @@ An example with object ref.
 
 ```js {5}
 import { refThrottled } from '@vueuse/core'
-import { shallowRef } from 'vue';
+import { shallowRef } from 'vue'
 
 const data = shallowRef({
   name: 'foo',

--- a/packages/shared/refThrottled/index.md
+++ b/packages/shared/refThrottled/index.md
@@ -24,23 +24,24 @@ import { refThrottled } from '@vueuse/core'
 import { shallowRef } from 'vue'
 
 const data = shallowRef({
+  count: 0,
   name: 'foo',
-  age: 18,
 })
 const throttled = refThrottled(data, 1000)
 
-function update() {
-  data.value = {
-    ...data.value,
-    name: 'bar',
-  }
-}
+data.value = { count: 1, name: 'foo' }
+console.log(throttled.value) // { count: 1, name: 'foo' } (immediate)
 
-console.log(throttled.value) // { name: 'foo', age: 18 }
+data.value = { count: 2, name: 'bar' }
+data.value = { count: 3, name: 'baz' }
+data.value = { count: 4, name: 'qux' }
+console.log(throttled.value) // { count: 1, name: 'foo' } (still first value)
 
+// After 1000ms, next change will be applied
 await sleep(1100)
-
-console.log(throttled.value) // { name: 'bar', age: 18 }
+data.value = { count: 5, name: 'final' }
+await nextTick()
+console.log(throttled.value) // { count: 5, name: 'final' } (updated)
 ```
 
 ### Trailing

--- a/packages/shared/refThrottled/index.md
+++ b/packages/shared/refThrottled/index.md
@@ -9,7 +9,7 @@ Throttle changing of a ref value.
 
 ## Usage
 
-```js
+```js {5}
 import { refThrottled } from '@vueuse/core'
 import { shallowRef } from 'vue'
 
@@ -19,7 +19,7 @@ const throttled = refThrottled(input, 1000)
 
 An example with object ref.
 
-```js {5}
+```js
 import { refThrottled } from '@vueuse/core'
 import { shallowRef } from 'vue'
 

--- a/packages/shared/refThrottled/index.md
+++ b/packages/shared/refThrottled/index.md
@@ -17,6 +17,32 @@ const input = shallowRef('')
 const throttled = refThrottled(input, 1000)
 ```
 
+An example with object ref.
+
+```js {5}
+import { refThrottled } from '@vueuse/core'
+import { shallowRef } from 'vue';
+
+const data = shallowRef({
+  name: 'foo',
+  age: 18,
+})
+const throttled = refThrottled(data, 1000)
+
+function update() {
+  data.value = {
+    ...data.value,
+    name: 'bar',
+  }
+}
+
+console.log(throttled.value) // { name: 'foo', age: 18 }
+
+await sleep(1100)
+
+console.log(throttled.value) // { name: 'bar', age: 18 }
+```
+
 ### Trailing
 
 If you don't want to watch trailing changes, set 3rd param `false` (it's `true` by default):


### PR DESCRIPTION
### Description

This PR adds examples of how to use objects with `refDebounced` and `refThrottled`.

Other APIs may encounter the same issue, so we should find a better place to provide a clear explanation.

### Additional context

Since we already have a working solution, the related PRs will be closed. Thanks for their contributions.

reference: #3158
closed: #3705
closed: #3969