### PR TITLE
fix(useElementSize): call directive handler immediately on mount

### DIFF
--- a/packages/core/useElementSize/directive.test.ts
+++ b/packages/core/useElementSize/directive.test.ts
@@ -1,7 +1,7 @@
 import type { VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { defineComponent } from 'vue'
+import { defineComponent, nextTick } from 'vue'
 import { vElementSize } from './directive'
 
 const App = defineComponent({
@@ -45,6 +45,14 @@ describe('vElementSize', () => {
     it('should be defined', () => {
       expect(wrapper).toBeDefined()
     })
+
+    it('should call handler immediately on mount', async () => {
+      await nextTick()
+      expect(onResize).toHaveBeenCalled()
+      expect(onResize).toHaveBeenCalledWith(
+        expect.objectContaining({ width: expect.any(Number), height: expect.any(Number) }),
+      )
+    })
   })
 
   describe('given options', () => {
@@ -67,6 +75,38 @@ describe('vElementSize', () => {
 
     it('should be defined', () => {
       expect(wrapper).toBeDefined()
+    })
+
+    it('should call handler immediately on mount with options', async () => {
+      await nextTick()
+      expect(onResize).toHaveBeenCalled()
+    })
+  })
+
+  describe('given border-box option', () => {
+    beforeEach(() => {
+      onResize = vi.fn()
+      const options = [{ width: 0, height: 0 }, { box: 'border-box' }]
+
+      wrapper = mount(App, {
+        props: {
+          onResize,
+          options,
+        },
+        global: {
+          directives: {
+            ElementSize: vElementSize,
+          },
+        },
+      })
+    })
+
+    it('should call handler with border-box option', async () => {
+      await nextTick()
+      expect(onResize).toHaveBeenCalled()
+      expect(onResize).toHaveBeenCalledWith(
+        expect.objectContaining({ width: expect.any(Number), height: expect.any(Number) }),
+      )
     })
   })
 })

--- a/packages/core/useElementSize/directive.ts
+++ b/packages/core/useElementSize/directive.ts
@@ -20,6 +20,6 @@ export const vElementSize: ObjectDirective<
     const options = (typeof binding.value === 'function' ? [] : binding.value.slice(1)) as RemoveFirstFromTuple<BindingValueArray>
 
     const { width, height } = useElementSize(el, ...options)
-    watch([width, height], ([width, height]) => handler({ width, height }))
+    watch([width, height], ([width, height]) => handler({ width, height }), { immediate: true })
   },
 }


### PR DESCRIPTION
When using `v-element-size` with `{ box: 'border-box' }`, the handler
is never invoked because `tryOnMounted` sets refs to offsetWidth/
offsetHeight synchronously, and the ResizeObserver reports the same
border-box values — so Vue's watch never detects a change.

Add `{ immediate: true }` to the watch in `directive.ts`, consistent
with how `useElementVisibility` directive already handles this case.

Closes #5347