### PR TITLE
fix(createReusableTemplate): isolate slot definitions per owner

### DIFF
--- a/packages/core/createReusableTemplate/index.test.ts
+++ b/packages/core/createReusableTemplate/index.test.ts
@@ -97,6 +97,52 @@ describe('createReusableTemplate', () => {
     expect(wrapper.text()).toBe('GoodbyeHi')
   })
 
+  it('does not leak slot definitions across component instances', async () => {
+    const [DefineFoo, ReuseFoo] = createReusableTemplate<{ msg: string }>()
+
+    const TemplateInstance = defineComponent({
+      name: 'TemplateInstance',
+      props: {
+        label: {
+          type: String,
+          required: true,
+        },
+        msg: {
+          type: String,
+          required: true,
+        },
+      },
+      components: {
+        DefineFoo,
+        ReuseFoo,
+      },
+      template: `
+        <DefineFoo v-slot="{ msg }">{{ label }}:{{ msg }}</DefineFoo>
+        <ReuseFoo :msg="msg" />
+      `,
+    })
+
+    const wrapper = mount({
+      components: { TemplateInstance },
+      data() {
+        return {
+          first: 'first',
+          second: 'second',
+        }
+      },
+      template: `
+        <TemplateInstance label="A" :msg="first" />
+        <TemplateInstance label="B" :msg="second" />
+      `,
+    })
+
+    expect(wrapper.text()).toBe('A:firstB:second')
+
+    await wrapper.setData({ first: 'updated' })
+
+    expect(wrapper.text()).toBe('A:updatedB:second')
+  })
+
   it('hyphen props', () => {
     const [DefineFoo, ReuseFoo] = createReusableTemplate<{ myMsg: string }>()
 

--- a/packages/core/createReusableTemplate/index.ts
+++ b/packages/core/createReusableTemplate/index.ts
@@ -1,6 +1,6 @@
 import type { ComponentObjectPropsOptions, DefineComponent, Slot } from 'vue'
 import { camelize, makeDestructurable } from '@vueuse/shared'
-import { defineComponent, shallowRef } from 'vue'
+import { defineComponent, getCurrentInstance } from 'vue'
 
 type ObjectLiteralWithPotentialObjectLiterals = Record<string, Record<string, any> | undefined>
 
@@ -69,13 +69,27 @@ export function createReusableTemplate<
     name = 'ReusableTemplate',
   } = options
 
-  const render = shallowRef<Slot | undefined>()
+  const render = new WeakMap<object, Slot | undefined>()
+  const fallback = {}
+
+  function getReuseOwner() {
+    let owner = getCurrentInstance()?.parent ?? null
+    while (owner && !render.has(owner))
+      owner = owner.parent
+    return owner ?? fallback
+  }
+
+  function getDefineOwner() {
+    return getCurrentInstance()?.parent ?? fallback
+  }
 
   const define = defineComponent({
     name: `${name}.define`,
     setup(_, { slots }) {
+      const key = getDefineOwner()
+
       return () => {
-        render.value = slots.default
+        render.set(key, slots.default)
       }
     },
   }) as unknown as DefineTemplateComponent<Bindings, MapSlotNameToSlotProps>
@@ -85,10 +99,14 @@ export function createReusableTemplate<
     name: `${name}.reuse`,
     props: options.props,
     setup(props, { attrs, slots }) {
+      const key = getReuseOwner()
+
       return () => {
-        if (!render.value && process.env.NODE_ENV !== 'production')
+        const renderSlot = render.get(key)
+
+        if (!renderSlot && process.env.NODE_ENV !== 'production')
           throw new Error('[VueUse] Failed to find the definition of reusable template')
-        const vnode = render.value?.({
+        const vnode = renderSlot?.({
           ...(options.props == null
             ? keysToCamelKebabCase(attrs)
             : props),


### PR DESCRIPTION
### Description

`createReusableTemplate()` stored the current `DefineTemplate` slot in one shared ref. When the pair is created outside component setup for Options API usage, multiple component instances share that ref and the latest definition can leak into another instance's `ReuseTemplate` render.

This changes the storage to a `WeakMap` keyed by the owning component instance, while still walking parent instances so nested reuse keeps working.

Fixes #3881.

### Validation

- `npm run test:unit -- packages/core/createReusableTemplate/index.test.ts`
- `npx eslint packages/core/createReusableTemplate/index.ts packages/core/createReusableTemplate/index.test.ts`
- `npm run typecheck`