### PR TITLE
fix: drop unnecessary `PURE` annotation to avoid Rollup warning

### DIFF
--- a/packages/core/useEventBus/internal.ts
+++ b/packages/core/useEventBus/internal.ts
@@ -1,4 +1,3 @@
 import type { EventBusEvents, EventBusIdentifier } from './index'
 
-/* #__PURE__ */
 export const events = new Map<EventBusIdentifier<any>, EventBusEvents<any>>()

--- a/packages/core/usePointer/index.ts
+++ b/packages/core/usePointer/index.ts
@@ -50,7 +50,7 @@ export interface UsePointerReturn {
   isInside: ShallowRef<boolean>
 }
 
-const defaultState: UsePointerState = /* #__PURE__ */ {
+const defaultState: UsePointerState = {
   x: 0,
   y: 0,
   pointerId: 0,


### PR DESCRIPTION
### Description

Fix #5387
Related #728
Related #647

### Additional context

Drop unnecessary `PURE` annotation, see Rollup [playground](https://rollupjs.org/repl/?version=4.60.3&shareable=eyJleGFtcGxlIjpudWxsLCJtb2R1bGVzIjpbeyJjb2RlIjoiLy8gY3JlYXRlIG9iamVjdFxuY29uc3QgZGVmYXVsdFN0YXRlID0gKHtcblx0eDogMCxcblx0eTogMCxcblx0cG9pbnRlcklkOiAwLFxuXHRwcmVzc3VyZTogMCxcblx0dGlsdFg6IDAsXG5cdHRpbHRZOiAwLFxuXHR3aWR0aDogMCxcblx0aGVpZ2h0OiAwLFxuXHR0d2lzdDogMCxcblx0cG9pbnRlclR5cGU6IG51bGxcbn0pO1xuY29uc3Qga2V5cyA9IE9iamVjdC5rZXlzKGRlZmF1bHRTdGF0ZSk7XG5cbi8vIGNyZWF0ZSBuZXcgbWFwXG5jb25zdCBnID0gbmV3IE1hcCgpIiwiaXNFbnRyeSI6dHJ1ZSwibmFtZSI6Im1haW4uanMifV0sIm9wdGlvbnMiOnsib3V0cHV0Ijp7ImZvcm1hdCI6ImVzIn0sInRyZWVzaGFrZSI6dHJ1ZX19).