### PR TITLE
fix(useElementSize): emit directive size immediately

### DIFF
--- a/packages/core/useElementSize/directive.test.ts
+++ b/packages/core/useElementSize/directive.test.ts
@@ -1,6 +1,6 @@
 import type { VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent } from 'vue'
 import { vElementSize } from './directive'
 
@@ -26,6 +26,11 @@ const App = defineComponent({
 describe('vElementSize', () => {
   let onResize = vi.fn()
   let wrapper: VueWrapper<any>
+
+  afterEach(() => {
+    wrapper?.unmount()
+    vi.restoreAllMocks()
+  })
 
   describe('given no options', () => {
     beforeEach(() => {
@@ -68,5 +73,39 @@ describe('vElementSize', () => {
     it('should be defined', () => {
       expect(wrapper).toBeDefined()
     })
+  })
+
+  it('calls handler with initialized border-box size', () => {
+    vi.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockReturnValue(45)
+    vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockReturnValue(24)
+
+    onResize = vi.fn()
+    wrapper = mount(
+      defineComponent({
+        props: {
+          onResize: {
+            type: Function,
+            required: true,
+          },
+        },
+        template: `
+          <div v-element-size="[onResize, { width: 0, height: 0 }, { box: 'border-box' }]">
+            Hello world!
+          </div>
+        `,
+      }),
+      {
+        props: {
+          onResize,
+        },
+        global: {
+          directives: {
+            ElementSize: vElementSize,
+          },
+        },
+      },
+    )
+
+    expect(onResize).toHaveBeenCalledWith({ width: 45, height: 24 })
   })
 })

--- a/packages/core/useElementSize/directive.ts
+++ b/packages/core/useElementSize/directive.ts
@@ -21,7 +21,9 @@ export const vElementSize = createDisposableDirective<
       const options = (typeof binding.value === 'function' ? [] : binding.value.slice(1)) as RemoveFirstFromTuple<BindingValueArray>
 
       const { width, height } = useElementSize(el, ...options)
-      watch([width, height], ([width, height]) => handler({ width, height }))
+      watch([width, height], ([width, height]) => handler({ width, height }), {
+        immediate: true,
+      })
     },
   },
 )


### PR DESCRIPTION
## Summary

Fixes #5347.

authored-by: codex

`v-element-size` now invokes its handler with the current `useElementSize` refs as soon as the directive starts watching. This preserves the existing update behavior and also covers the case where `tryOnMounted` has already initialized `width` and `height` before ResizeObserver reports the same border-box size.

The regression test mocks initialized `offsetWidth`/`offsetHeight` values and verifies that a `box: 'border-box'` directive handler receives them on mount.

## Validation

- `corepack pnpm vitest run packages/core/useElementSize/directive.test.ts` PASS, 3 passed
- `corepack pnpm eslint packages/core/useElementSize/directive.ts packages/core/useElementSize/directive.test.ts` PASS
- `corepack pnpm vue-tsc --noEmit` PASS
- `corepack pnpm --filter @vueuse/core build` PASS
- `git diff --check` PASS