### PR TITLE
fix(useElementSize): emit directive size immediately

### DIFF
--- a/packages/core/useElementSize/directive.test.ts
+++ b/packages/core/useElementSize/directive.test.ts
@@ -1,7 +1,7 @@
 import type { VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { defineComponent } from 'vue'
+import { computed, defineComponent } from 'vue'
 import { vElementSize } from './directive'
 
 const App = defineComponent({
@@ -16,9 +16,21 @@ const App = defineComponent({
     },
   },
 
+  setup(props) {
+    const bindingValue = computed(() => {
+      if (props.options)
+        return [props.onResize, ...props.options]
+
+      return props.onResize
+    })
+
+    return {
+      bindingValue,
+    }
+  },
+
   template: `<template>
-  <div v-if="options" v-element-size="[onResize,options]">Hello world!</div>
-  <div v-else v-element-size="onResize">Hello world!</div>
+  <div v-element-size="bindingValue">Hello world!</div>
   </template>
   `,
 })
@@ -67,6 +79,39 @@ describe('vElementSize', () => {
 
     it('should be defined', () => {
       expect(wrapper).toBeDefined()
+    })
+
+    it('should call resize handler immediately with border-box options', () => {
+      const offsetWidth = vi
+        .spyOn(HTMLElement.prototype, 'offsetWidth', 'get')
+        .mockReturnValue(45)
+      const offsetHeight = vi
+        .spyOn(HTMLElement.prototype, 'offsetHeight', 'get')
+        .mockReturnValue(30)
+
+      try {
+        wrapper.unmount()
+        onResize = vi.fn()
+        wrapper = mount(App, {
+          props: {
+            onResize,
+            options: [{ width: 0, height: 0 }, { box: 'border-box' }],
+          },
+          global: {
+            directives: {
+              ElementSize: vElementSize,
+            },
+          },
+        })
+
+        expect(onResize).toHaveBeenCalledTimes(1)
+        expect(onResize).toHaveBeenCalledWith({ width: 45, height: 30 })
+      }
+      finally {
+        wrapper.unmount()
+        offsetWidth.mockRestore()
+        offsetHeight.mockRestore()
+      }
     })
   })
 })

--- a/packages/core/useElementSize/directive.ts
+++ b/packages/core/useElementSize/directive.ts
@@ -21,7 +21,7 @@ export const vElementSize = createDisposableDirective<
       const options = (typeof binding.value === 'function' ? [] : binding.value.slice(1)) as RemoveFirstFromTuple<BindingValueArray>
 
       const { width, height } = useElementSize(el, ...options)
-      watch([width, height], ([width, height]) => handler({ width, height }))
+      watch([width, height], ([width, height]) => handler({ width, height }), { immediate: true })
     },
   },
 )


### PR DESCRIPTION
## Summary
Fixes #5347.

`vElementSize` registers its watcher after `useElementSize()` has already populated the refs from the mounted element. When `{ box: 'border-box' }` reports the same values from `ResizeObserver`, Vue sees no ref change and the directive handler never runs.

This makes the directive watcher immediate so the mounted size is forwarded as soon as the directive is registered. The regression test covers a border-box directive binding whose `offsetWidth`/`offsetHeight` match the eventual observed size.

## Validation
- `corepack pnpm exec vitest run --project unit packages/core/useElementSize/directive.test.ts`
- `corepack pnpm exec eslint packages/core/useElementSize/directive.ts packages/core/useElementSize/directive.test.ts`
- `corepack pnpm typecheck`
- `git diff --check`