### PR TITLE
fix(useTextareaAutosize): bind textarea ref in demo

### DIFF
--- a/packages/core/useTextareaAutosize/demo.vue
+++ b/packages/core/useTextareaAutosize/demo.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useTextareaAutosize } from '@vueuse/core'
 
-const { input } = useTextareaAutosize()
+const { textarea, input } = useTextareaAutosize()
 </script>
 
 <template>


### PR DESCRIPTION
## Summary

The `useTextareaAutosize` demo page was not binding the `textarea` ref to the composable, causing the auto-resize functionality to not work in the interactive demo.

## Problem

The demo component creates a `textarea` element but never passes the ref to `useTextareaAutosize()`. This means the demo doesn't actually demonstrate the composable's behavior.

## Fix

Bind the textarea ref properly in the demo component so the auto-resize functionality works as expected.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update