### PR TITLE
feat(onLongPress): allow function as value in delay

### DIFF
--- a/packages/core/onLongPress/index.test.ts
+++ b/packages/core/onLongPress/index.test.ts
@@ -24,9 +24,9 @@ describe('onLongPress', () => {
     expect(onLongPressCallback).toHaveBeenCalledTimes(1)
   }
 
-  async function triggerCallbackWithDelay(isRef: boolean) {
+  async function triggerCallbackWithDelay(isRef: boolean, delayFunc?: (ev: PointerEvent) => number) {
     const onLongPressCallback = vi.fn()
-    onLongPress(isRef ? element : element.value, onLongPressCallback, { delay: 1000 })
+    onLongPress(isRef ? element : element.value, onLongPressCallback, { delay: delayFunc ?? 1000 })
     // first pointer down
     element.value.dispatchEvent(pointerdownEvent)
 
@@ -199,6 +199,7 @@ describe('onLongPress', () => {
       it('should remove event listeners after being stopped', () => stopEventListeners(isRef))
       it('should trigger longpress if pointer is moved', () => triggerCallbackWithThreshold(isRef))
       it('should trigger onMouseUp when pointer is released', () => triggerOnMouseUp(isRef))
+      it('should trigger longpress after options.delay ms when options.delay is a function', () => triggerCallbackWithDelay(isRef, () => 1000))
     })
   }
 

--- a/packages/core/onLongPress/index.ts
+++ b/packages/core/onLongPress/index.ts
@@ -14,7 +14,7 @@ export interface OnLongPressOptions {
    *
    * @default 500
    */
-  delay?: number
+  delay?: number | ((ev: PointerEvent) => number)
 
   modifiers?: OnLongPressModifiers
 
@@ -64,6 +64,14 @@ export function onLongPress(
     hasLongPressed = false
   }
 
+  function getDelay(ev: PointerEvent): number {
+    const delay = options?.delay
+    if (typeof delay === 'function') {
+      return delay(ev)
+    }
+    return delay ?? DEFAULT_DELAY
+  }
+
   function onRelease(ev: PointerEvent) {
     const [_startTimestamp, _posStart, _hasLongPressed] = [startTimestamp, posStart, hasLongPressed]
     clear()
@@ -108,7 +116,7 @@ export function onLongPress(
         hasLongPressed = true
         handler(ev)
       },
-      options?.delay ?? DEFAULT_DELAY,
+      getDelay(ev),
     )
   }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

This PR is to resolve #4978 
I added `getDelay` to get the final delay value.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
