### PR TITLE
fix(useTextareaAutosize): wire demo textarea ref

### DIFF
--- a/packages/core/useTextareaAutosize/demo.vue
+++ b/packages/core/useTextareaAutosize/demo.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { useTextareaAutosize } from '@vueuse/core'
+import { useTemplateRef } from 'vue'
 
-const { input } = useTextareaAutosize()
+const textarea = useTemplateRef('textarea')
+const { input } = useTextareaAutosize({ element: textarea })
 </script>
 
 <template>


### PR DESCRIPTION
## Summary

Fixes #5380.

The `useTextareaAutosize` demo declared only `input`, so the template's `ref="textarea"` was never connected to the composable. That left the demo without an element for `useTextareaAutosize()` to measure, so typing in the live docs textarea did not grow it.

This switches the demo to Vue's `useTemplateRef()` pattern and passes the element ref explicitly into `useTextareaAutosize`.

## Validation

- `corepack pnpm exec vitest run packages/core/useTextareaAutosize/index.test.ts`
- `corepack pnpm exec eslint packages/core/useTextareaAutosize/demo.vue`
- `corepack pnpm typecheck`
- `corepack pnpm lint`
- `git diff --check`

Note: this repo does not include a Prettier config; standalone `prettier --check` disagrees with the existing Antfu ESLint formatter style, so I used the repo lint/formatter pipeline instead.