### PR TITLE
docs: document differences between VueUse toRef and Vue’s toRef

### DIFF
--- a/packages/shared/toRef/index.md
+++ b/packages/shared/toRef/index.md
@@ -27,16 +27,16 @@ VueUse's `toRef` is not the same as Vue’s `toRef` from the `vue` package.
 
 - Accepts **value**, **ref**, or **getter**
 - Returns:
-  - a **ref** for primitive values  
-  - a **ref** for existing refs  
-  - a **computed** for getter functions  
+  - a **ref** for primitive values
+  - a **ref** for existing refs
+  - a **computed** for getter functions
 - Does **not** accept `object + key`
 - Getters always produce readonly computed values
 
 ### Vue `toRef`
 
 - Accepts only:
-  - a **reactive object + property key**, or  
+  - a **reactive object + property key**, or
   - an existing **ref**
 - Produces a **writable ref** linked to the underlying reactive object
 - Does **not** accept primitive values
@@ -44,12 +44,11 @@ VueUse's `toRef` is not the same as Vue’s `toRef` from the `vue` package.
 
 ### Summary
 
-| Behavior                 | VueUse `toRef`       | Vue `toRef` |
-|-------------------------|----------------------|-------------|
-| Accepts primitive values | ✔️                   | ❌          |
-| Accepts getter           | ✔️ (computed)        | ❌          |
-| Accepts existing ref     | ✔️                   | ✔️          |
-| Accepts object + key     | ❌                   | ✔️          |
-| Writable                 | ✔️ (except getter)   | ✔️          |
+| Behavior                 | VueUse `toRef`            | Vue `toRef`             |
+| ------------------------ | ------------------------- | ----------------------- |
+| Accepts primitive values | ✔️                        | ❌                      |
+| Accepts getter           | ✔️ (computed)             | ❌                      |
+| Accepts existing ref     | ✔️                        | ✔️                      |
+| Accepts object + key     | ❌                        | ✔️                      |
+| Writable                 | ✔️ (except getter)        | ✔️                      |
 | Purpose                  | Normalize to ref/computed | Bind to reactive object |
-


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

This PR clarifies the differences between VueUse's `toRef` and Vue's native `toRef`.

- VueUse `toRef` accepts values, refs, and getters.
- Vue's `toRef` only works with reactive object + key or existing refs.
- VueUse returns `computed` for getters.
- Vue's version never accepts getters or primitive values.
- Added summary table for clearer comparison.

This resolves issue #5126.


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
