### PR TITLE
fix(useConfirmDialog): preserve array payload types

### DIFF
--- a/packages/core/useConfirmDialog/index.test.ts
+++ b/packages/core/useConfirmDialog/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, expectTypeOf, it } from 'vitest'
 import { nextTick, shallowRef } from 'vue'
 import { useConfirmDialog } from './index'
 
@@ -55,6 +55,24 @@ describe('useConfirmDialog', () => {
 
     cancel()
     expect(show.value).toBe(false)
+  })
+
+  it('should type hook payload arrays as single data arguments', () => {
+    const {
+      onReveal,
+      onConfirm,
+      onCancel,
+    } = useConfirmDialog<number[], string[], boolean[]>()
+
+    onReveal((data) => {
+      expectTypeOf(data).toEqualTypeOf<number[]>()
+    })
+    onConfirm((data) => {
+      expectTypeOf(data).toEqualTypeOf<string[]>()
+    })
+    onCancel((data) => {
+      expectTypeOf(data).toEqualTypeOf<boolean[]>()
+    })
   })
 
   it('should execute a callback inside `onConfirm` hook only after confirming', () => {

--- a/packages/core/useConfirmDialog/index.ts
+++ b/packages/core/useConfirmDialog/index.ts
@@ -1,4 +1,4 @@
-import type { EventHook, EventHookOn } from '@vueuse/shared'
+import type { EventHookOn } from '@vueuse/shared'
 import type { ComputedRef, ShallowRef } from 'vue'
 import { createEventHook, noop } from '@vueuse/shared'
 import { computed, shallowRef } from 'vue'
@@ -11,6 +11,8 @@ export type UseConfirmDialogRevealResult<C, D>
     data?: D
     isCanceled: true
   }
+
+type UseConfirmDialogEventHookOn<T> = EventHookOn<[T]>
 
 export interface UseConfirmDialogReturn<RevealData, ConfirmData, CancelData> {
   /**
@@ -41,19 +43,19 @@ export interface UseConfirmDialogReturn<RevealData, ConfirmData, CancelData> {
   /**
    * Event Hook to be triggered right before dialog creating.
    */
-  onReveal: EventHookOn<RevealData>
+  onReveal: UseConfirmDialogEventHookOn<RevealData>
 
   /**
    * Event Hook to be called on `confirm()`.
    * Gets data object from `confirm` function.
    */
-  onConfirm: EventHookOn<ConfirmData>
+  onConfirm: UseConfirmDialogEventHookOn<ConfirmData>
 
   /**
    * Event Hook to be called on `cancel()`.
    * Gets data object from `cancel` function.
    */
-  onCancel: EventHookOn<CancelData>
+  onCancel: UseConfirmDialogEventHookOn<CancelData>
 }
 
 /**
@@ -71,14 +73,14 @@ export function useConfirmDialog<
 >(
   revealed: ShallowRef<boolean> = shallowRef(false),
 ): UseConfirmDialogReturn<RevealData, ConfirmData, CancelData> {
-  const confirmHook: EventHook = createEventHook<ConfirmData>()
-  const cancelHook: EventHook = createEventHook<CancelData>()
-  const revealHook: EventHook = createEventHook<RevealData>()
+  const confirmHook = createEventHook<[ConfirmData]>()
+  const cancelHook = createEventHook<[CancelData]>()
+  const revealHook = createEventHook<[RevealData]>()
 
   let _resolve: (arg0: UseConfirmDialogRevealResult<ConfirmData, CancelData>) => void = noop
 
   const reveal = (data?: RevealData) => {
-    revealHook.trigger(data)
+    revealHook.trigger(data as RevealData)
     revealed.value = true
 
     return new Promise<UseConfirmDialogRevealResult<ConfirmData, CancelData>>((resolve) => {
@@ -88,14 +90,14 @@ export function useConfirmDialog<
 
   const confirm = (data?: ConfirmData) => {
     revealed.value = false
-    confirmHook.trigger(data)
+    confirmHook.trigger(data as ConfirmData)
 
     _resolve({ data, isCanceled: false })
   }
 
   const cancel = (data?: CancelData) => {
     revealed.value = false
-    cancelHook.trigger(data)
+    cancelHook.trigger(data as CancelData)
     _resolve({ data, isCanceled: true })
   }
 


### PR DESCRIPTION
## Summary
- wrap `createEventHook` payload generics so array data is treated as one hook argument instead of variadic arguments
- expose `onReveal`, `onConfirm`, and `onCancel` callbacks with the same payload shape as `reveal`, `confirm`, and `cancel`
- add type coverage for array payloads across all three hooks

Fixes #5176.

## Validation
- `corepack pnpm exec vitest run packages/core/useConfirmDialog/index.test.ts --project unit`
- `corepack pnpm exec eslint packages/core/useConfirmDialog/index.ts packages/core/useConfirmDialog/index.test.ts`
- `corepack pnpm typecheck`
- `git diff --check origin/main...HEAD`