### PR TITLE
feat(useAsyncState)!: set globalThis.reportError as default onError

### DIFF
--- a/packages/core/useAsyncState/index.ts
+++ b/packages/core/useAsyncState/index.ts
@@ -87,7 +87,7 @@ export function useAsyncState<Data, Params extends any[] = any[], Shallow extend
   const {
     immediate = true,
     delay = 0,
-    onError = noop,
+    onError = globalThis.reportError ?? noop,
     onSuccess = noop,
     resetOnExecute = true,
     shallow = true,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

In useAsyncState, awaited errors are silently ignored by default since onError has value noop. It should probably instead use either globalThis.reportError 

[Reproduction](https://playground.vueuse.org/#eNqdUk1P4zAQ/SsjX5JKVXvYPXVTtIAqAQdAwNGXKBlaF8eO7HFTVOW/M3boBwj1wG1m3vP4vZnZicu2nWwCipkofOVUS+CRQgu6NMu5FOSluJBGNa11BDsIHi/9u6meqSSEHl6dbSD7zx0YmVbWYSaNNJU1PtL9J23+9WFexhDyEcwvYCcNQNmViuCRuymPE4fe6g3m2Qq1ttnoX6TQytkODHawcM66XIqXlfKAMQEOfFcyucNaipE0/RhM0Ho8tFdNg7Xin2dALiDDTPkmcza02jv7rWRCT5+Kj9gaK8qP0rOvyh3G6WKdjVgVcErBGchukvmjlXNOiumwPd4VJ4RNq5nDGUBRq00KAHaHjfSHwqnpVC2mw4NietJGjPkUeFyvajlZe2v4XpIcKSrbtEqje2hJ8TilmA3jiVhayF2qRbHjfb1aYfX2Q33tt7EmxSOPE90GpThgVLol0gAvnu9xy/EBbGwdNLPPgE9xQSFqHGhXwdQs+4SX1N6mS1dm+eIXW0Lj96aGaQP0iS8Fn/z1GetHuX8mf9M7XpXoPwD8Xivd)
