### PR TITLE
fix(useTextareaAutosize): bind demo textarea ref

### DIFF
--- a/packages/core/useTextareaAutosize/demo.vue
+++ b/packages/core/useTextareaAutosize/demo.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { useTextareaAutosize } from '@vueuse/core'
+import { useTemplateRef } from 'vue'
 
-const { input } = useTextareaAutosize()
+const textarea = useTemplateRef<HTMLTextAreaElement>('textarea')
+const { input } = useTextareaAutosize({ element: textarea })
 </script>
 
 <template>


### PR DESCRIPTION
## Summary
Fixes #5380.

The live `useTextareaAutosize` demo created the composable without passing the `<textarea>` element, so typing into the demo updated `input` but never gave the composable an element to resize. This binds the template ref and passes it through the `element` option so the documentation demo grows again while typing.

## Validation
- `corepack pnpm exec eslint packages/core/useTextareaAutosize/demo.vue`
- `corepack pnpm typecheck`
- `git diff --check`