### PR TITLE
fix(useConfirmDialog): keep array payloads as one argument

### DIFF
--- a/packages/core/useConfirmDialog/index.test.ts
+++ b/packages/core/useConfirmDialog/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, expectTypeOf, it } from 'vitest'
 import { nextTick, shallowRef } from 'vue'
 import { useConfirmDialog } from './index'
 
@@ -55,6 +55,31 @@ describe('useConfirmDialog', () => {
 
     cancel()
     expect(show.value).toBe(false)
+  })
+
+  it('should type array payload hooks as single optional arguments', () => {
+    const {
+      reveal,
+      confirm,
+      cancel,
+      onReveal,
+      onConfirm,
+      onCancel,
+    } = useConfirmDialog<number[], string[], boolean[]>()
+
+    reveal([1, 2, 3])
+    confirm(['confirmed'])
+    cancel([true])
+
+    onReveal((data) => {
+      expectTypeOf(data).toEqualTypeOf<number[] | undefined>()
+    })
+    onConfirm((data) => {
+      expectTypeOf(data).toEqualTypeOf<string[] | undefined>()
+    })
+    onCancel((data) => {
+      expectTypeOf(data).toEqualTypeOf<boolean[] | undefined>()
+    })
   })
 
   it('should execute a callback inside `onConfirm` hook only after confirming', () => {

--- a/packages/core/useConfirmDialog/index.ts
+++ b/packages/core/useConfirmDialog/index.ts
@@ -1,4 +1,4 @@
-import type { EventHook, EventHookOn } from '@vueuse/shared'
+import type { EventHookOn } from '@vueuse/shared'
 import type { ComputedRef, ShallowRef } from 'vue'
 import { createEventHook, noop } from '@vueuse/shared'
 import { computed, shallowRef } from 'vue'
@@ -41,19 +41,19 @@ export interface UseConfirmDialogReturn<RevealData, ConfirmData, CancelData> {
   /**
    * Event Hook to be triggered right before dialog creating.
    */
-  onReveal: EventHookOn<RevealData>
+  onReveal: EventHookOn<[data?: RevealData]>
 
   /**
    * Event Hook to be called on `confirm()`.
    * Gets data object from `confirm` function.
    */
-  onConfirm: EventHookOn<ConfirmData>
+  onConfirm: EventHookOn<[data?: ConfirmData]>
 
   /**
    * Event Hook to be called on `cancel()`.
    * Gets data object from `cancel` function.
    */
-  onCancel: EventHookOn<CancelData>
+  onCancel: EventHookOn<[data?: CancelData]>
 }
 
 /**
@@ -71,9 +71,9 @@ export function useConfirmDialog<
 >(
   revealed: ShallowRef<boolean> = shallowRef(false),
 ): UseConfirmDialogReturn<RevealData, ConfirmData, CancelData> {
-  const confirmHook: EventHook = createEventHook<ConfirmData>()
-  const cancelHook: EventHook = createEventHook<CancelData>()
-  const revealHook: EventHook = createEventHook<RevealData>()
+  const confirmHook = createEventHook<[data?: ConfirmData]>()
+  const cancelHook = createEventHook<[data?: CancelData]>()
+  const revealHook = createEventHook<[data?: RevealData]>()
 
   let _resolve: (arg0: UseConfirmDialogRevealResult<ConfirmData, CancelData>) => void = noop
 


### PR DESCRIPTION
### Description

Fixes #5176.

`useConfirmDialog` always passes reveal/confirm/cancel data as a single optional payload, but its hook types used `EventHookOn<RevealData>`. Because `EventHookOn` treats array types as variadic tuples, `useConfirmDialog<number[]>().onReveal()` inferred the callback argument as `number` instead of `number[]`.

This changes the confirm dialog hooks to use a single optional tuple argument internally, preserving runtime behavior while keeping array payload types intact for `onReveal`, `onConfirm`, and `onCancel`.

### Additional context

Validation:

- `corepack pnpm exec vitest run --project unit packages/core/useConfirmDialog/index.test.ts`
- `corepack pnpm exec eslint packages/core/useConfirmDialog/index.ts packages/core/useConfirmDialog/index.test.ts`
- `corepack pnpm run typecheck`
- `corepack pnpm --filter @vueuse/core build`

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.