### PR TITLE
feat(refWithControl): support async api for onBeforeChange (#4668)

### DIFF
--- a/packages/shared/refWithControl/index.ts
+++ b/packages/shared/refWithControl/index.ts
@@ -1,4 +1,4 @@
-import type { Fn } from '../utils'
+import type { Awaitable, Fn } from '../utils'
 import { customRef } from 'vue'
 import { extendRef } from '../extendRef'
 
@@ -8,7 +8,7 @@ export interface ControlledRefOptions<T> {
    *
    * Returning `false` to dismiss the change.
    */
-  onBeforeChange?: (value: T, oldValue: T) => void | boolean
+  onBeforeChange?: (value: T, oldValue: T) => Awaitable<void | boolean>
 
   /**
    * Callback function after the ref changed
@@ -54,8 +54,20 @@ export function refWithControl<T>(
       return
 
     const old = source
-    if (options.onBeforeChange?.(value, old) === false)
+    const result = options.onBeforeChange?.(value, old)
+    if (result === false)
       return // dismissed
+    if (result instanceof Promise) {
+      result.then((res) => {
+        if (res === false)
+          return // dismissed
+        source = value
+        options.onChanged?.(value, old)
+        if (triggering)
+          trigger()
+      })
+      return
+    }
 
     source = value
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Support async return type for `onBeforeChange `, and extend unit tests.

### Additional context

#4668 
