### PR TITLE
fix(useDevicesList): refresh labels with granted permissions

### DIFF
--- a/packages/core/useDevicesList/index.test.ts
+++ b/packages/core/useDevicesList/index.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest'
+import { useDevicesList } from './index'
+
+describe('useDevicesList', () => {
+  it('requests a stream before updating devices when permission is already granted', async () => {
+    const devices = [
+      { kind: 'audioinput' },
+      { kind: 'videoinput' },
+    ] as MediaDeviceInfo[]
+    const stop = vi.fn()
+    const enumerateDevices = vi.fn().mockResolvedValue(devices)
+    const getUserMedia = vi.fn().mockResolvedValue({
+      getTracks: () => [{ stop }],
+    })
+    const mediaDevices = Object.assign(new EventTarget(), {
+      enumerateDevices,
+      getUserMedia,
+    })
+    const permissionStatus = Object.assign(new EventTarget(), {
+      state: 'granted' as PermissionState,
+    })
+    const navigator = {
+      mediaDevices,
+      permissions: {
+        query: vi.fn().mockResolvedValue(permissionStatus),
+      },
+    } as unknown as Navigator
+
+    const { ensurePermissions, permissionGranted, devices: listedDevices } = useDevicesList({ navigator })
+
+    await expect(ensurePermissions()).resolves.toBe(true)
+
+    expect(getUserMedia).toHaveBeenCalledWith({ audio: true, video: true })
+    expect(stop).toHaveBeenCalledTimes(1)
+    expect(permissionGranted.value).toBe(true)
+    expect(listedDevices.value).toEqual(devices)
+  })
+})

--- a/packages/core/useDevicesList/index.ts
+++ b/packages/core/useDevicesList/index.ts
@@ -81,9 +81,7 @@ export function useDevicesList(options: UseDevicesListOptions = {}): UseDevicesL
     if (permissionGranted.value)
       return true
 
-    const { state, query } = usePermission(deviceName, { controls: true })
-    await query()
-    if (state.value !== 'granted') {
+    const requestMediaStream = async () => {
       let granted = true
       try {
         const allDevices = await navigator!.mediaDevices.enumerateDevices()
@@ -91,18 +89,23 @@ export function useDevicesList(options: UseDevicesListOptions = {}): UseDevicesL
         const hasMicrophone = allDevices.some(device => device.kind === 'audioinput' || device.kind === 'audiooutput')
         constraints.video = hasCamera ? constraints.video : false
         constraints.audio = hasMicrophone ? constraints.audio : false
-        stream = await navigator!.mediaDevices.getUserMedia(constraints)
+        if (constraints.video || constraints.audio)
+          stream = await navigator!.mediaDevices.getUserMedia(constraints)
+        else
+          granted = false
       }
       catch {
         stream = null
         granted = false
       }
-      update()
-      permissionGranted.value = granted
+      return granted
     }
-    else {
-      permissionGranted.value = true
-    }
+
+    const { state, query } = usePermission(deviceName, { controls: true, navigator })
+    await query()
+    const granted = await requestMediaStream()
+    await update()
+    permissionGranted.value = granted || state.value === 'granted'
 
     return permissionGranted.value
   }


### PR DESCRIPTION
## Summary

Fixes #4672.

- Request a short-lived media stream inside `ensurePermissions()` even when the Permissions API already reports `granted`.
- Enumerate devices while that stream is active, then reuse the existing cleanup path to stop the tracks.
- Pass the configured navigator through to `usePermission`, keeping custom navigator/test environments consistent.
- Add regression coverage for the already-granted permission path.

## Validation

- `corepack pnpm exec vitest run --project unit packages/core/useDevicesList/index.test.ts`
- `corepack pnpm exec eslint packages/core/useDevicesList/index.ts packages/core/useDevicesList/index.test.ts`
- `corepack pnpm typecheck`
- `git diff --check`