### PR TITLE
fix(magic-keys-demo): adjust the minimum height to avoid the problem of Demo jittering.

### DIFF
--- a/packages/core/useMagicKeys/demo.vue
+++ b/packages/core/useMagicKeys/demo.vue
@@ -73,7 +73,7 @@ const Key = defineComponent({
 
       <div class="text-center mt-4">
         <Note>Keys Pressed</Note>
-        <div class="flex mt-2 justify-center space-x-1 min-h-1.5em">
+        <div class="flex mt-2 justify-center space-x-1 min-h-2em">
           <code
             v-for="key in keys"
             :key="key"


### PR DESCRIPTION
Adjust the minimum height to avoid the problem of Demo jittering.

<img width="532" height="567" alt="image" src="https://github.com/user-attachments/assets/32af5751-b3f7-4bc7-a9e2-5a003e445f62" />