### PR TITLE
feat: expose pointer event onLongPress

### DIFF
--- a/packages/core/onLongPress/index.md
+++ b/packages/core/onLongPress/index.md
@@ -85,8 +85,8 @@ You can provide an `onMouseUp` callback to be notified when the pointer is relea
 import { onLongPress } from '@vueuse/core'
 
 onLongPress(target, handler, {
-  onMouseUp(duration, distance, isLongPress) {
-    console.log(`Held for ${duration}ms, moved ${distance}px, long press: ${isLongPress}`)
+  onMouseUp(duration, distance, isLongPress, pointerEvent) {
+    console.log(`Held for ${duration}ms, moved ${distance}px, long press: ${isLongPress}, x: ${pointerEvent.clientX}`)
   },
 })
 ```

--- a/packages/core/onLongPress/index.test.ts
+++ b/packages/core/onLongPress/index.test.ts
@@ -163,7 +163,7 @@ describe('onLongPress', () => {
     pointerUpEvent = new PointerEvent('pointerup', { cancelable: true, bubbles: true })
     element.value.dispatchEvent(pointerUpEvent)
     expect(onMouseUpCallback).toHaveBeenCalledTimes(1)
-    expect(onMouseUpCallback).toBeCalledWith(expect.any(Number), 0, false)
+    expect(onMouseUpCallback).toBeCalledWith(expect.any(Number), 0, false, expect.any(PointerEvent))
     expect(onMouseUpCallback.mock.calls[0][0]).toBeGreaterThanOrEqual(250 - 2)
 
     // wait for 500ms after pointer up
@@ -182,7 +182,7 @@ describe('onLongPress', () => {
     pointerUpEvent = new PointerEvent('pointerup', { cancelable: true, bubbles: true })
     element.value.dispatchEvent(pointerUpEvent)
     expect(onMouseUpCallback).toHaveBeenCalledTimes(2)
-    expect(onMouseUpCallback).toBeCalledWith(expect.any(Number), 0, true)
+    expect(onMouseUpCallback).toBeCalledWith(expect.any(Number), 0, true, expect.any(PointerEvent))
     expect(onMouseUpCallback.mock.calls[1][0]).toBeGreaterThanOrEqual(500 - 2)
   }
 

--- a/packages/core/onLongPress/index.ts
+++ b/packages/core/onLongPress/index.ts
@@ -30,8 +30,9 @@ export interface OnLongPressOptions {
    * @param duration how long the element was pressed in ms
    * @param distance distance from the pointerdown position
    * @param isLongPress whether the action was a long press or not
+   * @param pointerEvent the native {@link PointerEvent} triggered by the browser
    */
-  onMouseUp?: (duration: number, distance: number, isLongPress: boolean) => void
+  onMouseUp?: (duration: number, distance: number, isLongPress: boolean, pointerEvent: PointerEvent) => void
 }
 
 export interface OnLongPressModifiers {
@@ -95,7 +96,7 @@ export function onLongPress(
     const dx = ev.x - _posStart.x
     const dy = ev.y - _posStart.y
     const distance = Math.sqrt(dx * dx + dy * dy)
-    options.onMouseUp(ev.timeStamp - _startTimestamp, distance, _hasLongPressed)
+    options.onMouseUp(ev.timeStamp - _startTimestamp, distance, _hasLongPressed, ev)
   }
 
   function onDown(ev: PointerEvent) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.

---

### Description

The `onMouseUp` did not provide the native event, I had a use case where a button has a `longPress` and `onMouseUp`. The onMouseUp should trigger a [confetti](https://www.npmjs.com/package/canvas-confetti), therefore the `x` and `y` is required of the event

```vue
<script setup lang="ts">
import confetti from 'canvas-confetti';
import { onLongPress } from '@vueuse/core';
import { useTemplateRef } from 'vue';

const htmlRefOnMouseUp = useTemplateRef('htmlRefOnMouseUp')

onLongPress(
  htmlRefOnMouseUp,
  onLongPressCallback,
  {
    distanceThreshold: 24,
    delay: 1000,
    onMouseUp,
  },
)

function onMouseUp(duration: number, distance: number, isLongPress: boolean, pointerEvent: PointerEvent) {
     const x = pointerEvent.clientX / window.innerWidth;
     const y = pointerEvent.clientY / window.innerHeight;

     confetti({ particleCount: 50, spread: 60, origin: { x, y } });
}
</script>

<template>
  <button ref="htmlRefOnMouseUp">
    Press long (1000ms) or click
  </button>
</template>
```
