### PR TITLE
fix(useFetch): include response body in error context

### DIFF
--- a/packages/core/useFetch/index.test.ts
+++ b/packages/core/useFetch/index.test.ts
@@ -572,6 +572,52 @@ describe('useFetch', () => {
     })
   })
 
+  it('should provide response body in onFetchError when request fails', async () => {
+    const errorBody = { title: 'Invalid request' }
+    let ctxData: unknown
+
+    const { data, error, statusCode } = useFetch(`${baseUrl}?status=400&json=${encodeURI(JSON.stringify(errorBody))}`, {
+      onFetchError(ctx) {
+        ctxData = ctx.data
+        return ctx
+      },
+    }).json()
+
+    await vi.waitFor(() => {
+      expect(statusCode.value).toEqual(400)
+      expect(error.value.message).toEqual('Bad Request')
+      expect(data.value).toBeNull()
+      expect(ctxData).toEqual(errorBody)
+    })
+  })
+
+  it('should fallback to text body on failed response when configured parser fails', async () => {
+    let ctxData: unknown
+
+    const { error, statusCode } = useFetch(`${baseUrl}?status=500&text=problem`, {
+      onFetchError(ctx) {
+        ctxData = ctx.data
+        return ctx
+      },
+    }).json()
+
+    await vi.waitFor(() => {
+      expect(statusCode.value).toEqual(500)
+      expect(error.value.message).toEqual('Internal Server Error')
+      expect(ctxData).toBe('problem')
+    })
+  })
+
+  it('should not fallback to text body on successful response when configured parser fails', async () => {
+    const { data, error, statusCode } = useFetch(`${baseUrl}?text=not-json`).json()
+
+    await vi.waitFor(() => {
+      expect(statusCode.value).toEqual(200)
+      expect(data.value).toBeNull()
+      expect(error.value).toBeTruthy()
+    })
+  })
+
   it('should return data in onFetchError when updateDataOnError is true', async () => {
     const { data, error, statusCode } = useFetch(`${baseUrl}?status=400&json`, {
       updateDataOnError: true,
@@ -629,6 +675,21 @@ describe('useFetch', () => {
       expect(onFetchErrorSpy).toHaveBeenCalled()
       expect(onFetchResponseSpy).not.toHaveBeenCalled()
       expect(onFetchFinallySpy).toHaveBeenCalled()
+    })
+  })
+
+  it('should emit response body in onFetchError event when request fails', async () => {
+    const errorBody = { title: 'Invalid request' }
+    let eventError: any
+    const { onFetchError } = useFetch(`${baseUrl}?status=400&json=${encodeURI(JSON.stringify(errorBody))}`).json()
+
+    onFetchError((error) => {
+      eventError = error
+    })
+
+    await vi.waitFor(() => {
+      expect(eventError.data).toEqual(errorBody)
+      expect(eventError.response).toBeInstanceOf(Response)
     })
   })
 

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -487,12 +487,30 @@ export function useFetch<T>(url: MaybeRefOrGetter<string>, ...args: any[]): UseF
         response.value = fetchResponse
         statusCode.value = fetchResponse.status
 
-        responseData = await fetchResponse.clone()[config.type]()
+        try {
+          responseData = await fetchResponse.clone()[config.type]()
+        }
+        catch (error) {
+          if (!fetchResponse.ok) {
+            try {
+              responseData = await fetchResponse.clone().text()
+            }
+            catch {
+              responseData = null
+            }
+          }
+          else {
+            throw error
+          }
+        }
 
         // see: https://www.tjvantoll.com/2015/09/13/fetch-and-errors/
         if (!fetchResponse.ok) {
           data.value = initialData || null
-          throw new Error(fetchResponse.statusText)
+          const error = new Error(fetchResponse.statusText)
+          ;(error as any).data = responseData
+          ;(error as any).response = fetchResponse
+          throw error
         }
 
         if (options.afterFetch) {


### PR DESCRIPTION
Fixes #5405

## Problem

When a fetch request fails (e.g., 4xx/5xx), the  callback receives an error object that only contains  (e.g., "Not Found"). The actual response body (like ) is lost.

## Root Cause

1. Response body parsing could fail silently, leaving  as null
2. The thrown Error only included , not the parsed body

## Fix

1. Added try-catch around response body parsing with fallback to 
2. The thrown error now includes  (parsed body) and  (full Response object)
3.  callback receives the parsed body in 