### PR TITLE
fix(core): avoid invalid pure annotations

### DIFF
--- a/packages/core/useEventBus/internal.ts
+++ b/packages/core/useEventBus/internal.ts
@@ -1,4 +1,3 @@
 import type { EventBusEvents, EventBusIdentifier } from './index'
 
-/* #__PURE__ */
-export const events = new Map<EventBusIdentifier<any>, EventBusEvents<any>>()
+export const events = /* @__PURE__ */ new Map<EventBusIdentifier<any>, EventBusEvents<any>>()

--- a/packages/core/usePointer/index.ts
+++ b/packages/core/usePointer/index.ts
@@ -50,7 +50,7 @@ export interface UsePointerReturn {
   isInside: ShallowRef<boolean>
 }
 
-const defaultState: UsePointerState = /* #__PURE__ */ {
+const defaultState: UsePointerState = {
   x: 0,
   y: 0,
   pointerId: 0,

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -1,6 +1,8 @@
+import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { checkBuildState } from 'tsdown-stale-guard'
 import { describePackagesApiSnapshots } from 'tsnapi/vitest'
+import { describe, expect, it } from 'vitest'
 
 const root = resolve(import.meta.dirname, '..')
 
@@ -12,4 +14,16 @@ describePackagesApiSnapshots({
       throw new Error('Build is not fresh, run `pnpm build` to fix it')
     }
   },
+})
+
+describe('build output', () => {
+  it('does not emit Rollup-invalid pure annotations in core output', async () => {
+    const result = await checkBuildState({ root: resolve(root, 'packages/core') })
+    if (!result.fresh)
+      throw new Error('Build is not fresh, run `pnpm build` to fix it')
+
+    const index = readFileSync(resolve(root, 'packages/core/dist/index.js'), 'utf-8')
+    expect(index).not.toMatch(/\/\* #__PURE__ \*\/\s*const events/)
+    expect(index).not.toContain('(/* #__PURE__ */ {')
+  })
 })


### PR DESCRIPTION
## Summary

Removes the PURE annotations that Rollup rejects in the generated `@vueuse/core` bundle:

- keeps the `useEventBus` `Map` allocation annotation directly on the `new Map()` expression
- removes the invalid annotation from the `usePointer` object literal
- adds an exports regression that checks the generated core bundle no longer contains those rejected annotation forms

Fixes #5387.

## Validation

- `corepack pnpm exec eslint packages/core/useEventBus/internal.ts packages/core/usePointer/index.ts test/exports.test.ts`
- `corepack pnpm --filter @vueuse/core build`
- `corepack pnpm exec vitest --project=exports test/exports.test.ts -t "build output"`
- `corepack pnpm exec vitest run --project unit packages/core/useEventBus/index.test.ts`
- `corepack pnpm run typecheck`
- `corepack pnpm build:packages`
- `corepack pnpm test:exports`