### PR TITLE
fix(useFetch): expose response data on error event

### DIFF
--- a/packages/core/useFetch/index.test.ts
+++ b/packages/core/useFetch/index.test.ts
@@ -632,6 +632,22 @@ describe('useFetch', () => {
     })
   })
 
+  it('should expose response data on fetch error event', async () => {
+    let fetchError: any
+    const { onFetchError, statusCode } = useFetch(`${baseUrl}?status=400&json`).json()
+
+    onFetchError((error) => {
+      fetchError = error
+    })
+
+    await vi.waitFor(() => {
+      expect(statusCode.value).toBe(400)
+      expect(fetchError.message).toBe('Bad Request')
+      expect(fetchError.data).toEqual(jsonMessage)
+      expect(fetchError.response.status).toBe(400)
+    })
+  })
+
   it('setting the request method w/ get and return type w/ json', async () => {
     const { data } = useFetch(jsonUrl).get().json()
     await vi.waitFor(() => {

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -273,6 +273,10 @@ function combineCallbacks<T = any>(combination: Combination, ...callbacks: (((ct
   }
 }
 
+function attachErrorPayload<T>(error: Error, data: T | null, response: Response) {
+  return Object.assign(error, { data, response })
+}
+
 export function createFetch(config: CreateFetchOptions = {}) {
   const _combination = config.combination || 'chain' as Combination
   const _options = config.options || {}
@@ -492,7 +496,11 @@ export function useFetch<T>(url: MaybeRefOrGetter<string>, ...args: any[]): UseF
         // see: https://www.tjvantoll.com/2015/09/13/fetch-and-errors/
         if (!fetchResponse.ok) {
           data.value = initialData || null
-          throw new Error(fetchResponse.statusText)
+          throw attachErrorPayload(
+            new Error(fetchResponse.statusText),
+            responseData,
+            fetchResponse,
+          )
         }
 
         if (options.afterFetch) {


### PR DESCRIPTION
### Description

Fixes #5405.

`useFetch` already parses the response body before converting non-2xx responses into errors, and the options-style `onFetchError(ctx)` can access that body through `ctx.data`. The event-style `onFetchError((error) => ...)` still received only the plain thrown `Error`, so callers could inspect `message`/`stack` but not the parsed body or response.

This attaches the parsed response data and original response to the thrown HTTP error before it is emitted. Existing `error.message` behavior remains unchanged, while event listeners can now read `error.data` and `error.response` for API error details.

### Additional context

Validation run locally:

- `corepack pnpm exec vitest run packages/core/useFetch/index.test.ts --project unit`
- `corepack pnpm exec eslint packages/core/useFetch/index.ts packages/core/useFetch/index.test.ts`
- `corepack pnpm typecheck`
- `git diff --check`