### PR TITLE
fix(createReusableTemplate): allow deferred generic type parameters for Bindings

### DIFF
--- a/packages/core/createReusableTemplate/index.ts
+++ b/packages/core/createReusableTemplate/index.ts
@@ -59,11 +59,11 @@ export interface CreateReusableTemplateOptions<Props extends Record<string, any>
  * @__NO_SIDE_EFFECTS__
  */
 export function createReusableTemplate<
-  Bindings extends Record<string, any>,
+  Bindings = Record<string, never>,
   MapSlotNameToSlotProps extends ObjectLiteralWithPotentialObjectLiterals = Record<'default', undefined>,
 >(
-  options: CreateReusableTemplateOptions<Bindings> = {},
-): ReusableTemplatePair<Bindings, MapSlotNameToSlotProps> {
+  options: CreateReusableTemplateOptions<Bindings & Record<string, any>> = {},
+): ReusableTemplatePair<Bindings & Record<string, any>, MapSlotNameToSlotProps> {
   const {
     inheritAttrs = true,
     name = 'ReusableTemplate',
@@ -78,7 +78,7 @@ export function createReusableTemplate<
         render.value = slots.default
       }
     },
-  }) as unknown as DefineTemplateComponent<Bindings, MapSlotNameToSlotProps>
+  }) as unknown as DefineTemplateComponent<Bindings & Record<string, any>, MapSlotNameToSlotProps>
 
   const reuse = defineComponent({
     inheritAttrs,
@@ -98,12 +98,12 @@ export function createReusableTemplate<
         return (inheritAttrs && vnode?.length === 1) ? vnode[0] : vnode
       }
     },
-  }) as unknown as ReuseTemplateComponent<Bindings, MapSlotNameToSlotProps>
+  }) as unknown as ReuseTemplateComponent<Bindings & Record<string, any>, MapSlotNameToSlotProps>
 
   return makeDestructurable(
     { define, reuse },
     [define, reuse],
-  ) as ReusableTemplatePair<Bindings, MapSlotNameToSlotProps>
+  ) as ReusableTemplatePair<Bindings & Record<string, any>, MapSlotNameToSlotProps>
 }
 
 function keysToCamelKebabCase(obj: Record<string, any>) {


### PR DESCRIPTION
## Summary

When using `<script setup generic="T">` with `createReusableTemplate<{ option: T }>()`, TypeScript fails with a type error because it cannot prove `{ option: T } extends Record<string, any>` at the call site — `T` is a deferred generic that is not yet resolved.

## Reproduction

```vue
<script lang="ts">
import { createReusableTemplate } from '@vueuse/core'

export type AcceptableValue =
    | string
    | { label: string; value: string | number | null }
    | null
</script>

<script setup lang="ts" generic="T extends AcceptableValue = AcceptableValue">
const [DefineTemplate, ReuseTemplate] = createReusableTemplate<{
  option: T
}>()
</script>

<template>
  <DefineTemplate #="{ option }">
    <div>Template: {{ option }}</div>
  </DefineTemplate>
  <ReuseTemplate option="awd" />
</template>
```

## Changes

- Removed the `extends Record<string, any>` constraint on the `Bindings` type parameter in `createReusableTemplate()`
- Changed default to `Bindings = Record<string, never>` (consistent with inferred type when no explicit arg)
- Used `Bindings & Record<string, any>` in all type positions that require the `Record<string, any>` constraint (options, return type, and `as` casts)

This preserves full type safety for downstream consumers while allowing deferred generics to pass through the function signature. Since `X & Record<string, any>` always satisfies `extends Record<string, any>`, the existing type aliases (`DefineTemplateComponent`, `ReuseTemplateComponent`, `ReusableTemplatePair`) work unchanged.

Fixes #5354