### PR TITLE
fix(useInfiniteScroll): make canLoadMore reactive

### DIFF
--- a/packages/core/useInfiniteScroll/index.test.ts
+++ b/packages/core/useInfiniteScroll/index.test.ts
@@ -56,6 +56,74 @@ describe('useInfiniteScroll', () => {
     expect(mockHandler).toHaveBeenCalledTimes(1)
   })
 
+  it('should not call loadMore when canLoadMore returns false', async () => {
+    const mockHandler = vi.fn()
+    const mockElement = givenMockElement()
+    givenElementVisibilityRefMock(true)
+
+    useInfiniteScroll(mockElement, mockHandler, {
+      canLoadMore: () => false,
+    })
+
+    expect(mockHandler).not.toHaveBeenCalled()
+  })
+
+  it('should call loadMore when canLoadMore returns true', async () => {
+    const mockHandler = vi.fn()
+    const mockElement = givenMockElement()
+    givenElementVisibilityRefMock(true)
+
+    useInfiniteScroll(mockElement, mockHandler, {
+      canLoadMore: () => true,
+    })
+
+    expect(mockHandler).toHaveBeenCalledTimes(1)
+  })
+
+  it('should stop calling loadMore when canLoadMore changes from true to false', async () => {
+    const mockHandler = vi.fn()
+    const mockElement = givenMockElement()
+    givenElementVisibilityRefMock(true)
+
+    const canLoad = deepRef(true)
+    const canLoadMoreSpy = vi.fn(() => canLoad.value)
+    useInfiniteScroll(mockElement, mockHandler, {
+      canLoadMore: canLoadMoreSpy,
+    })
+
+    await flushPromises()
+    expect(mockHandler).toHaveBeenCalledTimes(1)
+
+    canLoad.value = false
+
+    mockElement.dispatchEvent(new Event('scroll'))
+    await flushPromises()
+
+    expect(mockHandler).toHaveBeenCalledTimes(1)
+  })
+
+  it('should call loadMore when canLoadMore changes from false to true', async () => {
+    const mockHandler = vi.fn()
+    const mockElement = givenMockElement()
+    givenElementVisibilityRefMock(true)
+
+    const canLoad = deepRef(false)
+    const canLoadMoreSpy = vi.fn(() => canLoad.value)
+    useInfiniteScroll(mockElement, mockHandler, {
+      canLoadMore: canLoadMoreSpy,
+    })
+
+    await flushPromises()
+    expect(mockHandler).not.toHaveBeenCalled()
+
+    canLoad.value = true
+
+    mockElement.dispatchEvent(new Event('scroll'))
+    await flushPromises()
+
+    expect(mockHandler).toHaveBeenCalledTimes(1)
+  })
+
   function givenMockElement({
     scrollHeight = 0,
   } = {}): HTMLDivElement {

--- a/packages/core/useInfiniteScroll/index.ts
+++ b/packages/core/useInfiniteScroll/index.ts
@@ -76,10 +76,16 @@ export function useInfiniteScroll<T extends InfiniteScrollElement>(
 
   const isElementVisible = useElementVisibility(observedElement)
 
+  const canLoad = computed(() => {
+    if (!observedElement.value)
+      return false
+    return canLoadMore(observedElement.value as T)
+  })
+
   function checkAndLoad() {
     state.measure()
 
-    if (!observedElement.value || !isElementVisible.value || !canLoadMore(observedElement.value as T))
+    if (!observedElement.value || !isElementVisible.value || !canLoad.value || promise.value)
       return
 
     const { scrollHeight, clientHeight, scrollWidth, clientWidth } = observedElement.value as HTMLElement
@@ -88,23 +94,21 @@ export function useInfiniteScroll<T extends InfiniteScrollElement>(
       : scrollWidth <= clientWidth
 
     if (state.arrivedState[direction] || isNarrower) {
-      if (!promise.value) {
-        promise.value = Promise.all([
-          onLoadMore(state),
-          new Promise(resolve => setTimeout(resolve, interval)),
-        ])
-          .finally(() => {
-            promise.value = null
-            nextTick(() => checkAndLoad())
-          })
-      }
+      promise.value = Promise.all([
+        onLoadMore(state),
+        new Promise(resolve => setTimeout(resolve, interval)),
+      ])
+        .finally(() => {
+          promise.value = null
+          nextTick(() => checkAndLoad())
+        })
     }
   }
 
   const stop = watch(
-    () => [state.arrivedState[direction], isElementVisible.value],
+    () => [state.arrivedState[direction], isElementVisible.value, canLoad.value],
     checkAndLoad,
-    { immediate: true },
+    { immediate: true, flush: 'post' },
   )
 
   tryOnUnmounted(stop)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Fixes https://github.com/vueuse/vueuse/issues/4762.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
