### PR TITLE
fix(core): pass current position to useDraggable onStart

### DIFF
--- a/packages/core/useDraggable/index.test.ts
+++ b/packages/core/useDraggable/index.test.ts
@@ -70,6 +70,59 @@ describe('useDraggable', () => {
     expect(wrapper.get('div').element.dataset.isDragging).toBe('false')
   })
 
+  it('passes the current position to onStart', async () => {
+    const initialValue = { x: 40, y: 50 }
+    const onStart = vi.fn()
+    const onMove = vi.fn()
+
+    const wrapper = mount({
+      setup() {
+        const el = useTemplateRef<HTMLElement>('el')
+
+        const { style } = useDraggable(el, {
+          initialValue,
+          onStart,
+          onMove,
+        })
+
+        return () => h('div', {
+          ref: 'el',
+          style: style.value,
+        })
+      },
+    })
+
+    await nextTick()
+
+    const el = wrapper.get('div').element
+    vi.spyOn(el, 'getBoundingClientRect').mockReturnValue({
+      bottom: 60,
+      height: 10,
+      left: initialValue.x,
+      right: 50,
+      top: initialValue.y,
+      width: 10,
+      x: initialValue.x,
+      y: initialValue.y,
+      toJSON: () => undefined,
+    })
+
+    el.dispatchEvent(new PointerEvent('pointerdown', {
+      clientX: 45,
+      clientY: 65,
+    }))
+    await nextTick()
+
+    window.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: 55,
+      clientY: 75,
+    }))
+    await nextTick()
+
+    expect(onStart.mock.calls[0][0]).toEqual(initialValue)
+    expect(onMove.mock.calls[0][0]).toEqual({ x: 50, y: 60 })
+  })
+
   it('component', async () => {
     const onStart = vi.fn()
     const onMove = vi.fn()

--- a/packages/core/useDraggable/index.ts
+++ b/packages/core/useDraggable/index.ts
@@ -332,13 +332,13 @@ export function useDraggable(
     const container = toValue(containerElement)
     const containerRect = container?.getBoundingClientRect?.()
     const targetRect = toValue(target)!.getBoundingClientRect()
-    const pos = {
+    const delta = {
       x: e.clientX - (container ? targetRect.left - containerRect!.left + (autoScroll ? 0 : container.scrollLeft) : targetRect.left),
       y: e.clientY - (container ? targetRect.top - containerRect!.top + (autoScroll ? 0 : container.scrollTop) : targetRect.top),
     }
-    if (onStart?.(pos, e) === false)
+    if (onStart?.(position.value, e) === false)
       return
-    pressedDelta.value = pos
+    pressedDelta.value = delta
     handleEvent(e)
   }
 


### PR DESCRIPTION
## Summary

Fixes #3770.

`useDraggable` was passing the pointer offset from the draggable element as the `onStart(position)` argument. That made `onStart` inconsistent with `onMove` and `onEnd`, which both receive the draggable position.

This keeps the pointer offset as an internal drag delta for movement math, but passes the current draggable position to `onStart`.

## Validation

- `corepack pnpm exec vitest run packages/core/useDraggable/index.test.ts --project unit`
- `corepack pnpm exec eslint packages/core/useDraggable/index.ts packages/core/useDraggable/index.test.ts`
- `corepack pnpm exec vue-tsc --noEmit --pretty false`
- `corepack pnpm --filter @vueuse/core build`
- `git diff --check`