### PR TITLE
fix(useIDBKeyval): skip IndexedDB access during SSR

### DIFF
--- a/packages/integrations/useIDBKeyval/index.server.test.ts
+++ b/packages/integrations/useIDBKeyval/index.server.test.ts
@@ -1,0 +1,28 @@
+import { get, set, update } from 'idb-keyval'
+import { describe, expect, it, vi } from 'vitest'
+import { useIDBKeyval } from './index'
+
+vi.mock('idb-keyval', () => ({
+  get: vi.fn(),
+  set: vi.fn(),
+  update: vi.fn(),
+  del: vi.fn(),
+}))
+
+describe('useIDBKeyval SSR', () => {
+  it('does not access IndexedDB when it is unavailable', async () => {
+    const { data, isFinished, set: setData } = useIDBKeyval('key', 'initial')
+
+    expect(data.value).toBe('initial')
+    expect(isFinished.value).toBe(true)
+    expect(get).not.toHaveBeenCalled()
+    expect(set).not.toHaveBeenCalled()
+    expect(update).not.toHaveBeenCalled()
+
+    await setData('updated')
+
+    expect(data.value).toBe('updated')
+    expect(set).not.toHaveBeenCalled()
+    expect(update).not.toHaveBeenCalled()
+  })
+})

--- a/packages/integrations/useIDBKeyval/index.test.ts
+++ b/packages/integrations/useIDBKeyval/index.test.ts
@@ -46,6 +46,7 @@ describe('useIDBKeyval', () => {
 
   beforeEach(async () => {
     console.error = vi.fn()
+    vi.stubGlobal('indexedDB', {})
 
     await set(KEY3, 'hello');
 
@@ -56,6 +57,7 @@ describe('useIDBKeyval', () => {
 
   afterEach(() => {
     vi.clearAllMocks()
+    vi.unstubAllGlobals()
     cache.clear()
   })
 

--- a/packages/integrations/useIDBKeyval/index.ts
+++ b/packages/integrations/useIDBKeyval/index.ts
@@ -79,6 +79,18 @@ export function useIDBKeyval<T>(
 
   const rawInit: T = toValue(initialValue)
 
+  if (typeof indexedDB === 'undefined') {
+    isFinished.value = true
+
+    return {
+      set: async (value: T) => {
+        data.value = value
+      },
+      isFinished,
+      data: data as RemovableRef<T>,
+    }
+  }
+
   async function read() {
     try {
       const rawValue = await get<T>(key)


### PR DESCRIPTION
## Summary

Fixes #5222.

`useIDBKeyval` currently starts an `idb-keyval` read immediately, which can crash in SSR environments where `indexedDB` is unavailable. This adds an IndexedDB availability guard so SSR returns the initial ref, marks the composable as finished, and keeps `set()` local without touching IndexedDB.

The existing unit test now stubs `indexedDB` explicitly, and a server-side regression test asserts that no `idb-keyval` reads/writes run when IndexedDB is missing.

## Validation

- `corepack pnpm vitest run packages/integrations/useIDBKeyval/index.test.ts packages/integrations/useIDBKeyval/index.server.test.ts --project unit --project server`
- `corepack pnpm exec eslint packages/integrations/useIDBKeyval/index.ts packages/integrations/useIDBKeyval/index.test.ts packages/integrations/useIDBKeyval/index.server.test.ts`
- `corepack pnpm typecheck`
- `corepack pnpm --filter @vueuse/integrations build`
- `git diff --check`