### PR TITLE
feat(computedEager): deprecate `computedEager`

### DIFF
--- a/packages/shared/computedEager/index.md
+++ b/packages/shared/computedEager/index.md
@@ -7,6 +7,10 @@ alias: eagerComputed
 
 Eager computed without lazy evaluation.
 
+::: info
+This function will be removed in future version.
+:::
+
 ::: tip
 Note💡: If you are using Vue 3.4+, you can use `computed` right away, you no longer need this function.
 In Vue 3.4+, if the computed new value does not change, `computed`, `effect`, `watch`, `watchEffect`, `render` dependencies will not be triggered.

--- a/packages/shared/computedEager/index.ts
+++ b/packages/shared/computedEager/index.ts
@@ -9,6 +9,9 @@ export type ComputedEagerOptions = WatchOptionsBase
 export type ComputedEagerReturn<T = any> = Readonly<ShallowRef<T>>
 
 /**
+ *
+ * @deprecated This function will be removed in future version.
+ *
  * Note: If you are using Vue 3.4+, you can straight use computed instead.
  * Because in Vue 3.4+, if computed new value does not change,
  * computed, effect, watch, watchEffect, render dependencies will not be triggered.


### PR DESCRIPTION
### Description

This PR deprecates `computedEager`, as since Vue 3.4 the built-in `computed` already avoids triggering dependents when the value is unchanged, and with VueUse v14 requiring Vue 3.5+, users can use the native `computed` directly.

