### PR TITLE
fix(useSortable): preserve list update before callbacks

### DIFF
--- a/packages/integrations/useSortable/index.browser.test.ts
+++ b/packages/integrations/useSortable/index.browser.test.ts
@@ -2,7 +2,7 @@ import { mount } from '@vue/test-utils'
 import { unrefElement } from '@vueuse/core'
 import Sortable from 'sortablejs'
 import { describe, expect, it } from 'vitest'
-import { defineComponent, shallowRef, useTemplateRef } from 'vue'
+import { defineComponent, nextTick, shallowRef, useTemplateRef } from 'vue'
 import { useSortable } from './index'
 
 describe('useSortable', () => {
@@ -151,6 +151,45 @@ describe('useSortable', () => {
         wrapper.unmount()
       }
     })
+  })
+
+  it('updates the list before calling user update and end callbacks', async () => {
+    const wrapper = mount(defineComponent({
+      template: '<ul ref="el"><li v-for="item in list" :key="item">{{ item }}</li></ul>',
+      setup() {
+        const el = useTemplateRef<HTMLElement>('el')
+        const list = shallowRef(['a', 'b', 'c'])
+        const calls: string[] = []
+        const result = useSortable(el, list, {
+          onUpdate: () => calls.push(`update:${list.value.join(',')}`),
+          onEnd: () => calls.push(`end:${list.value.join(',')}`),
+        })
+
+        return { ...result, calls, el, list }
+      },
+    }))
+    const vm = wrapper.vm
+    try {
+      const sortable = Sortable.get(vm.el!)!
+      const event = {
+        from: vm.el!,
+        item: vm.el!.children[0],
+        newIndex: 2,
+        oldIndex: 0,
+      } as unknown as Sortable.SortableEvent
+
+      ;(sortable.option('onUpdate') as (e: Sortable.SortableEvent) => void)(event)
+      ;(sortable.option('onEnd') as (e: Sortable.SortableEvent) => void)(event)
+
+      await nextTick()
+      await Promise.resolve()
+
+      expect(vm.list).toEqual(['b', 'c', 'a'])
+      expect(vm.calls).toEqual(['update:b,c,a', 'end:b,c,a'])
+    }
+    finally {
+      wrapper.unmount()
+    }
   })
 
   it('accepts component refs', () => {

--- a/packages/integrations/useSortable/index.ts
+++ b/packages/integrations/useSortable/index.ts
@@ -59,9 +59,31 @@ export function useSortable<T>(
 
   const { document = defaultDocument, watchElement = false, ...resetOptions } = options
 
+  let lastUpdate: Promise<void> | undefined
+
+  const runAfterUpdate = (callback: ((e: Sortable.SortableEvent) => void) | undefined, e: Sortable.SortableEvent) => {
+    if (!callback)
+      return
+
+    if (lastUpdate != null)
+      void lastUpdate.then(() => callback(e))
+    else
+      callback(e)
+  }
+
   const defaultOptions: Options = {
+    ...resetOptions,
     onUpdate: (e) => {
-      moveArrayElement(list, e.oldIndex!, e.newIndex!, e)
+      lastUpdate = moveArrayElementOnNextTick(list, e.oldIndex!, e.newIndex!, e)
+      const update = lastUpdate
+      void update.finally(() => {
+        if (lastUpdate === update)
+          lastUpdate = undefined
+      })
+      runAfterUpdate(resetOptions.onUpdate, e)
+    },
+    onEnd: (e) => {
+      runAfterUpdate(resetOptions.onEnd, e)
     },
   }
 
@@ -73,7 +95,7 @@ export function useSortable<T>(
   const initSortable = (target: Element) => {
     if (!target || sortable !== undefined)
       return
-    sortable = new Sortable(target as HTMLElement, { ...defaultOptions, ...resetOptions })
+    sortable = new Sortable(target as HTMLElement, defaultOptions)
   }
 
   const start = () => {
@@ -157,6 +179,15 @@ export function moveArrayElement<T>(
   to: number,
   e: Sortable.SortableEvent | null = null,
 ): void {
+  void moveArrayElementOnNextTick(list, from, to, e)
+}
+
+function moveArrayElementOnNextTick<T>(
+  list: MaybeRef<T[]>,
+  from: number,
+  to: number,
+  e: Sortable.SortableEvent | null = null,
+): Promise<void> {
   if (e != null) {
     removeNode(e.item)
     insertNodeAt(e.from, e.item, from)
@@ -168,11 +199,13 @@ export function moveArrayElement<T>(
 
   if (to >= 0 && to < array.length) {
     const element = array.splice(from, 1)[0]
-    nextTick(() => {
+    return nextTick(() => {
       array.splice(to, 0, element)
       // When list is ref, assign array to list.value
       if (_valueIsRef)
         (list as MaybeRef).value = array
     })
   }
+
+  return Promise.resolve()
 }


### PR DESCRIPTION
Fixes #5360.

`useSortable` was installing VueUse's internal `onUpdate` handler as a default and then spreading user options over it. When a consumer supplied `onUpdate`, SortableJS replaced the internal handler, so the backing list could stop being moved at all. Even when the internal handler did run, the list update is intentionally scheduled on `nextTick`, so user `onUpdate` / `onEnd` callbacks could observe the pre-move order.

This change keeps the internal list synchronization wrapped around Sortable's update event, then runs user `onUpdate` and `onEnd` callbacks after the scheduled list mutation has completed. The exported `moveArrayElement` helper keeps its existing `void` API; the promise is only used internally for callback ordering.

Validation:
- `corepack pnpm exec eslint packages/integrations/useSortable/index.ts packages/integrations/useSortable/index.browser.test.ts`
- `corepack pnpm exec vue-tsc --noEmit --pretty false`
- `corepack pnpm exec vitest run packages/integrations/useSortable/index.browser.test.ts --project "browser (chromium)"`
- `corepack pnpm --filter @vueuse/integrations build`
- `git diff --check`