### PR TITLE
feat(useDebounceFn): add cancel method and pending state

### DIFF
--- a/packages/shared/useDebounceFn/demo.vue
+++ b/packages/shared/useDebounceFn/demo.vue
@@ -18,8 +18,14 @@ function clickedFn() {
   <button @click="clickedFn">
     Smash me!
   </button>
+
+  <button :disabled="!debouncedFn.pending" @click="debouncedFn.cancel()">
+    Cancel
+  </button>
+
   <note>Delay is set to 1000ms and maxWait is set to 5000ms for this demo.</note>
 
   <p>Button clicked: {{ clicked }}</p>
   <p>Event handler called: {{ updated }}</p>
+  <p>Pending: {{ debouncedFn.pending }}</p>
 </template>

--- a/packages/shared/useDebounceFn/index.md
+++ b/packages/shared/useDebounceFn/index.md
@@ -72,6 +72,45 @@ debouncedRequest()
 setTimeout(debouncedRequest, 500)
 ```
 
+## Cancel
+
+You can cancel any pending execution by calling the `cancel` method on the debounced function.
+
+```ts
+import { useDebounceFn } from '@vueuse/core'
+
+const debouncedFn = useDebounceFn(() => {
+  // do something
+}, 1000)
+
+debouncedFn()
+
+// Cancel the pending execution before it runs
+debouncedFn.cancel()
+```
+
+This is useful when you need to prevent the debounced function from executing, for example, when a component is unmounted or when user input changes context.
+
+## Pending State
+
+You can check if there's a pending execution using the `pending` property.
+
+```ts
+import { useDebounceFn } from '@vueuse/core'
+
+const debouncedFn = useDebounceFn(() => {
+  // do something
+}, 1000)
+
+debouncedFn()
+debouncedFn.pending // true
+
+// After debounce time elapses or cancel is called
+debouncedFn.pending // false
+```
+
+This is useful for showing loading indicators or disabling UI elements while waiting for the debounced function to execute.
+
 ## Recommended Reading
 
 - [**Debounce vs Throttle**: Definitive Visual Guide](https://kettanaito.com/blog/debounce-vs-throttle)

--- a/packages/shared/useDebounceFn/index.ts
+++ b/packages/shared/useDebounceFn/index.ts
@@ -1,8 +1,8 @@
 import type { MaybeRefOrGetter } from 'vue'
-import type { DebounceFilterOptions, FunctionArgs, PromisifyFn } from '../utils'
+import type { CancelablePromisifyFn, DebounceFilterOptions, FunctionArgs } from '../utils'
 import { createFilterWrapper, debounceFilter } from '../utils'
 
-export type UseDebounceFnReturn<T extends FunctionArgs> = PromisifyFn<T>
+export type UseDebounceFnReturn<T extends FunctionArgs> = CancelablePromisifyFn<T>
 
 /**
  * Debounce execution of a function.
@@ -12,7 +12,7 @@ export type UseDebounceFnReturn<T extends FunctionArgs> = PromisifyFn<T>
  * @param  ms          A zero-or-greater delay in milliseconds. For event callbacks, values around 100 or 250 (or even higher) are most useful.
  * @param  options     Options
  *
- * @return A new, debounce, function.
+ * @return A new, debounce, function with a `cancel` method to cancel any pending execution.
  *
  * @__NO_SIDE_EFFECTS__
  */


### PR DESCRIPTION
## Summary
- Add `cancel()` method to cancel pending debounced executions
- Add reactive `pending` property to track execution state
- Update demo to showcase cancel and pending functionality

## Test plan
- [x] Unit tests added for cancel functionality
- [x] Unit tests added for pending state tracking
- [x] Manual testing with Playwright verified reactive behavior
- [x] All existing tests pass (1403 tests)

Closes #4561