### PR TITLE
fix(useClipboard): prevents fail in Safari for async operation

### DIFF
--- a/packages/core/useClipboard/index.browser.test.ts
+++ b/packages/core/useClipboard/index.browser.test.ts
@@ -19,6 +19,16 @@ describe('useClipboard', () => {
       expect(copied.value).toBe(true)
     })
 
+    it('should copy text from async function', async () => {
+      const { text, copy, copied } = useClipboard()
+      expect(text.value).toBe('')
+      expect(copied.value).toBe(false)
+
+      await copy(async () => 'async text')
+      expect(text.value).toBe('async text')
+      expect(copied.value).toBe(true)
+    })
+
     it.todo('should read from legacy clipboard')
   })
 

--- a/packages/core/useClipboard/index.browser.test.ts
+++ b/packages/core/useClipboard/index.browser.test.ts
@@ -20,11 +20,15 @@ describe('useClipboard', () => {
     })
 
     it('should copy text from async function', async () => {
-      const { text, copy, copied } = useClipboard()
+      const { text, copy, copied, copyPending } = useClipboard()
       expect(text.value).toBe('')
       expect(copied.value).toBe(false)
 
-      await copy(async () => 'async text')
+      const promise = copy(async () => 'async text')
+      expect(copyPending.value).toBe(true)
+
+      await promise
+
       expect(text.value).toBe('async text')
       expect(copied.value).toBe(true)
     })

--- a/packages/core/useClipboard/index.ts
+++ b/packages/core/useClipboard/index.ts
@@ -157,7 +157,7 @@ export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<strin
   }
 
   return {
-    copyPending,
+    copyPending: shallowReadonly(copyPending),
     isSupported,
     text: shallowReadonly(text),
     copied: shallowReadonly(copied),

--- a/packages/core/useClipboard/index.ts
+++ b/packages/core/useClipboard/index.ts
@@ -38,10 +38,15 @@ export interface UseClipboardOptions<Source> extends ConfigurableNavigator {
   legacy?: boolean
 }
 
+type ClipboardValue = string | (() => Promise<string | undefined>)
+
 export interface UseClipboardReturn<Optional> extends Supportable {
   text: Readonly<ShallowRef<string>>
   copied: Readonly<ShallowRef<boolean>>
-  copy: Optional extends true ? (text?: string) => Promise<void> : (text: string) => Promise<void>
+  copyPending: Readonly<ShallowRef<boolean>>
+  copy: Optional extends true
+    ? (text?: ClipboardValue) => Promise<void>
+    : (text: ClipboardValue) => Promise<void>
 }
 
 /**
@@ -69,6 +74,7 @@ export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<strin
   const isSupported = computed(() => isClipboardApiSupported.value || legacy)
   const text = shallowRef('')
   const copied = shallowRef(false)
+  const copyPending = shallowRef(false)
   const timeout = useTimeoutFn(() => copied.value = false, copiedDuring, { immediate: false })
 
   async function updateText() {
@@ -89,23 +95,44 @@ export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<strin
   if (isSupported.value && read)
     useEventListener(['copy', 'cut'], updateText, { passive: true })
 
-  async function copy(value = toValue(source)) {
-    if (isSupported.value && value != null) {
+  async function copy(value?: ClipboardValue) {
+    const resolvedValue = value ?? toValue(source)
+    if (isSupported.value && resolvedValue != null) {
       let useLegacy = !(isClipboardApiSupported.value && isAllowed(permissionWrite.value))
       if (!useLegacy) {
         try {
-          await navigator!.clipboard.writeText(value)
+          copyPending.value = true
+          const clipboardItem = createClipboardItem(resolvedValue)
+          await navigator!.clipboard.write([clipboardItem])
+          copyPending.value = false
         }
         catch {
           useLegacy = true
+          copyPending.value = false
         }
       }
-      if (useLegacy)
-        legacyCopy(value)
 
-      text.value = value
+      if (useLegacy && typeof resolvedValue === 'string') {
+        legacyCopy(resolvedValue)
+      }
+
       copied.value = true
       timeout.start()
+    }
+  }
+
+  function createClipboardItem(value: ClipboardValue): ClipboardItem {
+    if (typeof value === 'string') {
+      text.value = value
+      return new ClipboardItem({ 'text/plain': value })
+    }
+    else {
+      return new ClipboardItem({
+        'text/plain': value().then((resolvedText = '') => {
+          text.value = resolvedText
+          return new Blob([resolvedText], { type: 'text/plain' })
+        }),
+      })
     }
   }
 
@@ -130,6 +157,7 @@ export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<strin
   }
 
   return {
+    copyPending,
     isSupported,
     text: shallowReadonly(text),
     copied: shallowReadonly(copied),

--- a/packages/core/useClipboard/index.ts
+++ b/packages/core/useClipboard/index.ts
@@ -96,6 +96,10 @@ export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<strin
     useEventListener(['copy', 'cut'], updateText, { passive: true })
 
   async function copy(value?: ClipboardValue) {
+    if (copyPending.value) {
+      return
+    }
+
     const resolvedValue = value ?? toValue(source)
     if (isSupported.value && resolvedValue != null) {
       let useLegacy = !(isClipboardApiSupported.value && isAllowed(permissionWrite.value))

--- a/packages/core/useClipboard/index.ts
+++ b/packages/core/useClipboard/index.ts
@@ -76,6 +76,7 @@ export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<strin
   const copied = shallowRef(false)
   const copyPending = shallowRef(false)
   const timeout = useTimeoutFn(() => copied.value = false, copiedDuring, { immediate: false })
+  let lastLegacyId = 0
 
   async function updateText() {
     let useLegacy = !(isClipboardApiSupported.value && isAllowed(permissionRead.value))
@@ -96,9 +97,6 @@ export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<strin
     useEventListener(['copy', 'cut'], updateText, { passive: true })
 
   async function copy(value?: ClipboardValue) {
-    if (copyPending.value)
-      return
-
     const resolvedValue = value ?? toValue(source)
     if (isSupported.value && resolvedValue != null) {
       copyPending.value = true
@@ -121,8 +119,9 @@ export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<strin
         }
         else {
           // For async functions in legacy mode, resolve and copy
+          const currentId = ++lastLegacyId
           const resolvedText = await resolvedValue()
-          if (resolvedText != null) {
+          if (resolvedText != null && currentId === lastLegacyId) {
             text.value = resolvedText
             legacyCopy(resolvedText)
           }

--- a/packages/core/useClipboard/index.ts
+++ b/packages/core/useClipboard/index.ts
@@ -96,34 +96,42 @@ export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<strin
     useEventListener(['copy', 'cut'], updateText, { passive: true })
 
   async function copy(value?: ClipboardValue) {
-    if (copyPending.value) {
+    if (copyPending.value)
       return
-    }
 
     const resolvedValue = value ?? toValue(source)
     if (isSupported.value && resolvedValue != null) {
+      copyPending.value = true
       let useLegacy = !(isClipboardApiSupported.value && isAllowed(permissionWrite.value))
+
       if (!useLegacy) {
         try {
-          copyPending.value = true
           const clipboardItem = createClipboardItem(resolvedValue)
           await navigator!.clipboard.write([clipboardItem])
-          copyPending.value = false
         }
         catch {
           useLegacy = true
         }
-        finally {
-          copyPending.value = false
-        }
       }
 
-      if (useLegacy && typeof resolvedValue === 'string') {
-        legacyCopy(resolvedValue)
+      if (useLegacy) {
+        if (typeof resolvedValue === 'string') {
+          text.value = resolvedValue
+          legacyCopy(resolvedValue)
+        }
+        else {
+          // For async functions in legacy mode, resolve and copy
+          const resolvedText = await resolvedValue()
+          if (resolvedText != null) {
+            text.value = resolvedText
+            legacyCopy(resolvedText)
+          }
+        }
       }
 
       copied.value = true
       timeout.start()
+      copyPending.value = false
     }
   }
 

--- a/packages/core/useClipboard/index.ts
+++ b/packages/core/useClipboard/index.ts
@@ -108,6 +108,8 @@ export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<strin
         }
         catch {
           useLegacy = true
+        }
+        finally {
           copyPending.value = false
         }
       }

--- a/test/__snapshots__/tsnapi/@vueuse/core/index.snapshot.d.ts
+++ b/test/__snapshots__/tsnapi/@vueuse/core/index.snapshot.d.ts
@@ -396,7 +396,8 @@ export interface UseClipboardOptions<Source> extends ConfigurableNavigator {
 export interface UseClipboardReturn<Optional> extends Supportable {
   text: Readonly<ShallowRef<string>>;
   copied: Readonly<ShallowRef<boolean>>;
-  copy: Optional extends true ? (text?: string) => Promise<void> : (text: string) => Promise<void>;
+  copyPending: Readonly<ShallowRef<boolean>>;
+  copy: Optional extends true ? (text?: ClipboardValue) => Promise<void> : (text: ClipboardValue) => Promise<void>;
 }
 export interface UseClonedOptions<T = any> extends WatchOptions {
   clone?: (_: T) => T;


### PR DESCRIPTION
### Description

resolves #5368 

### Additional context
I've ensured compatibility with the current implementation to prevent breaking changes. The copy method still accepts an optional string, continuing to default from the source. Additionally, it now can also accept a function that returns a Promise resolving to a string. Since this operation can now be asynchronous, I've added a new `copyPending` boolean to enable showing a pending state when necessary.

This is my first time contributing to Vueuse, so let me know if I'm missing anything. I'm not too familiar with the codebase.

This could be a first draft. We can improve readability as well, if needed.
We could also decide to create a completely separate composable.

Thanks again for taking the time to read this ❤️ 