### PR TITLE
docs(useElementBounding,useElementSize): convert `<script>` to `<script setup lang="ts">`

### DIFF
--- a/packages/core/useElementBounding/index.md
+++ b/packages/core/useElementBounding/index.md
@@ -9,22 +9,12 @@ Reactive [bounding box](https://developer.mozilla.org/en-US/docs/Web/API/Element
 ## Usage
 
 ```vue
-<script>
+<script setup lang="ts">
 import { useElementBounding } from '@vueuse/core'
 import { useTemplateRef } from 'vue'
 
-export default {
-  setup() {
-    const el = useTemplateRef('el')
-    const { x, y, top, right, bottom, left, width, height }
-        = useElementBounding(el)
-
-    return {
-      el,
-      /* ... */
-    }
-  },
-}
+const el = useTemplateRef('el')
+const { x, y, top, right, bottom, left, width, height } = useElementBounding(el)
 </script>
 
 <template>

--- a/packages/core/useElementSize/index.md
+++ b/packages/core/useElementSize/index.md
@@ -9,22 +9,12 @@ Reactive size of an HTML element. [ResizeObserver MDN](https://developer.mozilla
 ## Usage
 
 ```vue
-<script>
+<script setup lang="ts">
 import { useElementSize } from '@vueuse/core'
 import { useTemplateRef } from 'vue'
 
-export default {
-  setup() {
-    const el = useTemplateRef('el')
-    const { width, height } = useElementSize(el)
-
-    return {
-      el,
-      width,
-      height,
-    }
-  }
-}
+const el = useTemplateRef('el')
+const { width, height } = useElementSize(el)
 </script>
 
 <template>


### PR DESCRIPTION
The style should be consistent.