### PR TITLE
fix(useAxios): handle optional response data safely

### DIFF
--- a/packages/integrations/useAxios/index.ts
+++ b/packages/integrations/useAxios/index.ts
@@ -250,7 +250,7 @@ export function useAxios<T = any, R = AxiosResponse<T>, D = any>(...args: any[])
         if (isAborted.value)
           return
         response.value = r
-        const result = r.data
+        const result = r?.data
         data.value = result
         onSuccess(result)
       })


### PR DESCRIPTION
When cancelling duplicate requests, the error message "Cannot read properties of undefined (reading 'data')" appears.


<img width="428" height="36" alt="image" src="https://github.com/user-attachments/assets/83680cc0-3364-4ee6-9d63-4e6de8cefc3b" />
