### PR TITLE
chore(useIntersectionObserver): Align rootBounds assertion to the same callback entry in useIntersectionObserver test

### DIFF
--- a/packages/core/useIntersectionObserver/index.browser.test.ts
+++ b/packages/core/useIntersectionObserver/index.browser.test.ts
@@ -109,7 +109,7 @@ describe('useIntersectionObserver', () => {
       await vi.waitFor(() => {
         expect(callbackMock).toHaveBeenCalledTimes(2)
         expect(callbackMock.mock.calls[1][0][0].isIntersecting).toBe(true)
-        expect(callbackMock.mock.calls[0][0][0].rootBounds!.height).toBe(200)
+        expect(callbackMock.mock.calls[1][0][0].rootBounds!.height).toBe(200)
       })
     })
 


### PR DESCRIPTION
### Description
In it('can specify different root'), read rootBounds from the same (second) callback entry as the isIntersecting check (mock.calls[1][0][0]), ensuring both assertions refer to the same invocation and avoiding mixing data across calls.
