### PR TITLE
fix(useSortable): re-query DOM on every `start()` for string selectors

### DIFF
--- a/packages/integrations/useSortable/index.browser.test.ts
+++ b/packages/integrations/useSortable/index.browser.test.ts
@@ -316,4 +316,103 @@ describe('useSortable', () => {
       }
     })
   })
+
+  // Regression: 14.2 wrapped element lookup in a computed with no reactive
+  // deps for the string-selector branch, so a null result from the mount-time
+  // query was cached forever — later start()/stop()+start() calls never
+  // re-queried the DOM. These tests pin that start() must always re-query.
+  describe('string selector regression', () => {
+    it('attaches Sortable when start() is called after the target appears', async () => {
+      const wrapper = mount(defineComponent({
+        template: '<div v-if="show" ref="el" id="late-el"></div>',
+        setup() {
+          const el = useTemplateRef<HTMLElement>('el')
+          const show = shallowRef(false)
+          const list = shallowRef<string[]>([])
+          const result = useSortable('#late-el', list, {})
+
+          return { ...result, el, show }
+        },
+      }), { attachTo: document.body })
+      const vm = wrapper.vm
+      try {
+        // Target does not exist on mount — tryOnMounted(start) finds nothing.
+        expect(document.querySelector('#late-el')).toBeNull()
+
+        vm.show = true
+        await wrapper.vm.$nextTick()
+        expect(vm.el).toBeDefined()
+
+        vm.start()
+        expect(Sortable.get(vm.el!)).toBeDefined()
+      }
+      finally {
+        wrapper.unmount()
+      }
+    })
+
+    it('attaches Sortable when stop()+start() is called after the target appears', async () => {
+      const wrapper = mount(defineComponent({
+        template: '<div v-if="show" ref="el" id="late-el-2"></div>',
+        setup() {
+          const el = useTemplateRef<HTMLElement>('el')
+          const show = shallowRef(false)
+          const list = shallowRef<string[]>([])
+          const result = useSortable('#late-el-2', list, {})
+
+          return { ...result, el, show }
+        },
+      }), { attachTo: document.body })
+      const vm = wrapper.vm
+      try {
+        expect(document.querySelector('#late-el-2')).toBeNull()
+
+        vm.show = true
+        await wrapper.vm.$nextTick()
+        expect(vm.el).toBeDefined()
+
+        // Common workaround: destroy first, then retry. Must still work.
+        vm.stop()
+        vm.start()
+        expect(Sortable.get(vm.el!)).toBeDefined()
+      }
+      finally {
+        wrapper.unmount()
+      }
+    })
+
+    it('re-queries the DOM on every start() when the target is replaced', async () => {
+      const wrapper = mount(defineComponent({
+        template: '<div v-if="show" ref="el" id="toggle-el"></div>',
+        setup() {
+          const el = useTemplateRef<HTMLElement>('el')
+          const show = shallowRef(true)
+          const list = shallowRef<string[]>([])
+          const result = useSortable('#toggle-el', list, {})
+
+          return { ...result, el, show }
+        },
+      }), { attachTo: document.body })
+      const vm = wrapper.vm
+      try {
+        const firstElement = vm.el!
+        expect(Sortable.get(firstElement)).toBeDefined()
+
+        vm.show = false
+        await wrapper.vm.$nextTick()
+        vm.stop()
+
+        vm.show = true
+        await wrapper.vm.$nextTick()
+        const secondElement = vm.el!
+        expect(secondElement).not.toBe(firstElement)
+
+        vm.start()
+        expect(Sortable.get(secondElement)).toBeDefined()
+      }
+      finally {
+        wrapper.unmount()
+      }
+    })
+  })
 })

--- a/packages/integrations/useSortable/index.ts
+++ b/packages/integrations/useSortable/index.ts
@@ -3,7 +3,7 @@ import type { Options } from 'sortablejs'
 import type { MaybeRef, MaybeRefOrGetter } from 'vue'
 import { defaultDocument, tryOnMounted, tryOnScopeDispose, unrefElement } from '@vueuse/core'
 import Sortable from 'sortablejs'
-import { computed, isRef, nextTick, toValue, watch } from 'vue'
+import { isRef, nextTick, toValue, watch } from 'vue'
 
 export interface UseSortableReturn {
   /**
@@ -65,8 +65,6 @@ export function useSortable<T>(
     },
   }
 
-  const element = computed(() => (typeof el === 'string' ? document?.querySelector(el) : unrefElement(el)))
-
   const cleanup = () => {
     sortable?.destroy()
     sortable = undefined
@@ -79,7 +77,7 @@ export function useSortable<T>(
   }
 
   const start = () => {
-    const target = element.value
+    const target = typeof el === 'string' ? document?.querySelector(el) : unrefElement(el)
     if (target)
       initSortable(target)
   }
@@ -97,7 +95,7 @@ export function useSortable<T>(
   if (watchElement && typeof el !== 'string') {
     // New behavior: watch element changes and auto-reinitialize
     stopWatch = watch(
-      element,
+      () => unrefElement(el),
       (newElement) => {
         cleanup()
         if (newElement)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Since 14.2 (#5189), `useSortable` wraps the element lookup in a `computed`:

```ts
const element = computed(() =>
  typeof el === 'string' ? document?.querySelector(el) : unrefElement(el),
)
```

When `el` is a **string selector**, this getter reads nothing reactive, so Vue caches the first result forever. If the target DOM isn't in the document at mount time (e.g. behind `v-if` or inside a closed drawer), `element.value` is pinned to `null` and `start()` / `stop()` + `start()` can never recover, Sortable never attaches.

Ref inputs are fine because `unrefElement(ref)` tracks `ref.value` as a reactive dep.

### Additional context

The bug only triggers when all three hold: string selector + target missing at mount + integrations ≥ 14.2. Ref usage, `v-show`, and always-rendered tables are unaffected, which is why earlier review missed it.
