### PR TITLE
fix(useElementSize): call directive handler immediately on mount

### DIFF
--- a/packages/core/useElementSize/directive.test.ts
+++ b/packages/core/useElementSize/directive.test.ts
@@ -45,6 +45,10 @@ describe('vElementSize', () => {
     it('should be defined', () => {
       expect(wrapper).toBeDefined()
     })
+
+    it('should call handler immediately on mount', () => {
+      expect(onResize).toHaveBeenCalledWith({ width: expect.any(Number), height: expect.any(Number) })
+    })
   })
 
   describe('given options', () => {

--- a/packages/core/useElementSize/directive.ts
+++ b/packages/core/useElementSize/directive.ts
@@ -20,6 +20,6 @@ export const vElementSize: ObjectDirective<
     const options = (typeof binding.value === 'function' ? [] : binding.value.slice(1)) as RemoveFirstFromTuple<BindingValueArray>
 
     const { width, height } = useElementSize(el, ...options)
-    watch([width, height], ([width, height]) => handler({ width, height }))
+    watch([width, height], ([width, height]) => handler({ width, height }), { immediate: true })
   },
 }


### PR DESCRIPTION
## Summary

Fixes #5347

The `vElementSize` directive handler was never called when using `{ box: 'border-box' }` because the initial size values were set synchronously before the `watch` was registered.

## Root Cause

1. `useElementSize` calls `tryOnMounted` which runs **synchronously** in directive context (no component lifecycle)
2. `width`/`height` refs are set to the element's `offsetWidth`/`offsetHeight` immediately
3. `watch([width, height], handler)` starts watching from those already-correct values
4. `ResizeObserver` fires with the same border-box values → no change detected → handler never called

## Fix

Added `{ immediate: true }` to the `watch` in `directive.ts` so the handler is always called with the initial size values right after mount.

```diff
- watch([width, height], ([width, height]) => handler({ width, height }))
+ watch([width, height], ([width, height]) => handler({ width, height }), { immediate: true })
```

## Test

Added a test verifying the handler is called immediately on mount. All 3 directive tests pass.