### PR TITLE
docs: update info block background color

### DIFF
--- a/packages/.vitepress/theme/styles/vars.css
+++ b/packages/.vitepress/theme/styles/vars.css
@@ -19,7 +19,6 @@
   --vp-c-text-light-2: rgba(56 56 56 / 70%);
   --vp-c-text-dark-2: rgba(56 56 56 / 70%);
 
-  --vp-custom-block-info-bg: transparent;
   --vp-custom-block-tip-bg: transparent;
 
   --vp-custom-block-warning-bg: #d9a40605;


### PR DESCRIPTION
### Description

This PR changes the background color of info blocks to make them more visible.

Brfore:

<img width="1280" height="224" alt="CleanShot 2025-09-16 at 22 36 42@2x" src="https://github.com/user-attachments/assets/ec7a0d1c-4a6a-48e2-b9e6-53d9376dc4a3" />

After:

<img width="1406" height="308" alt="CleanShot 2025-09-16 at 22 34 27@2x" src="https://github.com/user-attachments/assets/946cab4f-b035-4c2e-91b7-6393efe2210b" />


