### PR TITLE
Fix useConfirmDialog array payload hook types

### DIFF
--- a/packages/core/useConfirmDialog/index.test.ts
+++ b/packages/core/useConfirmDialog/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, expectTypeOf, it } from 'vitest'
 import { nextTick, shallowRef } from 'vue'
 import { useConfirmDialog } from './index'
 
@@ -139,6 +139,24 @@ describe('useConfirmDialog', () => {
     cancel(data)
 
     expect(message.value).toBe('confirm')
+  })
+
+  it('should type array payloads as a single event argument', () => {
+    const {
+      onReveal,
+      onConfirm,
+      onCancel,
+    } = useConfirmDialog<number[], string[], boolean[]>()
+
+    onReveal((data) => {
+      expectTypeOf(data).toEqualTypeOf<number[]>()
+    })
+    onConfirm((data) => {
+      expectTypeOf(data).toEqualTypeOf<string[]>()
+    })
+    onCancel((data) => {
+      expectTypeOf(data).toEqualTypeOf<boolean[]>()
+    })
   })
 
   it('should return promise that will be resolved on `confirm()`', async () => {

--- a/packages/core/useConfirmDialog/index.ts
+++ b/packages/core/useConfirmDialog/index.ts
@@ -12,6 +12,8 @@ export type UseConfirmDialogRevealResult<C, D>
     isCanceled: true
   }
 
+type EventHookOnPayload<T> = EventHookOn<[T]>
+
 export interface UseConfirmDialogReturn<RevealData, ConfirmData, CancelData> {
   /**
    * Revealing state
@@ -41,19 +43,19 @@ export interface UseConfirmDialogReturn<RevealData, ConfirmData, CancelData> {
   /**
    * Event Hook to be triggered right before dialog creating.
    */
-  onReveal: EventHookOn<RevealData>
+  onReveal: EventHookOnPayload<RevealData>
 
   /**
    * Event Hook to be called on `confirm()`.
    * Gets data object from `confirm` function.
    */
-  onConfirm: EventHookOn<ConfirmData>
+  onConfirm: EventHookOnPayload<ConfirmData>
 
   /**
    * Event Hook to be called on `cancel()`.
    * Gets data object from `cancel` function.
    */
-  onCancel: EventHookOn<CancelData>
+  onCancel: EventHookOnPayload<CancelData>
 }
 
 /**


### PR DESCRIPTION
## Summary

- Wrap `useConfirmDialog` event hook payload types so array data is treated as one payload argument instead of a rest parameter list.
- Apply the same payload typing to `onReveal`, `onConfirm`, and `onCancel` for consistency with the runtime `trigger(data)` behavior.
- Add type assertions covering array payloads for all three hooks.

Fixes #5176.

## Test plan

- `corepack pnpm vitest run packages/core/useConfirmDialog/index.test.ts`
- `corepack pnpm exec eslint packages/core/useConfirmDialog/index.ts packages/core/useConfirmDialog/index.test.ts`
- `corepack pnpm typecheck`
- `corepack pnpm --filter @vueuse/core build`
- `git diff --check`