### PR TITLE
fix(unrefElement): accept typed component template refs

### DIFF
--- a/packages/core/unrefElement/index.test-d.ts
+++ b/packages/core/unrefElement/index.test-d.ts
@@ -1,0 +1,21 @@
+import type { ComponentPublicInstance, ShallowRef } from 'vue'
+import type { VueInstance } from './index'
+import { expectTypeOf } from 'vitest'
+import { useElementSize } from '../useElementSize'
+import { useFocusWithin } from '../useFocusWithin'
+
+type EmitsInstance = ComponentPublicInstance<
+  Record<string, never>,
+  Record<string, never>,
+  Record<string, never>,
+  Record<string, never>,
+  Record<string, never>,
+  { mounted: () => void }
+>
+
+declare const componentRef: Readonly<ShallowRef<EmitsInstance | null>>
+
+expectTypeOf<EmitsInstance>().toMatchTypeOf<VueInstance>()
+
+useElementSize(componentRef)
+useFocusWithin(componentRef)

--- a/packages/core/unrefElement/index.ts
+++ b/packages/core/unrefElement/index.ts
@@ -1,7 +1,9 @@
-import type { ComponentPublicInstance, MaybeRef, MaybeRefOrGetter } from 'vue'
+import type { MaybeRef, MaybeRefOrGetter } from 'vue'
 import { toValue } from 'vue'
 
-export type VueInstance = ComponentPublicInstance
+export interface VueInstance {
+  $el: any
+}
 export type MaybeElementRef<T extends MaybeElement = MaybeElement> = MaybeRef<T>
 export type MaybeComputedElementRef<T extends MaybeElement = MaybeElement> = MaybeRefOrGetter<T>
 export type MaybeElement = HTMLElement | SVGElement | VueInstance | undefined | null
@@ -15,5 +17,5 @@ export type UnRefElementReturn<T extends MaybeElement = MaybeElement> = T extend
  */
 export function unrefElement<T extends MaybeElement>(elRef: MaybeComputedElementRef<T>): UnRefElementReturn<T> {
   const plain = toValue(elRef)
-  return (plain as VueInstance)?.$el ?? plain
+  return ((plain as VueInstance)?.$el ?? plain) as UnRefElementReturn<T>
 }


### PR DESCRIPTION
### Description

Fixes #5072.

`MaybeElement` currently uses Vue's full `ComponentPublicInstance` type for component refs. That makes refs to components with typed `defineEmits` incompatible with composables such as `useElementSize` and `useFocusWithin`, even though `unrefElement` only needs the instance `$el` field.

This narrows the exported `VueInstance` contract to the `$el` surface used by `unrefElement`, so component refs with narrower `$emit` signatures remain valid element refs. A type regression covers a readonly template ref to a component instance with typed emits.

### Validation

- `corepack pnpm exec vue-tsc --noEmit --pretty false`
- `corepack pnpm exec eslint packages/core/unrefElement/index.ts packages/core/unrefElement/index.test-d.ts`
- `corepack pnpm exec vitest run --project "browser (chromium)" packages/core/unrefElement/index.browser.test.ts`
- `git diff --check HEAD~1..HEAD`