### PR TITLE
fix(useDropZone): reset drag counter on dragover

### DIFF
--- a/packages/core/useDropZone/index.test.ts
+++ b/packages/core/useDropZone/index.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { useDropZone } from './index'
+
+function createDragEvent(type: string) {
+  const event = new Event(type, {
+    bubbles: true,
+    cancelable: true,
+  }) as DragEvent
+
+  Object.defineProperty(event, 'dataTransfer', {
+    value: {
+      dropEffect: 'none',
+      files: [],
+      items: [{ type: 'text/plain' }],
+    },
+  })
+
+  return event
+}
+
+describe('useDropZone', () => {
+  it('should reset nested drag counter on dragover', () => {
+    const target = document.createElement('div')
+    const { isOverDropZone } = useDropZone(target)
+
+    target.dispatchEvent(createDragEvent('dragenter'))
+    target.dispatchEvent(createDragEvent('dragenter'))
+
+    expect(isOverDropZone.value).toBe(true)
+
+    target.dispatchEvent(createDragEvent('dragover'))
+    target.dispatchEvent(createDragEvent('dragleave'))
+
+    expect(isOverDropZone.value).toBe(false)
+  })
+})

--- a/packages/core/useDropZone/index.ts
+++ b/packages/core/useDropZone/index.ts
@@ -118,6 +118,8 @@ export function useDropZone(
           _options.onEnter?.(null, event)
           break
         case 'over':
+          counter = 1
+          isOverDropZone.value = true
           _options.onOver?.(null, event)
           break
         case 'leave':


### PR DESCRIPTION
### Description

Fixes #4652.

`useDropZone` tracks nested dragenter/dragleave events with a counter. If a nested element disappears during drag handling, the matching `dragleave` can be missed and the counter remains above zero. A later drag cancel/leave then decrements only once, leaving `isOverDropZone` stuck as `true`.

Dragover confirms the pointer is still over the drop zone, so this resets the counter to one during valid dragover handling. The next leave/drop can then clear the over state normally.

### Checklist

- [x] `corepack pnpm exec vitest run --project unit packages/core/useDropZone/index.test.ts`
- [x] `corepack pnpm exec eslint packages/core/useDropZone/index.ts packages/core/useDropZone/index.test.ts`
- [x] `corepack pnpm exec vue-tsc --noEmit --pretty false`
- [x] `git diff --check`