### PR TITLE
fix(type): provide the additional parsing method for $emit parameter to correct the type parser error when using useTemplateRef with component. fixes #5072

### DIFF
--- a/packages/core/unrefElement/index.ts
+++ b/packages/core/unrefElement/index.ts
@@ -1,7 +1,10 @@
 import type { ComponentPublicInstance, MaybeRef, MaybeRefOrGetter } from 'vue'
 import { toValue } from 'vue'
 
-export type VueInstance = ComponentPublicInstance
+type EmitFuncs<T> = T extends (event: infer J, ...args: any[]) => void & infer K ? (event: J extends string ? any : J, ...args: any[]) => void & EmitFuncs<K> : void
+export type VueInstance = {
+  [key in keyof ComponentPublicInstance]: key extends '$emit' ? EmitFuncs<ComponentPublicInstance[key]> : ComponentPublicInstance[key]
+}
 export type MaybeElementRef<T extends MaybeElement = MaybeElement> = MaybeRef<T>
 export type MaybeComputedElementRef<T extends MaybeElement = MaybeElement> = MaybeRefOrGetter<T>
 export type MaybeElement = HTMLElement | SVGElement | VueInstance | undefined | null


### PR DESCRIPTION
…orrect the type #5072

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [ ✅ ] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [ ✅ ] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ ✅ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ✅ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ✅ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
That pr resolve the type error when sub component have `defineEmits`.  See the problem at #5072.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
Thats a quick view of the solution, you can copy the following code into the `script` block of [reproduction](https://stackblitz.com/edit/stackblitz-starters-jqvqqvmh) provided by the issue submitter, and then run `npm run type-check` to see that problem is resolve.
```
<script setup lang="ts">
import { useTemplateRef } from 'vue';
import { useElementSize } from '@vueuse/core';
import type { ComponentPublicInstance } from 'vue';
import Component from './Component.vue';

type EmitFuncs<T> = T extends (event: infer J, ...args: any[]) => void & infer K
  ? (event: J extends string ? any : J, ...args: any[]) => void & EmitFuncs<K>
  : void;
type VueInstance = {
  [key in keyof ComponentPublicInstance]: key extends '$emit'
    ? EmitFuncs<ComponentPublicInstance[key]>
    : ComponentPublicInstance[key];
};

const componentRef = useTemplateRef<VueInstance>('componentRef');
const { width } = useElementSize(componentRef);

const componentConsumeEmitRef = useTemplateRef<VueInstance>(
  'componentConsumeEmitRef'
);
function onComponentMounted() {}
const { width: widthTwo } = useElementSize(componentConsumeEmitRef);
</script>
```