### PR TITLE
build: simplify baseConfig setup and improve `dist` output

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -33,7 +33,7 @@ export function createTsDownConfig(
     format.push('es')
   }
 
-  let baseConfig: UserConfig = {
+  const baseConfig: UserConfig = {
     target,
     dts,
     platform: 'browser',
@@ -53,23 +53,25 @@ export function createTsDownConfig(
     ).map(i => i.split('/')[0]))
   }
 
+  const entry: Record<string, string> = {}
+
   for (const fn of functionNames) {
-    baseConfig = {
-      ...baseConfig,
-      entry: {
-        [fn]: fn === 'index' ? 'index.ts' : `${fn}/index.ts`,
-      },
+    const fnEntry = {
+      [fn]: fn === 'index' ? 'index.ts' : `${fn}/index.ts`,
     }
 
-    configs.push({
-      ...baseConfig,
-      format,
-      copy,
-    })
+    Object.assign(entry, fnEntry)
+
+    const info = functions.find(i => i.name === fn)
+
+    if (info?.component) {
+      Object.assign(entry, { [`${fn}/component`]: `${fn}/component.ts` })
+    }
 
     if (iife !== false) {
       const BASE_IIFE_CONFIG: UserConfig = {
         ...baseConfig,
+        entry: fnEntry,
         format: 'iife',
         globalName: iifeName,
         outputOptions: {
@@ -89,18 +91,14 @@ export function createTsDownConfig(
         },
       )
     }
-
-    const info = functions.find(i => i.name === fn)
-
-    if (info?.component) {
-      configs.push({
-        ...baseConfig,
-        entry: {
-          [`${fn}/component`]: `${fn}/component.ts`,
-        },
-      })
-    }
   }
+
+  configs.push({
+    ...baseConfig,
+    entry,
+    format,
+    copy,
+  })
 
   return configs
 }

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -60,14 +60,6 @@ export function createTsDownConfig(
       [fn]: fn === 'index' ? 'index.ts' : `${fn}/index.ts`,
     }
 
-    Object.assign(entry, fnEntry)
-
-    const info = functions.find(i => i.name === fn)
-
-    if (info?.component) {
-      Object.assign(entry, { [`${fn}/component`]: `${fn}/component.ts` })
-    }
-
     if (iife !== false) {
       const BASE_IIFE_CONFIG: UserConfig = {
         ...baseConfig,
@@ -90,6 +82,14 @@ export function createTsDownConfig(
           }),
         },
       )
+    }
+
+    Object.assign(entry, fnEntry)
+
+    const info = functions.find(i => i.name === fn)
+
+    if (info?.component) {
+      Object.assign(entry, { [`${fn}/component`]: `${fn}/component.ts` })
     }
   }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

In PR #5004, to ensure consistency of the output code, when bundling packages with `submodules` set as true, multiple configs are generated based on functions as inputs for `tsdown`. This causes each module to be bundled independently, and repeated logic gets bundled multiple times.

This PR will directly add `key-value` pairs in the `entry` for:
- Faster bundling speed
- Smaller output size.

Below is an example for reference:

#### Build time
[Before](https://github.com/vueuse/vueuse/actions/runs/17378607349/job/49330556476?pr=5004):
<img width="1096" height="595" alt="image" src="https://github.com/user-attachments/assets/476c3cb8-8af5-4109-ab26-d78e06614c68" />

[After](https://github.com/vueuse/vueuse/actions/runs/17557498035/job/49865312905?pr=5021):
<img width="1094" height="598" alt="image" src="https://github.com/user-attachments/assets/acbdcdb9-0d47-48d6-9ca4-9f57a418550a" />

#### Output
Before:
<img width="1150" height="814" alt="image" src="https://github.com/user-attachments/assets/bd961d90-5174-4856-a408-4b86d2083b03" />

After:
<img width="1470" height="918" alt="image" src="https://github.com/user-attachments/assets/3449aaa7-6bf2-4b8d-ab2a-08def573f029" />

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
