### PR TITLE
feat(useWebSocket): `autoConnect.delay` support function

### DIFF
--- a/packages/core/useWebSocket/index.md
+++ b/packages/core/useWebSocket/index.md
@@ -62,6 +62,32 @@ const { status, data, close } = useWebSocket('ws://websocketurl', {
 })
 ```
 
+You can also pass a function to `delay` to calculate the delay based on the number of retries. This is useful for implementing exponential backoff:
+
+```ts
+import { useWebSocket } from '@vueuse/core'
+// ---cut---
+const { status, data, close } = useWebSocket('ws://websocketurl', {
+  autoReconnect: {
+    retries: 5,
+    // Exponential backoff: 1s, 2s, 4s, 8s, 16s
+    delay: retries => Math.min(1000 * 2 ** (retries - 1), 30000),
+  },
+})
+```
+
+```ts
+import { useWebSocket } from '@vueuse/core'
+// ---cut---
+const { status, data, close } = useWebSocket('ws://websocketurl', {
+  autoReconnect: {
+    retries: 5,
+    // Linear backoff: 1s, 2s, 3s, 4s, 5s
+    delay: retries => retries * 1000,
+  },
+})
+```
+
 Explicitly calling `close()` won't trigger the auto reconnection.
 
 ### heartbeat

--- a/packages/core/useWebSocket/index.ts
+++ b/packages/core/useWebSocket/index.ts
@@ -66,9 +66,11 @@ export interface UseWebSocketOptions {
     /**
      * Delay for reconnect, in milliseconds
      *
+     * Or you can pass a function to calculate the delay based on the number of retries.
+     *
      * @default 1000
      */
-    delay?: number
+    delay?: number | ((retries: number) => number)
 
     /**
      * On maximum retry times reached.
@@ -264,7 +266,8 @@ export function useWebSocket<Data = any>(
 
         if (checkRetires(retried)) {
           retried += 1
-          retryTimeout = setTimeout(_init, delay)
+          const delayTime = typeof delay === 'function' ? delay(retried) : delay
+          retryTimeout = setTimeout(_init, delayTime)
         }
         else {
           onFailed?.()


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

### Description

This PR adds support for an exponential backoff–like strategy in useWebSocket’s reconnection

