### PR TITLE
chore: dont use deprecated api internally

### DIFF
--- a/packages/core/useStorage/index.ts
+++ b/packages/core/useStorage/index.ts
@@ -2,7 +2,7 @@ import type { Awaitable, ConfigurableEventFilter, ConfigurableFlush, RemovableRe
 import type { MaybeRefOrGetter } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
 import type { StorageLike } from '../ssr-handlers'
-import { pausableWatch, tryOnMounted } from '@vueuse/shared'
+import { tryOnMounted, watchPausable } from '@vueuse/shared'
 import { computed, ref as deepRef, nextTick, shallowRef, toValue, watch } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { getSSRHandler } from '../ssr-handlers'
@@ -173,7 +173,7 @@ export function useStorage<T extends (string | number | boolean | object | null)
   const type = guessSerializerType<T>(rawInit)
   const serializer = options.serializer ?? StorageSerializers[type]
 
-  const { pause: pauseWatch, resume: resumeWatch } = pausableWatch(
+  const { pause: pauseWatch, resume: resumeWatch } = watchPausable(
     data,
     newValue => write(newValue),
     { flush, deep, eventFilter },

--- a/packages/core/useUrlSearchParams/index.ts
+++ b/packages/core/useUrlSearchParams/index.ts
@@ -1,5 +1,5 @@
 import type { ConfigurableWindow } from '../_configurable'
-import { pausableWatch } from '@vueuse/shared'
+import { watchPausable } from '@vueuse/shared'
 import { nextTick, reactive } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useEventListener } from '../useEventListener'
@@ -115,7 +115,7 @@ export function useUrlSearchParams<T extends Record<string, any> = UrlParams>(
     Array.from(unusedKeys).forEach(key => delete state[key])
   }
 
-  const { pause, resume } = pausableWatch(
+  const { pause, resume } = watchPausable(
     state,
     () => {
       const params = new URLSearchParams('')

--- a/packages/shared/syncRef/index.ts
+++ b/packages/shared/syncRef/index.ts
@@ -1,7 +1,7 @@
 import type { Ref } from 'vue'
 import type { ConfigurableFlushSync } from '../utils'
 import type { WatchPausableReturn } from '../watchPausable'
-import { pausableWatch } from '../watchPausable'
+import { watchPausable } from '../watchPausable'
 
 type Direction = 'ltr' | 'rtl' | 'both'
 type SpecificFieldPartial<T, K extends keyof T> = Partial<Pick<T, K>> & Omit<T, K>
@@ -151,7 +151,7 @@ export function syncRef<L, R, D extends Direction = 'both'>(
   const transformRTL = ('rtl' in transform && transform.rtl) || (v => v)
 
   if (direction === 'both' || direction === 'ltr') {
-    watchers.push(pausableWatch(
+    watchers.push(watchPausable(
       left,
       (newValue) => {
         watchers.forEach(w => w.pause())
@@ -163,7 +163,7 @@ export function syncRef<L, R, D extends Direction = 'both'>(
   }
 
   if (direction === 'both' || direction === 'rtl') {
-    watchers.push(pausableWatch(
+    watchers.push(watchPausable(
       right,
       (newValue) => {
         watchers.forEach(w => w.pause())


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

`pausableWatch` was deprecated in #5009

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
