### PR TITLE
fix(useElementVisibility): stop observer after first visibility change

### DIFF
--- a/packages/core/useElementVisibility/index.md
+++ b/packages/core/useElementVisibility/index.md
@@ -17,16 +17,28 @@ const target = useTemplateRef('target')
 const targetIsVisible = useElementVisibility(target)
 
 const target2 = useTemplateRef('target2')
-const targetVisibilityController = useElementVisibility(target2, { controls: true })
+const targetVisibility = useElementVisibility(target2, { controls: true })
+const { isVisible, isActive, pause, resume, stop } = targetVisibility
 </script>
 
 <template>
   <div ref="target">
     <h1>Hello world</h1>
+    <p>{{ targetIsVisible ? 'visible' : 'hidden' }}</p>
   </div>
 
   <div ref="target2">
     <h1>Hi there</h1>
+    <p>{{ isVisible ? 'visible' : 'hidden' }} / {{ isActive ? 'active' : 'inactive' }}</p>
+    <button @click="pause">
+      Pause
+    </button>
+    <button @click="resume">
+      Resume
+    </button>
+    <button @click="stop">
+      Stop
+    </button>
   </div>
 </template>
 ```

--- a/packages/core/useElementVisibility/index.test.ts
+++ b/packages/core/useElementVisibility/index.test.ts
@@ -1,5 +1,29 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
 import { useElementVisibility } from './index'
+
+vi.mock('../useIntersectionObserver', () => ({
+  useIntersectionObserver: vi.fn(() => {
+    const isActive = { value: true }
+    const stop = vi.fn(() => {
+      isActive.value = false
+    })
+    const pause = vi.fn(() => {
+      isActive.value = false
+    })
+    const resume = vi.fn(() => {
+      isActive.value = true
+    })
+
+    return {
+      isActive,
+      isSupported: { value: true },
+      pause,
+      resume,
+      stop,
+    }
+  }),
+}))
 
 describe('useElementVisibility', () => {
   let el: HTMLDivElement
@@ -32,13 +56,7 @@ describe('useElementVisibility', () => {
 
   describe('when internally using useIntersectionObserver', async () => {
     beforeAll(() => {
-      vi.resetAllMocks()
-      vi.mock('../useIntersectionObserver', () => ({
-        useIntersectionObserver: vi.fn((_target) => {
-          const stop = vi.fn()
-          return { stop }
-        }),
-      }))
+      vi.clearAllMocks()
     })
 
     const { useIntersectionObserver } = await import('../useIntersectionObserver')
@@ -82,10 +100,32 @@ describe('useElementVisibility', () => {
 
       // It should be false initially
       expect(visibilityState.isVisible.value).toBe(false)
+      expect(visibilityState.isActive.value).toBe(true)
 
       // It should become true if the callback gets an isIntersecting = true
       callMockCallbackWithIsIntersectingValue(true)
       expect(visibilityState.isVisible.value).toBe(true)
+
+      visibilityState.pause()
+      expect(visibilityState.isActive.value).toBe(false)
+
+      visibilityState.resume()
+      expect(visibilityState.isActive.value).toBe(true)
+    })
+
+    it('stops the visibility observer after the first visibility change when once is true', async () => {
+      const visibilityState = useElementVisibility(el, { controls: true, once: true })
+      const callback = vi.mocked(useIntersectionObserver).mock.lastCall?.[1]
+      const callMockCallbackWithIsIntersectingValue = (isIntersecting: boolean) => callback?.([{ isIntersecting, time: 1 } as IntersectionObserverEntry], {} as IntersectionObserver)
+
+      expect(visibilityState.isActive.value).toBe(true)
+
+      callMockCallbackWithIsIntersectingValue(true)
+      await nextTick()
+
+      expect(visibilityState.isVisible.value).toBe(true)
+      expect(visibilityState.isActive.value).toBe(false)
+      expect(visibilityState.stop).toHaveBeenCalledTimes(1)
     })
 
     it('uses the latest version of isIntersecting when multiple intersection entries are given', () => {

--- a/packages/core/useElementVisibility/index.ts
+++ b/packages/core/useElementVisibility/index.ts
@@ -82,12 +82,6 @@ export function useElementVisibility(
         }
       }
       isVisible.value = isIntersecting
-
-      if (once) {
-        watchOnce(isVisible, () => {
-          observerController.stop()
-        })
-      }
     },
     {
       root: scrollTarget,
@@ -96,6 +90,12 @@ export function useElementVisibility(
       rootMargin,
     },
   )
+
+  if (once) {
+    watchOnce(isVisible, () => {
+      observerController.stop()
+    })
+  }
 
   return options.controls
     ? { ...observerController, isVisible }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

fixes #5443

This PR fixes `useElementVisibility` when `once: true` is used together with `controls: true`.

`useElementVisibility` already returns the underlying `useIntersectionObserver` controls when `controls: true`, including `isActive`, `pause`, `resume`, and `stop`. However, the `once` watcher was registered inside the intersection callback after `isVisible` had already been updated, so the first visibility change did not stop the observer immediately.

This moves the `watchOnce(isVisible, ...)` setup outside the observer callback so the observer is stopped after the first visibility change as expected. It also adds tests for the exposed controls and documents `isActive` in the `controls: true` usage example.


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
