### PR TITLE
fix(useMagicKeys): prevent incorrect clearing of other keys after releasing shift

### DIFF
--- a/packages/core/useMagicKeys/index.test.ts
+++ b/packages/core/useMagicKeys/index.test.ts
@@ -63,4 +63,34 @@ describe('useMagicKeys', () => {
     }))
     expect(Ctrl_Shift_Period.value).toBe(true)
   })
+  it('prevent incorrect clearing of other keys after releasing shift', async () => {
+    const { v, u, e, shift } = useMagicKeys({ target })
+
+    target.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'v',
+    }))
+    target.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'u',
+    }))
+    target.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'e',
+    }))
+    target.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'shift',
+    }))
+
+    expect(v.value).toBe(true)
+    expect(u.value).toBe(true)
+    expect(e.value).toBe(true)
+    expect(shift.value).toBe(true)
+
+    target.dispatchEvent(new KeyboardEvent('keyup', {
+      key: 'shift',
+    }))
+
+    expect(v.value).toBe(true)
+    expect(u.value).toBe(true)
+    expect(e.value).toBe(true)
+    expect(shift.value).toBe(false)
+  })
 })

--- a/packages/core/useMagicKeys/index.ts
+++ b/packages/core/useMagicKeys/index.ts
@@ -121,9 +121,13 @@ export function useMagicKeys(options: UseMagicKeysOptions<boolean> = {}): any {
       setRefs(key, value)
     }
     if (key === 'shift' && !value) {
-      shiftDeps.forEach((key) => {
-        current.delete(key)
-        setRefs(key, false)
+      const shiftDepsArray = Array.from(shiftDeps)
+      const shiftIndex = shiftDepsArray.indexOf('shift')
+      shiftDepsArray.forEach((key, index) => {
+        if (index >= shiftIndex) {
+          current.delete(key)
+          setRefs(key, false)
+        }
       })
       shiftDeps.clear()
     }


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

This PR is to fix #4908 
When releasing **shift**, do not clear the keys pressed before pressing **shift**.

After modification

https://github.com/user-attachments/assets/29afb5a9-10d6-4176-bf88-efbc1b552767



### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
