### PR TITLE
refactor: add `@__NO_SIDE_EFFECTS__` annotations  to all pure functions

### DIFF
--- a/packages/core/createReusableTemplate/index.ts
+++ b/packages/core/createReusableTemplate/index.ts
@@ -51,6 +51,8 @@ export interface CreateReusableTemplateOptions<Props extends Record<string, any>
  * It also allow to pass a generic to bind with type.
  *
  * @see https://vueuse.org/createReusableTemplate
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function createReusableTemplate<
   Bindings extends Record<string, any>,

--- a/packages/core/createTemplatePromise/index.ts
+++ b/packages/core/createTemplatePromise/index.ts
@@ -61,6 +61,8 @@ export type TemplatePromise<Return, Args extends any[] = []> = DefineComponent<o
  * Creates a template promise component.
  *
  * @see https://vueuse.org/createTemplatePromise
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function createTemplatePromise<Return, Args extends any[] = []>(
   options: TemplatePromiseOptions = {},

--- a/packages/core/createUnrefFn/index.ts
+++ b/packages/core/createUnrefFn/index.ts
@@ -10,6 +10,8 @@ export type UnrefFn<T> = T extends (...args: infer A) => infer R
 /**
  * Make a plain function accepting ref and raw values as arguments.
  * Returns the same value the unconverted function returns, with proper typing.
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function createUnrefFn<T extends Function>(fn: T): UnrefFn<T> {
   return function (this: any, ...args: any[]) {

--- a/packages/core/templateRef/index.ts
+++ b/packages/core/templateRef/index.ts
@@ -8,6 +8,8 @@ import { customRef, getCurrentInstance, onUpdated } from 'vue'
  * @see https://vueuse.org/templateRef
  * @param key
  * @param initialValue
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function templateRef<T extends HTMLElement | SVGElement | Component | null, Keys extends string = string>(
   key: Keys,

--- a/packages/core/useActiveElement/index.ts
+++ b/packages/core/useActiveElement/index.ts
@@ -24,8 +24,9 @@ export interface UseActiveElementOptions extends ConfigurableWindow, Configurabl
  *
  * @see https://vueuse.org/useActiveElement
  * @param options
+ *
+ * @__NO_SIDE_EFFECTS__
  */
-/* #__NO_SIDE_EFFECTS__ */
 export function useActiveElement<T extends HTMLElement>(
   options: UseActiveElementOptions = {},
 ) {

--- a/packages/core/useActiveElement/index.ts
+++ b/packages/core/useActiveElement/index.ts
@@ -25,6 +25,7 @@ export interface UseActiveElementOptions extends ConfigurableWindow, Configurabl
  * @see https://vueuse.org/useActiveElement
  * @param options
  */
+/* #__NO_SIDE_EFFECTS__ */
 export function useActiveElement<T extends HTMLElement>(
   options: UseActiveElementOptions = {},
 ) {

--- a/packages/core/useBattery/index.ts
+++ b/packages/core/useBattery/index.ts
@@ -21,8 +21,9 @@ type NavigatorWithBattery = Navigator & {
  * Reactive Battery Status API.
  *
  * @see https://vueuse.org/useBattery
+ *
+ * @__NO_SIDE_EFFECTS__
  */
-/* #__NO_SIDE_EFFECTS__ */
 export function useBattery(options: ConfigurableNavigator = {}) {
   const { navigator = defaultNavigator } = options
   const events = ['chargingchange', 'chargingtimechange', 'dischargingtimechange', 'levelchange']

--- a/packages/core/useBattery/index.ts
+++ b/packages/core/useBattery/index.ts
@@ -22,6 +22,7 @@ type NavigatorWithBattery = Navigator & {
  *
  * @see https://vueuse.org/useBattery
  */
+/* #__NO_SIDE_EFFECTS__ */
 export function useBattery(options: ConfigurableNavigator = {}) {
   const { navigator = defaultNavigator } = options
   const events = ['chargingchange', 'chargingtimechange', 'dischargingtimechange', 'levelchange']

--- a/packages/core/useBluetooth/index.ts
+++ b/packages/core/useBluetooth/index.ts
@@ -43,6 +43,7 @@ export interface UseBluetoothOptions extends UseBluetoothRequestDeviceOptions, C
   acceptAllDevices?: boolean
 }
 
+/* #__NO_SIDE_EFFECTS__ */
 export function useBluetooth(options?: UseBluetoothOptions): UseBluetoothReturn {
   let {
     acceptAllDevices = false,

--- a/packages/core/useBluetooth/index.ts
+++ b/packages/core/useBluetooth/index.ts
@@ -43,7 +43,7 @@ export interface UseBluetoothOptions extends UseBluetoothRequestDeviceOptions, C
   acceptAllDevices?: boolean
 }
 
-/* #__NO_SIDE_EFFECTS__ */
+/* @__NO_SIDE_EFFECTS__ */
 export function useBluetooth(options?: UseBluetoothOptions): UseBluetoothReturn {
   let {
     acceptAllDevices = false,

--- a/packages/core/useBreakpoints/index.ts
+++ b/packages/core/useBreakpoints/index.ts
@@ -27,6 +27,8 @@ export interface UseBreakpointsOptions extends ConfigurableWindow {
  * Reactively viewport breakpoints
  *
  * @see https://vueuse.org/useBreakpoints
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useBreakpoints<K extends string>(
   breakpoints: Breakpoints<K>,

--- a/packages/core/useBrowserLocation/index.ts
+++ b/packages/core/useBrowserLocation/index.ts
@@ -37,8 +37,9 @@ export interface BrowserLocationState {
  * Reactive browser location.
  *
  * @see https://vueuse.org/useBrowserLocation
+ *
+ * @__NO_SIDE_EFFECTS__
  */
-/* #__NO_SIDE_EFFECTS__ */
 export function useBrowserLocation(options: ConfigurableWindow = {}) {
   const { window = defaultWindow } = options
   const refs = Object.fromEntries(

--- a/packages/core/useBrowserLocation/index.ts
+++ b/packages/core/useBrowserLocation/index.ts
@@ -38,6 +38,7 @@ export interface BrowserLocationState {
  *
  * @see https://vueuse.org/useBrowserLocation
  */
+/* #__NO_SIDE_EFFECTS__ */
 export function useBrowserLocation(options: ConfigurableWindow = {}) {
   const { window = defaultWindow } = options
   const refs = Object.fromEntries(

--- a/packages/core/useClipboard/index.ts
+++ b/packages/core/useClipboard/index.ts
@@ -49,6 +49,8 @@ export interface UseClipboardReturn<Optional> {
  *
  * @see https://vueuse.org/useClipboard
  * @param options
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useClipboard(options?: UseClipboardOptions<undefined>): UseClipboardReturn<false>
 export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<string>>): UseClipboardReturn<true>

--- a/packages/core/useClipboardItems/index.ts
+++ b/packages/core/useClipboardItems/index.ts
@@ -39,6 +39,8 @@ export interface UseClipboardItemsReturn<Optional> {
  *
  * @see https://vueuse.org/useClipboardItems
  * @param options
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useClipboardItems(options?: UseClipboardItemsOptions<undefined>): UseClipboardItemsReturn<false>
 export function useClipboardItems(options: UseClipboardItemsOptions<MaybeRefOrGetter<ClipboardItems>>): UseClipboardItemsReturn<true>

--- a/packages/core/useConfirmDialog/index.ts
+++ b/packages/core/useConfirmDialog/index.ts
@@ -61,6 +61,8 @@ export interface UseConfirmDialogReturn<RevealData, ConfirmData, CancelData> {
  *
  * @see https://vueuse.org/useConfirmDialog/
  * @param revealed `boolean` `ref` that handles a modal window
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useConfirmDialog<
   RevealData = any,

--- a/packages/core/useDeviceOrientation/index.ts
+++ b/packages/core/useDeviceOrientation/index.ts
@@ -12,8 +12,9 @@ import { useSupported } from '../useSupported'
  *
  * @see https://vueuse.org/useDeviceOrientation
  * @param options
+ *
+ * @__NO_SIDE_EFFECTS__
  */
-/* #__NO_SIDE_EFFECTS__ */
 export function useDeviceOrientation(options: ConfigurableWindow = {}) {
   const { window = defaultWindow } = options
   const isSupported = useSupported(() => window && 'DeviceOrientationEvent' in window)

--- a/packages/core/useDeviceOrientation/index.ts
+++ b/packages/core/useDeviceOrientation/index.ts
@@ -13,6 +13,7 @@ import { useSupported } from '../useSupported'
  * @see https://vueuse.org/useDeviceOrientation
  * @param options
  */
+/* #__NO_SIDE_EFFECTS__ */
 export function useDeviceOrientation(options: ConfigurableWindow = {}) {
   const { window = defaultWindow } = options
   const isSupported = useSupported(() => window && 'DeviceOrientationEvent' in window)

--- a/packages/core/useDevicePixelRatio/index.ts
+++ b/packages/core/useDevicePixelRatio/index.ts
@@ -8,8 +8,9 @@ import { useMediaQuery } from '../useMediaQuery'
  * Reactively track `window.devicePixelRatio`.
  *
  * @see https://vueuse.org/useDevicePixelRatio
+ *
+ * @__NO_SIDE_EFFECTS__
  */
-/* #__NO_SIDE_EFFECTS__ */
 export function useDevicePixelRatio(options: ConfigurableWindow = {}) {
   const {
     window = defaultWindow,

--- a/packages/core/useDevicePixelRatio/index.ts
+++ b/packages/core/useDevicePixelRatio/index.ts
@@ -9,6 +9,7 @@ import { useMediaQuery } from '../useMediaQuery'
  *
  * @see https://vueuse.org/useDevicePixelRatio
  */
+/* #__NO_SIDE_EFFECTS__ */
 export function useDevicePixelRatio(options: ConfigurableWindow = {}) {
   const {
     window = defaultWindow,

--- a/packages/core/useDocumentVisibility/index.ts
+++ b/packages/core/useDocumentVisibility/index.ts
@@ -8,8 +8,9 @@ import { useEventListener } from '../useEventListener'
  * Reactively track `document.visibilityState`.
  *
  * @see https://vueuse.org/useDocumentVisibility
+ *
+ * @__NO_SIDE_EFFECTS__
  */
-/* #__NO_SIDE_EFFECTS__ */
 export function useDocumentVisibility(options: ConfigurableDocument = {}): ShallowRef<DocumentVisibilityState> {
   const { document = defaultDocument } = options
   if (!document)

--- a/packages/core/useDocumentVisibility/index.ts
+++ b/packages/core/useDocumentVisibility/index.ts
@@ -9,6 +9,7 @@ import { useEventListener } from '../useEventListener'
  *
  * @see https://vueuse.org/useDocumentVisibility
  */
+/* #__NO_SIDE_EFFECTS__ */
 export function useDocumentVisibility(options: ConfigurableDocument = {}): ShallowRef<DocumentVisibilityState> {
   const { document = defaultDocument } = options
   if (!document)

--- a/packages/core/useEventBus/index.ts
+++ b/packages/core/useEventBus/index.ts
@@ -39,6 +39,7 @@ export interface UseEventBusReturn<T, P> {
   reset: () => void
 }
 
+/* @__NO_SIDE_EFFECTS__ */
 export function useEventBus<T = unknown, P = any>(key: EventBusIdentifier<T>): UseEventBusReturn<T, P> {
   const scope = getCurrentScope()
   function on(listener: EventBusListener<T, P>) {

--- a/packages/core/useEyeDropper/index.ts
+++ b/packages/core/useEyeDropper/index.ts
@@ -29,6 +29,7 @@ export interface UseEyeDropperOptions {
  *
  * @see https://vueuse.org/useEyeDropper
  */
+/* #__NO_SIDE_EFFECTS__ */
 export function useEyeDropper(options: UseEyeDropperOptions = {}) {
   const { initialValue = '' } = options
   const isSupported = useSupported(() => typeof window !== 'undefined' && 'EyeDropper' in window)

--- a/packages/core/useEyeDropper/index.ts
+++ b/packages/core/useEyeDropper/index.ts
@@ -28,8 +28,9 @@ export interface UseEyeDropperOptions {
  * Reactive [EyeDropper API](https://developer.mozilla.org/en-US/docs/Web/API/EyeDropper_API)
  *
  * @see https://vueuse.org/useEyeDropper
+ *
+ * @__NO_SIDE_EFFECTS__
  */
-/* #__NO_SIDE_EFFECTS__ */
 export function useEyeDropper(options: UseEyeDropperOptions = {}) {
   const { initialValue = '' } = options
   const isSupported = useSupported(() => typeof window !== 'undefined' && 'EyeDropper' in window)

--- a/packages/core/useFps/index.ts
+++ b/packages/core/useFps/index.ts
@@ -10,7 +10,7 @@ export interface UseFpsOptions {
   every?: number
 }
 
-/* #__NO_SIDE_EFFECTS__ */
+/* @__NO_SIDE_EFFECTS__ */
 export function useFps(options?: UseFpsOptions): ShallowRef<number> {
   const fps = shallowRef(0)
   if (typeof performance === 'undefined')

--- a/packages/core/useFps/index.ts
+++ b/packages/core/useFps/index.ts
@@ -10,6 +10,7 @@ export interface UseFpsOptions {
   every?: number
 }
 
+/* #__NO_SIDE_EFFECTS__ */
 export function useFps(options?: UseFpsOptions): ShallowRef<number> {
   const fps = shallowRef(0)
   if (typeof performance === 'undefined')

--- a/packages/core/useGamepad/index.ts
+++ b/packages/core/useGamepad/index.ts
@@ -59,6 +59,7 @@ export function mapGamepadToXbox360Controller(gamepad: Ref<Gamepad | undefined>)
   })
 }
 
+/* #__NO_SIDE_EFFECTS__ */
 export function useGamepad(options: UseGamepadOptions = {}) {
   const {
     navigator = defaultNavigator,

--- a/packages/core/useGamepad/index.ts
+++ b/packages/core/useGamepad/index.ts
@@ -59,7 +59,7 @@ export function mapGamepadToXbox360Controller(gamepad: Ref<Gamepad | undefined>)
   })
 }
 
-/* #__NO_SIDE_EFFECTS__ */
+/* @__NO_SIDE_EFFECTS__ */
 export function useGamepad(options: UseGamepadOptions = {}) {
   const {
     navigator = defaultNavigator,

--- a/packages/core/useKeyModifier/index.ts
+++ b/packages/core/useKeyModifier/index.ts
@@ -27,7 +27,7 @@ export interface UseModifierOptions<Initial> extends ConfigurableDocument {
 
 export type UseKeyModifierReturn<Initial> = ShallowRef<Initial extends boolean ? boolean : boolean | null>
 
-/* #__NO_SIDE_EFFECTS__ */
+/* @__NO_SIDE_EFFECTS__ */
 export function useKeyModifier<Initial extends boolean | null>(modifier: KeyModifier, options: UseModifierOptions<Initial> = {}): UseKeyModifierReturn<Initial> {
   const {
     events = defaultEvents,

--- a/packages/core/useKeyModifier/index.ts
+++ b/packages/core/useKeyModifier/index.ts
@@ -27,6 +27,7 @@ export interface UseModifierOptions<Initial> extends ConfigurableDocument {
 
 export type UseKeyModifierReturn<Initial> = ShallowRef<Initial extends boolean ? boolean : boolean | null>
 
+/* #__NO_SIDE_EFFECTS__ */
 export function useKeyModifier<Initial extends boolean | null>(modifier: KeyModifier, options: UseModifierOptions<Initial> = {}): UseKeyModifierReturn<Initial> {
   const {
     events = defaultEvents,

--- a/packages/core/useMemoize/index.ts
+++ b/packages/core/useMemoize/index.ts
@@ -65,6 +65,8 @@ export interface UseMemoizeOptions<Result, Args extends unknown[]> {
 
 /**
  * Reactive function result cache based on arguments
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useMemoize<Result, Args extends unknown[]>(
   resolver: (...args: Args) => Result,

--- a/packages/core/useMemory/index.ts
+++ b/packages/core/useMemory/index.ts
@@ -39,6 +39,7 @@ type PerformanceMemory = Performance & {
  * @see https://vueuse.org/useMemory
  * @param options
  */
+/* #__NO_SIDE_EFFECTS__ */
 export function useMemory(options: UseMemoryOptions = {}) {
   const memory = deepRef<MemoryInfo>()
   const isSupported = useSupported(() => typeof performance !== 'undefined' && 'memory' in performance)

--- a/packages/core/useMemory/index.ts
+++ b/packages/core/useMemory/index.ts
@@ -38,8 +38,9 @@ type PerformanceMemory = Performance & {
  *
  * @see https://vueuse.org/useMemory
  * @param options
+ *
+ * @__NO_SIDE_EFFECTS__
  */
-/* #__NO_SIDE_EFFECTS__ */
 export function useMemory(options: UseMemoryOptions = {}) {
   const memory = deepRef<MemoryInfo>()
   const isSupported = useSupported(() => typeof performance !== 'undefined' && 'memory' in performance)

--- a/packages/core/useMounted/index.ts
+++ b/packages/core/useMounted/index.ts
@@ -9,6 +9,8 @@ import {
  * Mounted state in ref.
  *
  * @see https://vueuse.org/useMounted
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useMounted() {
   const isMounted = shallowRef(false)

--- a/packages/core/useNavigatorLanguage/index.ts
+++ b/packages/core/useNavigatorLanguage/index.ts
@@ -36,6 +36,7 @@ export interface NavigatorLanguageState {
  * @see https://vueuse.org/useNavigatorLanguage
  *
  */
+/* #__NO_SIDE_EFFECTS__ */
 export function useNavigatorLanguage(options: ConfigurableWindow = {}): Readonly<NavigatorLanguageState> {
   const { window = defaultWindow } = options
 

--- a/packages/core/useNavigatorLanguage/index.ts
+++ b/packages/core/useNavigatorLanguage/index.ts
@@ -35,8 +35,8 @@ export interface NavigatorLanguageState {
  * Detects the currently selected user language and returns a reactive language
  * @see https://vueuse.org/useNavigatorLanguage
  *
+ * @__NO_SIDE_EFFECTS__
  */
-/* #__NO_SIDE_EFFECTS__ */
 export function useNavigatorLanguage(options: ConfigurableWindow = {}): Readonly<NavigatorLanguageState> {
   const { window = defaultWindow } = options
 

--- a/packages/core/useNetwork/index.ts
+++ b/packages/core/useNetwork/index.ts
@@ -57,6 +57,7 @@ export interface NetworkState {
  * @see https://vueuse.org/useNetwork
  * @param options
  */
+/* #__NO_SIDE_EFFECTS__ */
 export function useNetwork(options: ConfigurableWindow = {}): Readonly<NetworkState> {
   const { window = defaultWindow } = options
   const navigator = window?.navigator

--- a/packages/core/useNetwork/index.ts
+++ b/packages/core/useNetwork/index.ts
@@ -56,8 +56,9 @@ export interface NetworkState {
  *
  * @see https://vueuse.org/useNetwork
  * @param options
+ *
+ * @__NO_SIDE_EFFECTS__
  */
-/* #__NO_SIDE_EFFECTS__ */
 export function useNetwork(options: ConfigurableWindow = {}): Readonly<NetworkState> {
   const { window = defaultWindow } = options
   const navigator = window?.navigator

--- a/packages/core/useNow/index.ts
+++ b/packages/core/useNow/index.ts
@@ -32,9 +32,12 @@ export interface UseNowOptions<Controls extends boolean> {
  *
  * @see https://vueuse.org/useNow
  * @param options
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useNow(options?: UseNowOptions<false>): Ref<Date>
 export function useNow(options: UseNowOptions<true>): { now: Ref<Date> } & Pausable
+/* @__NO_SIDE_EFFECTS__ */
 export function useNow(options: UseNowOptions<boolean> = {}) {
   const {
     controls: exposeControls = false,

--- a/packages/core/useNow/index.ts
+++ b/packages/core/useNow/index.ts
@@ -37,7 +37,15 @@ export interface UseNowOptions<Controls extends boolean> {
  */
 export function useNow(options?: UseNowOptions<false>): Ref<Date>
 export function useNow(options: UseNowOptions<true>): { now: Ref<Date> } & Pausable
-/* @__NO_SIDE_EFFECTS__ */
+
+/**
+ * Reactive current Date instance.
+ *
+ * @see https://vueuse.org/useNow
+ * @param options
+ *
+ * @__NO_SIDE_EFFECTS__
+ */
 export function useNow(options: UseNowOptions<boolean> = {}) {
   const {
     controls: exposeControls = false,

--- a/packages/core/useOnline/index.ts
+++ b/packages/core/useOnline/index.ts
@@ -6,8 +6,9 @@ import { useNetwork } from '../useNetwork'
  *
  * @see https://vueuse.org/useOnline
  * @param options
+ *
+ * @__NO_SIDE_EFFECTS__
  */
-/* #__NO_SIDE_EFFECTS__ */
 export function useOnline(options: ConfigurableWindow = {}) {
   const { isOnline } = useNetwork(options)
   return isOnline

--- a/packages/core/useOnline/index.ts
+++ b/packages/core/useOnline/index.ts
@@ -7,6 +7,7 @@ import { useNetwork } from '../useNetwork'
  * @see https://vueuse.org/useOnline
  * @param options
  */
+/* #__NO_SIDE_EFFECTS__ */
 export function useOnline(options: ConfigurableWindow = {}) {
   const { isOnline } = useNetwork(options)
   return isOnline

--- a/packages/core/usePageLeave/index.ts
+++ b/packages/core/usePageLeave/index.ts
@@ -8,8 +8,9 @@ import { useEventListener } from '../useEventListener'
  *
  * @see https://vueuse.org/usePageLeave
  * @param options
+ *
+ * @__NO_SIDE_EFFECTS__
  */
-/* #__NO_SIDE_EFFECTS__ */
 export function usePageLeave(options: ConfigurableWindow = {}) {
   const { window = defaultWindow } = options
   const isLeft = shallowRef(false)

--- a/packages/core/usePageLeave/index.ts
+++ b/packages/core/usePageLeave/index.ts
@@ -9,6 +9,7 @@ import { useEventListener } from '../useEventListener'
  * @see https://vueuse.org/usePageLeave
  * @param options
  */
+/* #__NO_SIDE_EFFECTS__ */
 export function usePageLeave(options: ConfigurableWindow = {}) {
   const { window = defaultWindow } = options
   const isLeft = shallowRef(false)

--- a/packages/core/usePermission/index.ts
+++ b/packages/core/usePermission/index.ts
@@ -57,6 +57,7 @@ export function usePermission(
   permissionDesc: GeneralPermissionDescriptor | GeneralPermissionDescriptor['name'],
   options: UsePermissionOptions<true>,
 ): UsePermissionReturnWithControls
+/* #__NO_SIDE_EFFECTS__ */
 export function usePermission(
   permissionDesc: GeneralPermissionDescriptor | GeneralPermissionDescriptor['name'],
   options: UsePermissionOptions<boolean> = {},

--- a/packages/core/usePermission/index.ts
+++ b/packages/core/usePermission/index.ts
@@ -59,7 +59,14 @@ export function usePermission(
   permissionDesc: GeneralPermissionDescriptor | GeneralPermissionDescriptor['name'],
   options: UsePermissionOptions<true>,
 ): UsePermissionReturnWithControls
-/* @__NO_SIDE_EFFECTS__ */
+
+/**
+ * Reactive Permissions API.
+ *
+ * @see https://vueuse.org/usePermission
+ *
+ * @__NO_SIDE_EFFECTS__
+ */
 export function usePermission(
   permissionDesc: GeneralPermissionDescriptor | GeneralPermissionDescriptor['name'],
   options: UsePermissionOptions<boolean> = {},

--- a/packages/core/usePermission/index.ts
+++ b/packages/core/usePermission/index.ts
@@ -48,6 +48,8 @@ export interface UsePermissionReturnWithControls {
  * Reactive Permissions API.
  *
  * @see https://vueuse.org/usePermission
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function usePermission(
   permissionDesc: GeneralPermissionDescriptor | GeneralPermissionDescriptor['name'],
@@ -57,7 +59,7 @@ export function usePermission(
   permissionDesc: GeneralPermissionDescriptor | GeneralPermissionDescriptor['name'],
   options: UsePermissionOptions<true>,
 ): UsePermissionReturnWithControls
-/* #__NO_SIDE_EFFECTS__ */
+/* @__NO_SIDE_EFFECTS__ */
 export function usePermission(
   permissionDesc: GeneralPermissionDescriptor | GeneralPermissionDescriptor['name'],
   options: UsePermissionOptions<boolean> = {},

--- a/packages/core/usePointerLock/index.ts
+++ b/packages/core/usePointerLock/index.ts
@@ -23,6 +23,8 @@ export interface UsePointerLockOptions extends ConfigurableDocument {
  * @see https://vueuse.org/usePointerLock
  * @param target
  * @param options
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function usePointerLock(target?: MaybeElementRef, options: UsePointerLockOptions = {}) {
   const { document = defaultDocument } = options

--- a/packages/core/usePreferredColorScheme/index.ts
+++ b/packages/core/usePreferredColorScheme/index.ts
@@ -10,6 +10,7 @@ export type ColorSchemeType = 'dark' | 'light' | 'no-preference'
  * @see https://vueuse.org/usePreferredColorScheme
  * @param [options]
  */
+/* #__NO_SIDE_EFFECTS__ */
 export function usePreferredColorScheme(options?: ConfigurableWindow) {
   const isLight = useMediaQuery('(prefers-color-scheme: light)', options)
   const isDark = useMediaQuery('(prefers-color-scheme: dark)', options)

--- a/packages/core/usePreferredColorScheme/index.ts
+++ b/packages/core/usePreferredColorScheme/index.ts
@@ -9,8 +9,9 @@ export type ColorSchemeType = 'dark' | 'light' | 'no-preference'
  *
  * @see https://vueuse.org/usePreferredColorScheme
  * @param [options]
+ *
+ * @__NO_SIDE_EFFECTS__
  */
-/* #__NO_SIDE_EFFECTS__ */
 export function usePreferredColorScheme(options?: ConfigurableWindow) {
   const isLight = useMediaQuery('(prefers-color-scheme: light)', options)
   const isDark = useMediaQuery('(prefers-color-scheme: dark)', options)

--- a/packages/core/usePreferredContrast/index.ts
+++ b/packages/core/usePreferredContrast/index.ts
@@ -10,6 +10,7 @@ export type ContrastType = 'more' | 'less' | 'custom' | 'no-preference'
  * @see https://vueuse.org/usePreferredContrast
  * @param [options]
  */
+/* #__NO_SIDE_EFFECTS__ */
 export function usePreferredContrast(options?: ConfigurableWindow) {
   const isMore = useMediaQuery('(prefers-contrast: more)', options)
   const isLess = useMediaQuery('(prefers-contrast: less)', options)

--- a/packages/core/usePreferredContrast/index.ts
+++ b/packages/core/usePreferredContrast/index.ts
@@ -9,8 +9,9 @@ export type ContrastType = 'more' | 'less' | 'custom' | 'no-preference'
  *
  * @see https://vueuse.org/usePreferredContrast
  * @param [options]
+ *
+ * @__NO_SIDE_EFFECTS__
  */
-/* #__NO_SIDE_EFFECTS__ */
 export function usePreferredContrast(options?: ConfigurableWindow) {
   const isMore = useMediaQuery('(prefers-contrast: more)', options)
   const isLess = useMediaQuery('(prefers-contrast: less)', options)

--- a/packages/core/usePreferredDark/index.ts
+++ b/packages/core/usePreferredDark/index.ts
@@ -7,6 +7,7 @@ import { useMediaQuery } from '../useMediaQuery'
  * @see https://vueuse.org/usePreferredDark
  * @param [options]
  */
+/* #__NO_SIDE_EFFECTS__ */
 export function usePreferredDark(options?: ConfigurableWindow) {
   return useMediaQuery('(prefers-color-scheme: dark)', options)
 }

--- a/packages/core/usePreferredDark/index.ts
+++ b/packages/core/usePreferredDark/index.ts
@@ -6,8 +6,9 @@ import { useMediaQuery } from '../useMediaQuery'
  *
  * @see https://vueuse.org/usePreferredDark
  * @param [options]
+ *
+ * @__NO_SIDE_EFFECTS__
  */
-/* #__NO_SIDE_EFFECTS__ */
 export function usePreferredDark(options?: ConfigurableWindow) {
   return useMediaQuery('(prefers-color-scheme: dark)', options)
 }

--- a/packages/core/usePreferredLanguages/index.ts
+++ b/packages/core/usePreferredLanguages/index.ts
@@ -9,8 +9,9 @@ import { useEventListener } from '../useEventListener'
  *
  * @see https://vueuse.org/usePreferredLanguages
  * @param options
+ *
+ * @__NO_SIDE_EFFECTS__
  */
-/* #__NO_SIDE_EFFECTS__ */
 export function usePreferredLanguages(options: ConfigurableWindow = {}): Ref<readonly string[]> {
   const { window = defaultWindow } = options
   if (!window)

--- a/packages/core/usePreferredLanguages/index.ts
+++ b/packages/core/usePreferredLanguages/index.ts
@@ -10,6 +10,7 @@ import { useEventListener } from '../useEventListener'
  * @see https://vueuse.org/usePreferredLanguages
  * @param options
  */
+/* #__NO_SIDE_EFFECTS__ */
 export function usePreferredLanguages(options: ConfigurableWindow = {}): Ref<readonly string[]> {
   const { window = defaultWindow } = options
   if (!window)

--- a/packages/core/usePreferredReducedMotion/index.ts
+++ b/packages/core/usePreferredReducedMotion/index.ts
@@ -10,6 +10,7 @@ export type ReducedMotionType = 'reduce' | 'no-preference'
  * @see https://vueuse.org/usePreferredReducedMotion
  * @param [options]
  */
+/* #__NO_SIDE_EFFECTS__ */
 export function usePreferredReducedMotion(options?: ConfigurableWindow) {
   const isReduced = useMediaQuery('(prefers-reduced-motion: reduce)', options)
 

--- a/packages/core/usePreferredReducedMotion/index.ts
+++ b/packages/core/usePreferredReducedMotion/index.ts
@@ -9,8 +9,9 @@ export type ReducedMotionType = 'reduce' | 'no-preference'
  *
  * @see https://vueuse.org/usePreferredReducedMotion
  * @param [options]
+ *
+ * @__NO_SIDE_EFFECTS__
  */
-/* #__NO_SIDE_EFFECTS__ */
 export function usePreferredReducedMotion(options?: ConfigurableWindow) {
   const isReduced = useMediaQuery('(prefers-reduced-motion: reduce)', options)
 

--- a/packages/core/usePreferredReducedTransparency/index.ts
+++ b/packages/core/usePreferredReducedTransparency/index.ts
@@ -9,8 +9,9 @@ export type ReducedTransparencyType = 'reduce' | 'no-preference'
  *
  * @see https://vueuse.org/usePreferredReducedTransparency
  * @param [options]
+ *
+ * @__NO_SIDE_EFFECTS__
  */
-/* #__NO_SIDE_EFFECTS__ */
 export function usePreferredReducedTransparency(options?: ConfigurableWindow) {
   const isReduced = useMediaQuery('(prefers-reduced-transparency: reduce)', options)
 

--- a/packages/core/usePreferredReducedTransparency/index.ts
+++ b/packages/core/usePreferredReducedTransparency/index.ts
@@ -10,6 +10,7 @@ export type ReducedTransparencyType = 'reduce' | 'no-preference'
  * @see https://vueuse.org/usePreferredReducedTransparency
  * @param [options]
  */
+/* #__NO_SIDE_EFFECTS__ */
 export function usePreferredReducedTransparency(options?: ConfigurableWindow) {
   const isReduced = useMediaQuery('(prefers-reduced-transparency: reduce)', options)
 

--- a/packages/core/useSSRWidth/index.ts
+++ b/packages/core/useSSRWidth/index.ts
@@ -4,7 +4,7 @@ import { hasInjectionContext } from 'vue'
 
 const ssrWidthSymbol = Symbol('vueuse-ssr-width') as InjectionKey<number | null>
 
-/* #__NO_SIDE_EFFECTS__ */
+/* @__NO_SIDE_EFFECTS__ */
 export function useSSRWidth() {
   // Avoid injection warning outside of components
   const ssrWidth = hasInjectionContext() ? injectLocal(ssrWidthSymbol, null) : null

--- a/packages/core/useSSRWidth/index.ts
+++ b/packages/core/useSSRWidth/index.ts
@@ -4,6 +4,7 @@ import { hasInjectionContext } from 'vue'
 
 const ssrWidthSymbol = Symbol('vueuse-ssr-width') as InjectionKey<number | null>
 
+/* #__NO_SIDE_EFFECTS__ */
 export function useSSRWidth() {
   // Avoid injection warning outside of components
   const ssrWidth = hasInjectionContext() ? injectLocal(ssrWidthSymbol, null) : null

--- a/packages/core/useScreenOrientation/index.ts
+++ b/packages/core/useScreenOrientation/index.ts
@@ -22,8 +22,9 @@ export interface ScreenOrientation extends EventTarget {
  * Reactive screen orientation
  *
  * @see https://vueuse.org/useScreenOrientation
+ *
+ * @__NO_SIDE_EFFECTS__
  */
-/* #__NO_SIDE_EFFECTS__ */
 export function useScreenOrientation(options: ConfigurableWindow = {}) {
   const {
     window = defaultWindow,

--- a/packages/core/useScreenOrientation/index.ts
+++ b/packages/core/useScreenOrientation/index.ts
@@ -23,6 +23,7 @@ export interface ScreenOrientation extends EventTarget {
  *
  * @see https://vueuse.org/useScreenOrientation
  */
+/* #__NO_SIDE_EFFECTS__ */
 export function useScreenOrientation(options: ConfigurableWindow = {}) {
   const {
     window = defaultWindow,

--- a/packages/core/useShare/index.ts
+++ b/packages/core/useShare/index.ts
@@ -22,6 +22,8 @@ interface NavigatorWithShare {
  * @see https://vueuse.org/useShare
  * @param shareOptions
  * @param options
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useShare(shareOptions: MaybeRefOrGetter<UseShareOptions> = {}, options: ConfigurableNavigator = {}) {
   const { navigator = defaultNavigator } = options

--- a/packages/core/useStepper/index.ts
+++ b/packages/core/useStepper/index.ts
@@ -44,6 +44,7 @@ export interface UseStepperReturn<StepName, Steps, Step> {
 
 export function useStepper<T extends string | number>(steps: MaybeRef<T[]>, initialStep?: T): UseStepperReturn<T, T[], T>
 export function useStepper<T extends Record<string, any>>(steps: MaybeRef<T>, initialStep?: keyof T): UseStepperReturn<Exclude<keyof T, symbol>, T, T[keyof T]>
+/* @__NO_SIDE_EFFECTS__ */
 export function useStepper(steps: any, initialStep?: any): UseStepperReturn<any, any, any> {
   const stepsRef = deepRef<any[]>(steps)
   const stepNames = computed<any[]>(() => Array.isArray(stepsRef.value) ? stepsRef.value : Object.keys(stepsRef.value))

--- a/packages/core/useSupported/index.ts
+++ b/packages/core/useSupported/index.ts
@@ -1,6 +1,7 @@
 import { computed } from 'vue'
 import { useMounted } from '../useMounted'
 
+/* @__NO_SIDE_EFFECTS__ */
 export function useSupported(callback: () => unknown) {
   const isMounted = useMounted()
 

--- a/packages/core/useTemplateRefsList/index.ts
+++ b/packages/core/useTemplateRefsList/index.ts
@@ -5,6 +5,7 @@ export type TemplateRefsList<T> = T[] & {
   set: (el: object | null) => void
 }
 
+/* @__NO_SIDE_EFFECTS__ */
 export function useTemplateRefsList<T = Element>(): Readonly<Ref<Readonly<TemplateRefsList<T>>>> {
   const refs = deepRef<unknown>([]) as Ref<TemplateRefsList<T>>
   refs.value.set = (el: object | null) => {

--- a/packages/core/useTextDirection/index.ts
+++ b/packages/core/useTextDirection/index.ts
@@ -33,8 +33,9 @@ export interface UseTextDirectionOptions extends ConfigurableDocument {
  * Reactive dir of the element's text.
  *
  * @see https://vueuse.org/useTextDirection
+ *
+ * @__NO_SIDE_EFFECTS__
  */
-/* #__NO_SIDE_EFFECTS__ */
 export function useTextDirection(options: UseTextDirectionOptions = {}) {
   const {
     document = defaultDocument,

--- a/packages/core/useTextDirection/index.ts
+++ b/packages/core/useTextDirection/index.ts
@@ -34,6 +34,7 @@ export interface UseTextDirectionOptions extends ConfigurableDocument {
  *
  * @see https://vueuse.org/useTextDirection
  */
+/* #__NO_SIDE_EFFECTS__ */
 export function useTextDirection(options: UseTextDirectionOptions = {}) {
   const {
     document = defaultDocument,

--- a/packages/core/useTextSelection/index.ts
+++ b/packages/core/useTextSelection/index.ts
@@ -13,6 +13,7 @@ function getRangesFromSelection(selection: Selection) {
  *
  * @see https://vueuse.org/useTextSelection
  */
+/* #__NO_SIDE_EFFECTS__ */
 export function useTextSelection(options: ConfigurableWindow = {}) {
   const {
     window = defaultWindow,

--- a/packages/core/useTextSelection/index.ts
+++ b/packages/core/useTextSelection/index.ts
@@ -12,8 +12,9 @@ function getRangesFromSelection(selection: Selection) {
  * Reactively track user text selection based on [`Window.getSelection`](https://developer.mozilla.org/en-US/docs/Web/API/Window/getSelection).
  *
  * @see https://vueuse.org/useTextSelection
+ *
+ * @__NO_SIDE_EFFECTS__
  */
-/* #__NO_SIDE_EFFECTS__ */
 export function useTextSelection(options: ConfigurableWindow = {}) {
   const {
     window = defaultWindow,

--- a/packages/core/useTimeAgo/index.ts
+++ b/packages/core/useTimeAgo/index.ts
@@ -133,7 +133,14 @@ export type UseTimeAgoReturn<Controls extends boolean = false> = Controls extend
  */
 export function useTimeAgo<UnitNames extends string = UseTimeAgoUnitNamesDefault>(time: MaybeRefOrGetter<Date | number | string>, options?: UseTimeAgoOptions<false, UnitNames>): UseTimeAgoReturn<false>
 export function useTimeAgo<UnitNames extends string = UseTimeAgoUnitNamesDefault>(time: MaybeRefOrGetter<Date | number | string>, options: UseTimeAgoOptions<true, UnitNames>): UseTimeAgoReturn<true>
-/* @__NO_SIDE_EFFECTS__ */
+
+/**
+ * Reactive time ago formatter.
+ *
+ * @see https://vueuse.org/useTimeAgo
+ *
+ * @__NO_SIDE_EFFECTS__
+ */
 export function useTimeAgo<UnitNames extends string = UseTimeAgoUnitNamesDefault>(time: MaybeRefOrGetter<Date | number | string>, options: UseTimeAgoOptions<boolean, UnitNames> = {}) {
   const {
     controls: exposeControls = false,

--- a/packages/core/useTimeAgo/index.ts
+++ b/packages/core/useTimeAgo/index.ts
@@ -128,9 +128,12 @@ export type UseTimeAgoReturn<Controls extends boolean = false> = Controls extend
  * Reactive time ago formatter.
  *
  * @see https://vueuse.org/useTimeAgo
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useTimeAgo<UnitNames extends string = UseTimeAgoUnitNamesDefault>(time: MaybeRefOrGetter<Date | number | string>, options?: UseTimeAgoOptions<false, UnitNames>): UseTimeAgoReturn<false>
 export function useTimeAgo<UnitNames extends string = UseTimeAgoUnitNamesDefault>(time: MaybeRefOrGetter<Date | number | string>, options: UseTimeAgoOptions<true, UnitNames>): UseTimeAgoReturn<true>
+/* @__NO_SIDE_EFFECTS__ */
 export function useTimeAgo<UnitNames extends string = UseTimeAgoUnitNamesDefault>(time: MaybeRefOrGetter<Date | number | string>, options: UseTimeAgoOptions<boolean, UnitNames> = {}) {
   const {
     controls: exposeControls = false,

--- a/packages/core/useVModel/index.ts
+++ b/packages/core/useVModel/index.ts
@@ -48,20 +48,6 @@ export interface UseVModelOptions<T, Passive extends boolean = false> {
   shouldEmit?: (v: T) => boolean
 }
 
-export function useVModel<P extends object, K extends keyof P, Name extends string>(
-  props: P,
-  key?: K,
-  emit?: (name: Name, ...args: any[]) => void,
-  options?: UseVModelOptions<P[K], false>,
-): WritableComputedRef<P[K]>
-
-export function useVModel<P extends object, K extends keyof P, Name extends string>(
-  props: P,
-  key?: K,
-  emit?: (name: Name, ...args: any[]) => void,
-  options?: UseVModelOptions<P[K], true>,
-): Ref<UnwrapRef<P[K]>>
-
 /**
  * Shorthand for v-model binding, props + emit -> ref
  *
@@ -70,6 +56,18 @@ export function useVModel<P extends object, K extends keyof P, Name extends stri
  * @param key (default 'modelValue')
  * @param emit
  */
+export function useVModel<P extends object, K extends keyof P, Name extends string>(
+  props: P,
+  key?: K,
+  emit?: (name: Name, ...args: any[]) => void,
+  options?: UseVModelOptions<P[K], false>,
+): WritableComputedRef<P[K]>
+export function useVModel<P extends object, K extends keyof P, Name extends string>(
+  props: P,
+  key?: K,
+  emit?: (name: Name, ...args: any[]) => void,
+  options?: UseVModelOptions<P[K], true>,
+): Ref<UnwrapRef<P[K]>>
 export function useVModel<P extends object, K extends keyof P, Name extends string, Passive extends boolean>(
   props: P,
   key?: K,

--- a/packages/core/useVModel/index.ts
+++ b/packages/core/useVModel/index.ts
@@ -55,6 +55,7 @@ export interface UseVModelOptions<T, Passive extends boolean = false> {
  * @param props
  * @param key (default 'modelValue')
  * @param emit
+ * @param options
  *
  * @__NO_SIDE_EFFECTS__
  */
@@ -70,7 +71,18 @@ export function useVModel<P extends object, K extends keyof P, Name extends stri
   emit?: (name: Name, ...args: any[]) => void,
   options?: UseVModelOptions<P[K], true>,
 ): Ref<UnwrapRef<P[K]>>
-/* @__NO_SIDE_EFFECTS__ */
+
+/**
+ * Shorthand for v-model binding, props + emit -> ref
+ *
+ * @see https://vueuse.org/useVModel
+ * @param props
+ * @param key (default 'modelValue')
+ * @param emit
+ * @param options
+ *
+ * @__NO_SIDE_EFFECTS__
+ */
 export function useVModel<P extends object, K extends keyof P, Name extends string, Passive extends boolean>(
   props: P,
   key?: K,

--- a/packages/core/useVModel/index.ts
+++ b/packages/core/useVModel/index.ts
@@ -55,6 +55,8 @@ export interface UseVModelOptions<T, Passive extends boolean = false> {
  * @param props
  * @param key (default 'modelValue')
  * @param emit
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useVModel<P extends object, K extends keyof P, Name extends string>(
   props: P,
@@ -68,6 +70,7 @@ export function useVModel<P extends object, K extends keyof P, Name extends stri
   emit?: (name: Name, ...args: any[]) => void,
   options?: UseVModelOptions<P[K], true>,
 ): Ref<UnwrapRef<P[K]>>
+/* @__NO_SIDE_EFFECTS__ */
 export function useVModel<P extends object, K extends keyof P, Name extends string, Passive extends boolean>(
   props: P,
   key?: K,

--- a/packages/core/useVModels/index.ts
+++ b/packages/core/useVModels/index.ts
@@ -22,7 +22,17 @@ export function useVModels<P extends object, Name extends string>(
   emit?: (name: Name, ...args: any[]) => void,
   options?: UseVModelOptions<any, false>,
 ): ToRefs<P>
-/* @__NO_SIDE_EFFECTS__ */
+
+/**
+ * Shorthand for props v-model binding. Think like `toRefs(props)` but changes will also emit out.
+ *
+ * @see https://vueuse.org/useVModels
+ * @param props
+ * @param emit
+ * @param options
+ *
+ * @__NO_SIDE_EFFECTS__
+ */
 export function useVModels<P extends object, Name extends string, Passive extends boolean>(
   props: P,
   emit?: (name: Name, ...args: any[]) => void,

--- a/packages/core/useVModels/index.ts
+++ b/packages/core/useVModels/index.ts
@@ -9,6 +9,8 @@ import { useVModel } from '../useVModel'
  * @param props
  * @param emit
  * @param options
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useVModels<P extends object, Name extends string>(
   props: P,
@@ -20,6 +22,7 @@ export function useVModels<P extends object, Name extends string>(
   emit?: (name: Name, ...args: any[]) => void,
   options?: UseVModelOptions<any, false>,
 ): ToRefs<P>
+/* @__NO_SIDE_EFFECTS__ */
 export function useVModels<P extends object, Name extends string, Passive extends boolean>(
   props: P,
   emit?: (name: Name, ...args: any[]) => void,

--- a/packages/core/useVibrate/index.ts
+++ b/packages/core/useVibrate/index.ts
@@ -37,6 +37,8 @@ export interface UseVibrateOptions extends ConfigurableNavigator {
  * @see https://vueuse.org/useVibrate
  * @see https://developer.mozilla.org/en-US/docs/Web/API/Vibration_API
  * @param options
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useVibrate(options?: UseVibrateOptions) {
   const {

--- a/packages/core/useWakeLock/index.ts
+++ b/packages/core/useWakeLock/index.ts
@@ -26,6 +26,7 @@ export type UseWakeLockOptions = ConfigurableNavigator & ConfigurableDocument
  * @see https://vueuse.org/useWakeLock
  * @param options
  */
+/* #__NO_SIDE_EFFECTS__ */
 export function useWakeLock(options: UseWakeLockOptions = {}) {
   const {
     navigator = defaultNavigator,

--- a/packages/core/useWakeLock/index.ts
+++ b/packages/core/useWakeLock/index.ts
@@ -25,8 +25,9 @@ export type UseWakeLockOptions = ConfigurableNavigator & ConfigurableDocument
  *
  * @see https://vueuse.org/useWakeLock
  * @param options
+ *
+ * @__NO_SIDE_EFFECTS__
  */
-/* #__NO_SIDE_EFFECTS__ */
 export function useWakeLock(options: UseWakeLockOptions = {}) {
   const {
     navigator = defaultNavigator,

--- a/packages/core/useWindowFocus/index.ts
+++ b/packages/core/useWindowFocus/index.ts
@@ -8,8 +8,9 @@ import { useEventListener } from '../useEventListener'
  * Reactively track window focus with `window.onfocus` and `window.onblur`.
  *
  * @see https://vueuse.org/useWindowFocus
+ *
+ * @__NO_SIDE_EFFECTS__
  */
-/* #__NO_SIDE_EFFECTS__ */
 export function useWindowFocus(options: ConfigurableWindow = {}): ShallowRef<boolean> {
   const { window = defaultWindow } = options
   if (!window)

--- a/packages/core/useWindowFocus/index.ts
+++ b/packages/core/useWindowFocus/index.ts
@@ -9,6 +9,7 @@ import { useEventListener } from '../useEventListener'
  *
  * @see https://vueuse.org/useWindowFocus
  */
+/* #__NO_SIDE_EFFECTS__ */
 export function useWindowFocus(options: ConfigurableWindow = {}): ShallowRef<boolean> {
   const { window = defaultWindow } = options
   if (!window)

--- a/packages/core/useWindowSize/index.ts
+++ b/packages/core/useWindowSize/index.ts
@@ -37,6 +37,7 @@ export interface UseWindowSizeOptions extends ConfigurableWindow {
  * @see https://vueuse.org/useWindowSize
  * @param options
  */
+/* #__NO_SIDE_EFFECTS__ */
 export function useWindowSize(options: UseWindowSizeOptions = {}) {
   const {
     window = defaultWindow,

--- a/packages/core/useWindowSize/index.ts
+++ b/packages/core/useWindowSize/index.ts
@@ -36,8 +36,9 @@ export interface UseWindowSizeOptions extends ConfigurableWindow {
  *
  * @see https://vueuse.org/useWindowSize
  * @param options
+ *
+ * @__NO_SIDE_EFFECTS__
  */
-/* #__NO_SIDE_EFFECTS__ */
 export function useWindowSize(options: UseWindowSizeOptions = {}) {
   const {
     window = defaultWindow,

--- a/packages/electron/useIpcRendererInvoke/index.ts
+++ b/packages/electron/useIpcRendererInvoke/index.ts
@@ -11,6 +11,8 @@ import { shallowRef } from 'vue'
  *
  * @see https://www.electronjs.org/docs/api/ipc-renderer#ipcrendererinvokechannel-args
  * @see https://vueuse.org/useIpcRendererInvoke
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useIpcRendererInvoke<T>(ipcRenderer: IpcRenderer, channel: string, ...args: any[]): ShallowRef<T | null>
 
@@ -23,9 +25,21 @@ export function useIpcRendererInvoke<T>(ipcRenderer: IpcRenderer, channel: strin
  *
  * @see https://www.electronjs.org/docs/api/ipc-renderer#ipcrendererinvokechannel-args
  * @see https://vueuse.org/useIpcRendererInvoke
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useIpcRendererInvoke<T>(channel: string, ...args: any[]): ShallowRef<T | null>
 
+/**
+ * Returns Promise<any> - Resolves with the response from the main process.
+ *
+ * Send a message to the main process via channel and expect a result ~~asynchronously~~. As composition-api, it makes asynchronous operations look like synchronous.
+ *
+ * @see https://www.electronjs.org/docs/api/ipc-renderer#ipcrendererinvokechannel-args
+ * @see https://vueuse.org/useIpcRendererInvoke
+ *
+ * @__NO_SIDE_EFFECTS__
+ */
 export function useIpcRendererInvoke<T>(...args: any[]): ShallowRef<T | null> {
   let ipcRenderer: IpcRenderer | undefined
   let channel: string

--- a/packages/firebase/useAuth/index.ts
+++ b/packages/firebase/useAuth/index.ts
@@ -11,6 +11,8 @@ export interface UseFirebaseAuthOptions {
  * Reactive Firebase Auth binding
  *
  * @see https://vueuse.org/useAuth
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useAuth(auth: Auth) {
   const user = deepRef<User | null>(auth.currentUser)

--- a/packages/integrations/useChangeCase/index.ts
+++ b/packages/integrations/useChangeCase/index.ts
@@ -23,6 +23,8 @@ export function useChangeCase(input: MaybeRefOrGetter<string>, type: MaybeRefOrG
  * Reactive wrapper for `change-case`
  *
  * @see https://vueuse.org/useChangeCase
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useChangeCase(input: MaybeRefOrGetter<string>, type: MaybeRefOrGetter<ChangeCaseType>, options?: MaybeRefOrGetter<Options> | undefined) {
   const typeRef = computed(() => {

--- a/packages/integrations/useCookies/index.ts
+++ b/packages/integrations/useCookies/index.ts
@@ -27,6 +27,8 @@ export function createCookies(req?: IncomingMessage) {
  * @param options.doNotParse - don't try parse value as JSON
  * @param options.autoUpdateDependencies - automatically update watching dependencies
  * @param cookies - universal-cookie instance
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useCookies(
   dependencies?: string[] | null,

--- a/packages/math/createGenericProjection/index.ts
+++ b/packages/math/createGenericProjection/index.ts
@@ -5,6 +5,7 @@ export type ProjectorFunction<F, T> = (input: F, from: readonly [F, F], to: read
 
 export type UseProjection<F, T> = (input: MaybeRefOrGetter<F>) => ComputedRef<T>
 
+/* @__NO_SIDE_EFFECTS__ */
 export function createGenericProjection<F = number, T = number>(
   fromDomain: MaybeRefOrGetter<readonly [F, F]>,
   toDomain: MaybeRefOrGetter<readonly [T, T]>,

--- a/packages/math/createProjection/index.ts
+++ b/packages/math/createProjection/index.ts
@@ -6,6 +6,7 @@ function defaultNumericProjector(input: number, from: readonly [number, number],
   return (input - from[0]) / (from[1] - from[0]) * (to[1] - to[0]) + to[0]
 }
 
+/* @__NO_SIDE_EFFECTS__ */
 export function createProjection(
   fromDomain: MaybeRefOrGetter<readonly [number, number]>,
   toDomain: MaybeRefOrGetter<readonly [number, number]>,

--- a/packages/math/logicAnd/index.ts
+++ b/packages/math/logicAnd/index.ts
@@ -5,6 +5,8 @@ import { computed, toValue } from 'vue'
  * `AND` conditions for refs.
  *
  * @see https://vueuse.org/logicAnd
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function logicAnd(...args: MaybeRefOrGetter<any>[]): ComputedRef<boolean> {
   return computed(() => args.every(i => toValue(i)))

--- a/packages/math/logicNot/index.ts
+++ b/packages/math/logicNot/index.ts
@@ -6,6 +6,8 @@ import { computed, toValue } from 'vue'
  * `NOT` conditions for refs.
  *
  * @see https://vueuse.org/logicNot
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function logicNot(v: MaybeRefOrGetter<any>): ComputedRef<boolean> {
   return computed(() => !toValue(v))

--- a/packages/math/logicOr/index.ts
+++ b/packages/math/logicOr/index.ts
@@ -5,6 +5,8 @@ import { computed, toValue } from 'vue'
  * `OR` conditions for refs.
  *
  * @see https://vueuse.org/logicOr
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function logicOr(...args: MaybeRefOrGetter<any>[]): ComputedRef<boolean> {
   return computed(() => args.some(i => toValue(i)))

--- a/packages/math/useAbs/index.ts
+++ b/packages/math/useAbs/index.ts
@@ -5,6 +5,8 @@ import { computed, toValue } from 'vue'
  * Reactive `Math.abs`.
  *
  * @see https://vueuse.org/useAbs
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useAbs(value: MaybeRefOrGetter<number>): ComputedRef<number> {
   return computed(() => Math.abs(toValue(value)))

--- a/packages/math/useAverage/index.ts
+++ b/packages/math/useAverage/index.ts
@@ -10,6 +10,8 @@ export function useAverage(...args: MaybeRefOrGetter<number>[]): ComputedRef<num
  * Get the average of an array reactively
  *
  * @see https://vueuse.org/useAverage
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useAverage(...args: MaybeComputedRefArgs<number>): ComputedRef<number> {
   return computed(() => {

--- a/packages/math/useCeil/index.ts
+++ b/packages/math/useCeil/index.ts
@@ -5,6 +5,8 @@ import { computed, toValue } from 'vue'
  * Reactive `Math.ceil`.
  *
  * @see https://vueuse.org/useCeil
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useCeil(value: MaybeRefOrGetter<number>): ComputedRef<number> {
   return computed<number>(() => Math.ceil(toValue(value)))

--- a/packages/math/useClamp/index.ts
+++ b/packages/math/useClamp/index.ts
@@ -3,18 +3,6 @@ import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue'
 import { clamp } from '@vueuse/shared'
 import { computed, ref as deepRef, isReadonly, toValue } from 'vue'
 
-export function useClamp(
-  value: ReadonlyRefOrGetter<number>,
-  min: MaybeRefOrGetter<number>,
-  max: MaybeRefOrGetter<number>,
-): ComputedRef<number>
-
-export function useClamp(
-  value: MaybeRefOrGetter<number>,
-  min: MaybeRefOrGetter<number>,
-  max: MaybeRefOrGetter<number>,
-): Ref<number>
-
 /**
  * Reactively clamp a value between two other values.
  *
@@ -23,6 +11,16 @@ export function useClamp(
  * @param min
  * @param max
  */
+export function useClamp(
+  value: ReadonlyRefOrGetter<number>,
+  min: MaybeRefOrGetter<number>,
+  max: MaybeRefOrGetter<number>,
+): ComputedRef<number>
+export function useClamp(
+  value: MaybeRefOrGetter<number>,
+  min: MaybeRefOrGetter<number>,
+  max: MaybeRefOrGetter<number>,
+): Ref<number>
 export function useClamp(value: MaybeRefOrGetter<number>, min: MaybeRefOrGetter<number>, max: MaybeRefOrGetter<number>) {
   if (typeof value === 'function' || isReadonly(value))
     return computed(() => clamp(toValue(value), toValue(min), toValue(max)))

--- a/packages/math/useClamp/index.ts
+++ b/packages/math/useClamp/index.ts
@@ -10,6 +10,8 @@ import { computed, ref as deepRef, isReadonly, toValue } from 'vue'
  * @param value number
  * @param min
  * @param max
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useClamp(
   value: ReadonlyRefOrGetter<number>,
@@ -21,6 +23,17 @@ export function useClamp(
   min: MaybeRefOrGetter<number>,
   max: MaybeRefOrGetter<number>,
 ): Ref<number>
+
+/**
+ * Reactively clamp a value between two other values.
+ *
+ * @see https://vueuse.org/useClamp
+ * @param value number
+ * @param min
+ * @param max
+ *
+ * @__NO_SIDE_EFFECTS__
+ */
 export function useClamp(value: MaybeRefOrGetter<number>, min: MaybeRefOrGetter<number>, max: MaybeRefOrGetter<number>) {
   if (typeof value === 'function' || isReadonly(value))
     return computed(() => clamp(toValue(value), toValue(min), toValue(max)))

--- a/packages/math/useFloor/index.ts
+++ b/packages/math/useFloor/index.ts
@@ -5,6 +5,8 @@ import { computed, toValue } from 'vue'
  * Reactive `Math.floor`
  *
  * @see https://vueuse.org/useFloor
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useFloor(value: MaybeRefOrGetter<number>): ComputedRef<number> {
   return computed<number>(() => Math.floor(toValue(value)))

--- a/packages/math/useMath/index.ts
+++ b/packages/math/useMath/index.ts
@@ -7,6 +7,8 @@ export type UseMathKeys = keyof { [K in keyof Math as Math[K] extends (...args: 
  * Reactive `Math` methods.
  *
  * @see https://vueuse.org/useMath
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useMath<K extends keyof Math>(
   key: K,

--- a/packages/math/useMax/index.ts
+++ b/packages/math/useMax/index.ts
@@ -10,6 +10,8 @@ export function useMax(...args: MaybeRefOrGetter<number>[]): ComputedRef<number>
  * Reactively get maximum of values.
  *
  * @see https://vueuse.org/useMax
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useMax(...args: MaybeComputedRefArgs<number>) {
   return computed<number>(() => {

--- a/packages/math/useMin/index.ts
+++ b/packages/math/useMin/index.ts
@@ -10,6 +10,8 @@ export function useMin(...args: MaybeRefOrGetter<number>[]): ComputedRef<number>
  * Reactive `Math.min`.
  *
  * @see https://vueuse.org/useMin
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useMin(...args: MaybeComputedRefArgs<number>) {
   return computed<number>(() => {

--- a/packages/math/usePrecision/index.ts
+++ b/packages/math/usePrecision/index.ts
@@ -35,6 +35,8 @@ export interface UsePrecisionOptions {
  * Reactively set the precision of a number.
  *
  * @see https://vueuse.org/usePrecision
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function usePrecision(
   value: MaybeRefOrGetter<number>,

--- a/packages/math/useProjection/index.ts
+++ b/packages/math/useProjection/index.ts
@@ -6,6 +6,8 @@ import { createProjection } from '../createProjection'
  * Reactive numeric projection from one domain to another.
  *
  * @see https://vueuse.org/useProjection
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useProjection(
   input: MaybeRefOrGetter<number>,

--- a/packages/math/useRound/index.ts
+++ b/packages/math/useRound/index.ts
@@ -5,6 +5,8 @@ import { computed, toValue } from 'vue'
  * Reactive `Math.round`.
  *
  * @see https://vueuse.org/useRound
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useRound(value: MaybeRefOrGetter<number>): ComputedRef<number> {
   return computed<number>(() => Math.round(toValue(value)))

--- a/packages/math/useSum/index.ts
+++ b/packages/math/useSum/index.ts
@@ -10,6 +10,8 @@ export function useSum(...args: MaybeRefOrGetter<number>[]): ComputedRef<number>
  * Get the sum of a set of numbers.
  *
  * @see https://vueuse.org/useSum
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useSum(...args: MaybeComputedRefArgs<number>): ComputedRef<number> {
   return computed(() => toValueArgsFlat(args).reduce((sum, v) => sum += v, 0))

--- a/packages/math/useTrunc/index.ts
+++ b/packages/math/useTrunc/index.ts
@@ -5,6 +5,8 @@ import { computed, toValue } from 'vue'
  * Reactive `Math.trunc`.
  *
  * @see https://vueuse.org/useTrunc
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useTrunc(value: MaybeRefOrGetter<number>): ComputedRef<number> {
   return computed<number>(() => Math.trunc(toValue(value)))

--- a/packages/router/useRouteHash/index.ts
+++ b/packages/router/useRouteHash/index.ts
@@ -6,6 +6,7 @@ import { useRoute, useRouter } from 'vue-router'
 
 let _hash: RouteHashValueRaw
 
+/* @__NO_SIDE_EFFECTS__ */
 export function useRouteHash(
   defaultValue?: MaybeRefOrGetter<RouteHashValueRaw>,
   {

--- a/packages/rxjs/from/index.ts
+++ b/packages/rxjs/from/index.ts
@@ -3,6 +3,7 @@ import type { MaybeRef, Ref, WatchOptions } from 'vue'
 import { fromEvent as fromEventRx, from as fromRxjs, Observable } from 'rxjs'
 import { isRef, watch } from 'vue'
 
+/* @__NO_SIDE_EFFECTS__ */
 export function from<T>(value: ObservableInput<T> | Ref<T>, watchOptions?: WatchOptions): Observable<T> {
   if (isRef<T>(value))
     return new Observable(subscriber => watch(value, val => subscriber.next(val), watchOptions))

--- a/packages/rxjs/toObserver/index.ts
+++ b/packages/rxjs/toObserver/index.ts
@@ -1,6 +1,7 @@
 import type { NextObserver } from 'rxjs'
 import type { Ref } from 'vue'
 
+/* @__NO_SIDE_EFFECTS__ */
 export function toObserver<T>(value: Ref<T>): NextObserver<T> {
   return {
     next: (val: T) => {

--- a/packages/shared/createEventHook/index.ts
+++ b/packages/shared/createEventHook/index.ts
@@ -34,6 +34,8 @@ export type EventHookReturn<T> = EventHook<T>
  * Utility for creating event hooks
  *
  * @see https://vueuse.org/createEventHook
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function createEventHook<T = any>(): EventHookReturn<T> {
   const fns: Set<Callback<T>> = new Set()

--- a/packages/shared/createGlobalState/index.ts
+++ b/packages/shared/createGlobalState/index.ts
@@ -9,6 +9,7 @@ export type CreateGlobalStateReturn<Fn extends AnyFn = AnyFn> = Fn
  * @see https://vueuse.org/createGlobalState
  * @param stateFactory A factory function to create the state
  */
+/* #__NO_SIDE_EFFECTS__ */
 export function createGlobalState<Fn extends AnyFn>(
   stateFactory: Fn,
 ): CreateGlobalStateReturn<Fn> {

--- a/packages/shared/createGlobalState/index.ts
+++ b/packages/shared/createGlobalState/index.ts
@@ -8,8 +8,9 @@ export type CreateGlobalStateReturn<Fn extends AnyFn = AnyFn> = Fn
  *
  * @see https://vueuse.org/createGlobalState
  * @param stateFactory A factory function to create the state
+ *
+ * @__NO_SIDE_EFFECTS__
  */
-/* #__NO_SIDE_EFFECTS__ */
 export function createGlobalState<Fn extends AnyFn>(
   stateFactory: Fn,
 ): CreateGlobalStateReturn<Fn> {

--- a/packages/shared/createInjectionState/index.ts
+++ b/packages/shared/createInjectionState/index.ts
@@ -19,6 +19,7 @@ export interface CreateInjectionStateOptions<Return> {
  * @see https://vueuse.org/createInjectionState
  *
  */
+/* #__NO_SIDE_EFFECTS__ */
 export function createInjectionState<Arguments extends Array<any>, Return>(
   composable: (...args: Arguments) => Return,
   options?: CreateInjectionStateOptions<Return>,

--- a/packages/shared/createInjectionState/index.ts
+++ b/packages/shared/createInjectionState/index.ts
@@ -18,8 +18,8 @@ export interface CreateInjectionStateOptions<Return> {
  *
  * @see https://vueuse.org/createInjectionState
  *
+ * @__NO_SIDE_EFFECTS__
  */
-/* #__NO_SIDE_EFFECTS__ */
 export function createInjectionState<Arguments extends Array<any>, Return>(
   composable: (...args: Arguments) => Return,
   options?: CreateInjectionStateOptions<Return>,

--- a/packages/shared/createRef/index.ts
+++ b/packages/shared/createRef/index.ts
@@ -17,6 +17,8 @@ export type ShallowOrDeepRef<T = any, D extends boolean = false> = D extends tru
  * @param value
  * @param deep
  * @returns the `deepRef` or `shallowRef`
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function createRef<T = any, D extends boolean = false>(value: T, deep?: D): CreateRefReturn<T, D> {
   if (deep === true) {

--- a/packages/shared/createSharedComposable/index.ts
+++ b/packages/shared/createSharedComposable/index.ts
@@ -9,8 +9,9 @@ export type SharedComposableReturn<T extends AnyFn = AnyFn> = T
  * Make a composable function usable with multiple Vue instances.
  *
  * @see https://vueuse.org/createSharedComposable
+ *
+ * @__NO_SIDE_EFFECTS__
  */
-/* #__NO_SIDE_EFFECTS__ */
 export function createSharedComposable<Fn extends AnyFn>(composable: Fn): SharedComposableReturn<Fn> {
   let subscribers = 0
   let state: ReturnType<Fn> | undefined

--- a/packages/shared/createSharedComposable/index.ts
+++ b/packages/shared/createSharedComposable/index.ts
@@ -10,6 +10,7 @@ export type SharedComposableReturn<T extends AnyFn = AnyFn> = T
  *
  * @see https://vueuse.org/createSharedComposable
  */
+/* #__NO_SIDE_EFFECTS__ */
 export function createSharedComposable<Fn extends AnyFn>(composable: Fn): SharedComposableReturn<Fn> {
   let subscribers = 0
   let state: ReturnType<Fn> | undefined

--- a/packages/shared/injectLocal/index.ts
+++ b/packages/shared/injectLocal/index.ts
@@ -10,6 +10,7 @@ import { localProvidedStateMap } from '../provideLocal/map'
  * const injectedValue = injectLocal('MyInjectionKey') // injectedValue === 1
  * ```
  */
+/* #__NO_SIDE_EFFECTS__ */
 // @ts-expect-error overloads are not compatible
 export const injectLocal: typeof inject = (...args) => {
   const key = args[0] as string | symbol

--- a/packages/shared/injectLocal/index.ts
+++ b/packages/shared/injectLocal/index.ts
@@ -9,8 +9,9 @@ import { localProvidedStateMap } from '../provideLocal/map'
  * injectLocal('MyInjectionKey', 1)
  * const injectedValue = injectLocal('MyInjectionKey') // injectedValue === 1
  * ```
+ *
+ * @__NO_SIDE_EFFECTS__
  */
-/* #__NO_SIDE_EFFECTS__ */
 // @ts-expect-error overloads are not compatible
 export const injectLocal: typeof inject = (...args) => {
   const key = args[0] as string | symbol

--- a/packages/shared/makeDestructurable/index.ts
+++ b/packages/shared/makeDestructurable/index.ts
@@ -1,3 +1,4 @@
+/* @__NO_SIDE_EFFECTS__ */
 export function makeDestructurable<
   T extends Record<string, unknown>,
   A extends readonly any[],

--- a/packages/shared/reactify/index.ts
+++ b/packages/shared/reactify/index.ts
@@ -26,6 +26,8 @@ export interface ReactifyOptions<T extends boolean> {
  *
  * @param fn - Source function
  * @param options - Options
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function reactify<T extends AnyFn, K extends boolean = true>(fn: T, options?: ReactifyOptions<K>): ReactifyReturn<T, K> {
   const unrefFn = options?.computedGetter === false ? unref : toValue

--- a/packages/shared/reactifyObject/index.ts
+++ b/packages/shared/reactifyObject/index.ts
@@ -17,10 +17,12 @@ export interface ReactifyObjectOptions<T extends boolean> extends ReactifyOption
 
 /**
  * Apply `reactify` to an object
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function reactifyObject<T extends object, Keys extends keyof T>(obj: T, keys?: (keyof T)[]): ReactifyObjectReturn<T, Keys, true>
 export function reactifyObject<T extends object, S extends boolean = true>(obj: T, options?: ReactifyObjectOptions<S>): ReactifyObjectReturn<T, keyof T, S>
-
+/* @__NO_SIDE_EFFECTS__ */
 export function reactifyObject<T extends object, S extends boolean = true>(obj: T, optionsOrKeys: ReactifyObjectOptions<S> | (keyof T)[] = {}): ReactifyObjectReturn<T, keyof T, S> {
   let keys: string[] = []
   let options: ReactifyOptions<S> | undefined

--- a/packages/shared/reactifyObject/index.ts
+++ b/packages/shared/reactifyObject/index.ts
@@ -22,7 +22,12 @@ export interface ReactifyObjectOptions<T extends boolean> extends ReactifyOption
  */
 export function reactifyObject<T extends object, Keys extends keyof T>(obj: T, keys?: (keyof T)[]): ReactifyObjectReturn<T, Keys, true>
 export function reactifyObject<T extends object, S extends boolean = true>(obj: T, options?: ReactifyObjectOptions<S>): ReactifyObjectReturn<T, keyof T, S>
-/* @__NO_SIDE_EFFECTS__ */
+
+/**
+ * Apply `reactify` to an object
+ *
+ * @__NO_SIDE_EFFECTS__
+ */
 export function reactifyObject<T extends object, S extends boolean = true>(obj: T, optionsOrKeys: ReactifyObjectOptions<S> | (keyof T)[] = {}): ReactifyObjectReturn<T, keyof T, S> {
   let keys: string[] = []
   let options: ReactifyOptions<S> | undefined

--- a/packages/shared/refDefault/index.ts
+++ b/packages/shared/refDefault/index.ts
@@ -3,6 +3,8 @@ import { computed } from 'vue'
 
 /**
  * Apply default value to a ref.
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function refDefault<T>(source: Ref<T | undefined | null>, defaultValue: T): Ref<T> {
   return computed({

--- a/packages/shared/refWithControl/index.ts
+++ b/packages/shared/refWithControl/index.ts
@@ -20,6 +20,8 @@ export interface ControlledRefOptions<T> {
 
 /**
  * Fine-grained controls over ref and its reactivity.
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function refWithControl<T>(
   initial: T,

--- a/packages/shared/useArrayDifference/index.ts
+++ b/packages/shared/useArrayDifference/index.ts
@@ -35,6 +35,8 @@ export function useArrayDifference<T>(
  * @see https://vueuse.org/useArrayDifference
  * @returns - the difference of two array
  * @param args
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useArrayDifference<T>(...args: any[]): UseArrayDifferenceReturn<T> {
   const list: MaybeRefOrGetter<T[]> = args[0]

--- a/packages/shared/useArrayEvery/index.ts
+++ b/packages/shared/useArrayEvery/index.ts
@@ -11,6 +11,8 @@ export type UseArrayEveryReturn = ComputedRef<boolean>
  * @param fn - a function to test each element.
  *
  * @returns **true** if the `fn` function returns a **truthy** value for every element from the array. Otherwise, **false**.
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useArrayEvery<T>(
   list: MaybeRefOrGetter<MaybeRefOrGetter<T>[]>,

--- a/packages/shared/useArrayFilter/index.ts
+++ b/packages/shared/useArrayFilter/index.ts
@@ -22,7 +22,18 @@ export function useArrayFilter<T>(
   list: MaybeRefOrGetter<MaybeRefOrGetter<T>[]>,
   fn: (element: T, index: number, array: T[]) => unknown,
 ): UseArrayFilterReturn<T>
-/* @__NO_SIDE_EFFECTS__ */
+
+/**
+ * Reactive `Array.filter`
+ *
+ * @see https://vueuse.org/useArrayFilter
+ * @param list - the array was called upon.
+ * @param fn - a function that is called for every element of the given `list`. Each time `fn` executes, the returned value is added to the new array.
+ *
+ * @returns a shallow copy of a portion of the given array, filtered down to just the elements from the given array that pass the test implemented by the provided function. If no elements pass the test, an empty array will be returned.
+ *
+ * @__NO_SIDE_EFFECTS__
+ */
 export function useArrayFilter<T>(
   list: MaybeRefOrGetter<MaybeRefOrGetter<T>[]>,
   fn: (element: T, index: number, array: T[]) => unknown,

--- a/packages/shared/useArrayFilter/index.ts
+++ b/packages/shared/useArrayFilter/index.ts
@@ -11,6 +11,8 @@ export type UseArrayFilterReturn<T = any> = ComputedRef<T[]>
  * @param fn - a function that is called for every element of the given `list`. Each time `fn` executes, the returned value is added to the new array.
  *
  * @returns a shallow copy of a portion of the given array, filtered down to just the elements from the given array that pass the test implemented by the provided function. If no elements pass the test, an empty array will be returned.
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useArrayFilter<T, S extends T>(
   list: MaybeRefOrGetter<MaybeRefOrGetter<T>[]>,
@@ -20,6 +22,7 @@ export function useArrayFilter<T>(
   list: MaybeRefOrGetter<MaybeRefOrGetter<T>[]>,
   fn: (element: T, index: number, array: T[]) => unknown,
 ): UseArrayFilterReturn<T>
+/* @__NO_SIDE_EFFECTS__ */
 export function useArrayFilter<T>(
   list: MaybeRefOrGetter<MaybeRefOrGetter<T>[]>,
   fn: (element: T, index: number, array: T[]) => unknown,

--- a/packages/shared/useArrayFind/index.ts
+++ b/packages/shared/useArrayFind/index.ts
@@ -11,6 +11,8 @@ export type UseArrayFindReturn<T = any> = ComputedRef<T | undefined>
  * @param fn - a function to test each element.
  *
  * @returns the first element in the array that satisfies the provided testing function. Otherwise, undefined is returned.
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useArrayFind<T>(
   list: MaybeRefOrGetter<MaybeRefOrGetter<T>[]>,

--- a/packages/shared/useArrayFindIndex/index.ts
+++ b/packages/shared/useArrayFindIndex/index.ts
@@ -11,6 +11,8 @@ export type UseArrayFindIndexReturn = ComputedRef<number>
  * @param fn - a function to test each element.
  *
  * @returns the index of the first element in the array that passes the test. Otherwise, "-1".
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useArrayFindIndex<T>(
   list: MaybeRefOrGetter<MaybeRefOrGetter<T>[]>,

--- a/packages/shared/useArrayFindLast/index.ts
+++ b/packages/shared/useArrayFindLast/index.ts
@@ -21,6 +21,8 @@ export type UseArrayFindLastReturn<T = any> = ComputedRef<T | undefined>
  * @param fn - a function to test each element.
  *
  * @returns the last element in the array that satisfies the provided testing function. Otherwise, undefined is returned.
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useArrayFindLast<T>(
   list: MaybeRefOrGetter<MaybeRefOrGetter<T>[]>,

--- a/packages/shared/useArrayIncludes/index.ts
+++ b/packages/shared/useArrayIncludes/index.ts
@@ -39,7 +39,16 @@ export function useArrayIncludes<T, V = any>(
   value: MaybeRefOrGetter<V>,
   options?: UseArrayIncludesOptions<T, V>,
 ): UseArrayIncludesReturn
-/* @__NO_SIDE_EFFECTS__ */
+
+/**
+ * Reactive `Array.includes`
+ *
+ * @see https://vueuse.org/useArrayIncludes
+ *
+ * @returns true if the `value` is found in the array. Otherwise, false.
+ *
+ * @__NO_SIDE_EFFECTS__
+ */
 export function useArrayIncludes<T, V = any>(
   ...args: any[]
 ): UseArrayIncludesReturn {

--- a/packages/shared/useArrayIncludes/index.ts
+++ b/packages/shared/useArrayIncludes/index.ts
@@ -21,6 +21,8 @@ export type UseArrayIncludesReturn = ComputedRef<boolean>
  * @see https://vueuse.org/useArrayIncludes
  *
  * @returns true if the `value` is found in the array. Otherwise, false.
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useArrayIncludes<T, V = any>(
   list: MaybeRefOrGetter<MaybeRefOrGetter<T>[]>,
@@ -37,6 +39,7 @@ export function useArrayIncludes<T, V = any>(
   value: MaybeRefOrGetter<V>,
   options?: UseArrayIncludesOptions<T, V>,
 ): UseArrayIncludesReturn
+/* @__NO_SIDE_EFFECTS__ */
 export function useArrayIncludes<T, V = any>(
   ...args: any[]
 ): UseArrayIncludesReturn {

--- a/packages/shared/useArrayJoin/index.ts
+++ b/packages/shared/useArrayJoin/index.ts
@@ -11,6 +11,8 @@ export type UseArrayJoinReturn = ComputedRef<string>
  * @param separator - a string to separate each pair of adjacent elements of the array. If omitted, the array elements are separated with a comma (",").
  *
  * @returns a string with all array elements joined. If arr.length is 0, the empty string is returned.
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useArrayJoin(
   list: MaybeRefOrGetter<MaybeRefOrGetter<any>[]>,

--- a/packages/shared/useArrayMap/index.ts
+++ b/packages/shared/useArrayMap/index.ts
@@ -11,6 +11,8 @@ export type UseArrayMapReturn<T = any> = ComputedRef<T[]>
  * @param fn - a function that is called for every element of the given `list`. Each time `fn` executes, the returned value is added to the new array.
  *
  * @returns a new array with each element being the result of the callback function.
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useArrayMap<T, U = T>(
   list: MaybeRefOrGetter<MaybeRefOrGetter<T>[]>,

--- a/packages/shared/useArrayReduce/index.ts
+++ b/packages/shared/useArrayReduce/index.ts
@@ -11,6 +11,8 @@ export type UseArrayReducer<PV, CV, R> = (previousValue: PV, currentValue: CV, c
  * @param reducer - a "reducer" function.
  *
  * @returns the value that results from running the "reducer" callback function to completion over the entire array.
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useArrayReduce<T>(
   list: MaybeRefOrGetter<MaybeRefOrGetter<T>[]>,
@@ -26,6 +28,8 @@ export function useArrayReduce<T>(
  * @param initialValue - a value to be initialized the first time when the callback is called.
  *
  * @returns the value that results from running the "reducer" callback function to completion over the entire array.
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useArrayReduce<T, U>(
   list: MaybeRefOrGetter<MaybeRefOrGetter<T>[]>,
@@ -42,6 +46,8 @@ export function useArrayReduce<T, U>(
  * @param args
  *
  * @returns the value that results from running the "reducer" callback function to completion over the entire array.
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useArrayReduce<T>(
   list: MaybeRefOrGetter<MaybeRefOrGetter<T>[]>,

--- a/packages/shared/useArraySome/index.ts
+++ b/packages/shared/useArraySome/index.ts
@@ -11,6 +11,8 @@ export type UseArraySomeReturn = ComputedRef<boolean>
  * @param fn - a function to test each element.
  *
  * @returns **true** if the `fn` function returns a **truthy** value for any element from the array. Otherwise, **false**.
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useArraySome<T>(
   list: MaybeRefOrGetter<MaybeRefOrGetter<T>[]>,

--- a/packages/shared/useArrayUnique/index.ts
+++ b/packages/shared/useArrayUnique/index.ts
@@ -24,6 +24,8 @@ export type UseArrayUniqueReturn<T = any> = ComputedRef<T[]>
  * @param list - the array was called upon.
  * @param compareFn
  * @returns A computed ref that returns a unique array of items.
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useArrayUnique<T>(
   list: MaybeRefOrGetter<MaybeRefOrGetter<T>[]>,

--- a/packages/shared/useDateFormat/index.ts
+++ b/packages/shared/useDateFormat/index.ts
@@ -118,6 +118,8 @@ export type UseDateFormatReturn = ComputedRef<string>
  * @param date - The date to format, can either be a `Date` object, a timestamp, or a string
  * @param formatStr - The combination of tokens to format the date
  * @param options - UseDateFormatOptions
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useDateFormat(date: MaybeRefOrGetter<DateLike>, formatStr: MaybeRefOrGetter<string> = 'HH:mm:ss', options: UseDateFormatOptions = {}): UseDateFormatReturn {
   return computed(() => formatDate(normalizeDate(toValue(date)), toValue(formatStr), options))

--- a/packages/shared/useDebounceFn/index.ts
+++ b/packages/shared/useDebounceFn/index.ts
@@ -13,6 +13,8 @@ export type UseDebounceFnReturn<T extends FunctionArgs> = PromisifyFn<T>
  * @param  options     Options
  *
  * @return A new, debounce, function.
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useDebounceFn<T extends FunctionArgs>(
   fn: T,

--- a/packages/shared/useThrottleFn/index.ts
+++ b/packages/shared/useThrottleFn/index.ts
@@ -18,6 +18,8 @@ import { createFilterWrapper, throttleFilter } from '../utils'
  * @param [rejectOnCancel] if true, reject the last call if it's been cancel (default value: false)
  *
  * @return  A new, throttled, function.
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useThrottleFn<T extends FunctionArgs>(
   fn: T,

--- a/packages/shared/useToNumber/index.ts
+++ b/packages/shared/useToNumber/index.ts
@@ -27,6 +27,8 @@ export interface UseToNumberOptions {
 
 /**
  * Reactively convert a string ref to number.
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useToNumber(
   value: MaybeRefOrGetter<number | string>,

--- a/packages/shared/useToString/index.ts
+++ b/packages/shared/useToString/index.ts
@@ -5,6 +5,8 @@ import { computed, toValue } from 'vue'
  * Reactively convert a ref to string.
  *
  * @see https://vueuse.org/useToString
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useToString(
   value: MaybeRefOrGetter<unknown>,

--- a/packages/shared/useToggle/index.ts
+++ b/packages/shared/useToggle/index.ts
@@ -19,6 +19,8 @@ export function useToggle<Truthy = true, Falsy = false, T = Truthy | Falsy>(init
  * @see https://vueuse.org/useToggle
  * @param [initialValue]
  * @param options
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function useToggle(
   initialValue: MaybeRef<boolean> = false,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

---

### Description

Resolve #4906

### Side Effects Notes

| Symbol | Meaning                            |
| ------ | ---------------------------------- |
| 🟢     | No side effects                    |
| 🤔🟢   | No side effects in most situations |
| 🟠     | Potentially side effects           |
| 🔴     | Side effects                       |

I will add annotations to all functions that has "No side effects 🟢" only.
For other cases, I’d like to gather feedback from the community first.

### resolve getter (🤔🟢)
The function resolves getter from parameter immediately. This may contains side effects inside the getter closure.
```ts
const foo = computed(() => {
  someSideEffects()
  return 1
})

useRefHistory(foo)
```

### object param (🟢)
The param contains object. This may contains side effects inside the object getter.
```ts
const options = {
  get initialValue() {
    someSideEffects()
    return '#000'
  }
}

useEyeDropper(options)
```

---

| State                  | Pure | Notes                                               |
| ---------------------- | ---- | --------------------------------------------------- |
| createGlobalState      | 🟢   |                                                     |
| createInjectionState   | 🟢   |                                                     |
| createSharedComposable | 🟢   |                                                     |
| injectLocal            | 🟢   |                                                     |
| provideLocal           | 🔴   | provide data                                        |
| useAsyncState          | 🔴   | callbacks                                           |
| useDebouncedRefHistory | 🤔🟢 | used `useRefHistory`                                |
| useLastChanged         | 🤔🟢 | resolve getter `source` (by `watch`)                |
| useLocalStorage        | 🔴   | create storage when init                            |
| useManualRefHistory    | 🤔🟢 | resolve getter `source` (by `_createHistoryRecord`) |
| useRefHistory          | 🤔🟢 | resolve getter `source` (by `watchIgnorable`)       |
| useSessionStorage      | 🔴   | create storage when init                            |
| useStorage             | 🔴   | create storage when init                            |
| useStorageAsync        | 🔴   | create storage when init                            |
| useThrottledRefHistory | 🤔🟢 | used `useRefHistory`                                |

| Elements                | Pure | Notes                                                                                     |
| ----------------------- | ---- | ----------------------------------------------------------------------------------------- |
| useActiveElement        | 🟢   |                                                                                           |
| useDocumentVisibility   | 🟢   | object param (`options`)                                                                  |
| useDraggable            | 🔴   | make elements draggable                                                                   |
| useDropZone             | 🔴   | add listener to element                                                                   |
| useElementBounding      | 🤔🟢 | resolve getter `target` (by `watch`)                                                      |
| useElementSize          | 🤔🟢 | resolve getter  `target` (by `watch`)                                                     |
| useElementVisibility    | 🤔🟢 | resolve getter `element` (by `useIntersectionObserver watch` )                            |
| useIntersectionObserver | 🔴   | callback                                                                                  |
| useMouseInElement       | 🤔🟢 | resolve getter `target` (by `useResizeObserver`)<br>closure param (`options.eventFilter`) |
| useMutationObserver     | 🔴   | callback                                                                                  |
| useParentElement        | 🤔🟢 | resolve getter  `element` (by `watch`)                                                    |
| useResizeObserver       | 🔴   | callback                                                                                  |
| useWindowFocus          | 🟢   | object param (`options`)                                                                  |
| useWindowScroll         | 🔴   | callback (`options.onScroll`)                                                             |
| useWindowSize           | 🟢   | object param (`options`)                                                                  |

| Browser                         | Pure | Notes                                               |
| ------------------------------- | ---- | --------------------------------------------------- |
| useBluetooth                    | 🟢   | run after `requestDevice`                           |
| useBreakpoints                  | 🟢   | object param (`options`)                            |
| useBroadcastChannel             | 🤔🟢 | create `BroadcastChannel`                           |
| useBrowserLocation              | 🟢   |                                                     |
| useClipboard                    | 🟢   |                                                     |
| useClipboardItems               | 🟢   |                                                     |
| useColorMode                    | 🔴   | possibly use `useStorage`                           |
| useCssVar                       | 🔴   | possibly set css var                                |
| useDark                         | 🔴   | possibly use `useStorage`                           |
| useEventListener                | 🔴   | callback                                            |
| useEyeDropper                   | 🟢   | object param (`options`)                            |
| useFavicon                      | 🔴   | set favicon                                         |
| useFileDialog                   | 🤔🟢 | resolve getter  `options.input` (by `unrefElement`) |
| useFileSystemAccess             | 🤔🟢 | resolve getter `options.dataType` (by `watch`)      |
| useFullscreen                   | 🤔🟢 | resolve getter  `target` (by `unrefElement`)        |
| useGamepad                      | 🟢   | called `navigator.getGamepads()`                    |
| useImage                        | 🔴   | request `Image`                                     |
| useMediaControls                | 🔴   | set media src                                       |
| useMediaQuery                   | 🤔🟢 | resolve getter `query` (by `watchEffect`)           |
| useMemory                       | 🟢   |                                                     |
| useObjectUrl                    | 🤔🟢 | resolve getter `object` (by `watch`)                |
| usePerformanceObserver          | 🔴   | callback                                            |
| usePermission                   | 🟢   | object param (`options`)                            |
| usePreferredColorScheme         | 🟢   | object param (`options`)                            |
| usePreferredContrast            | 🟢   | object param (`options`)                            |
| usePreferredDark                | 🟢   | object param (`options`)                            |
| usePreferredLanguages           | 🟢   | object param (`options`)                            |
| usePreferredReducedMotion       | 🟢   | object param (`options`)                            |
| usePreferredReducedTransparency | 🟢   | object param (`options`)                            |
| useScreenOrientation            | 🟢   | object param (`options`)                            |
| useScreenSafeArea               | 🟠   | created `--vueuse-safe-area-*` CSS var              |
| useScriptTag                    | 🔴   | callback (`onLoaded`)                               |
| useShare                        | 🟢   | object param (`options`)                            |
| useSSRWidth                     | 🟢   |                                                     |
| useStyleTag                     | 🔴   | create style tag                                    |
| useTextareaAutosize             | 🔴   | callback (`options.onResize`)                       |
| useTextDirection                | 🟢   | object param (`options`)                            |
| useTitle                        | 🔴   | set title immediately                               |
| useUrlSearchParams              | 🤔🟢 | closure param (`options.stringify`)                 |
| useVibrate                      | 🟢   | object param (`options`)                            |
| useWakeLock                     | 🟢   |                                                     |
| useWebNotification              | 🔴   | request permission immediately                      |
| useWebWorker                    | 🔴   | load worker immediately                             |
| useWebWorkerFn                  | 🔴   | terminate worker immediately                        |

| Sensors              | Pure | Notes                                            |
| -------------------- | ---- | ------------------------------------------------ |
| onClickOutside       | 🔴   | callback                                         |
| onElementRemoval     | 🔴   | callback                                         |
| onKeyStroke          | 🔴   | callback                                         |
| onLongPress          | 🔴   | callback                                         |
| onStartTyping        | 🔴   | callback                                         |
| useBattery           | 🟢   | object param (`options`)                         |
| useDeviceMotion      | 🤔🟢 | closure param (`options.eventFilter`)            |
| useDeviceOrientation | 🟢   | object param (`options`)                         |
| useDevicePixelRatio  | 🟢   | object param (`options`)                         |
| useDevicesList       | 🔴   | possible `requestPermissions` immediately        |
| useDisplayMedia      | 🤔🟢 | resolve getter ``enabled`` (by `watch`)          |
| useElementByPoint    | 🤔🟢 | resolve getter `multiple` (by `toValue`)         |
| useElementHover      | 🤔🟢 | resolve getter `el` (by `useEventListener`)      |
| useFocus             | 🤔🟢 | resolve getter `target` (by `useEventListener`)  |
| useFocusWithin       | 🤔🟢 | resolve getter `target` (by `useEventListener`)  |
| useFps               | 🟢   | object param (`options`)                         |
| useGeolocation       | 🔴   | grant permission                                 |
| useIdle              | 🤔🟢 | closure param (`options.eventFilter`)            |
| useInfiniteScroll    | 🔴   | make element infinite scroll                     |
| useKeyModifier       | 🟢   | object param (`options`)                         |
| useMagicKeys         | 🟠   | callback (`onEventFired`)                        |
| useMouse             | 🤔🟢 | resolve getter `target` (by `useEventListener`)  |
| useMousePressed      | 🔴   | callback (`onPressed`)                           |
| useNavigatorLanguage | 🟢   | object param (`options`)                         |
| useNetwork           | 🟢   | object param (`options`)                         |
| useOnline            | 🟢   | object param (`options`)                         |
| usePageLeave         | 🟢   | object param (`options`)                         |
| useParallax          | 🤔🟢 | resolve getter `target` (by `useMouseInElement`) |
| usePointer           | 🤔🟢 | resolve getter `target` (by `useEventListener`)  |
| usePointerLock       | 🟢   | object param (`options`)                         |
| usePointerSwipe      | 🔴   | callback (`onSwipe`)                             |
| useScroll            | 🔴   | possible set scroll `behavior`                   |
| useScrollLock        | 🤔🟢 | resolve getter `element` (by `watch`)            |
| useSpeechRecognition | 🤔🟢 | resolve getter `lang` (by `watch`)               |
| useSpeechSynthesis   | 🤔🟢 | resolve getter `text` (by `watch > utterance`)   |
| useSwipe             | 🔴   | callback (`onSwipe`)                             |
| useTextSelection     | 🟢   | object param (`options`)                         |
| useUserMedia         | 🤔🟢 | resolve getter `enabled` (by `watch`)            |

| Network        | Pure | Notes                    |
| -------------- | ---- | ------------------------ |
| useEventSource | 🔴   | connect to `EventSource` |
| useFetch       | 🔴   | fetch url                |
| useWebSocket   | 🔴   | connect to WebSocket     |

| Animation     | Pure | Notes                    |
| ------------- | ---- | ------------------------ |
| useAnimate    | 🔴   | callback (`onReady`)     |
| useInterval   | 🔴   | callback                 |
| useIntervalFn | 🔴   | callback                 |
| useNow        | 🟢   | object param (`options`) |
| useRafFn      | 🔴   | callback                 |
| useTimeout    | 🔴   | callback                 |
| useTimeoutFn  | 🔴   | callback                 |
| useTimestamp  | 🔴   | callback                 |
| useTransition | 🔴   | callback                 |

| Component              | Pure | Notes                                               |
| ---------------------- | ---- | --------------------------------------------------- |
| computedInject         | 🤔🟢 | callback (`getter`)                                 |
| createReusableTemplate | 🟢   | object param (`options`)                            |
| createTemplatePromise  | 🟢   | object param (`options`)                            |
| templateRef            | 🟢   |                                                     |
| tryOnBeforeMount       | 🔴   | callback                                            |
| tryOnBeforeUnmount     | 🔴   | callback                                            |
| tryOnMounted           | 🔴   | callback                                            |
| tryOnScopeDispose      | 🔴   | callback                                            |
| tryOnUnmounted         | 🔴   | callback                                            |
| unrefElement           | 🤔🟢 | resolve getter `elRef` (by `toValue`)               |
| useCurrentElement      | 🤔🟢 | resolve getter  `rootComponent` (by `unrefElement`) |
| useMounted             | 🟢   |                                                     |
| useTemplateRefsList    | 🟢   |                                                     |
| useVirtualList         | 🤔🟢 | resolve getter  `list` (by `useWatchForSizes`)      |
| useVModel              | 🟢   | object param (`options`)                            |
| useVModels             | 🟢   | object param (`options`)                            |

| Watch            | Pure | Notes                                        |
| ---------------- | ---- | -------------------------------------------- |
| until            | 🤔🟢 | resolve getter `r: WatchSource` (by `watch`) |
| watchArray       | 🔴   | callback                                     |
| watchAtMost      | 🔴   | callback                                     |
| watchDebounced   | 🔴   | callback                                     |
| watchDeep        | 🔴   | callback                                     |
| watchIgnorable   | 🔴   | callback                                     |
| watchImmediate   | 🔴   | callback                                     |
| watchOnce        | 🔴   | callback                                     |
| watchPausable    | 🔴   | callback                                     |
| watchThrottled   | 🔴   | callback                                     |
| watchTriggerable | 🔴   | callback                                     |
| watchWithFilter  | 🔴   | callback                                     |
| whenever         | 🔴   | callback                                     |

| Reactivity          | Pure | Notes                                      |
| ------------------- | ---- | ------------------------------------------ |
| computedAsync       | 🔴   | callback (`onError`)                       |
| computedEager       | 🤔🟢 | resolve getter `fn` (by `watchEffect`)     |
| computedWithControl | 🤔🟢 | resolve getter `source` (by `watch`)       |
| createRef           | 🟢   |                                            |
| extendRef           | 🔴   | modify `ref` by `Object.defineProperty`    |
| reactify            | 🟢   |                                            |
| reactifyObject      | 🟢   | object param (`options`)                   |
| reactiveComputed    | 🤔🟢 | resolve getter `fn` (by `reactive`)        |
| reactiveOmit        | 🤔🟢 | closure param (`predicate`)                |
| reactivePick        | 🤔🟢 | closure param (`predicate`)                |
| refAutoReset        | 🤔🟢 | resolve getter defaultValue (by `toValue`) |
| refDebounced        | 🤔🟢 | resolve getter `value` (by `watch`)        |
| refDefault          | 🟢   |                                            |
| refThrottled        | 🤔🟢 | resolve getter `value` (by `watch`)        |
| refWithControl      | 🟢   |                                            |
| syncRef             | 🔴   |                                            |
| syncRefs            | 🔴   |                                            |
| toReactive          | 🤔🟢 | resolve getter `objectRef` by (`unref`)    |
| toRef               | 🤔🟢 | resolve getter `r` (by `vueToRef`)         |
| toRefs              | 🤔🟢 | resolve getter `r` (by `_toRefs`)          |
| toValue             | 🤔🟢 | resolve getter                             |

| Array              | Pure | Notes                      |
| ------------------ | ---- | -------------------------- |
| useArrayDifference | 🟢   |                            |
| useArrayEvery      | 🟢   |                            |
| useArrayFilter     | 🟢   |                            |
| useArrayFind       | 🟢   |                            |
| useArrayFindIndex  | 🟢   |                            |
| useArrayFindLast   | 🟢   |                            |
| useArrayIncludes   | 🟢   |                            |
| useArrayJoin       | 🟢   |                            |
| useArrayMap        | 🟢   |                            |
| useArrayReduce     | 🟢   |                            |
| useArraySome       | 🟢   |                            |
| useArrayUnique     | 🟢   |                            |
| useSorted          | 🔴   | `dirty` mode modify source |

| Time          | Pure | Notes                    |
| ------------- | ---- | ------------------------ |
| useCountdown  | 🔴   | callback (`onComplete`)  |
| useDateFormat | 🟢   | object param (`options`) |
| useTimeAgo    | 🟢   | object param (`options`) |

| Utilities           | Pure | Notes                                      |
| ------------------- | ---- | ------------------------------------------ |
| createEventHook     | 🟢   |                                            |
| createUnrefFn       | 🟢   |                                            |
| get                 | 🤔🟢 | resolve getter `obj` (by `unref`)          |
| isDefined           | 🤔🟢 | resolve getter `obj` (by `unref`)          |
| makeDestructurable  | 🟢   | object param (`obj`)                       |
| set                 | 🔴   | set ref value                              |
| useAsyncQueue       | 🔴   | executes async task                        |
| useBase64           | 🤔🟢 | resolve getter `target` (by `watch`)       |
| useCached           | 🤔🟢 | resolve getter `refValue` (by `watch`)     |
| useCloned           | 🤔🟢 | resolve getter `source` (by `watch`)       |
| useConfirmDialog    | 🟢   | ref param `revealed`                       |
| useCounter          | 🤔🟢 | resolve getter `initialValue` (by `unref`) |
| useCycleList        | 🤔🟢 | resolve getter `list` (by `watch`)         |
| useDebounceFn       | 🟢   | object param (`options`)                   |
| useEventBus         | 🟢   |                                            |
| useMemoize          | 🟢   |                                            |
| useOffsetPagination | 🔴   | callback (`onPageChange`)                  |
| usePrevious         | 🤔🟢 | resolve getter `value` (by `watch`)        |
| useStepper          | 🟢   |                                            |
| useSupported        | 🟢   |                                            |
| useThrottleFn       | 🟢   |                                            |
| useTimeoutPoll      | 🔴   | callback (`fn`)                            |
| useToggle           | 🟢   |                                            |
| useToNumber         | 🟢   |                                            |
| useToString         | 🟢   |                                            |

| `@Electron`            | Pure | Notes                         |
| -------------------- | ---- | ----------------------------- |
| useIpcRenderer       | 🟢   |                               |
| useIpcRendererInvoke | 🔴   | invoke channel                |
| useIpcRendererOn     | 🔴   | callback                      |
| useZoomFactor        | 🔴   | possible set init zoom factor |
| useZoomLevel         | 🔴   | possible set init zoom level  |

| `@Firebase `   | Pure | Notes                                     |
| ------------ | ---- | ----------------------------------------- |
| useAuth      | 🟢   | object param (`auth`)                     |
| useFirestore | 🤔🟢 | resolve getter `maybeDocRef` (by `watch`) |
| useRTDB      | 🟠   | listen for `docRef` (by `onValue`)        |


| `@Integrations`   | Pure | Notes                                 |
| ----------------- | ---- | ------------------------------------- |
| useAsyncValidator | 🔴   | call `validate`                       |
| useAxios          | 🔴   | fetch request                         |
| useChangeCase     | 🟢   |                                       |
| useCookies        | 🟢   |                                       |
| useDrauu          | 🤔🟢 | resolve getter `target` (by `watch`)  |
| useFocusTrap      | 🤔🟢 | resolve getter `target` (by `watch`)  |
| useFuse           | 🤔🟢 | resolve getter `options` (by `watch`) |
| useIDBKeyval      | 🔴   | callback (`onError`)                  |
| useJwt            | 🔴   | callback (`onError`)                  |
| useNProgress      | 🔴   | set progress                          |
| useQRCode         | 🤔🟢 | resolve getter `text` (by `watch`)    |
| useSortable       | 🔴   | start Sortable                        |


| `@Math`                 | Pure | Notes |
| ----------------------- | ---- | ----- |
| createGenericProjection | 🟢   |       |
| createProjection        | 🟢   |       |
| logicAnd                | 🟢   |       |
| logicNot                | 🟢   |       |
| logicOr                 | 🟢   |       |
| useAbs                  | 🟢   |       |
| useAverage              | 🟢   |       |
| useCeil                 | 🟢   |       |
| useClamp                | 🟢   |       |
| useFloor                | 🟢   |       |
| useMath                 | 🟢   |       |
| useMax                  | 🟢   |       |
| useMin                  | 🟢   |       |
| usePrecision            | 🟢   |       |
| useProjection           | 🟢   |       |
| useRound                | 🟢   |       |
| useSum                  | 🟢   |       |
| useTrunc                | 🟢   |       |

| @Router        | Pure | Notes                               |
| -------------- | ---- | ----------------------------------- |
| useRouteHash   | 🟢   |                                     |
| useRouteParams | 🤔🟢 | closure param (`options.transform`) |
| useRouteQuery  | 🤔🟢 | closure param (`options.transform`) |

| @RxJS                    | Pure | Notes                                |
| ------------------------ | ---- | ------------------------------------ |
| from                     | 🟢   |                                      |
| toObserver               | 🟢   |                                      |
| useExtractedObservable   | 🤔🟢 | resolve getter `source` (by `watch`) |
| useObservable            | 🔴   | callback (`onError`)                 |
| useSubject               | 🔴   | callback (`onError`)                 |
| useSubscription          | 🔴   | auto unsubscribe                     |
| watchExtractedObservable | 🔴   | callback                             |