### PR TITLE
docs: correct deprecated API names

### DIFF
--- a/packages/core/useBluetooth/index.md
+++ b/packages/core/useBluetooth/index.md
@@ -48,7 +48,7 @@ Here, we use the characteristicvaluechanged event listener to handle reading bat
 
 ```vue
 <script setup lang="ts">
-import { pausableWatch, useBluetooth, useEventListener } from '@vueuse/core'
+import { useBluetooth, useEventListener, watchPausable } from '@vueuse/core'
 
 const {
   isSupported,
@@ -89,7 +89,7 @@ async function getBatteryLevels() {
   batteryPercent.value = await batteryLevel.getUint8(0)
 }
 
-const { stop } = pausableWatch(isConnected, (newIsConnected) => {
+const { stop } = watchPausable(isConnected, (newIsConnected) => {
   if (!newIsConnected || !server.value || isGettingBatteryLevels.value)
     return
   // Attempt to get the battery levels of the device:

--- a/packages/core/useMemoize/index.md
+++ b/packages/core/useMemoize/index.md
@@ -33,17 +33,17 @@ getUser.delete(1) // Delete cache from user 1
 getUser.clear() // Clear full cache
 ```
 
-Combine with `computed` or `asyncComputed` to achieve reactivity:
+Combine with `computed` or `computedAsync` to achieve reactivity:
 
 ```ts
-import { asyncComputed, useMemoize } from '@vueuse/core'
+import { computedAsync, useMemoize } from '@vueuse/core'
 
 const getUser = useMemoize(
   async (userId: number): Promise<UserData> =>
     axios.get(`users/${userId}`).then(({ data }) => data),
 )
 // ---cut---
-const user1 = asyncComputed(() => getUser(1))
+const user1 = computedAsync(() => getUser(1))
 // ...
 await getUser.load(1) // Will also update user1
 ```

--- a/packages/guide/config.md
+++ b/packages/guide/config.md
@@ -36,16 +36,16 @@ motionControl.resume()
 
 VueUse's functions follow Vue's reactivity system defaults for [flush timing](https://vuejs.org/guide/essentials/watchers.html#callback-flush-timing) where possible.
 
-For `watch`-like composables (e.g. `pausableWatch`, `whenever`, `useStorage`, `useRefHistory`) the default is `{ flush: 'pre' }`. Which means they will buffer invalidated effects and flush them asynchronously. This avoids unnecessary duplicate invocation when there are multiple state mutations happening in the same "tick".
+For `watch`-like composables (e.g. `watchPausable`, `whenever`, `useStorage`, `useRefHistory`) the default is `{ flush: 'pre' }`. Which means they will buffer invalidated effects and flush them asynchronously. This avoids unnecessary duplicate invocation when there are multiple state mutations happening in the same "tick".
 
 In the same way as with `watch`, VueUse allows you to configure the timing by passing the `flush` option:
 
 ```ts twoslash
-import { pausableWatch } from '@vueuse/core'
+import { watchPausable } from '@vueuse/core'
 import { ref } from 'vue'
 
 const counter = ref(0)
-const { pause, resume } = pausableWatch(
+const { pause, resume } = watchPausable(
   counter,
   () => {
     // Safely access updated DOM
@@ -60,7 +60,7 @@ const { pause, resume } = pausableWatch(
 - `'post'`: async like 'pre' but fires after component updates so you can access the updated DOM
 - `'sync'`: forces the effect to always trigger synchronously
 
-**Note:** For `computed`-like composables (e.g. `syncRef`, `controlledComputed`), when flush timing is configurable, the default is changed to `{ flush: 'sync' }` to align them with the way computed refs works in Vue.
+**Note:** For `computed`-like composables (e.g. `syncRef`, `computedWithControl`), when flush timing is configurable, the default is changed to `{ flush: 'sync' }` to align them with the way computed refs works in Vue.
 
 ### Configurable Global Dependencies
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

These API names were renamed in #1325 for v8.

### Additional context

Is it time to deprecate these alias names?
