### PR TITLE
fix(useTextareaAutosize): wire demo textarea ref

### DIFF
--- a/packages/core/useTextareaAutosize/demo.vue
+++ b/packages/core/useTextareaAutosize/demo.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { useTextareaAutosize } from '@vueuse/core'
+import { useTemplateRef } from 'vue'
 
-const { input } = useTextareaAutosize()
+const textarea = useTemplateRef('textarea')
+const { input } = useTextareaAutosize({ element: textarea })
 </script>
 
 <template>


### PR DESCRIPTION
## Summary

Fixes #5380.

The `useTextareaAutosize` demo rendered a textarea with `ref="textarea"`, but the composable was created without receiving that element ref. As a result, typing in the live docs demo updated the model but did not give `useTextareaAutosize` a textarea element to measure and resize.

This wires the template ref into `useTextareaAutosize` so the docs demo grows as users type.

## Validation

- `corepack pnpm exec eslint packages/core/useTextareaAutosize/demo.vue`
- `corepack pnpm exec vue-tsc --noEmit --pretty false`
- `git diff origin/main...HEAD --check`