### PR TITLE
feat(useAsyncState): allow initial value to be a ref

### DIFF
--- a/packages/core/useAsyncState/index.test.ts
+++ b/packages/core/useAsyncState/index.test.ts
@@ -1,6 +1,6 @@
 import { promiseTimeout } from '@vueuse/shared'
 import { describe, expect, it, vi } from 'vitest'
-import { nextTick } from 'vue'
+import { nextTick, shallowRef } from 'vue'
 import { useAsyncState } from './index'
 
 describe('useAsyncState', () => {
@@ -109,5 +109,14 @@ describe('useAsyncState', () => {
     await nextTick()
     expect(mockReportError).toHaveBeenCalledWith(error)
     globalThis.reportError = originalReportError
+  })
+
+  it('supports initialState as shallow ref', async () => {
+    const initialState = shallowRef(200)
+    const asyncValue = Promise.resolve(100)
+    const { state } = useAsyncState(asyncValue, initialState)
+    await asyncValue
+    expect(state.value).toBe(100)
+    expect(initialState).toBe(state)
   })
 })

--- a/packages/core/useAsyncState/index.ts
+++ b/packages/core/useAsyncState/index.ts
@@ -1,6 +1,6 @@
-import type { Ref, ShallowRef, UnwrapRef } from 'vue'
+import type { MaybeRef, Ref, ShallowRef, UnwrapRef } from 'vue'
 import { noop, promiseTimeout, until } from '@vueuse/shared'
-import { ref as deepRef, shallowRef } from 'vue'
+import { ref as deepRef, shallowRef, toValue } from 'vue'
 
 export interface UseAsyncStateReturnBase<Data, Params extends any[], Shallow extends boolean> {
   state: Shallow extends true ? Ref<Data> : Ref<UnwrapRef<Data>>
@@ -81,7 +81,7 @@ export interface UseAsyncStateOptions<Shallow extends boolean, D = any> {
  */
 export function useAsyncState<Data, Params extends any[] = any[], Shallow extends boolean = true>(
   promise: Promise<Data> | ((...args: Params) => Promise<Data>),
-  initialState: Data,
+  initialState: MaybeRef<Data>,
   options?: UseAsyncStateOptions<Shallow, Data>,
 ): UseAsyncStateReturn<Data, Params, Shallow> {
   const {
@@ -100,7 +100,7 @@ export function useAsyncState<Data, Params extends any[] = any[], Shallow extend
 
   async function execute(delay = 0, ...args: any[]) {
     if (resetOnExecute)
-      state.value = initialState
+      state.value = toValue(initialState)
     error.value = undefined
     isReady.value = false
     isLoading.value = true


### PR DESCRIPTION
Outside of typescript, we can already do this if `resetOnExecute: false`.

If it is `true`, we cause a maximum stack call exception since we're setting `ref.value = ref` (infinitely).

This updates the source so you can pass a ref in and we turn it into a value before using it as such.

This means you can now use your own ref:

```ts
const myRef = shallowRef(200);
useAsyncState(asyncPromise, myRef);
// some time later, `myRef.value` is whatever `asyncPromise` resolved to
```

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
