### PR TITLE
fix(useWebSocket): prevent stale onclose from pausing new connection …

### DIFF
--- a/packages/core/useWebSocket/index.test.ts
+++ b/packages/core/useWebSocket/index.test.ts
@@ -437,6 +437,46 @@ describe('useWebSocket', () => {
       expect(mockWebSocket.prototype.close).not.toHaveBeenCalled()
     })
 
+    it('should not pause heartbeat when old ws.onclose fires after new ws.onopen on URL change', async () => {
+      const url = shallowRef('ws://server1')
+      const messageSpy = vi.fn(() => 'ping')
+
+      vm = useSetup(() => {
+        const ref = useWebSocket(url, {
+          heartbeat: {
+            message: messageSpy,
+            interval: 500,
+            pongTimeout: 1000,
+          },
+        })
+        return { ref }
+      })
+
+      const oldWs = vm.ref.ws.value!
+      oldWs.onopen?.(new Event('open'))
+      expect(vm.ref.status.value).toBe('OPEN')
+
+      await vi.advanceTimersByTimeAsync(500)
+      expect(messageSpy).toHaveBeenCalledTimes(1)
+      messageSpy.mockClear()
+
+      url.value = 'ws://server2'
+      await nextTick()
+
+      const newWs = vm.ref.ws.value!
+      expect(newWs).not.toBe(oldWs)
+
+      newWs.onopen?.(new Event('open'))
+      expect(vm.ref.status.value).toBe('OPEN')
+
+      oldWs.onclose?.(new CloseEvent('close'))
+
+      expect(vm.ref.status.value).toBe('OPEN')
+
+      await vi.advanceTimersByTimeAsync(500)
+      expect(messageSpy).toHaveBeenCalledTimes(1)
+    })
+
     it('should not send a heartbeat if the connection is closed', async () => {
       const messageSpy = vi.fn(() => 'ping')
       vm = useSetup(() => {

--- a/packages/core/useWebSocket/index.ts
+++ b/packages/core/useWebSocket/index.ts
@@ -268,8 +268,10 @@ export function useWebSocket<Data = any>(
       if (wsRef.value === ws)
         status.value = 'CLOSED'
 
-      resetHeartbeat()
-      heartbeatPause?.()
+      if (!wsRef.value || wsRef.value === ws) {
+        resetHeartbeat()
+        heartbeatPause?.()
+      }
       onDisconnected?.(ws, ev)
 
       if (!explicitlyClosed && options.autoReconnect && (wsRef.value == null || ws === wsRef.value)) {


### PR DESCRIPTION
fix #5229 

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

### Problem

When using `useWebSocket` with a reactive URL and heartbeat enabled, changing the URL can cause the heartbeat to permanently stop.

This happens due to a race condition: `open()` synchronously calls `close(oldWs)` then `_init(newWs)`, but `oldWs.onclose` fires asynchronously. If the server takes a few extra milliseconds to ACK the close, the timeline becomes:

1. `newWs.onopen` → `status = 'OPEN'`, `heartbeatResume()` √
2. `oldWs.onclose` → `resetHeartbeat()`, `heartbeatPause()` × (kills new heartbeat)

The `status` assignment already had a `wsRef.value === ws` guard, but `resetHeartbeat()` and `heartbeatPause()` did not.

### Fix

Wrap `resetHeartbeat()` and `heartbeatPause()` in `onclose` with the same guard:

```js
if (!wsRef.value || wsRef.value === ws) {
  resetHeartbeat()
  heartbeatPause?.()
}

### Additional context
