### PR TITLE
fix(useConfirmDialog): type array payload hooks as single values

### DIFF
--- a/packages/core/useConfirmDialog/index.test.ts
+++ b/packages/core/useConfirmDialog/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, expectTypeOf, it } from 'vitest'
 import { nextTick, shallowRef } from 'vue'
 import { useConfirmDialog } from './index'
 
@@ -55,6 +55,31 @@ describe('useConfirmDialog', () => {
 
     cancel()
     expect(show.value).toBe(false)
+  })
+
+  it('should type array reveal data as a single payload', () => {
+    const {
+      reveal,
+      confirm,
+      cancel,
+      onReveal,
+      onConfirm,
+      onCancel,
+    } = useConfirmDialog<number[], string[], boolean[]>()
+
+    onReveal((data) => {
+      expectTypeOf(data).toEqualTypeOf<number[]>()
+    })
+    onConfirm((data) => {
+      expectTypeOf(data).toEqualTypeOf<string[]>()
+    })
+    onCancel((data) => {
+      expectTypeOf(data).toEqualTypeOf<boolean[]>()
+    })
+
+    reveal([1, 2, 3])
+    confirm(['confirmed'])
+    cancel([true])
   })
 
   it('should execute a callback inside `onConfirm` hook only after confirming', () => {

--- a/packages/core/useConfirmDialog/index.ts
+++ b/packages/core/useConfirmDialog/index.ts
@@ -1,4 +1,4 @@
-import type { EventHook, EventHookOn } from '@vueuse/shared'
+import type { EventHookOn } from '@vueuse/shared'
 import type { ComputedRef, ShallowRef } from 'vue'
 import { createEventHook, noop } from '@vueuse/shared'
 import { computed, shallowRef } from 'vue'
@@ -41,19 +41,19 @@ export interface UseConfirmDialogReturn<RevealData, ConfirmData, CancelData> {
   /**
    * Event Hook to be triggered right before dialog creating.
    */
-  onReveal: EventHookOn<RevealData>
+  onReveal: EventHookOn<[RevealData]>
 
   /**
    * Event Hook to be called on `confirm()`.
    * Gets data object from `confirm` function.
    */
-  onConfirm: EventHookOn<ConfirmData>
+  onConfirm: EventHookOn<[ConfirmData]>
 
   /**
    * Event Hook to be called on `cancel()`.
    * Gets data object from `cancel` function.
    */
-  onCancel: EventHookOn<CancelData>
+  onCancel: EventHookOn<[CancelData]>
 }
 
 /**
@@ -71,14 +71,14 @@ export function useConfirmDialog<
 >(
   revealed: ShallowRef<boolean> = shallowRef(false),
 ): UseConfirmDialogReturn<RevealData, ConfirmData, CancelData> {
-  const confirmHook: EventHook = createEventHook<ConfirmData>()
-  const cancelHook: EventHook = createEventHook<CancelData>()
-  const revealHook: EventHook = createEventHook<RevealData>()
+  const confirmHook = createEventHook<[ConfirmData]>()
+  const cancelHook = createEventHook<[CancelData]>()
+  const revealHook = createEventHook<[RevealData]>()
 
   let _resolve: (arg0: UseConfirmDialogRevealResult<ConfirmData, CancelData>) => void = noop
 
   const reveal = (data?: RevealData) => {
-    revealHook.trigger(data)
+    revealHook.trigger(data as RevealData)
     revealed.value = true
 
     return new Promise<UseConfirmDialogRevealResult<ConfirmData, CancelData>>((resolve) => {
@@ -88,14 +88,14 @@ export function useConfirmDialog<
 
   const confirm = (data?: ConfirmData) => {
     revealed.value = false
-    confirmHook.trigger(data)
+    confirmHook.trigger(data as ConfirmData)
 
     _resolve({ data, isCanceled: false })
   }
 
   const cancel = (data?: CancelData) => {
     revealed.value = false
-    cancelHook.trigger(data)
+    cancelHook.trigger(data as CancelData)
     _resolve({ data, isCanceled: true })
   }
 

--- a/test/__snapshots__/tsnapi/@vueuse/core/index.snapshot.d.ts
+++ b/test/__snapshots__/tsnapi/@vueuse/core/index.snapshot.d.ts
@@ -425,9 +425,9 @@ export interface UseConfirmDialogReturn<RevealData, ConfirmData, CancelData> {
   reveal: (_?: RevealData) => Promise<UseConfirmDialogRevealResult<ConfirmData, CancelData>>;
   confirm: (_?: ConfirmData) => void;
   cancel: (_?: CancelData) => void;
-  onReveal: EventHookOn<RevealData>;
-  onConfirm: EventHookOn<ConfirmData>;
-  onCancel: EventHookOn<CancelData>;
+  onReveal: EventHookOn<[RevealData]>;
+  onConfirm: EventHookOn<[ConfirmData]>;
+  onCancel: EventHookOn<[CancelData]>;
 }
 export interface UseCountdownOptions extends ConfigurableScheduler {
   interval?: MaybeRefOrGetter<number>;


### PR DESCRIPTION
## Summary
Fixes #5176.

`createEventHook` treats array generic parameters as rest arguments, so `useConfirmDialog<number[]>()` exposed `onReveal` as if the callback received a `number` instead of the actual `number[]` payload. This wraps the reveal/confirm/cancel hook payload types in single-element tuples so array payloads stay typed as one value.

The test covers array payloads for `onReveal`, `onConfirm`, and `onCancel`, and the public type snapshot is updated to match.

## Validation
- `corepack pnpm exec vitest run --project unit packages/core/useConfirmDialog/index.test.ts`
- `corepack pnpm exec eslint packages/core/useConfirmDialog/index.ts packages/core/useConfirmDialog/index.test.ts test/__snapshots__/tsnapi/@vueuse/core/index.snapshot.d.ts` (snapshot file is ignored by ESLint; source/test lint passed)
- `corepack pnpm typecheck`
- `corepack pnpm build`
- `corepack pnpm test:exports`
- `git diff --check origin/main...HEAD`
