### PR TITLE
fix: typescript type of `isIOS` constant

### DIFF
--- a/packages/shared/utils/is.ts
+++ b/packages/shared/utils/is.ts
@@ -23,8 +23,8 @@ export const hasOwn = <T extends object, K extends keyof T>(val: T, key: K): key
 
 export const isIOS = /* #__PURE__ */ getIsIOS()
 
-function getIsIOS() {
-  return isClient && window?.navigator?.userAgent && (
+function getIsIOS(): boolean {
+  return isClient && !!window?.navigator?.userAgent && (
     (/iP(?:ad|hone|od)/.test(window.navigator.userAgent))
     // The new iPad Pro Gen3 does not identify itself as iPad, but as Macintosh.
     // https://github.com/vueuse/vueuse/issues/3577


### PR DESCRIPTION
The automatic typing of this constant right now is `boolean | ""`, due to the && usage. This is a possible value if `window.navigator.userAgent` is the empty string. While unlikely, it is easy to correctly handle this case and always return a boolean value.

```js
> ua = ""
''
// broken
> true && ua && (/iP(?:ad|hone|od)/.test(ua))
''
// fixed
> true && !!ua && (/iP(?:ad|hone|od)/.test(ua))
false
```

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).