### PR TITLE
fix(types): allow async functions in useDebounceFn and useThrottleFn

### DIFF
--- a/packages/shared/utils/filters.ts
+++ b/packages/shared/utils/filters.ts
@@ -4,7 +4,7 @@ import { isRef, readonly, toValue } from 'vue'
 import { toRef } from '../toRef'
 import { noop } from './is'
 
-export type FunctionArgs<Args extends any[] = any[], Return = any> = (...args: Args) => Return
+export type FunctionArgs<Args extends any[] = any[], Return = unknown> = (...args: Args) => Return
 
 export interface FunctionWrapperOptions<Args extends any[] = any[], This = any> {
   fn: FunctionArgs<Args, This>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description
Resolve #4082 
Fixes TypeScript ESLint warning when passing async functions to [useDebounceFn](file:///Volumes/M2/vueuse/packages/shared/useDebounceFn/index.ts#L18-L27) and [useThrottleFn](file:///Volumes/M2/vueuse/packages/shared/useThrottleFn/index.ts#L23-L34).

When using the `@typescript-eslint/no-misused-promises` rule, passing async functions (or any function returning a Promise) to [useDebounceFn](file:///Volumes/M2/vueuse/packages/shared/useDebounceFn/index.ts#L18-L27) or [useThrottleFn](file:///Volumes/M2/vueuse/packages/shared/useThrottleFn/index.ts#L23-L34) triggers the following warning:

### Additional context

```typescript
// Before
export type FunctionArgs<Args extends any[] = any[], Return = void> = (...args: Args) => Return

// After  
export type FunctionArgs<Args extends any[] = any[], Return = any> = (...args: Args) => Return
