### PR TITLE
fix(useSortable): change UseSortableOptions from interface to type intersection

### DIFF
--- a/packages/integrations/useSortable/index.ts
+++ b/packages/integrations/useSortable/index.ts
@@ -23,7 +23,7 @@ export interface UseSortableReturn {
   option: (<K extends keyof Sortable.Options>(name: K, value: Sortable.Options[K]) => void) & (<K extends keyof Sortable.Options>(name: K) => Sortable.Options[K])
 }
 
-export interface UseSortableOptions extends Options, ConfigurableDocument {
+export type UseSortableOptions = Options & ConfigurableDocument & {
   /**
    * Watch the element reference for changes and automatically reinitialize Sortable
    * when the element changes.


### PR DESCRIPTION
## Summary

Fixes #5287

When using `useSortable`, passing valid SortableJS options like `animation` causes a TypeScript error:

```
'animation' does not exist in type 'UseSortableOptions'
```

## Root Cause

`interface extends` is stricter than type intersection when the base types (`Options` from SortableJS) have complex overloads or index signatures. TypeScript narrows the allowed keys more aggressively with `interface extends`.

## Fix

```diff
- export interface UseSortableOptions extends Options, ConfigurableDocument {
+ export type UseSortableOptions = Options & ConfigurableDocument & {
```

One-line change. Type intersection (`&`) preserves all properties from `Options` without the narrowing issue.

## References

This is the exact fix suggested in the issue by the reporter.