### PR TITLE
feat(useDropZone): add checkValidity function

### DIFF
--- a/packages/core/useDropZone/index.ts
+++ b/packages/core/useDropZone/index.ts
@@ -16,6 +16,11 @@ export interface UseDropZoneOptions {
    * Also can be a function to check the data types.
    */
   dataTypes?: MaybeRef<readonly string[]> | ((types: readonly string[]) => boolean)
+  /**
+   * Similar to dataTypes, but exposes the DataTransferItemList for custom validation.
+   * If provided, this function takes precedence over dataTypes.
+   */
+  checkValidity?: (items: DataTransferItemList) => boolean
   onDrop?: (files: File[] | null, event: DragEvent) => void
   onEnter?: (files: File[] | null, event: DragEvent) => void
   onLeave?: (files: File[] | null, event: DragEvent) => void
@@ -67,6 +72,10 @@ export function useDropZone(
     }
 
     const checkValidity = (items: DataTransferItemList) => {
+      if (_options.checkValidity) {
+        return _options.checkValidity(items)
+      }
+
       const types = Array.from(items ?? []).map(item => item.type)
 
       const dataTypesValid = checkDataTypes(types)


### PR DESCRIPTION

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This change adds a new `checkValidity` option for custom validation of dropped items to give users more control over the items allowed to drop than only `dataTypes`.

For me, this fixes this very concrete problem:

In my app, there is an editor, where users can drag text around. Having a global dropzone to upload files will also intercept this text dragging and dropping. For `dataTypes`, text that's dragged around from an editor also has a type of `text/plain`, the same as a `.txt` file. This makes it impossible to distinguish between a text file (which is a legitimate upload file) and text the user is dragging around in the editor. Exposing the `DataTransferItemList` for filtering allows me to use the `kind` property of one of these items to filter the dropzone for files only.

