### PR TITLE
docs(useVirtualList): remove confusing words in demo

### DIFF
--- a/packages/core/useVirtualList/demo.vue
+++ b/packages/core/useVirtualList/demo.vue
@@ -42,7 +42,7 @@ function handleScrollTo() {
     <div>
       <div class="inline-block mr-4">
         Filter list by size
-        <input v-model="search" placeholder="e.g. small, medium, large" type="search">
+        <input v-model="search" placeholder="e.g. small, large" type="search">
       </div>
     </div>
     <div v-bind="containerProps" class="h-300px overflow-auto p-2 bg-gray-500/5 rounded">


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the `https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md` .
- [x] Read the `https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md` .
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

This PR fixes a minor inconsistency in the `useVirtualList` demo. The placeholder text in the search input mentioned "e.g. small, medium, large" but the actual data only contains "small" and "large" sizes. This could confuse users who might try to filter by "medium" and get no results.

The change updates the placeholder text from "e.g. small, medium, large" to "e.g. small, large" to accurately reflect the available data options.

### Additional context

This is a small UI consistency fix that improves user experience by ensuring the placeholder text matches the actual data options. No functional changes were made to the `useVirtualList` function itself, only the demo UI was updated.

Since this is a minor documentation/demo fix, no additional tests are needed.