### PR TITLE
fix(docs): useStorage wrong parameters order in docs for mergeDefaults

### DIFF
--- a/packages/core/useStorage/index.md
+++ b/packages/core/useStorage/index.md
@@ -68,7 +68,7 @@ const state = useStorage(
   'my-store',
   { hello: 'hi', greeting: 'hello' },
   localStorage,
-  { mergeDefaults: (storageValue, defaults) => deepMerge(defaults, storageValue) } // <--
+  { mergeDefaults: (storageValue, defaults) => deepMerge(storageValue, defaults) } // <--
 )
 ```
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description
According to the deepmerge docs https://www.npmjs.com/package/deepmerge

> merge(x, y, [options])
> Merge two objects x and y deeply, returning a new merged object with the elements from both x and y.
> 
> **If an element at the same key is present for both x and y, the value from y will appear in the result.**
> 
> Merging creates a new object, so that neither x or y is modified.

the params in the useStorage example should be inverted as we want to merge the defaults to the storage ones

