### PR TITLE
fix(core): call vElementSize handler immediately

### DIFF
--- a/packages/core/useElementSize/directive.test.ts
+++ b/packages/core/useElementSize/directive.test.ts
@@ -1,6 +1,6 @@
 import type { VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent } from 'vue'
 import { vElementSize } from './directive'
 
@@ -17,7 +17,7 @@ const App = defineComponent({
   },
 
   template: `<template>
-  <div v-if="options" v-element-size="[onResize,options]">Hello world!</div>
+  <div v-if="options" v-element-size="[onResize,...options]">Hello world!</div>
   <div v-else v-element-size="onResize">Hello world!</div>
   </template>
   `,
@@ -26,6 +26,10 @@ const App = defineComponent({
 describe('vElementSize', () => {
   let onResize = vi.fn()
   let wrapper: VueWrapper<any>
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
 
   describe('given no options', () => {
     beforeEach(() => {
@@ -67,6 +71,34 @@ describe('vElementSize', () => {
 
     it('should be defined', () => {
       expect(wrapper).toBeDefined()
+    })
+  })
+
+  describe('given border-box options', () => {
+    beforeEach(() => {
+      vi.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockReturnValue(45)
+      vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockReturnValue(35)
+
+      onResize = vi.fn()
+      const options = [{ width: 0, height: 0 }, { box: 'border-box' }]
+
+      wrapper = mount(App, {
+        props: {
+          onResize,
+          options,
+        },
+        global: {
+          directives: {
+            ElementSize: vElementSize,
+          },
+        },
+      })
+    })
+
+    it('calls the handler with the mounted border-box size', () => {
+      expect(wrapper).toBeDefined()
+      expect(onResize).toHaveBeenCalledTimes(1)
+      expect(onResize).toHaveBeenCalledWith({ width: 45, height: 35 })
     })
   })
 })

--- a/packages/core/useElementSize/directive.ts
+++ b/packages/core/useElementSize/directive.ts
@@ -21,7 +21,7 @@ export const vElementSize = createDisposableDirective<
       const options = (typeof binding.value === 'function' ? [] : binding.value.slice(1)) as RemoveFirstFromTuple<BindingValueArray>
 
       const { width, height } = useElementSize(el, ...options)
-      watch([width, height], ([width, height]) => handler({ width, height }))
+      watch([width, height], ([width, height]) => handler({ width, height }), { immediate: true })
     },
   },
 )


### PR DESCRIPTION
## Summary

Fixes #5347.

`vElementSize` registers its watcher after `useElementSize` has already synchronously populated the refs from the mounted element in directive usage. With `{ box: "border-box" }`, the later `ResizeObserver` value can be identical to that mounted border-box size, so the watcher never observes a change and the handler is never called.

This updates the directive watcher to run immediately after registration so consumers receive the mounted size even when the first observer callback reports the same value. The regression test covers the `border-box` tuple form and asserts the handler receives the element's mounted dimensions.

## Validation

- `corepack pnpm vitest run --project unit packages/core/useElementSize/directive.test.ts`
- `corepack pnpm exec eslint packages/core/useElementSize/directive.ts packages/core/useElementSize/directive.test.ts`
- `corepack pnpm typecheck`
- `git diff --check`
