### PR TITLE
fix(useVirtualList): react to changes made in mutable arrays properly

### DIFF
--- a/packages/core/useVirtualList/index.test.ts
+++ b/packages/core/useVirtualList/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref as deepRef } from 'vue'
+import { ref as deepRef, nextTick } from 'vue'
 import { useVirtualList } from './index'
 
 describe('useVirtualList', () => {
@@ -139,5 +139,25 @@ describe('useVirtualList, horizontal', () => {
 
     expect(readonlyList.value).toBeDefined()
     expect(mutableList.value).toBeDefined()
+  })
+
+  it('reacts to changes in a source ref when mutated if no size changes are made to the container', async () => {
+    const mutableInput = deepRef(['a', 'b'])
+
+    const {
+      list,
+      containerProps: { ref: containerRef },
+      scrollTo,
+    } = useVirtualList(mutableInput, { itemHeight: () => 10 })
+
+    containerRef.value = { ...document.createElement('div'), clientHeight: 100 }
+    scrollTo(0)
+
+    expect(list.value.map(i => i.data)).toEqual(['a', 'b'])
+
+    mutableInput.value.push('c', 'd')
+    await nextTick()
+
+    expect(list.value.map(i => i.data)).toEqual(['a', 'b', 'c', 'd'])
   })
 })

--- a/packages/core/useVirtualList/index.ts
+++ b/packages/core/useVirtualList/index.ts
@@ -1,5 +1,5 @@
 import type { ComputedRef, MaybeRef, Ref, ShallowRef, StyleValue } from 'vue'
-import { computed, ref as deepRef, shallowRef, toValue, watch } from 'vue'
+import { computed, ref as deepRef, shallowRef, watch } from 'vue'
 import { useElementSize } from '../useElementSize'
 
 type UseVirtualListItemSize = number | ((index: number) => number)
@@ -200,8 +200,8 @@ function createGetDistance<T>(itemSize: UseVirtualListItemSize, source: UseVirtu
   }
 }
 
-function useWatchForSizes<T>(size: UseVirtualElementSizes, list: MaybeRef<readonly T[]>, containerRef: Ref<HTMLElement | null>, calculateRange: () => void) {
-  watch([size.width, size.height, () => toValue(list), containerRef], () => {
+function useWatchForSizes<T>(size: UseVirtualElementSizes, listRef: Ref<readonly T[]>, containerRef: Ref<HTMLElement | null>, calculateRange: () => void) {
+  watch([size.width, size.height, listRef, containerRef], () => {
     calculateRange()
   })
 }
@@ -248,7 +248,7 @@ function useHorizontalVirtualList<T>(options: UseHorizontalVirtualListOptions, l
 
   const totalWidth = createComputedTotalSize(itemWidth, source)
 
-  useWatchForSizes(size, list, containerRef, calculateRange)
+  useWatchForSizes(size, source, containerRef, calculateRange)
 
   const scrollTo = createScrollTo('horizontal', calculateRange, getDistanceLeft, containerRef)
 
@@ -294,7 +294,7 @@ function useVerticalVirtualList<T>(options: UseVerticalVirtualListOptions, list:
 
   const totalHeight = createComputedTotalSize(itemHeight, source)
 
-  useWatchForSizes(size, list, containerRef, calculateRange)
+  useWatchForSizes(size, source, containerRef, calculateRange)
 
   const scrollTo = createScrollTo('vertical', calculateRange, getDistanceTop, containerRef)
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

---

### Description

Due to the use of `toValue` in the original watch code, the watcher that updates the list returned to the caller would not execute unless the actual value of the array changed (meaning it was treated as immutable), or if the change to the array also resulted in a change to the size of the container.

Since we already are converting the caller's inputs to a Ref, we can directly watch that and allow the caller to optimize their own code by choosing the correct ref implementation for their use case.
