### PR TITLE
fix: reset drop zone counter on dragover

### DIFF
--- a/packages/core/useDropZone/index.test.ts
+++ b/packages/core/useDropZone/index.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { useDropZone } from './index'
+
+function createDragEvent(type: string) {
+  const event = new Event(type, { bubbles: true, cancelable: true }) as DragEvent
+
+  Object.defineProperty(event, 'dataTransfer', {
+    value: {
+      dropEffect: 'none',
+      files: [],
+      items: [{ type: 'text/plain' }],
+    },
+  })
+
+  return event
+}
+
+describe('useDropZone', () => {
+  it('resets the drag counter on dragover', () => {
+    const target = document.createElement('div')
+    const { isOverDropZone } = useDropZone(target)
+
+    target.dispatchEvent(createDragEvent('dragenter'))
+    target.dispatchEvent(createDragEvent('dragenter'))
+
+    expect(isOverDropZone.value).toBe(true)
+
+    target.dispatchEvent(createDragEvent('dragover'))
+    target.dispatchEvent(createDragEvent('dragleave'))
+
+    expect(isOverDropZone.value).toBe(false)
+  })
+})

--- a/packages/core/useDropZone/index.ts
+++ b/packages/core/useDropZone/index.ts
@@ -118,6 +118,7 @@ export function useDropZone(
           _options.onEnter?.(null, event)
           break
         case 'over':
+          counter = 1
           _options.onOver?.(null, event)
           break
         case 'leave':


### PR DESCRIPTION
## Summary

`useDropZone()` increments an internal counter for nested `dragenter` events and decrements it on `dragleave`. If a nested element disappears during a drag, the matching `dragleave` can be missed and `isOverDropZone` remains stuck as `true` after the next leave.

This normalizes the counter back to the active drop-zone level on valid `dragover` events. The regression test simulates two enters, a dragover, and a single leave, matching the missed nested-leave case from the issue.

Fixes #4652.

## Validation

- `corepack pnpm vitest run packages/core/useDropZone/index.test.ts`
- `corepack pnpm eslint packages/core/useDropZone/index.ts packages/core/useDropZone/index.test.ts`
- `corepack pnpm vue-tsc --noEmit`
- `corepack pnpm --filter @vueuse/core build`
- `git diff --check`

authored-by: codex