### PR TITLE
fix(useDropZone): reset drag counter on dragover

### DIFF
--- a/packages/core/useDropZone/index.test.ts
+++ b/packages/core/useDropZone/index.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { useDropZone } from './index'
+
+function createDragEvent(type: string) {
+  const event = new Event(type, {
+    bubbles: true,
+    cancelable: true,
+  }) as DragEvent
+  const items = [{ type: 'text/plain' }] as DataTransferItem[]
+
+  Object.defineProperty(event, 'dataTransfer', {
+    value: {
+      dropEffect: 'none',
+      files: [],
+      items,
+    },
+  })
+
+  return event
+}
+
+describe('useDropZone', () => {
+  it('resets stale nested drag counters on dragover', () => {
+    const target = document.createElement('div')
+    const { isOverDropZone } = useDropZone(target)
+
+    target.dispatchEvent(createDragEvent('dragenter'))
+    target.dispatchEvent(createDragEvent('dragenter'))
+
+    expect(isOverDropZone.value).toBe(true)
+
+    target.dispatchEvent(createDragEvent('dragover'))
+    target.dispatchEvent(createDragEvent('dragleave'))
+
+    expect(isOverDropZone.value).toBe(false)
+  })
+})

--- a/packages/core/useDropZone/index.ts
+++ b/packages/core/useDropZone/index.ts
@@ -118,6 +118,8 @@ export function useDropZone(
           _options.onEnter?.(null, event)
           break
         case 'over':
+          counter = 1
+          isOverDropZone.value = true
           _options.onOver?.(null, event)
           break
         case 'leave':


### PR DESCRIPTION
### Description

Fixes #4652.

`useDropZone` tracks nested drag events with an internal counter. If a dragged-over child is removed before its `dragleave` event is observed, the counter can stay above `1`; then the final `dragleave` from cancelling the drag does not reset `isOverDropZone` back to `false`.

This resets the active drag depth during a valid `dragover`, which follows drag target transitions in the browser drag-and-drop processing model. The next `dragleave` can then clear the hover state even if an intermediate leave was missed.

### Additional context

Added a regression test that simulates two nested `dragenter` events, a `dragover`, and then one `dragleave`. Without the fix, `isOverDropZone` remains stuck at `true`.

### Validation

- `corepack pnpm exec vitest run --project unit packages/core/useDropZone/index.test.ts`
- `corepack pnpm exec eslint packages/core/useDropZone/index.ts packages/core/useDropZone/index.test.ts`
- `corepack pnpm run typecheck`
- `corepack pnpm --filter @vueuse/core build`

Note: I ran `corepack pnpm run update` locally first to generate the gitignored `packages/metadata/index.json` required by this checkout's `typecheck`.