### PR TITLE
fix(useStorage): preserve updates when key changes

### DIFF
--- a/packages/core/useStorage/index.test.ts
+++ b/packages/core/useStorage/index.test.ts
@@ -571,7 +571,8 @@ describe('useStorage', () => {
     key.value = KEY
     data.value = 3
     await nextTick()
-    expect(storage.getItem(KEY)).toBe('2')
+    expect(data.value).toBe(3)
+    expect(storage.getItem(KEY)).toBe('3')
     expect(storage.getItem(ANOTHER_KEY)).toBe('1')
   })
 
@@ -591,6 +592,19 @@ describe('useStorage', () => {
     key.value = KEY
     await nextTick()
     expect(data.value).toBe(0)
+    expect(storage.getItem(KEY)).toBe('0')
+    expect(storage.getItem(ANOTHER_KEY)).toBe('2')
+  })
+
+  it('keeps the new value when key and value change in the same tick', async () => {
+    const key = deepRef(KEY)
+    const data = useStorage(key, 0, storage)
+
+    key.value = ANOTHER_KEY
+    data.value = 2
+    await nextTick()
+
+    expect(data.value).toBe(2)
     expect(storage.getItem(KEY)).toBe('0')
     expect(storage.getItem(ANOTHER_KEY)).toBe('2')
   })

--- a/packages/core/useStorage/index.ts
+++ b/packages/core/useStorage/index.ts
@@ -179,7 +179,8 @@ export function useStorage<T extends (string | number | boolean | object | null)
     { flush, deep, eventFilter },
   )
 
-  watch(keyComputed, () => update(), { flush })
+  const keyWatcherFlush = flush === 'sync' ? 'sync' : 'post'
+  watch(keyComputed, () => update(), { flush: keyWatcherFlush })
 
   let firstMounted = false
   const onStorageEvent = (ev: StorageEvent): void => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the Contributing Guidelines (https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the Pull Request Guidelines (https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses what the PR is solving, or reference the issue that it solves
(e.g. fixes #4767).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

- adjust the useStorage key watcher to flush in the post phase (sync mode unchanged), ensuring we don’t read from
storage before same-tick explicit writes land.
- add a regression test covering “change key and value within the same tick” to prove the new value now sticks, and
update the prior expectation that relied on the old behaviour.

### Additional context

- tests: pnpm vitest run packages/core/useStorage/index.test.ts
