### PR TITLE
fix(useElementVisibility): move watchOnce outside intersection callback

### DIFF
--- a/packages/core/useElementVisibility/index.test.ts
+++ b/packages/core/useElementVisibility/index.test.ts
@@ -129,5 +129,23 @@ describe('useElementVisibility', () => {
       useElementVisibility(el, { scrollTarget: mockScrollTarget })
       expect(vi.mocked(useIntersectionObserver).mock.lastCall?.[2]?.root).toBe(mockScrollTarget)
     })
+
+    it('stops the observer after visibility changes once when once option is true', async () => {
+      useElementVisibility(el, { once: true })
+      const stopMock = vi.mocked(useIntersectionObserver).mock.results.at(-1)?.value?.stop
+      const callback = vi.mocked(useIntersectionObserver).mock.lastCall?.[1]
+
+      expect(stopMock).not.toHaveBeenCalled()
+
+      // Trigger visibility change — observer should stop afterwards
+      callback?.([{ isIntersecting: true, time: 1 } as IntersectionObserverEntry], {} as IntersectionObserver)
+      await Promise.resolve()
+      expect(stopMock).toHaveBeenCalledTimes(1)
+
+      // Subsequent intersection events must not trigger additional stop calls
+      callback?.([{ isIntersecting: false, time: 2 } as IntersectionObserverEntry], {} as IntersectionObserver)
+      await Promise.resolve()
+      expect(stopMock).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/packages/core/useElementVisibility/index.ts
+++ b/packages/core/useElementVisibility/index.ts
@@ -82,12 +82,6 @@ export function useElementVisibility(
         }
       }
       isVisible.value = isIntersecting
-
-      if (once) {
-        watchOnce(isVisible, () => {
-          observerController.stop()
-        })
-      }
     },
     {
       root: scrollTarget,
@@ -96,6 +90,12 @@ export function useElementVisibility(
       rootMargin,
     },
   )
+
+  if (once) {
+    watchOnce(isVisible, () => {
+      observerController.stop()
+    })
+  }
 
   return options.controls
     ? { ...observerController, isVisible }


### PR DESCRIPTION
## What

The `watchOnce` call that stops the observer when `once: true` was placed
inside the `useIntersectionObserver` callback. This meant a brand-new
watcher was registered on **every** intersection event, creating an
ever-growing list of watchers that would each try to call `stop()`.

## Fix

Move the `watchOnce` call outside the callback, so it is registered
exactly once when `useElementVisibility` initialises with `once: true`.

## Test

Added a test that verifies:
1. `stop()` is called after the first visibility change.
2. Subsequent intersection events do **not** cause additional `stop()`
   calls (i.e., no new watchers are created per callback invocation).

Closes #4704
Closes #4723 