### PR TITLE
docs(refAutoReset): clarify deep update

### DIFF
--- a/packages/shared/refAutoReset/index.md
+++ b/packages/shared/refAutoReset/index.md
@@ -21,5 +21,7 @@ function setMessage() {
 ```
 
 ::: info
-You can use `triggerRef` to trigger effects after making deep mutations to the inner value of a refAutoReset.
+You can reassign the entire object to trigger updates after making deep mutations to the inner value.
+
+[Learn more about shallow refs →](https://vuejs.org/api/reactivity-advanced#shallowref)
 :::


### PR DESCRIPTION
### Description

Clarify the documentation for `refAutoReset` regarding deep mutations.
### Additional context

https://github.com/vueuse/vueuse/issues/3839#issuecomment-3489264689
