### PR TITLE
fix(vElementSize): call handler on mount

### DIFF
--- a/packages/core/useElementSize/directive.test.ts
+++ b/packages/core/useElementSize/directive.test.ts
@@ -69,4 +69,35 @@ describe('vElementSize', () => {
       expect(wrapper).toBeDefined()
     })
   })
+
+  it('should call handler on mount with border-box sizes', () => {
+    onResize = vi.fn()
+    const offsetWidthSpy = vi
+      .spyOn(HTMLElement.prototype, 'offsetWidth', 'get')
+      .mockReturnValue(45)
+    const offsetHeightSpy = vi
+      .spyOn(HTMLElement.prototype, 'offsetHeight', 'get')
+      .mockReturnValue(30)
+
+    try {
+      wrapper = mount(App, {
+        props: {
+          onResize,
+          options: [{ width: 0, height: 0 }, { box: 'border-box' }],
+        },
+        global: {
+          directives: {
+            ElementSize: vElementSize,
+          },
+        },
+      })
+
+      expect(wrapper).toBeDefined()
+      expect(onResize).toHaveBeenCalledWith({ width: 45, height: 30 })
+    }
+    finally {
+      offsetWidthSpy.mockRestore()
+      offsetHeightSpy.mockRestore()
+    }
+  })
 })

--- a/packages/core/useElementSize/directive.ts
+++ b/packages/core/useElementSize/directive.ts
@@ -21,7 +21,7 @@ export const vElementSize = createDisposableDirective<
       const options = (typeof binding.value === 'function' ? [] : binding.value.slice(1)) as RemoveFirstFromTuple<BindingValueArray>
 
       const { width, height } = useElementSize(el, ...options)
-      watch([width, height], ([width, height]) => handler({ width, height }))
+      watch([width, height], ([width, height]) => handler({ width, height }), { immediate: true })
     },
   },
 )


### PR DESCRIPTION
## Summary

`vElementSize` now forwards the initial size from `useElementSize` to the directive handler by making the watcher immediate. This covers the `border-box` case where `useElementSize` can initialize from `offsetWidth`/`offsetHeight`, and the next ResizeObserver notification reports the same values so the directive handler never fires.

Fixes #5347.

## Validation

- `corepack pnpm exec vitest run --project unit packages/core/useElementSize/directive.test.ts`
- `corepack pnpm exec eslint packages/core/useElementSize/directive.ts packages/core/useElementSize/directive.test.ts`
- `corepack pnpm run typecheck`
- `corepack pnpm --filter @vueuse/core build`