### PR TITLE
fix(useDraggable): pass current position to onStart

### DIFF
--- a/packages/core/useDraggable/index.browser.test.ts
+++ b/packages/core/useDraggable/index.browser.test.ts
@@ -3,7 +3,7 @@ import type { ComponentPublicInstance } from 'vue'
 import type { UseDraggableOptions } from './index'
 import { mount } from '@vue/test-utils'
 import { useDraggable } from '@vueuse/core'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, nextTick, shallowRef, useTemplateRef } from 'vue'
 
 interface DraggableAutoScrollOptions {
@@ -324,6 +324,48 @@ describe('useDraggable', () => {
       })
 
       await endDrag(wrapper)
+    })
+
+    it('should pass the current draggable position to onStart when using a container', async () => {
+      const onStart = vi.fn()
+      const initialValue = { x: 120, y: 80 }
+
+      const wrapper = mount(defineComponent({
+        template: `
+          <div ref="container" style="position: relative; width: 300px; height: 200px;">
+            <div ref="el" :style="style" style="position: absolute; width: 40px; height: 30px;" />
+          </div>
+        `,
+        setup() {
+          const el = useTemplateRef<HTMLElement>('el')
+          const container = useTemplateRef<HTMLElement>('container')
+          const draggable = useDraggable(el, {
+            initialValue,
+            containerElement: container,
+            onStart,
+          })
+
+          return { el, container, ...draggable }
+        },
+      }), {
+        attachTo: document.body,
+      })
+
+      await nextTick()
+
+      const rect = wrapper.vm.el!.getBoundingClientRect()
+      wrapper.vm.el!.dispatchEvent(new PointerEvent('pointerdown', {
+        clientX: rect.left + 10,
+        clientY: rect.top + 15,
+        ...baseMousePointerEventOptions,
+      }))
+
+      expect(onStart).toHaveBeenCalledWith(
+        initialValue,
+        expect.any(PointerEvent),
+      )
+
+      wrapper.unmount()
     })
 
     it('should disabled dragging behaviour', async () => {

--- a/packages/core/useDraggable/index.ts
+++ b/packages/core/useDraggable/index.ts
@@ -332,13 +332,13 @@ export function useDraggable(
     const container = toValue(containerElement)
     const containerRect = container?.getBoundingClientRect?.()
     const targetRect = toValue(target)!.getBoundingClientRect()
-    const pos = {
+    const pointerOffset = {
       x: e.clientX - (container ? targetRect.left - containerRect!.left + (autoScroll ? 0 : container.scrollLeft) : targetRect.left),
       y: e.clientY - (container ? targetRect.top - containerRect!.top + (autoScroll ? 0 : container.scrollTop) : targetRect.top),
     }
-    if (onStart?.(pos, e) === false)
+    if (onStart?.(position.value, e) === false)
       return
-    pressedDelta.value = pos
+    pressedDelta.value = pointerOffset
     handleEvent(e)
   }
 


### PR DESCRIPTION
### Description

Fixes #3770.

`useDraggable` used the same value for two different concepts during `pointerdown`: the pointer offset inside the draggable target and the public callback position. That made `onStart` receive the click offset, for example `{ x: 10, y: 15 }`, instead of the current draggable position exposed by `position`, `onMove`, and `onEnd`.

This keeps the pointer offset for internal drag math, but passes the current draggable position to `onStart` so the callback receives a consistent position value.

### Validation

- `corepack pnpm exec vitest run --project "browser (chromium)" packages/core/useDraggable/index.browser.test.ts`
- `corepack pnpm exec vitest run --project unit packages/core/useDraggable/index.test.ts`
- `corepack pnpm exec eslint packages/core/useDraggable/index.ts packages/core/useDraggable/index.browser.test.ts`
- `corepack pnpm exec vue-tsc --noEmit --pretty false`
- `git diff --check`