### PR TITLE
fix(docs): add `ignoreDeprecations` for twoslash TS 6.0 compat

### DIFF
--- a/packages/.vitepress/config.ts
+++ b/packages/.vitepress/config.ts
@@ -77,6 +77,9 @@ export default withPwa(defineConfig({
     codeTransformers: [
       transformerTwoslash({
         twoslashOptions: {
+          compilerOptions: {
+            ignoreDeprecations: '6.0',
+          },
           handbookOptions: {
             noErrors: true,
           },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

The docs build fails with TypeScript 6.0.2 because twoslash internally sets `baseUrl` and defaults to `moduleResolution=node10`, both deprecated in TS 6.0. This adds `ignoreDeprecations: '6.0'` to the twoslash compilerOptions in the VitePress config to fix the build.

### Additional context

The deprecation errors originate from `@typescript/vfs` when twoslash creates its virtual TS environment. Since `baseUrl` is set internally by twoslash (needed for its virtual filesystem), the cleanest fix is to silence the deprecation warnings.