### PR TITLE
fix(useDropZone): reset drag counter on dragover

### DIFF
--- a/packages/core/useDropZone/index.test.ts
+++ b/packages/core/useDropZone/index.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { useDropZone } from './index'
+
+function createDragEvent(type: string) {
+  const event = new Event(type, { bubbles: true, cancelable: true }) as DragEvent
+
+  Object.defineProperty(event, 'dataTransfer', {
+    value: {
+      dropEffect: 'none',
+      files: [],
+      items: [{ type: 'text/plain' }],
+    },
+  })
+
+  return event
+}
+
+describe('useDropZone', () => {
+  it('should be defined', () => {
+    expect(useDropZone).toBeDefined()
+  })
+
+  it('should reset hover state when a nested dragleave is missed', () => {
+    const target = document.createElement('div')
+    const child = document.createElement('div')
+    target.appendChild(child)
+
+    const { isOverDropZone } = useDropZone(target)
+
+    target.dispatchEvent(createDragEvent('dragenter'))
+    child.dispatchEvent(createDragEvent('dragenter'))
+    expect(isOverDropZone.value).toBe(true)
+
+    child.remove()
+    target.dispatchEvent(createDragEvent('dragover'))
+    target.dispatchEvent(createDragEvent('dragleave'))
+
+    expect(isOverDropZone.value).toBe(false)
+  })
+})

--- a/packages/core/useDropZone/index.ts
+++ b/packages/core/useDropZone/index.ts
@@ -118,6 +118,7 @@ export function useDropZone(
           _options.onEnter?.(null, event)
           break
         case 'over':
+          counter = 1
           _options.onOver?.(null, event)
           break
         case 'leave':


### PR DESCRIPTION
### Description

Fixes #4652.

`useDropZone` uses a counter to avoid clearing `isOverDropZone` while moving across nested elements. If a nested element is removed during drag, its `dragleave` can be missed and the counter can stay above `1`; when the outer drop zone later receives `dragleave`, the state remains stuck as `true`.

`dragover` confirms the drag is currently over the active drop zone, so this resets the counter to `1` before the final leave/drop path. The regression test covers a removed child element with a missed nested `dragleave`.

### Additional context

Validation:

- `corepack pnpm exec vitest run packages/core/useDropZone/index.test.ts --project unit`
- `corepack pnpm exec eslint packages/core/useDropZone/index.ts packages/core/useDropZone/index.test.ts`
- `corepack pnpm typecheck`
- `corepack pnpm --filter @vueuse/core build`
- `git diff --check`

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.