### PR TITLE
fix(useAnimate): respect `immediate: false` with conditionally rendered elements

### DIFF
--- a/packages/core/useAnimate/index.browser.test.ts
+++ b/packages/core/useAnimate/index.browser.test.ts
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 import { useAnimate } from '@vueuse/core'
 import { describe, expect, it, vi } from 'vitest'
 import { defineComponent, shallowRef } from 'vue'
@@ -70,6 +70,36 @@ describe('useAnimate', () => {
         transform: 'rotate(180deg)',
       }])
     })
+
+    wrapper.unmount()
+  })
+
+  it('should not automatically start the animation when shown if `immediate` is false', async () => {
+    const wrapper = mount(defineComponent({
+      template: '<p v-if="show" ref="el">test</p>',
+      setup() {
+        const show = shallowRef(false)
+        const el = shallowRef<HTMLElement>()
+        const animate = useAnimate(el, { transform: 'rotate(360deg)' }, {
+          duration: 100,
+          immediate: false,
+        })
+
+        return { ...animate, el, show }
+      },
+    }))
+
+    const vm = wrapper.vm
+
+    // It is initially hidden
+    expect(vm.animate).toBeUndefined()
+
+    // Toggle element into view
+    vm.show = true
+    await flushPromises()
+
+    // It should not have started automatically
+    expect(vm.animate?.playState).toBe('paused')
 
     wrapper.unmount()
   })

--- a/packages/core/useAnimate/index.ts
+++ b/packages/core/useAnimate/index.ts
@@ -225,7 +225,7 @@ export function useAnimate(
 
   watch(() => unrefElement(target), (el) => {
     if (el) {
-      update()
+      update(true)
     }
     else {
       animate.value = undefined


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Previously, animations would start immediately when elements were toggled into view using `v-if`, even if `immediate: false` was specified. This was due to the call to `update()` in the `el` watcher missing the `init` flag, which is required for the `immediate` option to be respected and the animation to be paused.

This fix treats an element becoming visible via `v-if` the same as it being mounted for the first time.

| Before | After |
| - | - |
| Animation starts immediately even with `immediate: false`.<br><br> ![Screenshot-useAnimate  VueUse-2025-08-06-23-04-27](https://github.com/user-attachments/assets/d299a6dd-daf5-4451-8e0a-efb3609feefb) | Animation does not start immediately.<br><br> ![Screenshot-useAnimate  VueUse-2025-08-06-23-06-20](https://github.com/user-attachments/assets/02d3ffcb-03af-4d13-b750-e34ef981df42)

