### PR TITLE
fix(whenever): improve old value types

### DIFF
--- a/packages/shared/whenever/index.test.ts
+++ b/packages/shared/whenever/index.test.ts
@@ -102,4 +102,43 @@ describe('whenever', () => {
 
     vm.unmount()
   })
+
+  it('immediate', async () => {
+    const vm = useSetup(() => {
+      const number = shallowRef<number | null>(null)
+      const lazyWatchCount = shallowRef(0)
+      const eagerWatchCount = shallowRef(0)
+
+      whenever(number, (value, prevValue) => {
+        lazyWatchCount.value++
+        expectType<number>(value)
+        expectType<number | null>(prevValue)
+      }, { immediate: false })
+
+      whenever(number, (value, prevValue) => {
+        eagerWatchCount.value++
+        expectType<number>(value)
+        expectType<number | null | undefined>(prevValue)
+      }, { immediate: true })
+
+      const changeNumber = (v: number) => number.value = v
+
+      return { number, lazyWatchCount, eagerWatchCount, changeNumber }
+    })
+
+    expect(toValue(vm.lazyWatchCount)).toBe(0)
+    expect(toValue(vm.eagerWatchCount)).toBe(0)
+
+    vm.changeNumber(1)
+    await nextTick()
+    expect(toValue(vm.lazyWatchCount)).toBe(1)
+    expect(toValue(vm.eagerWatchCount)).toBe(1)
+
+    vm.changeNumber(2)
+    await nextTick()
+    expect(toValue(vm.lazyWatchCount)).toBe(2)
+    expect(toValue(vm.eagerWatchCount)).toBe(2)
+
+    vm.unmount()
+  })
 })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Previously, `oldValue` was inferred as `any`, which made it inconsistent with Vue's native `watch` types.
This change ensures that `oldValue` correctly matches the source type (excluding falsy values) and also includes `undefined` when `immediate: true`.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

- The original signature explicitly included `false | null | undefined` in the generic `WatchSource` type. I'm trying to understand in what specific cases these explicit falsy types are required. I replaced them with a generic `T` in the `WatchSource` and applied `Truthy<T>` in the `WatchCallback`, assuming the falsy handling was intended to be type-inferred rather than hardcoded. 
- I wasn't able to remove the `as Truthy<T>` assertion, since `NonNullable<T>` doesn't exclude `false`. Maybe there's a cleaner way to fix it without an explicit cast?
- Regarding the new test: should the reactive changes (`changeNumber`, counters, etc.) remain, or would `expectType` checks be sufficient since this change only affects typing?