### PR TITLE
fix(useTextareaAutosize): bind demo textarea ref

### DIFF
--- a/packages/core/useTextareaAutosize/demo.vue
+++ b/packages/core/useTextareaAutosize/demo.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { useTextareaAutosize } from '@vueuse/core'
+import { useTemplateRef } from 'vue'
 
-const { input } = useTextareaAutosize()
+const textarea = useTemplateRef<HTMLTextAreaElement>('textarea')
+const { input } = useTextareaAutosize({ element: textarea })
 </script>
 
 <template>


### PR DESCRIPTION
Fixes #5380.

## Summary
- bind the demo textarea through `useTemplateRef`
- pass the template ref to `useTextareaAutosize` so the official demo receives the textarea element and resizes while typing

## Validation
- PASS `corepack pnpm eslint packages/core/useTextareaAutosize/demo.vue`
- PASS `corepack pnpm vue-tsc --noEmit`
- PASS `corepack pnpm --filter @vueuse/core build`
- PASS `git diff --check`