### PR TITLE
fix(useFetch): expose response data on error events

### DIFF
--- a/packages/core/useFetch/index.test.ts
+++ b/packages/core/useFetch/index.test.ts
@@ -632,6 +632,22 @@ describe('useFetch', () => {
     })
   })
 
+  it('should expose response data on fetch error event', async () => {
+    let fetchError: any
+    const { onFetchError, statusCode } = useFetch(`${baseUrl}?status=400&json`).json()
+
+    onFetchError((error) => {
+      fetchError = error
+    })
+
+    await vi.waitFor(() => {
+      expect(statusCode.value).toBe(400)
+      expect(fetchError.message).toBe('Bad Request')
+      expect(fetchError.data).toEqual(jsonMessage)
+      expect(fetchError.response.status).toBe(400)
+    })
+  })
+
   it('setting the request method w/ get and return type w/ json', async () => {
     const { data } = useFetch(jsonUrl).get().json()
     await vi.waitFor(() => {

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -273,6 +273,10 @@ function combineCallbacks<T = any>(combination: Combination, ...callbacks: (((ct
   }
 }
 
+function attachErrorPayload<T>(error: Error, data: T | null, response: Response) {
+  return Object.assign(error, { data, response })
+}
+
 export function createFetch(config: CreateFetchOptions = {}) {
   const _combination = config.combination || 'chain' as Combination
   const _options = config.options || {}
@@ -492,7 +496,11 @@ export function useFetch<T>(url: MaybeRefOrGetter<string>, ...args: any[]): UseF
         // see: https://www.tjvantoll.com/2015/09/13/fetch-and-errors/
         if (!fetchResponse.ok) {
           data.value = initialData || null
-          throw new Error(fetchResponse.statusText)
+          throw attachErrorPayload(
+            new Error(fetchResponse.statusText),
+            responseData,
+            fetchResponse,
+          )
         }
 
         if (options.afterFetch) {


### PR DESCRIPTION
### Description

Expose the parsed response body and raw `Response` on the `onFetchError` event error object for non-2xx HTTP responses.

`useFetch` already parses the body before routing HTTP failures through the error path, and options-level `onFetchError(ctx)` receives that parsed `ctx.data`. This makes the event hook carry the same useful response details so consumers can show API problem details from `onFetchError((error) => ...)` without having to duplicate request handling.

Fixes #5405.

### Additional context

The existing `error` ref behavior is preserved: it still stores the message by default unless `options.onFetchError` overrides it. The added payload is attached to the thrown/event error object only.

### Validation

- `corepack pnpm exec vitest run packages/core/useFetch/index.test.ts --project unit`
- `corepack pnpm exec eslint packages/core/useFetch/index.ts packages/core/useFetch/index.test.ts`
- `corepack pnpm typecheck`
- `git diff --check origin/main...HEAD`