### PR TITLE
docs(useIntersectionObserver): use ref instead of shallowRef in examples

### DIFF
--- a/packages/core/useIntersectionObserver/index.md
+++ b/packages/core/useIntersectionObserver/index.md
@@ -11,10 +11,10 @@ Detects changes to a target element's visibility.
 ```vue
 <script setup lang="ts">
 import { useIntersectionObserver } from '@vueuse/core'
-import { shallowRef, useTemplateRef } from 'vue'
+import { ref, useTemplateRef } from 'vue'
 
 const target = useTemplateRef('target')
-const targetIsVisible = shallowRef(false)
+const targetIsVisible = ref(false)
 
 const { stop } = useIntersectionObserver(
   target,
@@ -36,11 +36,11 @@ const { stop } = useIntersectionObserver(
 ```vue
 <script setup lang="ts">
 import { vIntersectionObserver } from '@vueuse/components'
-import { shallowRef, useTemplateRef } from 'vue'
+import { ref, useTemplateRef } from 'vue'
 
 const root = useTemplateRef('root')
 
-const isVisible = shallowRef(false)
+const isVisible = ref(false)
 
 function onIntersectionObserver([entry]: IntersectionObserverEntry[]) {
   isVisible.value = entry?.isIntersecting || false


### PR DESCRIPTION
## Summary
Hey! First of all I wanna say thank you for all the work on this package, I use it daily and really appreciate it, you all rock!

This one is just a lil nitpick, nothing special, feel free to close it if you don't think it's worth the noise. It's essentially about following Vue conventions (`ref` vs `shallowRef`) purely on the docs side. I noticed the guidelines recommend `shallowRef` and there's an ESLint rule enforcing it across the codebase, so I scoped this strictly to the `.md` files (which the lint rule explicitly excludes). The composable code and demo are untouched since the outcome is identical and there's no behavioral difference for primitives.

This PR is strictly for the consumer reading the docs, adhering to Vue's idiomatic conventions.

- Switch `shallowRef(false)` → `ref(false)` in `useIntersectionObserver/index.md` examples
- Behavior is identical for primitives,  this is a docs-clarity change, not a reactivity fix

## Why
Per Vue's reactivity advanced API, `shallowRef` is typically used as an optimization to skip deep tracking on large objects. For primitives, there is no deep tracking to skip, so `shallowRef(false)` and `ref(false)` behave identically.

Because documentation snippets are read by users learning the API, using Vue's idiomatic default (`ref`) makes them more standard and easier to copy-paste into a typical application without raising questions. Notably, the project's own `guidelines.md` already uses `ref(false)` for a primitive boolean in its examples, so this PR simply aligns this document with that established pattern.

## Scope
- `index.md` only
- `index.ts` and `demo.vue` are unchanged

Happy to expand this to other docs files for consistency, or keep it scoped to just this one — let me know your preference!

<!-- Thank you for contributing! -->