### PR TITLE
fix(useDraggable): pass current position to onStart

### DIFF
--- a/packages/core/useDraggable/index.test.ts
+++ b/packages/core/useDraggable/index.test.ts
@@ -118,4 +118,33 @@ describe('useDraggable', () => {
     expect(onMove).toHaveBeenCalledOnce()
     expect(onEnd).toHaveBeenCalledOnce()
   })
+
+  it('should call onStart with current position instead of pointer offset', async () => {
+    const onStart = vi.fn()
+
+    const wrapper = mount({
+      setup() {
+        const el = useTemplateRef<HTMLElement>('el')
+
+        useDraggable(el, {
+          initialValue: { x: 40, y: 80 },
+          onStart,
+        })
+
+        return () => h('div', { ref: 'el' })
+      },
+    })
+
+    await nextTick()
+
+    wrapper.get('div').element.dispatchEvent(new PointerEvent('pointerdown', {
+      clientX: 10,
+      clientY: 20,
+    }))
+
+    expect(onStart).toHaveBeenCalledWith(
+      { x: 40, y: 80 },
+      expect.any(PointerEvent),
+    )
+  })
 })

--- a/packages/core/useDraggable/index.ts
+++ b/packages/core/useDraggable/index.ts
@@ -336,7 +336,7 @@ export function useDraggable(
       x: e.clientX - (container ? targetRect.left - containerRect!.left + (autoScroll ? 0 : container.scrollLeft) : targetRect.left),
       y: e.clientY - (container ? targetRect.top - containerRect!.top + (autoScroll ? 0 : container.scrollTop) : targetRect.top),
     }
-    if (onStart?.(pos, e) === false)
+    if (onStart?.(position.value, e) === false)
       return
     pressedDelta.value = pos
     handleEvent(e)


### PR DESCRIPTION
## Summary

Fixes #3770.

`useDraggable` internally computes a pointer offset on pointerdown and stores it in `pressedDelta`. That offset is necessary for drag movement, but it was also passed to the public `onStart(position, event)` callback. As a result, `onStart` received pointer-relative values while `onMove` and `onEnd` received the draggable position.

This keeps the internal offset for movement math, but passes the current draggable `position.value` to `onStart`, making the callback payload consistent with `onMove` and `onEnd`.

## Validation

- `corepack pnpm exec vitest run packages/core/useDraggable/index.test.ts`
- `corepack pnpm exec vitest run packages/core/useDraggable/index.browser.test.ts --project "browser (chromium)"`
- `corepack pnpm exec eslint packages/core/useDraggable/index.ts packages/core/useDraggable/index.test.ts`
- `corepack pnpm typecheck`
- `corepack pnpm lint`
- `git diff --check`