### PR TITLE
feat(createReusableTemplate): add support for specifying component names

### DIFF
--- a/packages/core/createReusableTemplate/index.ts
+++ b/packages/core/createReusableTemplate/index.ts
@@ -41,6 +41,10 @@ export interface CreateReusableTemplateOptions<Props extends Record<string, any>
    */
   inheritAttrs?: boolean
   /**
+   * Name for the reuse component (useful for devtools).
+   */
+  name?: string
+  /**
    * Props definition for reuse component.
    */
   props?: ComponentObjectPropsOptions<Props>
@@ -62,11 +66,13 @@ export function createReusableTemplate<
 ): ReusableTemplatePair<Bindings, MapSlotNameToSlotProps> {
   const {
     inheritAttrs = true,
+    name = 'ReusableTemplate',
   } = options
 
   const render = shallowRef<Slot | undefined>()
 
   const define = defineComponent({
+    name: `${name}.define`,
     setup(_, { slots }) {
       return () => {
         render.value = slots.default
@@ -76,6 +82,7 @@ export function createReusableTemplate<
 
   const reuse = defineComponent({
     inheritAttrs,
+    name: `${name}.reuse`,
     props: options.props,
     setup(props, { attrs, slots }) {
       return () => {


### PR DESCRIPTION
This adds support for passing a component name to createReusableTemplate().

This is useful for development/debugging, e.g. in the component view in the Vue DevTools:

- Before: each instance is listed twice (once for the ‘define’ and once for the ‘reuse’ part) as ‘Anonymous Component’. This quickly becomes unwieldy and hard to navigate.

- After this change: components are shown in DevTools as ‘MyName.define’ / ‘MyName.reuse’ if specified, and ‘ReusableTemplate.define’ / ‘ReusableTemplate.reuse’ if no name was given, which is still more useful than ‘Anonymous Component’ (which also applies to functional components, for example).