### PR TITLE
docs(useCloned): add tip about watch flush timing

### DIFF
--- a/packages/core/useCloned/index.md
+++ b/packages/core/useCloned/index.md
@@ -18,6 +18,8 @@ const { cloned } = useCloned(original)
 original.value.key = 'some new value'
 
 console.log(cloned.value.key) // 'value'
+
+nextTick(() => console.log(cloned.value.key)) // 'some new value'
 ```
 
 ## Manual cloning

--- a/packages/core/useCloned/index.md
+++ b/packages/core/useCloned/index.md
@@ -18,8 +18,17 @@ const { cloned } = useCloned(original)
 original.value.key = 'some new value'
 
 console.log(cloned.value.key) // 'value'
+```
 
-nextTick(() => console.log(cloned.value.key)) // 'some new value'
+Changes to the source are not reflected in the cloned ref immediately. 
+Use `{ flush: 'sync' }` to obtain the updated value without delay.
+
+```ts
+const { cloned } = useCloned(original, { flush: 'sync' })
+
+original.value.key = 'some new value'
+
+console.log(cloned.value.key) // 'some new value'
 ```
 
 ## Manual cloning

--- a/packages/core/useCloned/index.md
+++ b/packages/core/useCloned/index.md
@@ -20,7 +20,7 @@ original.value.key = 'some new value'
 console.log(cloned.value.key) // 'value'
 ```
 
-Changes to the source are not reflected in the cloned ref immediately. 
+Changes to the source are not reflected in the cloned ref immediately.
 Use `{ flush: 'sync' }` to obtain the updated value without delay.
 
 ```ts


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

In the `useCloned` documentation, the current usage example modifies the original ref and immediately prints the cloned value synchronously. Because Vue's `watch` is asynchronous by default, it prints the old value (`'value'`). 
This might confuse some users into thinking that `useCloned` does not automatically track changes. 

To resolve this confusion, I've added a tip in the documentation to clarify the default async behavior and provided a snippet showing how to use `{ flush: 'sync' }` to get immediate updates:
```ts
const original = ref({ key: 'value' })
const { cloned } = useCloned(original, { flush: 'sync' })
original.value.key = 'some new value'
console.log(cloned.value.key) // 'some new value'
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
