### PR TITLE
fix(useElementSize): width & height should take watched element sizes

### DIFF
--- a/packages/core/useElementSize/index.ts
+++ b/packages/core/useElementSize/index.ts
@@ -70,8 +70,14 @@ export function useElementSize(
   const stop2 = watch(
     () => unrefElement(target),
     (ele) => {
-      width.value = ele ? initialSize.width : 0
-      height.value = ele ? initialSize.height : 0
+      width.value =
+                ele && "offsetWidth" in ele
+                    ? ele.offsetWidth
+                    : initialSize.width;
+      height.value =
+          ele && "offsetHeight" in ele
+              ? ele.offsetHeight
+              : initialSize.height;
     },
   )
 

--- a/packages/core/useElementSize/index.ts
+++ b/packages/core/useElementSize/index.ts
@@ -70,14 +70,14 @@ export function useElementSize(
   const stop2 = watch(
     () => unrefElement(target),
     (ele) => {
-      width.value =
-                ele && "offsetWidth" in ele
-                    ? ele.offsetWidth
-                    : initialSize.width;
-      height.value =
-          ele && "offsetHeight" in ele
-              ? ele.offsetHeight
-              : initialSize.height;
+      width.value
+        = ele && 'offsetWidth' in ele
+          ? ele.offsetWidth
+          : initialSize.width
+      height.value
+        = ele && 'offsetHeight' in ele
+          ? ele.offsetHeight
+          : initialSize.height
     },
   )
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Fix a bug where width and height were set to initial size (0 by default) instead of watched element sizes.

This caused issues when trying to access these values on mount as the watcher watches for a template ref.
