### PR TITLE
fix(useIDBKeyval): skip IndexedDB access during SSR

### DIFF
--- a/packages/integrations/useIDBKeyval/index.server.test.ts
+++ b/packages/integrations/useIDBKeyval/index.server.test.ts
@@ -1,0 +1,28 @@
+import { get, set, update } from 'idb-keyval'
+import { describe, expect, it, vi } from 'vitest'
+import { useIDBKeyval } from './index'
+
+vi.mock('idb-keyval', () => ({
+  get: vi.fn(),
+  set: vi.fn(),
+  update: vi.fn(),
+  del: vi.fn(),
+}))
+
+describe('useIDBKeyval SSR', () => {
+  it('does not access IndexedDB when it is unavailable', async () => {
+    const { data, isFinished, set: setData } = useIDBKeyval('key', 'initial')
+
+    expect(data.value).toBe('initial')
+    expect(isFinished.value).toBe(true)
+    expect(get).not.toHaveBeenCalled()
+    expect(set).not.toHaveBeenCalled()
+    expect(update).not.toHaveBeenCalled()
+
+    await setData('updated')
+
+    expect(data.value).toBe('updated')
+    expect(set).not.toHaveBeenCalled()
+    expect(update).not.toHaveBeenCalled()
+  })
+})

--- a/packages/integrations/useIDBKeyval/index.test.ts
+++ b/packages/integrations/useIDBKeyval/index.test.ts
@@ -46,6 +46,7 @@ describe('useIDBKeyval', () => {
 
   beforeEach(async () => {
     console.error = vi.fn()
+    vi.stubGlobal('indexedDB', {})
 
     await set(KEY3, 'hello');
 
@@ -56,6 +57,7 @@ describe('useIDBKeyval', () => {
 
   afterEach(() => {
     vi.clearAllMocks()
+    vi.unstubAllGlobals()
     cache.clear()
   })
 

--- a/packages/integrations/useIDBKeyval/index.ts
+++ b/packages/integrations/useIDBKeyval/index.ts
@@ -79,6 +79,18 @@ export function useIDBKeyval<T>(
 
   const rawInit: T = toValue(initialValue)
 
+  if (typeof indexedDB === 'undefined') {
+    isFinished.value = true
+
+    return {
+      set: async (value: T) => {
+        data.value = value
+      },
+      isFinished,
+      data: data as RemovableRef<T>,
+    }
+  }
+
   async function read() {
     try {
       const rawValue = await get<T>(key)


### PR DESCRIPTION
### Description

Fixes #5222.

`useIDBKeyval` currently calls into `idb-keyval` during setup, which can throw in SSR environments where `indexedDB` is not available. This adds an SSR guard that keeps the composable usable with its initial value, marks loading as finished, and lets the returned setter update the local ref without touching IndexedDB.

### Additional context

The browser/jsdom path still exercises IndexedDB behavior by stubbing `indexedDB` in the existing tests.

### Checklist

- [x] `corepack pnpm exec vitest run --project server packages/integrations/useIDBKeyval/index.server.test.ts`
- [x] `corepack pnpm exec vitest run --project unit packages/integrations/useIDBKeyval/index.test.ts`
- [x] `corepack pnpm exec eslint packages/integrations/useIDBKeyval/index.ts packages/integrations/useIDBKeyval/index.test.ts packages/integrations/useIDBKeyval/index.server.test.ts`
- [x] `corepack pnpm exec vue-tsc --noEmit --pretty false`
- [x] `git diff origin/main...HEAD --check`