### PR TITLE
feat(useClipboardItems): add `options.immediate` and expose `read`

### DIFF
--- a/packages/core/useClipboardItems/demo.vue
+++ b/packages/core/useClipboardItems/demo.vue
@@ -4,7 +4,7 @@ import { effect, shallowRef } from 'vue'
 
 const input = shallowRef('')
 
-const { content, isSupported, copy } = useClipboardItems()
+const { content, isSupported, copy, read } = useClipboardItems()
 const computedText = shallowRef('')
 const computedMimeType = shallowRef('')
 effect(() => {
@@ -37,11 +37,14 @@ function createClipboardItems(text: string) {
     </p>
     <input v-model="input" type="text">
     <button
-      @click="
-        copy([createClipboardItems(input)])
-      "
+      @click="() => copy([createClipboardItems(input)])"
     >
       Copy
+    </button>
+    <button
+      @click="() => read()"
+    >
+      Read
     </button>
   </div>
   <p v-else>

--- a/packages/core/useClipboardItems/index.ts
+++ b/packages/core/useClipboardItems/index.ts
@@ -1,7 +1,7 @@
-import type { ComputedRef, MaybeRefOrGetter } from 'vue'
+import type { ComputedRef, MaybeRefOrGetter, Ref, ShallowRef } from 'vue'
 import type { ConfigurableNavigator } from '../_configurable'
-import { useTimeoutFn } from '@vueuse/shared'
-import { ref as deepRef, shallowRef, toValue } from 'vue'
+import { tryOnMounted, useTimeoutFn } from '@vueuse/shared'
+import { ref as deepRef, readonly, shallowReadonly, shallowRef, toValue } from 'vue'
 import { defaultNavigator } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 import { useSupported } from '../useSupported'
@@ -25,13 +25,19 @@ export interface UseClipboardItemsOptions<Source> extends ConfigurableNavigator 
    * @default 1500
    */
   copiedDuring?: number
+
+  /**
+   * Whether to read clipboard content immediately on mount
+   */
+  immediate?: boolean
 }
 
 export interface UseClipboardItemsReturn<Optional> {
   isSupported: ComputedRef<boolean>
-  content: ComputedRef<ClipboardItems>
-  copied: ComputedRef<boolean>
+  content: Readonly<Ref<ClipboardItems>>
+  copied: Readonly<ShallowRef<boolean>>
   copy: Optional extends true ? (content?: ClipboardItems) => Promise<void> : (text: ClipboardItems) => Promise<void>
+  read: () => void
 }
 
 /**
@@ -65,8 +71,14 @@ export function useClipboardItems(options: UseClipboardItemsOptions<MaybeRefOrGe
     }
   }
 
-  if (isSupported.value && read)
+  if (isSupported.value && read) {
     useEventListener(['copy', 'cut'], updateContent, { passive: true })
+    if (options.immediate) {
+      tryOnMounted(() => {
+        updateContent()
+      })
+    }
+  }
 
   async function copy(value = toValue(source)) {
     if (isSupported.value && value != null) {
@@ -80,8 +92,9 @@ export function useClipboardItems(options: UseClipboardItemsOptions<MaybeRefOrGe
 
   return {
     isSupported,
-    content: content as ComputedRef<ClipboardItems>,
-    copied: copied as ComputedRef<boolean>,
+    content: shallowReadonly(content),
+    copied: readonly(copied),
     copy,
+    read: updateContent,
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

This PR adds `options.immediate` to allow read onMounted. It does also exposes the `read` function for manual reads.

ToDos:

- tests
- discussion about `options.immediate`. This option is only used when `options.read` is set to true. Should we reuse `read` for this?
```
  /**
   * Enabled reading for clipboard
   *
   * @default false
   */
  read?: boolean | { immediate: boolean}
```
- had to use `shallowReadonly` for content.. `readonly` did not work, possibly because some keys of `ClipboardItem` are already readonly?

@43081j @ilyaliao wdyt?

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
