### PR TITLE
feat(useDraggable): capture active pointer while dragging

### DIFF
--- a/packages/core/useDraggable/index.test.ts
+++ b/packages/core/useDraggable/index.test.ts
@@ -70,6 +70,55 @@ describe('useDraggable', () => {
     expect(wrapper.get('div').element.dataset.isDragging).toBe('false')
   })
 
+  it('should capture the active pointer on the drag handle', async () => {
+    const setPointerCapture = vi.fn()
+    const hasPointerCapture = vi.fn(() => true)
+    const releasePointerCapture = vi.fn()
+
+    const wrapper = mount({
+      setup() {
+        const el = useTemplateRef<HTMLElement>('el')
+
+        const { isDragging } = useDraggable(el)
+
+        return () => h('div', {
+          'data-is-dragging': isDragging.value,
+          'ref': 'el',
+        })
+      },
+    })
+
+    await nextTick()
+
+    const el = wrapper.get('div').element as unknown as HTMLElement & {
+      setPointerCapture: typeof setPointerCapture
+      hasPointerCapture: typeof hasPointerCapture
+      releasePointerCapture: typeof releasePointerCapture
+    }
+    el.setPointerCapture = setPointerCapture
+    el.hasPointerCapture = hasPointerCapture
+    el.releasePointerCapture = releasePointerCapture
+
+    el.dispatchEvent(new PointerEvent('pointerdown', {
+      clientX: 0,
+      clientY: 0,
+      pointerId: 42,
+    }))
+    await nextTick()
+
+    expect(setPointerCapture).toHaveBeenCalledWith(42)
+    expect(wrapper.get('div').element.dataset.isDragging).toBe('true')
+
+    window.dispatchEvent(new PointerEvent('pointerup', {
+      pointerId: 42,
+    }))
+    await nextTick()
+
+    expect(hasPointerCapture).toHaveBeenCalledWith(42)
+    expect(releasePointerCapture).toHaveBeenCalledWith(42)
+    expect(wrapper.get('div').element.dataset.isDragging).toBe('false')
+  })
+
   it('component', async () => {
     const onStart = vi.fn()
     const onMove = vi.fn()

--- a/packages/core/useDraggable/index.ts
+++ b/packages/core/useDraggable/index.ts
@@ -202,6 +202,8 @@ export function useDraggable(
   )
 
   const pressedDelta = deepRef<Position>()
+  let capturedPointerTarget: HTMLElement | SVGElement | null = null
+  let capturedPointerId: number | null = null
 
   const filterEvent = (e: PointerEvent) => {
     if (pointerTypes)
@@ -321,6 +323,38 @@ export function useDraggable(
     watch(position, checkAutoScroll)
   }
 
+  function capturePointer(e: PointerEvent) {
+    const handle = toValue(draggingHandle)
+    if (!handle || !('setPointerCapture' in handle))
+      return
+
+    try {
+      handle.setPointerCapture(e.pointerId)
+      capturedPointerTarget = handle
+      capturedPointerId = e.pointerId
+    }
+    catch {}
+  }
+
+  function releasePointer() {
+    if (!capturedPointerTarget || capturedPointerId == null)
+      return
+
+    try {
+      if (
+        'releasePointerCapture' in capturedPointerTarget
+        && (!('hasPointerCapture' in capturedPointerTarget) || capturedPointerTarget.hasPointerCapture(capturedPointerId))
+      ) {
+        capturedPointerTarget.releasePointerCapture(capturedPointerId)
+      }
+    }
+    catch {}
+    finally {
+      capturedPointerTarget = null
+      capturedPointerId = null
+    }
+  }
+
   const start = (e: PointerEvent) => {
     if (!toValue(buttons).includes(e.button))
       return
@@ -339,6 +373,7 @@ export function useDraggable(
     if (onStart?.(pos, e) === false)
       return
     pressedDelta.value = pos
+    capturePointer(e)
     handleEvent(e)
   }
 
@@ -402,6 +437,7 @@ export function useDraggable(
     if (!pressedDelta.value)
       return
     pressedDelta.value = undefined
+    releasePointer()
     if (autoScroll)
       stopAutoScroll()
     onEnd?.(position.value, e)


### PR DESCRIPTION
### Description

Capture the active pointer on the drag handle while `useDraggable` is dragging, then release it on pointerup.

This helps avoid losing `pointermove`/`pointerup` events when dragging across iframes or other content that can capture pointer events away from the window listener. The behavior is defensive: it only runs when the handle supports pointer capture and silently falls back to the current behavior otherwise.

Closes #5325.

### Validation

- `corepack pnpm exec vitest run packages/core/useDraggable/index.test.ts --project unit`
- `corepack pnpm exec eslint packages/core/useDraggable/index.ts packages/core/useDraggable/index.test.ts`
- `corepack pnpm typecheck`
- `git diff --check origin/main...HEAD`