### PR TITLE
test(useResizeObserver): cover template refs

### DIFF
--- a/packages/core/useResizeObserver/index.browser.test.ts
+++ b/packages/core/useResizeObserver/index.browser.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup } from 'vitest-browser-vue'
+import { page } from 'vitest/browser'
+import { defineComponent, useTemplateRef } from 'vue'
+import { useResizeObserver } from '.'
+
+describe('useResizeObserver', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('supports useTemplateRef target and avoids readonly assignment warnings', async () => {
+    const callbackMock = vi.fn()
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      const Target = defineComponent({
+        template: '<div ref="target" style="width: 10px; height: 10px;"></div>',
+        setup() {
+          const target = useTemplateRef<HTMLElement>('target')
+          useResizeObserver(target, callbackMock)
+        },
+      })
+
+      page.render(Target)
+
+      await vi.waitFor(() => {
+        expect(callbackMock).toHaveBeenCalled()
+      })
+
+      const readonlyWarnMessage = 'Set operation on key "value" failed: target is readonly'
+      expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining(readonlyWarnMessage))
+    }
+    finally {
+      warnSpy.mockRestore()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Refs #4759.

- Add browser regression coverage for `useResizeObserver` when the target is created with Vue's `useTemplateRef`.
- Assert the resize observer callback runs for the template ref target.
- Assert Vue does not emit the readonly-ref assignment warning reported in #4759.

The current repo setup with Vue 3.5.33 no longer reproduces the warning, so this pins the intended behavior and guards against regressions in VueUse's target handling.

## Validation

- `corepack pnpm exec eslint packages/core/useResizeObserver/index.browser.test.ts`
- `corepack pnpm exec vitest run --project "browser (chromium)" packages/core/useResizeObserver/index.browser.test.ts`
- `corepack pnpm typecheck`
- `git diff --check`