### PR TITLE
fix(useConfirmDialog): preserve array hook payload types

### DIFF
--- a/packages/core/useConfirmDialog/index.test.ts
+++ b/packages/core/useConfirmDialog/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, expectTypeOf, it } from 'vitest'
 import { nextTick, shallowRef } from 'vue'
 import { useConfirmDialog } from './index'
 
@@ -55,6 +55,24 @@ describe('useConfirmDialog', () => {
 
     cancel()
     expect(show.value).toBe(false)
+  })
+
+  it('should type array payloads as a single hook argument', () => {
+    const { onReveal, onConfirm, onCancel } = useConfirmDialog<
+      number[],
+      string[],
+      boolean[]
+    >()
+
+    onReveal((data) => {
+      expectTypeOf(data).toEqualTypeOf<number[]>()
+    })
+    onConfirm((data) => {
+      expectTypeOf(data).toEqualTypeOf<string[]>()
+    })
+    onCancel((data) => {
+      expectTypeOf(data).toEqualTypeOf<boolean[]>()
+    })
   })
 
   it('should execute a callback inside `onConfirm` hook only after confirming', () => {

--- a/packages/core/useConfirmDialog/index.ts
+++ b/packages/core/useConfirmDialog/index.ts
@@ -4,13 +4,16 @@ import { createEventHook, noop } from '@vueuse/shared'
 import { computed, shallowRef } from 'vue'
 
 export type UseConfirmDialogRevealResult<C, D>
-  = {
+  = | {
     data?: C
     isCanceled: false
-  } | {
+  }
+  | {
     data?: D
     isCanceled: true
   }
+
+type UseConfirmDialogEventHookOn<T> = EventHookOn<[T]>
 
 export interface UseConfirmDialogReturn<RevealData, ConfirmData, CancelData> {
   /**
@@ -22,7 +25,9 @@ export interface UseConfirmDialogReturn<RevealData, ConfirmData, CancelData> {
    * Opens the dialog.
    * Create promise and return it. Triggers `onReveal` hook.
    */
-  reveal: (data?: RevealData) => Promise<UseConfirmDialogRevealResult<ConfirmData, CancelData>>
+  reveal: (
+    data?: RevealData,
+  ) => Promise<UseConfirmDialogRevealResult<ConfirmData, CancelData>>
 
   /**
    * Confirms and closes the dialog. Triggers a callback inside `onConfirm` hook.
@@ -41,19 +46,19 @@ export interface UseConfirmDialogReturn<RevealData, ConfirmData, CancelData> {
   /**
    * Event Hook to be triggered right before dialog creating.
    */
-  onReveal: EventHookOn<RevealData>
+  onReveal: UseConfirmDialogEventHookOn<RevealData>
 
   /**
    * Event Hook to be called on `confirm()`.
    * Gets data object from `confirm` function.
    */
-  onConfirm: EventHookOn<ConfirmData>
+  onConfirm: UseConfirmDialogEventHookOn<ConfirmData>
 
   /**
    * Event Hook to be called on `cancel()`.
    * Gets data object from `cancel` function.
    */
-  onCancel: EventHookOn<CancelData>
+  onCancel: UseConfirmDialogEventHookOn<CancelData>
 }
 
 /**
@@ -71,31 +76,36 @@ export function useConfirmDialog<
 >(
   revealed: ShallowRef<boolean> = shallowRef(false),
 ): UseConfirmDialogReturn<RevealData, ConfirmData, CancelData> {
-  const confirmHook: EventHook = createEventHook<ConfirmData>()
-  const cancelHook: EventHook = createEventHook<CancelData>()
-  const revealHook: EventHook = createEventHook<RevealData>()
+  const confirmHook: EventHook<[ConfirmData]>
+    = createEventHook<[ConfirmData]>()
+  const cancelHook: EventHook<[CancelData]> = createEventHook<[CancelData]>()
+  const revealHook: EventHook<[RevealData]> = createEventHook<[RevealData]>()
 
-  let _resolve: (arg0: UseConfirmDialogRevealResult<ConfirmData, CancelData>) => void = noop
+  let _resolve: (
+    arg0: UseConfirmDialogRevealResult<ConfirmData, CancelData>,
+  ) => void = noop
 
   const reveal = (data?: RevealData) => {
-    revealHook.trigger(data)
+    revealHook.trigger(data as RevealData)
     revealed.value = true
 
-    return new Promise<UseConfirmDialogRevealResult<ConfirmData, CancelData>>((resolve) => {
-      _resolve = resolve
-    })
+    return new Promise<UseConfirmDialogRevealResult<ConfirmData, CancelData>>(
+      (resolve) => {
+        _resolve = resolve
+      },
+    )
   }
 
   const confirm = (data?: ConfirmData) => {
     revealed.value = false
-    confirmHook.trigger(data)
+    confirmHook.trigger(data as ConfirmData)
 
     _resolve({ data, isCanceled: false })
   }
 
   const cancel = (data?: CancelData) => {
     revealed.value = false
-    cancelHook.trigger(data)
+    cancelHook.trigger(data as CancelData)
     _resolve({ data, isCanceled: true })
   }
 


### PR DESCRIPTION
### Description

Fixes #5176.

`useConfirmDialog` passes reveal, confirm, and cancel payloads as single values, but it exposed those hooks as `EventHookOn<T>`. `createEventHook` treats array generics as rest arguments, so `useConfirmDialog<number[]>().onReveal(...)` inferred the callback argument as `number` even though the runtime value is `number[]`.

This wraps the confirm-dialog hook payload types in single-element tuples so array payloads are typed as one argument for `onReveal`, `onConfirm`, and `onCancel`.

### Additional context

The runtime API is unchanged; this only corrects the hook payload typing.

### Checklist

- [x] `corepack pnpm exec vitest run --project unit packages/core/useConfirmDialog/index.test.ts`
- [x] `corepack pnpm exec eslint packages/core/useConfirmDialog/index.ts packages/core/useConfirmDialog/index.test.ts`
- [x] `corepack pnpm exec vue-tsc --noEmit --pretty false`
- [x] `git diff --check`