### PR TITLE
fix(useFileDialog): remove capture attribute when option is absent or falsy

### DIFF
--- a/packages/core/useFileDialog/index.test.ts
+++ b/packages/core/useFileDialog/index.test.ts
@@ -228,4 +228,31 @@ describe('useFileDialog', () => {
 
     expect(input.capture).toBe('environment')
   })
+
+  it('should remove capture attribute when capture option is omitted', async () => {
+    const input = document.createElement('input')
+    input.click = vi.fn()
+
+    const { open } = useFileDialog({ input, capture: 'user' })
+
+    expect(input.capture).toBe('user')
+
+    // Open without capture — the attribute should be removed
+    open({ capture: undefined })
+
+    expect(input.hasAttribute('capture')).toBe(false)
+  })
+
+  it('should remove capture attribute when capture option is set to empty string', async () => {
+    const input = document.createElement('input')
+    input.click = vi.fn()
+
+    const { open } = useFileDialog({ input, capture: 'user' })
+
+    expect(input.capture).toBe('user')
+
+    open({ capture: '' })
+
+    expect(input.hasAttribute('capture')).toBe(false)
+  })
 })

--- a/packages/core/useFileDialog/index.ts
+++ b/packages/core/useFileDialog/index.ts
@@ -124,8 +124,11 @@ export function useFileDialog(options: UseFileDialogOptions = {}): UseFileDialog
     el.accept = toValue(options.accept)!
     // webkitdirectory key is not stabled, maybe replaced in the future.
     el.webkitdirectory = toValue(options.directory)!
-    if (hasOwn(options, 'capture'))
-      el.capture = toValue(options.capture)!
+    const capture = hasOwn(options, 'capture') ? toValue(options.capture) : undefined
+    if (capture)
+      el.setAttribute('capture', capture)
+    else
+      el.removeAttribute('capture')
   }
 
   const open = (localOptions?: Partial<UseFileDialogOptions>) => {


### PR DESCRIPTION
Fixes #5391

## Root cause

In `applyOptions`, the `capture` attribute was set via `el.capture = value` when the option was present, but never removed via `el.removeAttribute('capture')` when the option was absent or updated to a falsy value.

This meant that once `capture` was applied (e.g. via `useFileDialog({ capture: 'user' })` or `open({ capture: 'user' })`), subsequent calls without the `capture` option left the attribute on the hidden input element permanently.

The HTML `capture` attribute on `<input type="file">` controls whether the device camera/microphone is invoked directly. Leaving it stale changes behaviour on mobile browsers without the user expecting it.

## Fix

Replace the `el.capture = value` assignment with `setAttribute`/`removeAttribute` so the attribute is always brought in sync with the current option value:

```ts
// Before
if (hasOwn(options, 'capture'))
  el.capture = toValue(options.capture)!

// After
const capture = hasOwn(options, 'capture') ? toValue(options.capture) : undefined
if (capture)
  el.setAttribute('capture', capture)
else
  el.removeAttribute('capture')
```

## Tests added

- `should remove capture attribute when capture option is omitted` — verifies that calling `open({ capture: undefined })` after a previous `capture: 'user'` removes the attribute.
- `should remove capture attribute when capture option is set to empty string` — verifies that an explicit empty-string value also removes the attribute.