### PR TITLE
feat(createInjectionState): non-undefined return when default specified

### DIFF
--- a/packages/shared/createInjectionState/index.md
+++ b/packages/shared/createInjectionState/index.md
@@ -149,6 +149,7 @@ const [useProvideCounterStore, useCounterStore] = createInjectionState((initialV
 import { createInjectionState } from '@vueuse/core'
 import { computed, shallowRef } from 'vue'
 
+// useCounterStore does not return undefined when defaultValue is specified
 const [useProvideCounterStore, useCounterStore] = createInjectionState((initialValue: number) => {
   // state
   const count = shallowRef(initialValue)

--- a/packages/shared/createInjectionState/index.test.ts
+++ b/packages/shared/createInjectionState/index.test.ts
@@ -102,4 +102,18 @@ describe('createInjectionState', () => {
     expect(vm.count).toBe(114514)
     vm.unmount()
   })
+
+  it('should have useInjectedState return default value when not providing state', async () => {
+    const [_useProvideCountState, useCountState] = createInjectionState(() => {
+      return shallowRef(663512)
+    }, { defaultValue: shallowRef(543742) })
+    const vm = useSetup(() => {
+      const count = useCountState()
+
+      return { count }
+    })
+    await nextTick()
+    expect(vm.count).toBe(543742)
+    vm.unmount()
+  })
 })

--- a/packages/shared/createInjectionState/index.ts
+++ b/packages/shared/createInjectionState/index.ts
@@ -2,20 +2,20 @@ import type { InjectionKey } from 'vue'
 import { injectLocal } from '../injectLocal'
 import { provideLocal } from '../provideLocal'
 
-export type CreateInjectionStateReturn<Arguments extends Array<any>, Return> = Readonly<[
+export type CreateInjectionStateReturn<Arguments extends Array<any>, ProvideReturn, InjectReturn> = Readonly<[
   /**
    * Call this function in a provider component to create and provide the state.
    *
    * @param args Arguments passed to the composable
    * @returns The state returned by the composable
    */
-  useProvidingState: (...args: Arguments) => Return,
+  useProvidingState: (...args: Arguments) => ProvideReturn,
   /**
    * Call this function in a consumer component to inject the state.
    *
    * @returns The injected state, or `undefined` if not provided and no default value was set.
    */
-  useInjectedState: () => Return | undefined,
+  useInjectedState: () => InjectReturn,
 ]>
 
 export interface CreateInjectionStateOptions<Return> {
@@ -38,8 +38,16 @@ export interface CreateInjectionStateOptions<Return> {
  */
 export function createInjectionState<Arguments extends Array<any>, Return>(
   composable: (...args: Arguments) => Return,
+  options: { defaultValue: Return } & CreateInjectionStateOptions<Return>,
+): CreateInjectionStateReturn<Arguments, Return, Return>
+export function createInjectionState<Arguments extends Array<any>, Return>(
+  composable: (...args: Arguments) => Return,
   options?: CreateInjectionStateOptions<Return>,
-): CreateInjectionStateReturn<Arguments, Return> {
+): CreateInjectionStateReturn<Arguments, Return, Return | undefined>
+export function createInjectionState<Arguments extends Array<any>, Return>(
+  composable: (...args: Arguments) => Return,
+  options?: CreateInjectionStateOptions<Return>,
+): CreateInjectionStateReturn<Arguments, Return, Return | undefined> {
   const key: string | InjectionKey<Return> = options?.injectionKey || Symbol(composable.name || 'InjectionState')
   const defaultValue = options?.defaultValue
   const useProvidingState = (...args: Arguments) => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Previously, the type of "use" function from `createInjectionState` did return the return type of the setup function _or_ `undefined`, even when a default value was specified (`useInjectedState: () => Return | undefined`).

Comparing it to the API of Vue's `defineModel`, where the return type does not include `undefined` when `{ required: true }` is set as options, I thought maybe a similar approach would make sense here.

Now the "use" function still returns `Return | undefined` when no default value is specified, but instead returns `Return` when a default value _was_ specified.

### Additional context

Note: This PR only changes Typescript types, the implementation stays identical. The types were just adapted to better fit the already existing implementation.

Example:
```ts
const [useProvideCountState, useCountState] = createInjectionState(() => {
  return shallowRef(456)
}, { defaultValue: shallowRef(123) })

// Previously:
const countState: ShallowRef<number> | undefined = useCountState();

// Now:
const countState: ShallowRef<number> = useCountState();
```
