### PR TITLE
fix(shared): support provideLocal/injectLocal in vapor mode

### DIFF
--- a/packages/shared/injectLocal/index.ts
+++ b/packages/shared/injectLocal/index.ts
@@ -1,5 +1,5 @@
 import type { InjectionKey } from 'vue'
-import { getCurrentInstance, hasInjectionContext, inject } from 'vue'
+import { getCurrentInstance, getCurrentScope, hasInjectionContext, inject } from 'vue'
 import { localProvidedStateMap } from '../provideLocal/map'
 
 /**
@@ -17,11 +17,13 @@ import { localProvidedStateMap } from '../provideLocal/map'
 export const injectLocal: typeof inject = <T>(...args) => {
   const key = args[0] as InjectionKey<T> | string | number
   const instance = getCurrentInstance()?.proxy
-  if (instance == null && !hasInjectionContext())
+  const owner = instance ?? getCurrentScope()
+
+  if (owner == null && !hasInjectionContext())
     throw new Error('injectLocal must be called in setup')
 
-  if (instance && localProvidedStateMap.has(instance) && key in localProvidedStateMap.get(instance)!)
-    return localProvidedStateMap.get(instance)![key]
+  if (owner && localProvidedStateMap.has(owner) && key in localProvidedStateMap.get(owner)!)
+    return localProvidedStateMap.get(owner)![key]
 
   // @ts-expect-error overloads are not compatible
   return inject(...args)

--- a/packages/shared/provideLocal/index.ts
+++ b/packages/shared/provideLocal/index.ts
@@ -1,6 +1,6 @@
 import type { InjectionKey } from 'vue'
 import type { LocalProvidedKey } from './map'
-import { getCurrentInstance, provide } from 'vue'
+import { getCurrentInstance, getCurrentScope, provide } from 'vue'
 import { localProvidedStateMap } from './map'
 
 export type ProvideLocalReturn = void
@@ -16,13 +16,15 @@ export type ProvideLocalReturn = void
  */
 export function provideLocal<T, K = LocalProvidedKey<T>>(key: K, value: K extends InjectionKey<infer V> ? V : T): ProvideLocalReturn {
   const instance = getCurrentInstance()?.proxy
-  if (instance == null)
+  const owner = instance ?? getCurrentScope()
+
+  if (owner == null)
     throw new Error('provideLocal must be called in setup')
 
-  if (!localProvidedStateMap.has(instance))
-    localProvidedStateMap.set(instance, Object.create(null))
+  if (!localProvidedStateMap.has(owner))
+    localProvidedStateMap.set(owner, Object.create(null))
 
-  const localProvidedState = localProvidedStateMap.get(instance)!
+  const localProvidedState = localProvidedStateMap.get(owner)!
   // @ts-expect-error allow InjectionKey as key
   localProvidedState[key] = value
   return provide<T, K>(key, value)

--- a/packages/shared/provideLocal/map.ts
+++ b/packages/shared/provideLocal/map.ts
@@ -1,7 +1,9 @@
-import type { InjectionKey } from 'vue'
+import type { EffectScope, InjectionKey } from 'vue'
 import type { InstanceProxy } from '../utils'
 
 export type LocalProvidedKey<T> = InjectionKey<T> | string | number
 export type LocalProvidedState<T> = Record<LocalProvidedKey<T>, unknown>
 
-export const localProvidedStateMap = new WeakMap<InstanceProxy, LocalProvidedState<any>>()
+export type LocalProvidedOwner = InstanceProxy | EffectScope
+
+export const localProvidedStateMap = new WeakMap<LocalProvidedOwner, LocalProvidedState<any>>()


### PR DESCRIPTION
  - fall back to current effect scope when component instance is missing
  - share the same owner lookup between provideLocal and injectLocal
  - allow localProvidedStateMap to key off either component proxies or scopes scopesCloses #4875

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.



<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

### Description

This PR addresses the compatibility issue with Vue's Vapor mode where `getCurrentInstance()` returns `null`, causing `provideLocal` and `injectLocal` to fail. The key changes are:

1. Added fallback to `getCurrentScope()` when component instance is unavailable, ensuring proper context resolution in Vapor mode
2. Unified the owner lookup logic between `provideLocal` and `injectLocal` for consistency
3. Updated `localProvidedStateMap` to support both component proxies and effect scopes as keys

These changes maintain backward compatibility with traditional Vue components while adding support for Vapor mode, where component instances may not be available but effect scopes still provide valid context.

### Additional context

The primary focus of this PR is to maintain the functionality of local injection APIs in environments where component instances aren't available, specifically Vue's new Vapor rendering mode. By using effect scopes as a fallback, we ensure the local provide/inject pattern works consistently across both rendering modes.

Testing should verify:
- Existing functionality remains intact in traditional Vue components
- Proper operation in Vapor mode components
- Correct scoping of provided values when using effect scopes directly

This fix closes #4875 by addressing the root cause of the instance check failure in Vapor mode.
