### PR TITLE
chore(useEventSource): make 'message' events trigger only onmessage →…

### DIFF
--- a/packages/core/useEventSource/index.ts
+++ b/packages/core/useEventSource/index.ts
@@ -133,6 +133,8 @@ export function useEventSource<Events extends string[], Data = any>(
   let explicitlyClosed = false
   let retried = 0
 
+  const DEFAULT_EVENT = 'message'
+
   const {
     withCredentials = false,
     immediate = true,
@@ -192,12 +194,12 @@ export function useEventSource<Events extends string[], Data = any>(
     }
 
     es.onmessage = (e: MessageEvent) => {
-      event.value = null
+      event.value = DEFAULT_EVENT
       data.value = serializer.read(e.data) ?? null
       lastEventId.value = e.lastEventId
     }
-
-    for (const event_name of events) {
+    const customEvents = events.filter(e => e !== DEFAULT_EVENT)
+    for (const event_name of customEvents) {
       useEventListener(es, event_name, (e: Event & { data?: string, lastEventId?: string }) => {
         event.value = event_name
         data.value = serializer.read(e.data) ?? null


### PR DESCRIPTION

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
1. If ‘message’ is added to the second parameter event, both onmessage and the ‘message’ event listener will be triggered, causing unnecessary calls.
2. The default event is currently null, but per the SSE specification, if the backend doesn’t provide an event type, the browser treats it as 'message'. To align with browser behavior we should set the default to 'message'.
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
