### PR TITLE
fix(useEventSource): replace wrong `Data` generic with `string`

### DIFF
--- a/packages/core/useEventSource/index.ts
+++ b/packages/core/useEventSource/index.ts
@@ -50,12 +50,12 @@ export interface UseEventSourceOptions extends EventSourceInit {
   autoConnect?: boolean
 }
 
-export interface UseEventSourceReturn<Events extends string[], Data = any> {
+export interface UseEventSourceReturn<Events extends string[]> {
   /**
    * Reference to the latest data received via the EventSource,
    * can be watched to respond to incoming messages
    */
-  data: ShallowRef<Data | null>
+  data: ShallowRef<string | null>
 
   /**
    * The current state of the connection, can be only one of:
@@ -110,13 +110,13 @@ function resolveNestedOptions<T>(options: T | true): T {
  * @param events
  * @param options
  */
-export function useEventSource<Events extends string[], Data = any>(
+export function useEventSource<Events extends string[]>(
   url: MaybeRefOrGetter<string | URL | undefined>,
   events: Events = [] as unknown as Events,
   options: UseEventSourceOptions = {},
-): UseEventSourceReturn<Events, Data> {
+): UseEventSourceReturn<Events> {
   const event: ShallowRef<string | null> = shallowRef(null)
-  const data: ShallowRef<Data | null> = shallowRef(null)
+  const data: ShallowRef<string | null> = shallowRef(null)
   const status = shallowRef<EventSourceStatus>('CONNECTING')
   const eventSource = deepRef<EventSource | null>(null)
   const error = shallowRef<Event | null>(null)
@@ -181,14 +181,14 @@ export function useEventSource<Events extends string[], Data = any>(
       }
     }
 
-    es.onmessage = (e: MessageEvent) => {
+    es.onmessage = (e: MessageEvent<string>) => {
       event.value = null
       data.value = e.data
       lastEventId.value = e.lastEventId
     }
 
     for (const event_name of events) {
-      useEventListener(es, event_name, (e: Event & { data?: Data, lastEventId?: string }) => {
+      useEventListener(es, event_name, (e: Event & { data?: string, lastEventId?: string }) => {
         event.value = event_name
         data.value = e.data || null
         lastEventId.value = e.lastEventId || null


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Remove the `Data` generic from `useEventSource` and just use `string` instead, as SSE's data could only be string.

https://html.spec.whatwg.org/multipage/server-sent-events.html#the-eventsource-interface

### Additional context

In [the original PR](https://github.com/vueuse/vueuse/pull/4598#issuecomment-2661102701), the author referenced MDN's docs:

> The data sent by the message emitter; this can be any data type, depending on what originated this event

Yes, this applies to `MessageEvent`, because that `MessageEvent` is not only born for `EventSource`, but also used in non-SSE scenarios like `postMessage`. This is possible to be other types in other scenarios, but only `string` is possible for SSE.