### PR TITLE
fix(useFocusTrap): update `focus-trap` range to `^7 || ^8`

### DIFF
--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -58,7 +58,7 @@
     "axios": "^1",
     "change-case": "^5",
     "drauu": "^0.4",
-    "focus-trap": "^7",
+    "focus-trap": "^7 || ^8",
     "fuse.js": "^7",
     "idb-keyval": "^6",
     "jwt-decode": "^4",


### PR DESCRIPTION
this loosens the `focus-trap` range to allow upgrading. `focus-trap` recently had a major release, but without API changes affecting `useFocusTrap()`; see https://github.com/focus-trap/focus-trap/releases/tag/v8.0.0