### PR TITLE
feat(nuxt): auto-register directives from @vueuse/components

### DIFF
--- a/packages/nuxt/index.ts
+++ b/packages/nuxt/index.ts
@@ -107,7 +107,7 @@ export default defineNuxtModule<VueUseNuxtOptions>({
     })
 
     if (options.autoImports) {
-      // auto import
+      // auto import functions
       nuxt.hook('imports:sources', (sources: (Import | Preset)[]) => {
         if (sources.find(i => fullPackages.includes((i as Import).from)))
           return
@@ -152,6 +152,44 @@ export default defineNuxtModule<VueUseNuxtOptions>({
             imports,
             priority: -1,
           })
+        }
+
+        // Auto-import directives from @vueuse/components if installed
+        if (isPackageExists(
+          '@vueuse/components',
+          { paths: nuxt.options._layers.map(layer => layer.config.rootDir) },
+        )) {
+          const directiveImports = metadata
+            .functions
+            .filter(i => i.directive && !i.internal)
+            .map((i): Import => {
+              // Convert function name to directive name
+              // onClickOutside -> vOnClickOutside
+              // useElementSize -> vElementSize
+              const directiveName = i.name.startsWith('on')
+                ? `v${i.name.charAt(0).toUpperCase()}${i.name.slice(1)}`
+                : `v${i.name.replace(/^use/, '')}`
+
+              return {
+                from: '@vueuse/components',
+                name: directiveName,
+                as: directiveName,
+                priority: -1,
+                meta: {
+                  description: `Directive version of ${i.name}`,
+                  docsUrl: i.docs,
+                  category: i.category,
+                },
+              }
+            })
+
+          if (directiveImports.length > 0) {
+            sources.push({
+              from: '@vueuse/components',
+              imports: directiveImports,
+              priority: -1,
+            })
+          }
         }
       })
     }


### PR DESCRIPTION
## Description

Closes #5203

When \`@vueuse/components\` is installed, the Nuxt module now automatically imports directives like \`vOnClickOutside\`, \`vElementSize\`, etc.

This brings parity with the existing function auto-imports and allows users to use directives directly in templates without manual imports.

## Usage

\`\`\`vue
<template>
  <div v-on-click-outside="handleClick">...</div>
  <div v-element-size="handleResize">...</div>
</template>
\`\`\`

## How it works

- The module checks if \`@vueuse/components\` is installed (using \`isPackageExists\`)
- If installed, it generates directive imports from the metadata
- Directive names are derived from function names:
  - \`onClickOutside\` → \`vOnClickOutside\`
  - \`useElementSize\` → \`vElementSize\`
  - etc.

## Supported Directives

All directives from \`@vueuse/components\` are supported:
- \`vOnClickOutside\`
- \`vOnKeyStroke\`
- \`vOnLongPress\`
- \`vElementBounding\`
- \`vElementHover\`
- \`vElementSize\`
- \`vElementVisibility\`
- \`vInfiniteScroll\`
- \`vIntersectionObserver\`
- \`vMouseInElement\`
- \`vResizeObserver\`
- \`vScroll\`
- \`vScrollLock\`

## Checklist

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md)
- [x] Read the [docs](https://vueuse.org/guide)