### PR TITLE
fix(useDropZone): reset drag state during dragover

### DIFF
--- a/packages/core/useDropZone/index.test.ts
+++ b/packages/core/useDropZone/index.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { useDropZone } from './index'
+
+function createDragEvent(type: string) {
+  const event = new Event(type, { bubbles: true, cancelable: true }) as DragEvent
+
+  Object.defineProperty(event, 'dataTransfer', {
+    value: {
+      dropEffect: 'move',
+      files: [],
+      items: [],
+    },
+  })
+
+  return event
+}
+
+describe('useDropZone', () => {
+  it('resets nested drag state on dragover so dragleave clears the drop zone', () => {
+    const target = document.createElement('div')
+    const { isOverDropZone } = useDropZone(target)
+
+    target.dispatchEvent(createDragEvent('dragenter'))
+    target.dispatchEvent(createDragEvent('dragenter'))
+    expect(isOverDropZone.value).toBe(true)
+
+    target.dispatchEvent(createDragEvent('dragover'))
+    target.dispatchEvent(createDragEvent('dragleave'))
+
+    expect(isOverDropZone.value).toBe(false)
+  })
+})

--- a/packages/core/useDropZone/index.ts
+++ b/packages/core/useDropZone/index.ts
@@ -118,6 +118,8 @@ export function useDropZone(
           _options.onEnter?.(null, event)
           break
         case 'over':
+          counter = 1
+          isOverDropZone.value = true
           _options.onOver?.(null, event)
           break
         case 'leave':


### PR DESCRIPTION
## Summary

Fixes #4652.

- Clamp the internal drag counter back to the active drop-zone level during `dragover`.
- Keep `isOverDropZone` true while valid dragover events are still flowing.
- Add regression coverage for the missed-`dragleave` case where a later leave should clear `isOverDropZone`.

## Validation

- `corepack pnpm exec vitest run --project unit packages/core/useDropZone/index.test.ts`
- `corepack pnpm exec eslint packages/core/useDropZone/index.ts packages/core/useDropZone/index.test.ts`
- `corepack pnpm typecheck`
- `git diff --check`