### PR TITLE
fix(useInfiniteScroll): clear pending promise `onUnmounted` to avoid stale finally calls

### DIFF
--- a/packages/core/useInfiniteScroll/index.ts
+++ b/packages/core/useInfiniteScroll/index.ts
@@ -84,6 +84,10 @@ export function useInfiniteScroll<T extends InfiniteScrollElement>(
   })
 
   function checkAndLoad() {
+    // might be triggered asynchronously
+    if (unmounted.value)
+      return
+
     state.measure()
 
     if (!observedElement.value || !isElementVisible.value || !canLoad.value)
@@ -102,10 +106,7 @@ export function useInfiniteScroll<T extends InfiniteScrollElement>(
         ])
           .finally(() => {
             promise.value = null
-            nextTick(() => {
-              if (!unmounted.value)
-                checkAndLoad()
-            })
+            nextTick(() => checkAndLoad())
           })
       }
     }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

This prevents the `finally` callback from executing after the instance has been destroyed, avoiding potential memory leaks or unexpected reloads.

### Additional context

This is also an attempt to fix the `getComputedStyle` errors in our CI.
