### PR TITLE
fix(useFileDialog): remove falsy capture attribute

### DIFF
--- a/packages/core/useFileDialog/index.test.ts
+++ b/packages/core/useFileDialog/index.test.ts
@@ -206,7 +206,7 @@ describe('useFileDialog', () => {
     const input = document.createElement('input')
     input.click = vi.fn()
 
-    const captureRef = shallowRef('user')
+    const captureRef = shallowRef<string | undefined>('user')
 
     const { open } = useFileDialog({
       input,
@@ -227,5 +227,20 @@ describe('useFileDialog', () => {
     open()
 
     expect(input.capture).toBe('environment')
+
+    captureRef.value = undefined
+    await nextTick()
+
+    expect(input.hasAttribute('capture')).toBe(false)
+    expect(input.capture).toBe('')
+
+    open({ capture: 'user' })
+
+    expect(input.capture).toBe('user')
+
+    open({ capture: '' })
+
+    expect(input.hasAttribute('capture')).toBe(false)
+    expect(input.capture).toBe('')
   })
 })

--- a/packages/core/useFileDialog/index.ts
+++ b/packages/core/useFileDialog/index.ts
@@ -20,7 +20,7 @@ export interface UseFileDialogOptions extends ConfigurableDocument {
    * Select the input source for the capture file.
    * @see [HTMLInputElement Capture](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/capture)
    */
-  capture?: MaybeRef<string>
+  capture?: MaybeRef<string | false | null | undefined>
   /**
    * Reset when open file dialog.
    * @default false
@@ -124,8 +124,16 @@ export function useFileDialog(options: UseFileDialogOptions = {}): UseFileDialog
     el.accept = toValue(options.accept)!
     // webkitdirectory key is not stabled, maybe replaced in the future.
     el.webkitdirectory = toValue(options.directory)!
-    if (hasOwn(options, 'capture'))
-      el.capture = toValue(options.capture)!
+    if (hasOwn(options, 'capture')) {
+      const capture = toValue(options.capture)
+      if (capture) {
+        el.capture = capture
+      }
+      else {
+        el.capture = ''
+        el.removeAttribute('capture')
+      }
+    }
   }
 
   const open = (localOptions?: Partial<UseFileDialogOptions>) => {


### PR DESCRIPTION
## Summary
Fixes #5391.

When `capture` had previously been set, later falsy values only left the old value in place. This clears the reflected `input.capture` property and removes the `capture` attribute whenever a provided `capture` option resolves to a falsy value.

The type now accepts falsy capture values explicitly so callers can disable capture through refs or local `open()` options.

## Validation
- `corepack pnpm exec vitest run --project unit packages/core/useFileDialog/index.test.ts`
- `corepack pnpm exec eslint packages/core/useFileDialog/index.ts packages/core/useFileDialog/index.test.ts`
- `corepack pnpm typecheck`
- `git diff --check origin/main...HEAD`
