### PR TITLE
fix: isolate reusable template instances

### DIFF
--- a/packages/core/createReusableTemplate/index.test.ts
+++ b/packages/core/createReusableTemplate/index.test.ts
@@ -80,6 +80,45 @@ describe('createReusableTemplate', () => {
     expect(wrapper.get('#bar').classes()).toEqual(['foo', 'bar'])
   })
 
+  it('is isolated between component instances', async () => {
+    const [DefineTemplate, ReuseTemplate] = createReusableTemplate()
+
+    const Item = defineComponent({
+      props: {
+        text: String,
+        reuse: Boolean,
+      },
+      render() {
+        return h(Fragment, null, [
+          this.reuse
+            ? h(ReuseTemplate)
+            : h(DefineTemplate, () => this.text),
+        ])
+      },
+    })
+
+    const App = defineComponent({
+      data: () => ({
+        reuse: false,
+      }),
+      render() {
+        return h(Fragment, null, [
+          h(Item, { text: 'A', reuse: this.reuse }),
+          h(Item, { text: 'B', reuse: this.reuse }),
+        ])
+      },
+    })
+
+    const wrapper = mount(App)
+
+    expect(wrapper.text()).toBe('')
+
+    wrapper.vm.reuse = true
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.text()).toBe('AB')
+  })
+
   it('slots', () => {
     const [DefineFoo, ReuseFoo] = createReusableTemplate<{ msg: string }, { default: Slot }>()
 

--- a/packages/core/createReusableTemplate/index.ts
+++ b/packages/core/createReusableTemplate/index.ts
@@ -1,6 +1,6 @@
 import type { ComponentObjectPropsOptions, DefineComponent, Slot } from 'vue'
 import { camelize, makeDestructurable } from '@vueuse/shared'
-import { defineComponent, shallowRef } from 'vue'
+import { defineComponent, getCurrentInstance } from 'vue'
 
 type ObjectLiteralWithPotentialObjectLiterals = Record<string, Record<string, any> | undefined>
 
@@ -69,13 +69,27 @@ export function createReusableTemplate<
     name = 'ReusableTemplate',
   } = options
 
-  const render = shallowRef<Slot | undefined>()
+  const renderMap = new WeakMap<object, Slot | undefined>()
+
+  const getReusableTemplateRegistrationInstance = () => {
+    const instance = getCurrentInstance()
+    return instance?.parent ?? instance
+  }
+
+  const getReusableTemplateInstance = () => {
+    let instance = getCurrentInstance()
+    while (instance && !renderMap.has(instance))
+      instance = instance.parent
+    return instance
+  }
 
   const define = defineComponent({
     name: `${name}.define`,
     setup(_, { slots }) {
       return () => {
-        render.value = slots.default
+        const instance = getReusableTemplateRegistrationInstance()
+        if (instance)
+          renderMap.set(instance, slots.default)
       }
     },
   }) as unknown as DefineTemplateComponent<Bindings, MapSlotNameToSlotProps>
@@ -86,9 +100,11 @@ export function createReusableTemplate<
     props: options.props,
     setup(props, { attrs, slots }) {
       return () => {
-        if (!render.value && process.env.NODE_ENV !== 'production')
+        const instance = getReusableTemplateInstance()
+        const render = instance ? renderMap.get(instance) : undefined
+        if (!render && process.env.NODE_ENV !== 'production')
           throw new Error('[VueUse] Failed to find the definition of reusable template')
-        const vnode = render.value?.({
+        const vnode = render?.({
           ...(options.props == null
             ? keysToCamelKebabCase(attrs)
             : props),


### PR DESCRIPTION
## Summary

`createReusableTemplate()` stored the defined slot in one shared ref for the pair. When the same pair was used by multiple component instances, the last rendered `<DefineTemplate>` could overwrite the slot used by every `<ReuseTemplate>` instance.

This scopes the stored slot by the defining component instance using a `WeakMap`, and resolves `<ReuseTemplate>` by walking up the component ancestry to the nearest registered definition. That preserves the existing parent/child reusable-template behavior while isolating sibling component instances.

Fixes #3881.

## Validation

- `corepack pnpm vitest run packages/core/createReusableTemplate/index.test.ts`
- `corepack pnpm eslint packages/core/createReusableTemplate/index.ts packages/core/createReusableTemplate/index.test.ts`
- `corepack pnpm vue-tsc --noEmit`
- `git diff --check`

authored-by: codex