### PR TITLE
fix(refManualReset): add explicit return type annotation

### DIFF
--- a/packages/shared/refManualReset/index.ts
+++ b/packages/shared/refManualReset/index.ts
@@ -18,7 +18,7 @@ export interface ManualResetRefReturn<T> extends Ref<T> {
  * @see https://vueuse.org/refManualReset
  * @param defaultValue The value which will be set.
  */
-export function refManualReset<T>(defaultValue: MaybeRefOrGetter<T>) {
+export function refManualReset<T>(defaultValue: MaybeRefOrGetter<T>): ManualResetRefReturn<T> {
   let value: T = toValue(defaultValue)
   let trigger: Fn
 


### PR DESCRIPTION
Added explicit return type `ManualResetRefReturn<T>` to fix TypeScript declaration generation issues.

  Closes #5232

  ### Before submitting the PR, please make sure you do the following

  - [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
  - [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
  - [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
  - [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
  - [ ] Ideally, include relevant tests that fail without this PR but pass with it.

  ---

  ### Description

  Added explicit return type `ManualResetRefReturn<T>` to `refManualReset` function.

  The function was missing an explicit return type annotation, which caused TypeScript declaration files (.d.ts) to not properly export the type information. This made `refManualReset` unusable when imported as an npm package.

  Fixes #5232

  ### Additional context

  Simple one-line fix. The interface `ManualResetRefReturn<T>` was already defined but not used in the function signature.