### PR TITLE
fix(useElementVisibility): move watchOnce outside intersection observer callback

### DIFF
--- a/packages/core/useElementVisibility/index.ts
+++ b/packages/core/useElementVisibility/index.ts
@@ -82,12 +82,6 @@ export function useElementVisibility(
         }
       }
       isVisible.value = isIntersecting
-
-      if (once) {
-        watchOnce(isVisible, () => {
-          observerController.stop()
-        })
-      }
     },
     {
       root: scrollTarget,
@@ -96,6 +90,12 @@ export function useElementVisibility(
       rootMargin,
     },
   )
+
+  if (once) {
+    watchOnce(isVisible, () => {
+      observerController.stop()
+    })
+  }
 
   return options.controls
     ? { ...observerController, isVisible }


### PR DESCRIPTION
## Summary
Fixed `useElementVisibility` to move the `watchOnce` call outside the intersection observer callback, preventing multiple watcher instances from being created on each intersection event.

## Why
When `once: true` is set, `watchOnce` was being called inside the intersection observer callback. This meant a new watcher was created on every intersection event, and each watcher would try to stop the observer independently. Moving `watchOnce` outside ensures proper cleanup and only one watcher is ever created.

## What changed
- Moved the `if (once) { watchOnce(isVisible, ...) }` block from inside the observer callback to after the `useIntersectionObserver` call

## Test plan
- [ ] Verify `once: true` correctly stops observing after the first visibility change
- [ ] Verify no memory leaks from multiple watcher instances