### PR TITLE
perf(usePreferredLanguages): use shallowRef for better performance

### DIFF
--- a/packages/core/usePreferredLanguages/index.ts
+++ b/packages/core/usePreferredLanguages/index.ts
@@ -1,6 +1,6 @@
-import type { Ref } from 'vue'
+import type { ShallowRef } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
-import { ref as deepRef } from 'vue'
+import { shallowRef } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 
@@ -12,13 +12,13 @@ import { useEventListener } from '../useEventListener'
  *
  * @__NO_SIDE_EFFECTS__
  */
-export function usePreferredLanguages(options: ConfigurableWindow = {}): Ref<readonly string[]> {
+export function usePreferredLanguages(options: ConfigurableWindow = {}): ShallowRef<readonly string[]> {
   const { window = defaultWindow } = options
   if (!window)
-    return deepRef(['en'])
+    return shallowRef(['en'])
 
   const navigator = window.navigator
-  const value = deepRef<readonly string[]>(navigator.languages)
+  const value = shallowRef<readonly string[]>(navigator.languages)
 
   useEventListener(window, 'languagechange', () => {
     value.value = navigator.languages


### PR DESCRIPTION
### Description

This PR refactors `usePreferredLanguages` to use `shallowRef` for better performance.