### PR TITLE
fix(usePointerSwipe): handle pointercancel event to reset state and trigger onSwipeEnd

### DIFF
--- a/packages/core/usePointerSwipe/index.ts
+++ b/packages/core/usePointerSwipe/index.ts
@@ -144,17 +144,7 @@ export function usePointerSwipe(
         onSwipe?.(e)
     }, listenerOptions),
 
-    useEventListener(target, 'pointerup', (e: PointerEvent) => {
-      if (!eventIsAllowed(e))
-        return
-      if (isSwiping.value)
-        onSwipeEnd?.(e, direction.value)
-
-      isPointerDown.value = false
-      isSwiping.value = false
-    }, listenerOptions),
-
-    useEventListener(target, 'pointercancel', (e: PointerEvent) => {
+    useEventListener(target, ['pointerup', 'pointercancel'], (e: PointerEvent) => {
       if (!eventIsAllowed(e))
         return
       if (isSwiping.value)

--- a/packages/core/usePointerSwipe/index.ts
+++ b/packages/core/usePointerSwipe/index.ts
@@ -153,6 +153,16 @@ export function usePointerSwipe(
       isPointerDown.value = false
       isSwiping.value = false
     }, listenerOptions),
+
+    useEventListener(target, 'pointercancel', (e: PointerEvent) => {
+      if (!eventIsAllowed(e))
+        return
+      if (isSwiping.value)
+        onSwipeEnd?.(e, direction.value)
+
+      isPointerDown.value = false
+      isSwiping.value = false
+    }, listenerOptions),
   ]
 
   tryOnMounted(() => {


### PR DESCRIPTION
Fixes #5370.

## Problem

`usePointerSwipe` listens to `pointerdown`, `pointermove`, and `pointerup`, but not `pointercancel`. In touch environments (e.g. Chrome DevTools touch emulation, real mobile devices), the browser fires `pointercancel` instead of `pointerup` when a touch gesture is interrupted — for example when a non-vertical swipe triggers native scroll. When this happens:

- `isSwiping` stays `true` permanently
- `onSwipeEnd` is never called
- The internal state is permanently dirty until the next `pointerdown`

## Fix

Add a `pointercancel` listener that mirrors the existing `pointerup` handler exactly: call `onSwipeEnd` if the pointer was swiping, then reset `isPointerDown` and `isSwiping`.

This is the standard W3C-recommended way to handle cancelled pointer gestures — the [Pointer Events spec](https://www.w3.org/TR/pointerevents3/#the-pointercancel-event) explicitly states that `pointercancel` must be treated as equivalent to `pointerup` for cleanup purposes.