### PR TITLE
fix(core): reset useDropZone counter on dragover

### DIFF
--- a/packages/core/useDropZone/index.test.ts
+++ b/packages/core/useDropZone/index.test.ts
@@ -1,0 +1,53 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { h, nextTick, useTemplateRef } from 'vue'
+import { useDropZone } from './index'
+
+function createDragEvent(type: string) {
+  const event = new Event(type, {
+    bubbles: true,
+    cancelable: true,
+  }) as DragEvent
+
+  Object.defineProperty(event, 'dataTransfer', {
+    value: {
+      dropEffect: 'move',
+      files: [],
+      items: [{ type: 'text/plain' }],
+    },
+  })
+
+  return event
+}
+
+describe('useDropZone', () => {
+  it('resets the enter counter on dragover', async () => {
+    let dropZone!: ReturnType<typeof useDropZone>
+
+    const wrapper = mount({
+      setup() {
+        const target = useTemplateRef<HTMLElement>('target')
+        dropZone = useDropZone(target)
+
+        return () => h('div', {
+          ref: 'target',
+        })
+      },
+    })
+
+    await nextTick()
+
+    const target = wrapper.get('div').element
+
+    target.dispatchEvent(createDragEvent('dragenter'))
+    target.dispatchEvent(createDragEvent('dragenter'))
+    expect(dropZone.isOverDropZone.value).toBe(true)
+
+    target.dispatchEvent(createDragEvent('dragover'))
+    target.dispatchEvent(createDragEvent('dragleave'))
+
+    expect(dropZone.isOverDropZone.value).toBe(false)
+
+    wrapper.unmount()
+  })
+})

--- a/packages/core/useDropZone/index.ts
+++ b/packages/core/useDropZone/index.ts
@@ -118,6 +118,8 @@ export function useDropZone(
           _options.onEnter?.(null, event)
           break
         case 'over':
+          counter = 1
+          isOverDropZone.value = true
           _options.onOver?.(null, event)
           break
         case 'leave':


### PR DESCRIPTION
## Summary

Fixes #4652.

`useDropZone` tracks nested `dragenter`/`dragleave` events with an internal counter. Dynamic overlays and transitions can remove an intermediate target before its matching `dragleave` is delivered, which leaves the counter above zero and keeps `isOverDropZone` stuck on `true` after the drag ends.

This treats a valid `dragover` as the current in-zone state by resetting the counter to `1`, so the next real `dragleave` can clear `isOverDropZone` instead of being held by stale enters.

## Validation

- `corepack pnpm exec vitest run packages/core/useDropZone/index.test.ts --project unit`
- `corepack pnpm exec eslint packages/core/useDropZone/index.ts packages/core/useDropZone/index.test.ts`
- `corepack pnpm exec vue-tsc --noEmit --pretty false`
- `corepack pnpm --filter @vueuse/core build`
- `git diff --check`