### PR TITLE
fix(useUrlSearchParams): Prevent "params.keys() is not iterable" in Firefox content scripts

### DIFF
--- a/packages/core/useUrlSearchParams/index.test.ts
+++ b/packages/core/useUrlSearchParams/index.test.ts
@@ -384,4 +384,27 @@ describe('useUrlSearchParams', () => {
     window.location.hash = newHash
     expect(window.location.hash).toBe(newHash)
   })
+
+  it('works when URLSearchParams.keys() iterator is not iterable', async () => {
+    const originalKeys = URLSearchParams.prototype.keys
+
+    URLSearchParams.prototype.keys = function () {
+      const iterator = originalKeys.call(this)
+      return Object.assign(iterator, { [Symbol.iterator]: undefined })
+    }
+
+    try {
+      window.location.search = '?test=value&foo=bar&foo=baz'
+
+      const params = useUrlSearchParams('history')
+
+      await nextTick()
+
+      expect(params.test).toBe('value')
+      expect(params.foo).toEqual(['bar', 'baz'])
+    }
+    finally {
+      URLSearchParams.prototype.keys = originalKeys
+    }
+  })
 })

--- a/packages/core/useUrlSearchParams/index.ts
+++ b/packages/core/useUrlSearchParams/index.ts
@@ -105,7 +105,7 @@ export function useUrlSearchParams<T extends Record<string, any> = UrlParams>(
 
   function updateState(params: URLSearchParams) {
     const unusedKeys = new Set(Object.keys(state))
-    for (const key of params.keys()) {
+    for (const [key] of params) {
       const paramsForKey = params.getAll(key)
       state[key] = paramsForKey.length > 1
         ? paramsForKey
@@ -175,7 +175,7 @@ export function useUrlSearchParams<T extends Record<string, any> = UrlParams>(
     useEventListener(window, 'hashchange', onChanged, listenerOptions)
 
   const initial = read()
-  if (initial.keys().next().value)
+  if (initial.toString())
     updateState(initial)
   else
     Object.assign(state, initialValue)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

### Description

In the context of Firefox content scripts (for instance Firefox extensions), [`UrlSearchParams.keys()` is not iterable](https://bugzilla.mozilla.org/show_bug.cgi?id=1023984), making `useUrlSearchParams()` throw the error `TypeError: params.keys() is not iterable`.

This PR avoids the need to use `URLSearchParams.prototype.keys`. The behavior of the composable stays the same.