### PR TITLE
test(useWindowFocus): add test to cover all features

### DIFF
--- a/packages/core/useWindowFocus/index.test.ts
+++ b/packages/core/useWindowFocus/index.test.ts
@@ -1,0 +1,48 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { h, nextTick } from 'vue'
+import { UseWindowFocus } from './component'
+import { useWindowFocus } from './index'
+
+describe('useWindowFocus', () => {
+  it('should be defined', () => {
+    expect(useWindowFocus).toBeDefined()
+  })
+
+  it('should work with event triggers', () => {
+    const focused = useWindowFocus()
+    expect(focused.value).toBeFalsy()
+
+    window.dispatchEvent(new Event('focus'))
+    expect(focused.value).toBeTruthy()
+
+    window.dispatchEvent(new Event('blur'))
+    expect(focused.value).toBeFalsy()
+  })
+
+  describe.sequential('should work with component', async () => {
+    const wrapper = mount({
+      render: () =>
+        h(UseWindowFocus, {}, {
+          default: ({ focused }: { focused: boolean }) => h('span', focused),
+        }),
+    })
+
+    it('should be false with initial', async () => {
+      await nextTick()
+      expect(wrapper.text()).toContain('false')
+    })
+
+    it('should be true with trigger focus event', async () => {
+      window.dispatchEvent(new Event('focus'))
+      await nextTick()
+      expect(wrapper.text()).toContain('true')
+    })
+
+    it('should be false with trigger blur event', async () => {
+      window.dispatchEvent(new Event('blur'))
+      await nextTick()
+      expect(wrapper.text()).toContain('false')
+    })
+  })
+})


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
- Add  test cases covering all functionality of `useWindowFocus`
- Include `methods` and `components`
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
nothings.
