### PR TITLE
docs(useSortable): moveArrayElement arguments

### DIFF
--- a/packages/integrations/useSortable/index.md
+++ b/packages/integrations/useSortable/index.md
@@ -106,7 +106,7 @@ import { moveArrayElement } from '@vueuse/integrations/useSortable'
 useSortable(el, list, {
   onUpdate: (e) => {
     // do something
-    moveArrayElement(list.value, e.oldIndex, e.newIndex, e)
+    moveArrayElement(list, e.oldIndex, e.newIndex, e)
     // nextTick required here as moveArrayElement is executed in a microtask
     // so we need to wait until the next tick until that is finished.
     nextTick(() => {


### PR DESCRIPTION
### Description

closed: #4902 

When moveArrayElement passes the value of shallowRef `list.value` , the responsive setter will not be triggered

```ts {5}
import { moveArrayElement } from '@vueuse/integrations/useSortable'

useSortable(el, list, {
  onUpdate: (e) => {
    // If the passed list is a shallowRef, then the responsive setter will not be triggered.
    // If it is a deepRef, there will be no such problem.
    moveArrayElement(list.value, e.oldIndex, e.newIndex, e)
  }
})
```

```ts
// So in the document, if you pass in a ref, there will be no such problem.
moveArrayElement(list, e.oldIndex, e.newIndex, e)
```