### PR TITLE
test(onLongPress): use custom timer in test assertion

### DIFF
--- a/packages/core/onLongPress/index.test.ts
+++ b/packages/core/onLongPress/index.test.ts
@@ -45,7 +45,7 @@ describe('onLongPress', () => {
     element.value.dispatchEvent(pointerdownEvent)
 
     // wait for 1000ms after pointer down
-    await vi.advanceTimersByTimeAsync(1000)
+    await vi.advanceTimersByTimeAsync(delayFunc ? delayFunc(pointerdownEvent) : 1000)
     expect(onLongPressCallback).toHaveBeenCalledTimes(1)
   }
 
@@ -199,7 +199,7 @@ describe('onLongPress', () => {
       it('should remove event listeners after being stopped', () => stopEventListeners(isRef))
       it('should trigger longpress if pointer is moved', () => triggerCallbackWithThreshold(isRef))
       it('should trigger onMouseUp when pointer is released', () => triggerOnMouseUp(isRef))
-      it('should trigger longpress after options.delay ms when options.delay is a function', () => triggerCallbackWithDelay(isRef, () => 1000))
+      it('should trigger longpress after options.delay ms when options.delay is a function', () => triggerCallbackWithDelay(isRef, () => 2000))
     })
   }
 


### PR DESCRIPTION
The test can pass even if we don't call the callback, currently. This is
because the callback returns the same time as the default.

This updates the test to use a non-default time to prove that the
callback is actually called.
