### PR TITLE
feat: mark watchPausable as deprecated

### DIFF
--- a/packages/shared/watchPausable/index.md
+++ b/packages/shared/watchPausable/index.md
@@ -7,6 +7,10 @@ alias: pausableWatch
 
 Pausable watch
 
+::: info
+This function will be removed in future version.
+:::
+
 ::: tip
 
 [Pausable Watcher](https://vuejs.org/api/reactivity-core.html#watch) has been added to Vue [since 3.5](https://github.com/vuejs/core/pull/9651), use `const { stop, pause, resume } = watch(watchSource, callback)` instead.

--- a/packages/shared/watchPausable/index.ts
+++ b/packages/shared/watchPausable/index.ts
@@ -10,6 +10,9 @@ export interface WatchPausableReturn extends Pausable {
 
 export type WatchPausableOptions<Immediate> = WatchWithFilterOptions<Immediate> & PausableFilterOptions
 
+/**
+ * @deprecated This function will be removed in future version.
+ */
 export function watchPausable<T extends Readonly<WatchSource<unknown>[]>, Immediate extends Readonly<boolean> = false>(sources: [...T], cb: WatchCallback<MapSources<T>, MapOldSources<T, Immediate>>, options?: WatchPausableOptions<Immediate>): WatchPausableReturn
 export function watchPausable<T, Immediate extends Readonly<boolean> = false>(source: WatchSource<T>, cb: WatchCallback<T, Immediate extends true ? T | undefined : T>, options?: WatchPausableOptions<Immediate>): WatchPausableReturn
 export function watchPausable<T extends object, Immediate extends Readonly<boolean> = false>(source: T, cb: WatchCallback<T, Immediate extends true ? T | undefined : T>, options?: WatchPausableOptions<Immediate>): WatchPausableReturn


### PR DESCRIPTION
### Description

This PR deprecates watchPausable, as Vue 3.5’s built‑in watch now provides pause(), resume(), and stop() controls, making the utility redundant; the docs add a removal notice and the API is annotated with @deprecated to guide users to the native watch.

