### PR TITLE
fix(useIntersectionObserver): accept useTemplateRef with array type as target

### DIFF
--- a/packages/core/useIntersectionObserver/index.ts
+++ b/packages/core/useIntersectionObserver/index.ts
@@ -47,7 +47,7 @@ export interface UseIntersectionObserverReturn extends Supportable, Pausable {
  * @param options
  */
 export function useIntersectionObserver(
-  target: MaybeComputedElementRef | MaybeRefOrGetter<MaybeElement[]> | MaybeComputedElementRef[],
+  target: MaybeComputedElementRef | MaybeRefOrGetter<MaybeElement[] | null> | MaybeComputedElementRef[],
   callback: IntersectionObserverCallback,
   options: UseIntersectionObserverOptions = {},
 ): UseIntersectionObserverReturn {


### PR DESCRIPTION
Fixes #4712

## Problem

When using `useTemplateRef` with a `v-for` binding in Vue 3.5+, the returned type is `Readonly<ShallowRef<HTMLDivElement[] | null>>`. Passing this to `useIntersectionObserver` fails at compile time:

```ts
const $events = useTemplateRef('$events') // Readonly<ShallowRef<HTMLDivElement[] | null>>
useIntersectionObserver($events, () => {}) // TS error: not assignable to target type
```

The error comes from the `MaybeRefOrGetter<MaybeElement[]>` variant in the target union -- it does not allow `null` as the ref's value type.

## Fix

Change `MaybeRefOrGetter<MaybeElement[]>` to `MaybeRefOrGetter<MaybeElement[] | null>` in the target parameter.

The runtime already handles null correctly: the computed getter calls `filter(notNullish)` which drops null/undefined elements before passing them to the observer.

## Change

One line change in the function signature. No logic changes.