### PR TITLE
fix(useClipboard): add readonly attribute to textarea fallback to support Safari 15

### DIFF
--- a/packages/core/useClipboard/index.ts
+++ b/packages/core/useClipboard/index.ts
@@ -114,6 +114,7 @@ export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<strin
     ta.value = value
     ta.style.position = 'absolute'
     ta.style.opacity = '0'
+    ta.setAttribute('readonly', '')
     document.body.appendChild(ta)
     ta.select()
     document.execCommand('copy')


### PR DESCRIPTION
Fixes #5178 

This PR fixes a compatibility issue in old Safari (<=15.6) where 
document.execCommand('copy') does not work if the textarea used 
for fallback copy is editable.

Safari requires the textarea to be readonly in order to allow 
select() + execCommand('copy') to succeed.

Adding:

ta.setAttribute('readonly', '')

resolves the issue on macOS 10.15.7 Safari 15.6.1 and does not
affect behavior on other browsers.

Tested in Chrome, Firefox, and Safari 17.
