### PR TITLE
fix(useDraggable): pass current position to onStart

### DIFF
--- a/packages/core/useDraggable/index.browser.test.ts
+++ b/packages/core/useDraggable/index.browser.test.ts
@@ -3,7 +3,7 @@ import type { ComponentPublicInstance } from 'vue'
 import type { UseDraggableOptions } from './index'
 import { mount } from '@vue/test-utils'
 import { useDraggable } from '@vueuse/core'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, nextTick, shallowRef, useTemplateRef } from 'vue'
 
 interface DraggableAutoScrollOptions {
@@ -324,6 +324,48 @@ describe('useDraggable', () => {
       })
 
       await endDrag(wrapper)
+    })
+
+    it('should pass the current draggable position to onStart when using a container', async () => {
+      const onStart = vi.fn()
+      const initialValue = { x: 120, y: 80 }
+
+      const wrapper = mount(defineComponent({
+        template: `
+          <div ref="container" style="position: relative; width: 300px; height: 200px;">
+            <div ref="el" :style="style" style="position: absolute; width: 40px; height: 30px;" />
+          </div>
+        `,
+        setup() {
+          const el = useTemplateRef<HTMLElement>('el')
+          const container = useTemplateRef<HTMLElement>('container')
+          const draggable = useDraggable(el, {
+            initialValue,
+            containerElement: container,
+            onStart,
+          })
+
+          return { el, container, ...draggable }
+        },
+      }), {
+        attachTo: document.body,
+      })
+
+      await nextTick()
+
+      const rect = wrapper.vm.el!.getBoundingClientRect()
+      wrapper.vm.el!.dispatchEvent(new PointerEvent('pointerdown', {
+        clientX: rect.left + 10,
+        clientY: rect.top + 15,
+        ...baseMousePointerEventOptions,
+      }))
+
+      expect(onStart).toHaveBeenCalledWith(
+        initialValue,
+        expect.any(PointerEvent),
+      )
+
+      wrapper.unmount()
     })
 
     it('should disabled dragging behaviour', async () => {

--- a/packages/core/useDraggable/index.ts
+++ b/packages/core/useDraggable/index.ts
@@ -332,13 +332,13 @@ export function useDraggable(
     const container = toValue(containerElement)
     const containerRect = container?.getBoundingClientRect?.()
     const targetRect = toValue(target)!.getBoundingClientRect()
-    const pos = {
+    const pointerOffset = {
       x: e.clientX - (container ? targetRect.left - containerRect!.left + (autoScroll ? 0 : container.scrollLeft) : targetRect.left),
       y: e.clientY - (container ? targetRect.top - containerRect!.top + (autoScroll ? 0 : container.scrollTop) : targetRect.top),
     }
-    if (onStart?.(pos, e) === false)
+    if (onStart?.(position.value, e) === false)
       return
-    pressedDelta.value = pos
+    pressedDelta.value = pointerOffset
     handleEvent(e)
   }
 


### PR DESCRIPTION
### Description

Pass the current draggable position to `onStart` instead of the internal pointer offset used for drag calculations.

`onMove` and `onEnd` already expose the draggable position. This keeps `onStart` consistent with those callbacks while preserving the pointer-offset value internally as `pressedDelta` for movement calculations.

Fixes #3770.

### Validation

- corepack pnpm exec vitest run packages/core/useDraggable/index.browser.test.ts --project browser-chromium
- corepack pnpm exec eslint packages/core/useDraggable/index.ts packages/core/useDraggable/index.browser.test.ts
- corepack pnpm typecheck
- git diff --check origin/main...HEAD
