### PR TITLE
feat(useIDBKeyval)!: sync changes across tabs

### DIFF
--- a/packages/integrations/useIDBKeyval/index.browser.test.ts
+++ b/packages/integrations/useIDBKeyval/index.browser.test.ts
@@ -1,0 +1,141 @@
+import { del, get } from 'idb-keyval'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import { useIDBKeyval } from './index'
+
+const KEY = 'vueuse-idb-browser-sync-test'
+const CHANNEL_NAME = `vueuse-idb-${JSON.stringify(KEY)}`
+
+afterEach(async () => {
+  await del(KEY)
+})
+
+describe('cross-tab syncing via BroadcastChannel', () => {
+  it('isSupported reflects BroadcastChannel availability', () => {
+    const { isSupported } = useIDBKeyval(KEY, 'initial')
+    expect(isSupported.value).toBe(true)
+  })
+
+  it('broadcasts set message when data changes', async () => {
+    const { data } = useIDBKeyval(KEY, 'initial')
+    await nextTick()
+
+    const received: any[] = []
+    const receiver = new BroadcastChannel(CHANNEL_NAME)
+    receiver.addEventListener('message', (e: MessageEvent) => received.push(e.data))
+
+    data.value = 'updated'
+
+    await vi.waitFor(() => {
+      expect(received).toContainEqual({ type: 'set', value: 'updated' })
+    })
+
+    receiver.close()
+  })
+
+  it('broadcasts delete message when data is set to null', async () => {
+    const { data } = useIDBKeyval<string | null>(KEY, 'initial')
+    await nextTick()
+
+    const received: any[] = []
+    const receiver = new BroadcastChannel(CHANNEL_NAME)
+    receiver.addEventListener('message', (e: MessageEvent) => received.push(e.data))
+
+    data.value = null
+
+    await vi.waitFor(() => {
+      expect(received).toContainEqual({ type: 'delete' })
+    })
+
+    receiver.close()
+  })
+
+  it('updates data when receiving a set message from another tab', async () => {
+    const { data } = useIDBKeyval(KEY, 'initial')
+    await nextTick()
+
+    const sender = new BroadcastChannel(CHANNEL_NAME)
+    sender.postMessage({ type: 'set', value: 'from-other-tab' })
+
+    await vi.waitFor(() => {
+      expect(data.value).toBe('from-other-tab')
+    })
+
+    sender.close()
+  })
+
+  it('resets data to initial value when receiving a delete message from another tab', async () => {
+    const { data } = useIDBKeyval(KEY, 'initial')
+    await nextTick()
+
+    data.value = 'changed'
+    await nextTick()
+
+    const sender = new BroadcastChannel(CHANNEL_NAME)
+    sender.postMessage({ type: 'delete' })
+
+    await vi.waitFor(() => {
+      expect(data.value).toBe('initial')
+    })
+
+    sender.close()
+  })
+
+  it('does not write back to IDB or re-broadcast when receiving a message from another tab', async () => {
+    const { data } = useIDBKeyval(KEY, 'initial')
+    await nextTick()
+
+    const sender = new BroadcastChannel(CHANNEL_NAME)
+    sender.postMessage({ type: 'set', value: 'from-other-tab' })
+
+    await vi.waitFor(() => expect(data.value).toBe('from-other-tab'))
+
+    // Give time for any spurious write to settle
+    await new Promise(resolve => setTimeout(resolve, 50))
+
+    // IDB should still have 'initial' — the incoming sync must not trigger a write-back
+    expect(await get(KEY)).toBe('initial')
+
+    sender.close()
+  })
+
+  it('calls onError and keeps watcher active if serializer.read throws on incoming message', async () => {
+    const onError = vi.fn()
+    const serializer = {
+      read: vi.fn(() => { throw new Error('read error') }),
+      write: (v: string) => v,
+    }
+
+    const { data } = useIDBKeyval<string>(KEY, 'initial', { serializer, onError })
+    await nextTick()
+
+    const sender = new BroadcastChannel(CHANNEL_NAME)
+    sender.postMessage({ type: 'set', value: 'from-other-tab' })
+
+    await vi.waitFor(() => expect(onError).toHaveBeenCalledTimes(1))
+    expect(data.value).toBe('initial')
+
+    // Watcher should still be active — a local write should still update IDB
+    data.value = 'local-update'
+    await vi.waitFor(async () => {
+      expect(await get(KEY)).toBe('local-update')
+    })
+
+    sender.close()
+  })
+
+  it('does not sync changes when listenToStorageChanges is false', async () => {
+    const { data } = useIDBKeyval(KEY, 'initial', { listenToStorageChanges: false })
+    await nextTick()
+
+    const sender = new BroadcastChannel(CHANNEL_NAME)
+    sender.postMessage({ type: 'set', value: 'from-other-tab' })
+
+    // Wait long enough for a message to have been delivered if a listener existed
+    await new Promise(resolve => setTimeout(resolve, 100))
+
+    expect(data.value).toBe('initial')
+
+    sender.close()
+  })
+})

--- a/packages/integrations/useIDBKeyval/index.md
+++ b/packages/integrations/useIDBKeyval/index.md
@@ -36,3 +36,12 @@ console.log('IDB transaction finished!')
 // delete data from idb storage
 storedObject.value = null
 ```
+
+## Cross-tab syncing
+
+Changes are automatically synced across browser tabs using the [`BroadcastChannel` API](https://developer.mozilla.org/en-US/docs/Web/API/BroadcastChannel). This is enabled by default and can be disabled via the `listenToStorageChanges` option.
+
+```ts
+// disable cross-tab syncing
+const { data } = useIDBKeyval('my-key', 'default', { listenToStorageChanges: false })
+```

--- a/packages/integrations/useIDBKeyval/index.ts
+++ b/packages/integrations/useIDBKeyval/index.ts
@@ -1,15 +1,16 @@
+import type { ConfigurableWindow } from '@vueuse/core'
 import type { ConfigurableFlush, RemovableRef } from '@vueuse/shared'
-import type { MaybeRefOrGetter, Ref, ShallowRef } from 'vue'
-import { watchPausable } from '@vueuse/core'
+import type { ComputedRef, MaybeRefOrGetter, Ref, ShallowRef } from 'vue'
+import { defaultWindow, tryOnScopeDispose, useSupported, watchPausable } from '@vueuse/core'
 import { del, get, set, update } from 'idb-keyval'
-import { ref as deepRef, shallowRef, toRaw, toValue } from 'vue'
+import { ref as deepRef, nextTick, shallowRef, toRaw, toValue } from 'vue'
 
 interface Serializer<T> {
   read: (raw: unknown) => T
   write: (value: T) => unknown
 }
 
-export interface UseIDBOptions<T> extends ConfigurableFlush {
+export interface UseIDBOptions<T> extends ConfigurableFlush, ConfigurableWindow {
   /**
    * Watch for deep changes
    *
@@ -41,11 +42,20 @@ export interface UseIDBOptions<T> extends ConfigurableFlush {
    * Custom data serialization
    */
   serializer?: Serializer<T>
+
+  /**
+   * Listen to storage changes from other tabs via BroadcastChannel,
+   * useful for multiple tabs applications
+   *
+   * @default true
+   */
+  listenToStorageChanges?: boolean
 }
 
 export interface UseIDBKeyvalReturn<T> {
   data: RemovableRef<T>
   isFinished: ShallowRef<boolean>
+  isSupported: ComputedRef<boolean>
   set: (value: T) => Promise<void>
 }
 
@@ -68,11 +78,15 @@ export function useIDBKeyval<T>(
       console.error(e)
     },
     writeDefaults = true,
+    listenToStorageChanges = true,
+    window = defaultWindow,
     serializer = {
       read: (raw: unknown) => raw as T,
       write: (value: T) => value,
     },
   } = options
+
+  const isSupported = useSupported(() => window && 'BroadcastChannel' in window)
 
   const isFinished = shallowRef(false)
   const data = (shallow ? shallowRef : deepRef)(initialValue) as Ref<T>
@@ -100,15 +114,21 @@ export function useIDBKeyval<T>(
 
   read()
 
-  async function write() {
+  let channel: BroadcastChannel | undefined
+
+  async function write(broadcastChange = true) {
     try {
       if (data.value == null) {
         await del(key)
+        if (broadcastChange)
+          channel?.postMessage({ type: 'delete' })
       }
       else {
         const rawValue = toRaw(data.value)
         const serializedValue = serializer.write(rawValue)
         await update(key, () => serializedValue)
+        if (broadcastChange)
+          channel?.postMessage({ type: 'set', value: serializedValue })
       }
     }
     catch (e) {
@@ -121,6 +141,28 @@ export function useIDBKeyval<T>(
     resume: resumeWatch,
   } = watchPausable(data, () => write(), { flush, deep })
 
+  if (listenToStorageChanges && isSupported.value) {
+    channel = new BroadcastChannel(`vueuse-idb-${JSON.stringify(key)}`)
+    tryOnScopeDispose(() => channel?.close())
+
+    channel.addEventListener('message', (event: MessageEvent) => {
+      const { type, value } = event.data ?? {}
+      pauseWatch()
+      try {
+        if (type === 'delete')
+          data.value = rawInit
+        else if (type === 'set')
+          data.value = serializer.read(value)
+      }
+      catch (e) {
+        onError(e)
+      }
+      finally {
+        nextTick(resumeWatch)
+      }
+    })
+  }
+
   async function setData(value: T): Promise<void> {
     pauseWatch()
     data.value = value
@@ -131,6 +173,7 @@ export function useIDBKeyval<T>(
   return {
     set: setData,
     isFinished,
+    isSupported,
     data: data as RemovableRef<T>,
   }
 }

--- a/packages/integrations/useIDBKeyval/index.ts
+++ b/packages/integrations/useIDBKeyval/index.ts
@@ -1,15 +1,16 @@
+import type { ConfigurableWindow } from '@vueuse/core'
 import type { ConfigurableFlush, RemovableRef } from '@vueuse/shared'
-import type { MaybeRefOrGetter, Ref, ShallowRef } from 'vue'
-import { watchPausable } from '@vueuse/core'
+import type { ComputedRef, MaybeRefOrGetter, Ref, ShallowRef } from 'vue'
+import { defaultWindow, tryOnScopeDispose, useSupported, watchPausable } from '@vueuse/core'
 import { del, get, set, update } from 'idb-keyval'
-import { ref as deepRef, shallowRef, toRaw, toValue } from 'vue'
+import { ref as deepRef, nextTick, shallowRef, toRaw, toValue } from 'vue'
 
 interface Serializer<T> {
   read: (raw: unknown) => T
   write: (value: T) => unknown
 }
 
-export interface UseIDBOptions<T> extends ConfigurableFlush {
+export interface UseIDBOptions<T> extends ConfigurableFlush, ConfigurableWindow {
   /**
    * Watch for deep changes
    *
@@ -41,11 +42,20 @@ export interface UseIDBOptions<T> extends ConfigurableFlush {
    * Custom data serialization
    */
   serializer?: Serializer<T>
+
+  /**
+   * Listen to storage changes from other tabs via BroadcastChannel,
+   * useful for multiple tabs applications
+   *
+   * @default true
+   */
+  listenToStorageChanges?: boolean
 }
 
 export interface UseIDBKeyvalReturn<T> {
   data: RemovableRef<T>
   isFinished: ShallowRef<boolean>
+  isSupported: ComputedRef<boolean>
   set: (value: T) => Promise<void>
 }
 
@@ -68,11 +78,15 @@ export function useIDBKeyval<T>(
       console.error(e)
     },
     writeDefaults = true,
+    listenToStorageChanges = true,
+    window = defaultWindow,
     serializer = {
       read: (raw: unknown) => raw as T,
       write: (value: T) => value,
     },
   } = options
+
+  const isSupported = useSupported(() => window && 'BroadcastChannel' in window)
 
   const isFinished = shallowRef(false)
   const data = (shallow ? shallowRef : deepRef)(initialValue) as Ref<T>
@@ -100,15 +114,19 @@ export function useIDBKeyval<T>(
 
   read()
 
+  let channel: BroadcastChannel | undefined
+
   async function write() {
     try {
       if (data.value == null) {
         await del(key)
+        channel?.postMessage({ type: 'delete' })
       }
       else {
         const rawValue = toRaw(data.value)
         const serializedValue = serializer.write(rawValue)
         await update(key, () => serializedValue)
+        channel?.postMessage({ type: 'set', value: serializedValue })
       }
     }
     catch (e) {
@@ -121,6 +139,28 @@ export function useIDBKeyval<T>(
     resume: resumeWatch,
   } = watchPausable(data, () => write(), { flush, deep })
 
+  if (listenToStorageChanges && isSupported.value) {
+    channel = new BroadcastChannel(`vueuse-idb-${JSON.stringify(key)}`)
+    tryOnScopeDispose(() => channel?.close())
+
+    channel.addEventListener('message', (event: MessageEvent) => {
+      const { type, value } = event.data ?? {}
+      pauseWatch()
+      try {
+        if (type === 'delete')
+          data.value = rawInit
+        else if (type === 'set')
+          data.value = serializer.read(value)
+      }
+      catch (e) {
+        onError(e)
+      }
+      finally {
+        nextTick(resumeWatch)
+      }
+    })
+  }
+
   async function setData(value: T): Promise<void> {
     pauseWatch()
     data.value = value
@@ -131,6 +171,7 @@ export function useIDBKeyval<T>(
   return {
     set: setData,
     isFinished,
+    isSupported,
     data: data as RemovableRef<T>,
   }
 }

--- a/test/__snapshots__/tsnapi/@vueuse/integrations/useIDBKeyval.snapshot.d.ts
+++ b/test/__snapshots__/tsnapi/@vueuse/integrations/useIDBKeyval.snapshot.d.ts
@@ -5,14 +5,16 @@
 export interface UseIDBKeyvalReturn<T> {
   data: RemovableRef<T>;
   isFinished: ShallowRef<boolean>;
+  isSupported: ComputedRef<boolean>;
   set: (_: T) => Promise<void>;
 }
-export interface UseIDBOptions<T> extends ConfigurableFlush {
+export interface UseIDBOptions<T> extends ConfigurableFlush, ConfigurableWindow {
   deep?: boolean;
   onError?: (_: unknown) => void;
   shallow?: boolean;
   writeDefaults?: boolean;
   serializer?: Serializer<T>;
+  listenToStorageChanges?: boolean;
 }
 // #endregion
 


### PR DESCRIPTION
Add `listenToStorageChanges` option to `useIDBKeyval` to sync value changes across tabs like in `useStorage`. Uses `BroadcastChannel` and not `StorageEvent`, but kept the same option name for consistency.

Useful for a project I have where I store most things in local storage, but I have one instance of `useIDBKeyval` to store webcrypto keys in an un-exportable state. I want to have the same cross-tab syncing that `useStorage` has.

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
