### PR TITLE
fix(useDropZone): validate deferred data types on drop

### DIFF
--- a/packages/core/useDropZone/index.test.ts
+++ b/packages/core/useDropZone/index.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from 'vitest'
+import { useDropZone } from './index'
+
+function createDragEvent(
+  type: string,
+  options: {
+    files?: File[]
+    items?: Array<Pick<DataTransferItem, 'kind' | 'type'>>
+  } = {},
+) {
+  const event = new Event(type, {
+    bubbles: true,
+    cancelable: true,
+  }) as DragEvent
+
+  Object.defineProperty(event, 'dataTransfer', {
+    value: {
+      dropEffect: 'move',
+      files: options.files ?? [],
+      items: options.items ?? [],
+    },
+  })
+
+  return event
+}
+
+describe('useDropZone', () => {
+  it('validates file data types on drop when drag items are unavailable', () => {
+    const target = document.createElement('div')
+    const file = new File(['image'], 'image.png', { type: 'image/png' })
+    const onDrop = vi.fn()
+
+    const { files, isOverDropZone } = useDropZone(target, {
+      dataTypes: ['image/png'],
+      onDrop,
+    })
+
+    target.dispatchEvent(createDragEvent('dragenter'))
+
+    expect(isOverDropZone.value).toBe(true)
+
+    target.dispatchEvent(createDragEvent('drop', { files: [file] }))
+
+    expect(files.value).toEqual([file])
+    expect(isOverDropZone.value).toBe(false)
+    expect(onDrop).toHaveBeenCalledWith([file], expect.any(Event))
+  })
+
+  it('rejects files with unsupported data types when validation is deferred to drop', () => {
+    const target = document.createElement('div')
+    const file = new File(['text'], 'file.txt', { type: 'text/plain' })
+    const onDrop = vi.fn()
+
+    const { files, isOverDropZone } = useDropZone(target, {
+      dataTypes: ['image/png'],
+      onDrop,
+    })
+
+    target.dispatchEvent(createDragEvent('dragenter'))
+
+    expect(isOverDropZone.value).toBe(true)
+
+    target.dispatchEvent(createDragEvent('drop', { files: [file] }))
+
+    expect(files.value).toBeNull()
+    expect(isOverDropZone.value).toBe(false)
+    expect(onDrop).not.toHaveBeenCalled()
+  })
+
+  it('rejects unsupported data types immediately when drag item types are available', () => {
+    const target = document.createElement('div')
+    const onEnter = vi.fn()
+
+    const { isOverDropZone } = useDropZone(target, {
+      dataTypes: ['image/png'],
+      onEnter,
+    })
+
+    const event = createDragEvent('dragenter', {
+      items: [{ kind: 'file', type: 'text/plain' }],
+    })
+
+    target.dispatchEvent(event)
+
+    expect(isOverDropZone.value).toBe(false)
+    expect(event.dataTransfer?.dropEffect).toBe('none')
+    expect(onEnter).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/useDropZone/index.ts
+++ b/packages/core/useDropZone/index.ts
@@ -84,20 +84,42 @@ export function useDropZone(
       return dataTypesValid && multipleFilesValid
     }
 
-    const isSafari = () => (
-      /^(?:(?!chrome|android).)*safari/i.test(navigator.userAgent)
-      && !('chrome' in window)
-    )
+    const checkFileValidity = (fileList: FileList | null | undefined) => {
+      if (_options.checkValidity)
+        return false
+
+      if (!fileList)
+        return false
+
+      const droppedFiles = Array.from(fileList)
+      const dataTypesValid = checkDataTypes(droppedFiles.map(file => file.type))
+      const multipleFilesValid = multiple || droppedFiles.length <= 1
+
+      return dataTypesValid && multipleFilesValid
+    }
 
     const handleDragEvent = (event: DragEvent, eventType: 'enter' | 'over' | 'leave' | 'drop') => {
       const dataTransferItemList = event.dataTransfer?.items
-      isValid = (dataTransferItemList && checkValidity(dataTransferItemList)) ?? false
+      if (dataTransferItemList?.length) {
+        isValid = checkValidity(dataTransferItemList)
+      }
+      else if (eventType === 'drop') {
+        isValid = checkFileValidity(event.dataTransfer?.files)
+      }
+      else {
+        isValid = !_options.checkValidity
+      }
 
       if (preventDefaultForUnhandled) {
         event.preventDefault()
       }
 
-      if (!isSafari() && !isValid) {
+      if (eventType === 'drop') {
+        counter = 0
+        isOverDropZone.value = false
+      }
+
+      if (!isValid) {
         if (event.dataTransfer) {
           event.dataTransfer.dropEffect = 'none'
         }
@@ -127,8 +149,6 @@ export function useDropZone(
           _options.onLeave?.(null, event)
           break
         case 'drop':
-          counter = 0
-          isOverDropZone.value = false
           if (isValid) {
             files.value = currentFiles
             _options.onDrop?.(currentFiles, event)


### PR DESCRIPTION
## Summary
- defer `dataTypes` validation when drag events do not expose item metadata
- validate dropped files against `dataTypes` and `multiple` when the final drop event has files
- reset drop-zone state for rejected deferred drops

Fixes #3573

## Tests
- `pnpm exec vitest run --project unit packages/core/useDropZone/index.test.ts`
- `pnpm test:unit`
- `pnpm lint`
- `pnpm typecheck`