### PR TITLE
docs(useTextareaAutosize): add note for native css option

### DIFF
--- a/packages/core/useTextareaAutosize/index.md
+++ b/packages/core/useTextareaAutosize/index.md
@@ -6,6 +6,9 @@ category: Browser
 
 Automatically update the height of a textarea depending on the content.
 
+> [!TIP]
+> You may not need this function anymore. Textarea autosizing can now be achieved natively with CSS, see [`field-sizing: content`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/field-sizing) for more information.
+
 ## Usage
 
 ### Simple example


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

For many, [`useTextareaAutosize`](https://vueuse.org/core/useTextareaAutosize/) is not necessary anymore and can be implemented using [`field-sizing: content`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/field-sizing). Firefox was the last major browser to implement this, [but it's now enabled by default](https://bugzilla.mozilla.org/show_bug.cgi?id=2036620) and will be released soon.

<img width="1425" height="688" alt="Screenshot 2026-05-07 at 3 05 54 PM" src="https://github.com/user-attachments/assets/dd272004-758e-4d83-8b13-497e173bdff4" />

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Others have had difficulty with this function, so letting people know there is a native option may help us deprecate this function in the future.

- https://github.com/vueuse/vueuse/issues/3372
- https://github.com/vueuse/vueuse/issues/3133
- https://github.com/vueuse/vueuse/issues/5380