### PR TITLE
feat(useIntersectionObserver): support `scrollMargin` option

### DIFF
--- a/packages/core/useIntersectionObserver/index.ts
+++ b/packages/core/useIntersectionObserver/index.ts
@@ -27,7 +27,7 @@ export interface UseIntersectionObserverOptions extends ConfigurableWindow {
   rootMargin?: string
 
   /**
-   * A string which specifies a set of offsets to add to the clipping rectangle of 
+   * A string which specifies a set of offsets to add to the clipping rectangle of
    * nested scrollable containers when calculating intersections.
    */
   scrollMargin?: string


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

##### `IntersectionObserver` supports new option `scrollMargin`. Refer to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#scrollmargin)

>[scrollMargin](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#scrollmargin)
Margin around nested [scroll containers](https://developer.mozilla.org/en-US/docs/Glossary/Scroll_container) that takes the same values/has same default as rootMargin. The margins are applied to nested scrollable containers before computing intersections. Positive values grow the clipping rectangle of the container, allowing targets to intersect before they becomes visible, while negative values shrink the clipping rectangle.

---
You will see this ts issue `'scrollMargin' does not exist in type 'IntersectionObserverInit`.

<img width="1395" height="836" alt="image" src="https://github.com/user-attachments/assets/0961060c-16fd-4758-b4df-5341e7c85c90" />


Please ignore it,  the latest ts version(`Typescript@5.9.3`) dosen't support it for now.

Coz, it will be released in next version. Refer to [commit](https://github.com/microsoft/TypeScript/commit/9c4c37704452997d1198ce98c3025d75745d6213)
<img width="1186" height="293" alt="image" src="https://github.com/user-attachments/assets/1d41a775-132b-436a-adfe-564ba4e735c7" />

This is a very new option ^_^.

### Additional context
Can I Use:
<img width="1364" height="476" alt="image" src="https://github.com/user-attachments/assets/72e5df4c-04c7-48c6-9025-4fd12901d429" />
