### PR TITLE
fix(useElementSize): fix svg size for scale transform

### DIFF
--- a/packages/core/useElementSize/index.browser.test.ts
+++ b/packages/core/useElementSize/index.browser.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it } from 'vitest'
+import { page } from 'vitest/browser'
+import { computed, defineComponent, shallowRef } from 'vue'
+import { useElementSize } from './index'
+
+const DOMComponent = defineComponent({
+  template:
+  `<div style="overflow: auto">
+    <div style="heigth: 300vh">
+      <div ref="el" :style v-if="hasElement"/>
+      <pre data-testId="data">{{size}}</pre>
+      <button data-testId="width" @click="handleWidth">b</button>
+      <button data-testId="margin" @click="handleMargin">m</button>
+      <button data-testId="remove" @click="handleRemove">r</button>
+      <button data-testId="scale" @click="handleScale">s</button>
+    </div>
+  </div>`,
+  props: ['margin', 'padding', 'options'],
+  setup(props) {
+    const el = shallowRef()
+    const size = useElementSize(el, props.options)
+    const hasElement = shallowRef(true)
+    const width = shallowRef(props.margin ?? '200px')
+    const margin = shallowRef('0')
+    const scale = shallowRef('1')
+    const style = computed(() => {
+      return `width: ${width.value};height:50px;margin:${margin.value};padding:${props.padding ?? 0};transform: scale(${scale.value});`
+    })
+    const handleWidth = () => {
+      width.value = '34px'
+    }
+    const handleMargin = () => {
+      margin.value = '69px'
+    }
+    const handleScale = () => {
+      scale.value = '1.5'
+    }
+    const handleRemove = () => {
+      hasElement.value = false
+    }
+
+    return { el, size, style, handleWidth, handleMargin, hasElement, handleRemove, handleScale }
+  },
+})
+const SVGComponent = defineComponent({
+  template:
+  `<div style="overflow: auto">
+    <div style="heigth: 300vh">
+      <div v-if="hasElement" :style="containerStyle">
+        <svg ref="el" width="100%" height="100%" :style="style"/>
+      </div>
+      <pre data-testId="data">{{size}}</pre>
+      <button data-testId="width" @click="handleWidth">b</button>
+      <button data-testId="margin" @click="handleMargin">m</button>
+      <button data-testId="remove" @click="handleRemove">r</button>
+      <button data-testId="scale" @click="handleScale">s</button>
+    </div>
+  </div>`,
+  props: ['margin', 'padding', 'options'],
+  setup(props) {
+    const el = shallowRef()
+    const size = useElementSize(el, props.options)
+    const hasElement = shallowRef(true)
+    const width = shallowRef(props.margin ?? '200px')
+    const margin = shallowRef('0')
+    const scale = shallowRef('1')
+    const style = computed(() => {
+      return `margin:${margin.value};padding:${props.padding ?? 0};transform: scale(${scale.value});`
+    })
+    const containerStyle = computed(() => {
+      return `width:${width.value};height:50px;transform:scale(${scale.value});`
+    })
+    const handleWidth = () => {
+      width.value = '34px'
+    }
+    const handleMargin = () => {
+      margin.value = '69px'
+    }
+    const handleScale = () => {
+      scale.value = '1.5'
+    }
+    const handleRemove = () => {
+      hasElement.value = false
+    }
+
+    return { el, size, containerStyle, style, handleWidth, handleMargin, hasElement, handleRemove, handleScale }
+  },
+})
+
+describe('useElementSize', () => {
+  describe('dOM Element', () => {
+    it('should return width and height of DOM element', async () => {
+      const screen = page.render(DOMComponent)
+      const pre = screen.getByTestId('data')
+      await expect.element(pre).toBeVisible()
+      expect(pre.query()?.textContent).toMatchInlineSnapshot(`
+        "{
+          "width": 200,
+          "height": 50
+        }"
+      `)
+    })
+
+    it('should have reactive values', async () => {
+      const screen = page.render(DOMComponent)
+      const pre = screen.getByTestId('data')
+      const widthButton = screen.getByTestId('width')
+      const marginButton = screen.getByTestId('margin')
+      await expect.element(widthButton).toBeVisible()
+      await expect.element(marginButton).toBeVisible()
+      await widthButton.click()
+      await marginButton.click()
+      await expect.element(pre).toBeVisible()
+      expect(pre.query()?.textContent).toMatchInlineSnapshot(`
+        "{
+          "width": 34,
+          "height": 50
+        }"
+    `)
+    })
+
+    it('should respect padding and margin', async () => {
+      const screen = page.render(DOMComponent, { props: { margin: '400px', padding: '123px' } })
+      const pre = screen.getByTestId('data')
+      await expect.element(pre).toBeVisible()
+      expect(pre.query()?.textContent).toMatchInlineSnapshot(`
+        "{
+          "width": 646,
+          "height": 296
+        }"
+      `)
+    })
+
+    it('should reset values to 0 if el is unmounted', async () => {
+      const screen = page.render(DOMComponent)
+      const pre = screen.getByTestId('data')
+      const button = screen.getByTestId('remove')
+      await expect.element(pre).toBeVisible()
+      await expect.element(button).toBeVisible()
+      await button.click()
+      expect(pre.query()?.textContent).toMatchInlineSnapshot(`
+        "{
+          "width": 0,
+          "height": 0
+        }"
+      `)
+    })
+
+    it.todo('should respect border-box option')
+
+    it.todo('should respect content-box option')
+
+    it('should work with scale transform', async () => {
+      const screen = page.render(DOMComponent)
+      const pre = screen.getByTestId('data')
+      const scaleButton = screen.getByTestId('scale')
+
+      await expect.element(scaleButton).toBeVisible()
+      await scaleButton.click()
+
+      await expect.element(pre).toBeVisible()
+      expect(pre.query()?.textContent).toMatchInlineSnapshot(`
+        "{
+          "width": 200,
+          "height": 50
+        }"
+      `)
+    })
+  })
+
+  describe('sVG Element', () => {
+    it('should return width and height of SVG element', async () => {
+      const screen = page.render(SVGComponent)
+      const pre = screen.getByTestId('data')
+      await expect.element(pre).toBeVisible()
+      expect(pre.query()?.textContent).toMatchInlineSnapshot(`
+        "{
+          "width": 200,
+          "height": 50
+        }"
+      `)
+    })
+
+    it('should have reactive values', async () => {
+      const screen = page.render(SVGComponent)
+      const pre = screen.getByTestId('data')
+      const widthButton = screen.getByTestId('width')
+      const marginButton = screen.getByTestId('margin')
+      await expect.element(widthButton).toBeVisible()
+      await expect.element(marginButton).toBeVisible()
+      await widthButton.click()
+      await marginButton.click()
+      await expect.element(pre).toBeVisible()
+      expect(pre.query()?.textContent).toMatchInlineSnapshot(`
+        "{
+          "width": 34,
+          "height": 50
+        }"
+    `)
+    })
+
+    it('should respect padding and margin', async () => {
+      const screen = page.render(SVGComponent, { props: { margin: '400px', padding: '123px' } })
+      const pre = screen.getByTestId('data')
+      await expect.element(pre).toBeVisible()
+      expect(pre.query()?.textContent).toMatchInlineSnapshot(`
+        "{
+          "width": 646,
+          "height": 296
+        }"
+      `)
+    })
+
+    it('should reset values to 0 if el is unmounted', async () => {
+      const screen = page.render(SVGComponent)
+      const pre = screen.getByTestId('data')
+      const button = screen.getByTestId('remove')
+      await expect.element(pre).toBeVisible()
+      await expect.element(button).toBeVisible()
+      await button.click()
+      expect(pre.query()?.textContent).toMatchInlineSnapshot(`
+        "{
+          "width": 0,
+          "height": 0
+        }"
+      `)
+    })
+
+    it.todo('should respect border-box option')
+
+    it.todo('should respect content-box option')
+
+    it('should work with scale transform', async () => {
+      const screen = page.render(SVGComponent)
+      const pre = screen.getByTestId('data')
+      const scaleButton = screen.getByTestId('scale')
+
+      await expect.element(scaleButton).toBeVisible()
+      await scaleButton.click()
+
+      await expect.element(pre).toBeVisible()
+      expect(pre.query()?.textContent).toMatchInlineSnapshot(`
+        "{
+          "width": 200,
+          "height": 50
+        }"
+      `)
+    })
+  })
+})

--- a/packages/core/useElementSize/index.ts
+++ b/packages/core/useElementSize/index.ts
@@ -78,8 +78,9 @@ export function useElementSize(
   const stop2 = watch(
     () => unrefElement(target),
     (ele) => {
-      width.value = ele ? initialSize.width : 0
-      height.value = ele ? initialSize.height : 0
+      // todo: margin and padding handling
+      width.value = ele?.clientWidth ?? initialSize.width
+      height.value = ele?.clientHeight ?? initialSize.height
     },
   )
 

--- a/packages/core/useElementSize/index.ts
+++ b/packages/core/useElementSize/index.ts
@@ -45,24 +45,22 @@ export function useElementSize(
           ? entry.contentBoxSize
           : entry.devicePixelContentBoxSize
 
-      if (window && isSVG.value) {
+      if (boxSize) {
+        const formatBoxSize = toArray(boxSize)
+        width.value = formatBoxSize.reduce((acc, { inlineSize }) => acc + inlineSize, 0)
+        height.value = formatBoxSize.reduce((acc, { blockSize }) => acc + blockSize, 0)
+      }
+      else if (entry.contentRect) {
+        // fallback
+        width.value = entry.contentRect.width
+        height.value = entry.contentRect.height
+      }
+      else if (window && isSVG.value) {
         const $elem = unrefElement(target)
         if ($elem) {
           const rect = $elem.getBoundingClientRect()
           width.value = rect.width
           height.value = rect.height
-        }
-      }
-      else {
-        if (boxSize) {
-          const formatBoxSize = toArray(boxSize)
-          width.value = formatBoxSize.reduce((acc, { inlineSize }) => acc + inlineSize, 0)
-          height.value = formatBoxSize.reduce((acc, { blockSize }) => acc + blockSize, 0)
-        }
-        else {
-          // fallback
-          width.value = entry.contentRect.width
-          height.value = entry.contentRect.height
         }
       }
     },


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

---

### Description

This PR aims to fix #5326.

Since morden browsers have supported observing `SVGElement` with `ResizeObserver` already, may we use the size from `ResizeObserverEntry` entries in priority.

### Additional context

The following change is required for the test. There might be better implementation for it though, see also #5088

[packages/core/useElementSize/index.ts](https://github.com/Fan-iX/vueuse/blob/a0c0ab8096fa38a00bb7d7744585bf2daa5087af/packages/core/useElementSize/index.ts#L81-L83)
