### PR TITLE
fix(createReusableTemplate): scope definitions to owner instances

### DIFF
--- a/packages/core/createReusableTemplate/index.test.ts
+++ b/packages/core/createReusableTemplate/index.test.ts
@@ -97,6 +97,55 @@ describe('createReusableTemplate', () => {
     expect(wrapper.text()).toBe('GoodbyeHi')
   })
 
+  it('keeps slots scoped to each owner instance', async () => {
+    const [DefineFoo, ReuseFoo] = createReusableTemplate()
+
+    const Child = defineComponent({
+      data() {
+        return {
+          count: 0,
+        }
+      },
+      render() {
+        return h('button', {
+          onClick: () => {
+            this.count += 1
+          },
+        }, [String(this.count), h(ReuseFoo)])
+      },
+    })
+
+    const Host = defineComponent({
+      props: {
+        label: {
+          required: true,
+          type: String,
+        },
+      },
+      render() {
+        return h('section', [
+          h(DefineFoo, () => h('span', this.label)),
+          h(Child),
+        ])
+      },
+    })
+
+    const wrapper = mount({
+      render() {
+        return h(Fragment, null, [
+          h(Host, { label: 'A' }),
+          h(Host, { label: 'B' }),
+        ])
+      },
+    })
+
+    expect(wrapper.text()).toBe('0A0B')
+
+    await wrapper.findAll('button')[0].trigger('click')
+
+    expect(wrapper.text()).toBe('1A0B')
+  })
+
   it('hyphen props', () => {
     const [DefineFoo, ReuseFoo] = createReusableTemplate<{ myMsg: string }>()
 

--- a/packages/core/createReusableTemplate/index.ts
+++ b/packages/core/createReusableTemplate/index.ts
@@ -1,6 +1,6 @@
-import type { ComponentObjectPropsOptions, DefineComponent, Slot } from 'vue'
+import type { ComponentInternalInstance, ComponentObjectPropsOptions, DefineComponent, Slot } from 'vue'
 import { camelize, makeDestructurable } from '@vueuse/shared'
-import { defineComponent, shallowRef } from 'vue'
+import { defineComponent, getCurrentInstance, shallowRef } from 'vue'
 
 type ObjectLiteralWithPotentialObjectLiterals = Record<string, Record<string, any> | undefined>
 
@@ -70,12 +70,34 @@ export function createReusableTemplate<
   } = options
 
   const render = shallowRef<Slot | undefined>()
+  const renders = new WeakMap<ComponentInternalInstance, Slot | undefined>()
+
+  const setRender = (instance: ComponentInternalInstance | null, slot: Slot | undefined) => {
+    render.value = slot
+
+    if (instance?.parent)
+      renders.set(instance.parent, slot)
+  }
+
+  const getRender = (instance: ComponentInternalInstance | null) => {
+    let owner = instance?.parent
+
+    while (owner) {
+      if (renders.has(owner))
+        return renders.get(owner)
+      owner = owner.parent
+    }
+
+    return render.value
+  }
 
   const define = defineComponent({
     name: `${name}.define`,
     setup(_, { slots }) {
+      const instance = getCurrentInstance()
+
       return () => {
-        render.value = slots.default
+        setRender(instance, slots.default)
       }
     },
   }) as unknown as DefineTemplateComponent<Bindings, MapSlotNameToSlotProps>
@@ -85,10 +107,14 @@ export function createReusableTemplate<
     name: `${name}.reuse`,
     props: options.props,
     setup(props, { attrs, slots }) {
+      const instance = getCurrentInstance()
+
       return () => {
-        if (!render.value && process.env.NODE_ENV !== 'production')
+        const renderSlot = getRender(instance)
+
+        if (!renderSlot && process.env.NODE_ENV !== 'production')
           throw new Error('[VueUse] Failed to find the definition of reusable template')
-        const vnode = render.value?.({
+        const vnode = renderSlot?.({
           ...(options.props == null
             ? keysToCamelKebabCase(attrs)
             : props),


### PR DESCRIPTION
## Summary

Fixes #3881.

`createReusableTemplate` stored the latest definition in a single shared ref. That worked inside one component tree, but when the same `DefineTemplate`/`ReuseTemplate` components were registered once and reused from multiple Options API component instances, the last rendered instance overwrote the slot used by every other instance.

This keeps the existing shared fallback, and additionally stores definitions in a `WeakMap` keyed by the owning component instance. `ReuseTemplate` resolves the nearest owner definition by walking up its parent chain, so nested children render the slot for their own host instance instead of another instance that rendered later.

## Validation

- `corepack pnpm exec vitest run --project unit packages/core/createReusableTemplate/index.test.ts`
- `corepack pnpm exec eslint packages/core/createReusableTemplate/index.ts packages/core/createReusableTemplate/index.test.ts`
- `corepack pnpm exec vue-tsc --noEmit --pretty false`
- `git diff origin/main...HEAD --check`