### PR TITLE
feat: add custom scheduler option to `useIntervalFn-based` composables and unify options

### DIFF
--- a/packages/core/useMemory/index.ts
+++ b/packages/core/useMemory/index.ts
@@ -1,4 +1,4 @@
-import type { UseIntervalFnOptions } from '@vueuse/shared'
+import type { ConfigurableSchedulerImmediate } from '@vueuse/shared'
 import { useIntervalFn } from '@vueuse/shared'
 import { ref as deepRef } from 'vue'
 import { useSupported } from '../useSupported'
@@ -25,8 +25,7 @@ export interface MemoryInfo {
   [Symbol.toStringTag]: 'MemoryInfo'
 }
 
-export interface UseMemoryOptions extends UseIntervalFnOptions {
-  interval?: number
+export interface UseMemoryOptions extends ConfigurableSchedulerImmediate {
 }
 
 type PerformanceMemory = Performance & {
@@ -46,10 +45,16 @@ export function useMemory(options: UseMemoryOptions = {}) {
   const isSupported = useSupported(() => typeof performance !== 'undefined' && 'memory' in performance)
 
   if (isSupported.value) {
-    const { interval = 1000 } = options
-    useIntervalFn(() => {
+    const {
+      scheduler = useIntervalFn,
+      interval = 1000,
+      immediate,
+      immediateCallback,
+    } = options
+
+    scheduler(() => {
       memory.value = (performance as PerformanceMemory).memory
-    }, interval, { immediate: options.immediate, immediateCallback: options.immediateCallback })
+    }, interval, { immediate, immediateCallback })
   }
 
   return { isSupported, memory }

--- a/packages/core/useVibrate/index.ts
+++ b/packages/core/useVibrate/index.ts
@@ -1,11 +1,11 @@
-import type { Pausable } from '@vueuse/shared'
+import type { ConfigurableScheduler, Pausable } from '@vueuse/shared'
 import type { MaybeRefOrGetter } from 'vue'
 import type { ConfigurableNavigator } from '../_configurable'
 import { toRef, useIntervalFn } from '@vueuse/shared'
 import { defaultNavigator } from '../_configurable'
 import { useSupported } from '../useSupported'
 
-export interface UseVibrateOptions extends ConfigurableNavigator {
+export interface UseVibrateOptions extends ConfigurableNavigator, ConfigurableScheduler {
   /**
    *
    * Vibration Pattern
@@ -43,6 +43,9 @@ export interface UseVibrateOptions extends ConfigurableNavigator {
 export function useVibrate(options?: UseVibrateOptions) {
   const {
     pattern = [],
+    scheduler = useIntervalFn,
+    immediate = false,
+    immediateCallback = false,
     interval = 0,
     navigator = defaultNavigator,
   } = options || {}
@@ -66,12 +69,12 @@ export function useVibrate(options?: UseVibrateOptions) {
   }
 
   if (interval > 0) {
-    intervalControls = useIntervalFn(
+    intervalControls = scheduler(
       vibrate,
       interval,
       {
-        immediate: false,
-        immediateCallback: false,
+        immediate,
+        immediateCallback,
       },
     )
   }

--- a/packages/shared/useInterval/index.ts
+++ b/packages/shared/useInterval/index.ts
@@ -1,22 +1,15 @@
 import type { MaybeRefOrGetter, ShallowRef } from 'vue'
-import type { Pausable } from '../utils'
+import type { ConfigurableSchedulerImmediate, Pausable } from '../utils'
 import { shallowReadonly, shallowRef } from 'vue'
 import { useIntervalFn } from '../useIntervalFn'
 
-export interface UseIntervalOptions<Controls extends boolean> {
+export interface UseIntervalOptions<Controls extends boolean> extends Omit<ConfigurableSchedulerImmediate, 'interval'> {
   /**
    * Expose more controls
    *
    * @default false
    */
   controls?: Controls
-
-  /**
-   * Execute the update immediately on calling
-   *
-   * @default true
-   */
-  immediate?: boolean
 
   /**
    * Callback on every interval
@@ -43,7 +36,9 @@ export function useInterval(interval: MaybeRefOrGetter<number>, options: UseInte
 export function useInterval(interval: MaybeRefOrGetter<number> = 1000, options: UseIntervalOptions<boolean> = {}): UseIntervalReturn {
   const {
     controls: exposeControls = false,
+    scheduler = useIntervalFn,
     immediate = true,
+    immediateCallback,
     callback,
   } = options
 
@@ -52,7 +47,7 @@ export function useInterval(interval: MaybeRefOrGetter<number> = 1000, options: 
   const reset = () => {
     counter.value = 0
   }
-  const controls = useIntervalFn(
+  const controls = scheduler(
     callback
       ? () => {
           update()
@@ -60,7 +55,7 @@ export function useInterval(interval: MaybeRefOrGetter<number> = 1000, options: 
         }
       : update,
     interval,
-    { immediate },
+    { immediate, immediateCallback },
   )
 
   if (exposeControls) {

--- a/packages/shared/utils/types.ts
+++ b/packages/shared/utils/types.ts
@@ -1,4 +1,5 @@
-import type { ComputedRef, getCurrentInstance, MaybeRef, Ref, ShallowRef, WatchOptions, WatchSource } from 'vue'
+import type { ComputedRef, getCurrentInstance, MaybeRef, MaybeRefOrGetter, Ref, ShallowRef, WatchOptions, WatchSource } from 'vue'
+import type { useIntervalFn, UseIntervalFnOptions } from '../useIntervalFn'
 
 /**
  * Void function
@@ -146,3 +147,28 @@ export type IsAny<T> = IfAny<T, true, false>
 export type TimerHandle = ReturnType<typeof setTimeout> | undefined
 
 export type InstanceProxy = NonNullable<NonNullable<ReturnType<typeof getCurrentInstance>>['proxy']>
+
+export type IntervalScheduler = (cb: Fn, interval?: MaybeRefOrGetter<number>, options?: { immediate?: boolean }) => Pausable
+
+export interface ConfigurableSchedulerImmediate extends UseIntervalFnOptions {
+  /**
+   *
+   * @default useIntervalFn
+   */
+  scheduler?: typeof useIntervalFn
+  /**
+   *  Interval, in milliseconds.
+   *
+   * @default 1000
+   */
+  interval?: MaybeRefOrGetter<number>
+}
+
+export interface ConfigurableScheduler extends ConfigurableSchedulerImmediate {
+  /**
+   * Start the interval immediately
+   *
+   * @default false
+   */
+  immediate?: boolean
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

This PR unifies the options of composables built on top of `useIntervalFn` and introduces a customizable scheduler option:

- [`useInterval`](https://vueuse.org/useInterval)
- [`useCountDown`](https://vueuse.org/useCountDown)
- [`useMemory`](https://vueuse.org/useMemory)
- [`useVibrate`](https://vueuse.org/useVibrate)
- [`useWebSocket`](https://vueuse.org/useWebSocket) - a bit special

There are also a few functions that currently allow choosing between useRaf and useIntervalFn through an interval option. I didn’t make changes to those in this PR, and I’d like to hear everyone’s thoughts on this.

- [`useElementByPoint`](https://vueuse.org/useElementByPoint)
- [`useNow`](https://vueuse.org/useNow)
- [`useTimestamp`](https://vueuse.org/useTimestamp)

We can update the [configurations documentation](https://vueuse.org/guide/config.html#configurations) once we’ve discussed and agreed on a suitable approach.

### Additional context

Related: #5043

<!-- e.g. is there anything you'd like reviewers to focus on? -->
