### PR TITLE
fix(useTextareaAutosize): bind textarea ref in demo

### DIFF
--- a/packages/core/useTextareaAutosize/demo.vue
+++ b/packages/core/useTextareaAutosize/demo.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useTextareaAutosize } from '@vueuse/core'
 
-const { input } = useTextareaAutosize()
+const { textarea, input } = useTextareaAutosize()
 </script>
 
 <template>


### PR DESCRIPTION
## Summary

The demo for `useTextareaAutosize` only destructured `input` from the composable return value:

```diff
-const { input } = useTextareaAutosize()
+const { textarea, input } = useTextareaAutosize()
```

Without destructuring `textarea`, the template ref `ref="textarea"` had no matching script ref in `<script setup>`. The `textarea` ref inside `useTextareaAutosize()` was never populated, remaining `undefined`. This caused `triggerResize()` to return early at the `if (!textarea.value) return` guard on every call, so the textarea never resized.

## Fix

Added `textarea` to the destructuring so Vue 3's template ref binding connects the DOM element to the composable's internal ref.

Fixes #5380