### PR TITLE
fix(vElementSize): handler never called with border-box option

### DIFF
--- a/packages/core/useElementSize/directive.ts
+++ b/packages/core/useElementSize/directive.ts
@@ -21,7 +21,7 @@ export const vElementSize = createDisposableDirective<
       const options = (typeof binding.value === 'function' ? [] : binding.value.slice(1)) as RemoveFirstFromTuple<BindingValueArray>
 
       const { width, height } = useElementSize(el, ...options)
-      watch([width, height], ([width, height]) => handler({ width, height }))
+      watch([width, height], ([width, height]) => handler({ width, height }), { immediate: true })
     },
   },
 )


### PR DESCRIPTION
## Summary

Fixes #5347

When `v-element-size` is used with `{ box: "border-box" }`, the handler is **never called** — not on mount and not on ResizeObserver callbacks.

## Root Cause

1. `useElementSize` pre-fills `width`/`height` via `offsetWidth`/`offsetHeight` in `tryOnMounted`. These are always **border-box** values.
2. The directive watches `[width, height]` **without** `{ immediate: true }`.
3. When `ResizeObserver` fires with `box: 'border-box'`, it reports the same border-box values that were already pre-filled.
4. Vue sees no change (`45 → 45`) and skips the handler.

The `{ box: 'content-box' }` default case works by accident — `offsetWidth` (border-box) ≠ `contentBoxSize`, so the watch detects a real change.

## Fix

Add `{ immediate: true }` to the watch in `directive.ts`. This ensures the handler fires on mount with the pre-filled values.

For `content-box` (the default), this adds one extra immediate call on mount, which is harmless since the handler simply reports the current size.

## Changes

- `packages/core/useElementSize/directive.ts`: Added `{ immediate: true }` to the watch callback (1 line change)
