### PR TITLE
chore(useDark): test basic usage

### DIFF
--- a/packages/core/useDark/index.test.ts
+++ b/packages/core/useDark/index.test.ts
@@ -102,7 +102,7 @@ describe('useDark', () => {
 
   it('component', async () => {
     const wrapper = mount({
-      render: () => h(UseDark, null, {
+      render: () => h(UseDark, { initialValue: 'light' }, {
         default: ({ toggleDark }: any) => h('button', { onClick: toggleDark }),
       }),
     })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Similar PR to https://github.com/vueuse/vueuse/pull/5073

Just increasing test coverage, `useDark` currently has no tests. I may start using this chore as a way get my brain going in the mornings 🙂

### Additional context

https://app.codecov.io/gh/vueuse/vueuse/blob/main/packages%2Fcore%2FuseDark%2Findex.ts

This function also relies on `useColorMode` and `usePreferredColorScheme`, so some coverage might change there as well.