### PR TITLE
feat(useStorageAsync): support initOnMounted option

### DIFF
--- a/packages/core/useStorageAsync/index.test.ts
+++ b/packages/core/useStorageAsync/index.test.ts
@@ -1,6 +1,8 @@
 import type { Awaitable, StorageLikeAsync } from '@vueuse/core'
+import { mount } from '@vue/test-utils'
 import { createEventHook, useStorageAsync } from '@vueuse/core'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, nextTick } from 'vue'
 
 const KEY = 'custom-key'
 const KEY2 = 'custom-key2'
@@ -85,5 +87,30 @@ describe('useStorageAsync', () => {
       const result = await storage
       expect(result.value).toBe('AnotherValue')
     })
+  })
+
+  it('initOnMounted', async () => {
+    localStorage.setItem(KEY, 'random')
+
+    let basicRef: ReturnType<typeof useStorageAsync<string>> | undefined
+
+    mount(defineComponent({
+      setup() {
+        basicRef = useStorageAsync(KEY, '', new AsyncStubStorage(), { initOnMounted: true })
+        // Pre-mount, the ref still holds the default value because the
+        // initial read is deferred until the component is mounted.
+        expect(basicRef.value).toBe('')
+        return {}
+      },
+      render() {
+        return null
+      },
+    }))
+
+    await nextTick()
+    await vi.runAllTimersAsync()
+    await nextTick()
+
+    expect(basicRef!.value).toBe('random')
   })
 })

--- a/packages/core/useStorageAsync/index.ts
+++ b/packages/core/useStorageAsync/index.ts
@@ -2,7 +2,7 @@ import type { RemovableRef } from '@vueuse/shared'
 import type { MaybeRefOrGetter } from 'vue'
 import type { StorageLikeAsync } from '../ssr-handlers'
 import type { SerializerAsync, UseStorageOptions } from '../useStorage'
-import { watchWithFilter } from '@vueuse/shared'
+import { tryOnMounted, watchWithFilter } from '@vueuse/shared'
 import { ref as deepRef, shallowRef, toValue } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { getSSRHandler } from '../ssr-handlers'
@@ -56,6 +56,7 @@ export function useStorageAsync<T extends(string | number | boolean | object | n
       console.error(e)
     },
     onReady,
+    initOnMounted,
   } = options
 
   const rawInit: T = toValue(initialValue)
@@ -101,15 +102,32 @@ export function useStorageAsync<T extends(string | number | boolean | object | n
     }
   }
 
+  let firstMounted = false
+
   const promise = new Promise((resolve) => {
-    read().then(() => {
+    const initialRead = () => read().then(() => {
       onReady?.(data.value)
       resolve(data)
     })
+
+    if (initOnMounted) {
+      tryOnMounted(() => {
+        firstMounted = true
+        initialRead()
+      })
+    }
+    else {
+      initialRead()
+    }
   })
 
-  if (window && listenToStorageChanges)
-    useEventListener(window, 'storage', e => Promise.resolve().then(() => read(e)), { passive: true })
+  if (window && listenToStorageChanges) {
+    useEventListener(window, 'storage', (e) => {
+      if (initOnMounted && !firstMounted)
+        return
+      return Promise.resolve().then(() => read(e))
+    }, { passive: true })
+  }
 
   if (storage) {
     watchWithFilter(


### PR DESCRIPTION
Closes [#4488](https://github.com/AhmadHannan037/test-utils/issues/4488).

Mirrors the initOnMounted behavior already supported by useStorage (added in [#3504](https://github.com/AhmadHannan037/test-utils/issues/3504)): defers the initial async read until the component is mounted to avoid SSR/hydration mismatches when the persisted value differs from the server-rendered default.

What changed
Destructures initOnMounted (already part of the inherited UseStorageOptions) inside useStorageAsync.
When initOnMounted: true, runs the initial read() inside tryOnMounted instead of immediately. The Promise returned by the composable resolves once that deferred read completes.
Storage events fired before mount are ignored while initOnMounted is set, so the ref stays at the default until the deferred read.
Why
Same motivation as [#3504](https://github.com/AhmadHannan037/test-utils/issues/3504) for the sync version: prevents Hydration text content mismatch warnings when client localStorage holds a value that wasn't present on the server.

Test
Added an initOnMounted test in packages/core/useStorageAsync/index.test.ts, mirroring the structure of the equivalent test in useStorage. Asserts the ref is the default value pre-mount and the persisted value once the post-mount async read completes. All existing useStorageAsync and sibling useStorage tests continue to pass (38 of them).