### PR TITLE
fix(useDropZone): validate dropped files when item types are unavailable

### DIFF
--- a/packages/core/useDropZone/index.test.ts
+++ b/packages/core/useDropZone/index.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest'
+import { useDropZone } from './index'
+
+function createDragEvent(type: string, dataTransfer: Partial<DataTransfer>) {
+  const event = new Event(type, { bubbles: true, cancelable: true }) as DragEvent
+
+  Object.defineProperty(event, 'dataTransfer', {
+    value: dataTransfer,
+  })
+
+  return event
+}
+
+function createDataTransfer(files: File[], items: Partial<DataTransferItem>[] = []) {
+  return {
+    dropEffect: 'none',
+    files,
+    items,
+  } as unknown as DataTransfer
+}
+
+describe('useDropZone', () => {
+  it('validates dropped files when drag item types are unavailable', () => {
+    const target = document.createElement('div')
+    const onDrop = vi.fn()
+    const image = new File(['content'], 'image.png', { type: 'image/png' })
+
+    const { files } = useDropZone(target, {
+      dataTypes: ['image/png'],
+      onDrop,
+    })
+
+    target.dispatchEvent(createDragEvent('dragenter', createDataTransfer([], [])))
+    target.dispatchEvent(createDragEvent('drop', createDataTransfer([image], [])))
+
+    expect(files.value).toEqual([image])
+    expect(onDrop).toHaveBeenCalledWith([image], expect.any(Event))
+  })
+
+  it('rejects dropped files with unavailable drag item types when the file type is invalid', () => {
+    const target = document.createElement('div')
+    const onDrop = vi.fn()
+    const text = new File(['content'], 'notes.txt', { type: 'text/plain' })
+
+    const { files } = useDropZone(target, {
+      dataTypes: ['image/png'],
+      onDrop,
+    })
+
+    target.dispatchEvent(createDragEvent('drop', createDataTransfer([text], [])))
+
+    expect(files.value).toBeNull()
+    expect(onDrop).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/useDropZone/index.ts
+++ b/packages/core/useDropZone/index.ts
@@ -49,8 +49,10 @@ export function useDropZone(
     const multiple = _options.multiple ?? true
     const preventDefaultForUnhandled = _options.preventDefaultForUnhandled ?? false
 
+    const getFileList = (event: DragEvent) => Array.from(event.dataTransfer?.files ?? [])
+
     const getFiles = (event: DragEvent) => {
-      const list = Array.from(event.dataTransfer?.files ?? [])
+      const list = getFileList(event)
       return list.length === 0 ? null : (multiple ? list : [list[0]])
     }
 
@@ -84,6 +86,15 @@ export function useDropZone(
       return dataTypesValid && multipleFilesValid
     }
 
+    const checkFileListValidity = (list: File[]) => {
+      const types = list.map(file => file.type)
+
+      const dataTypesValid = checkDataTypes(types)
+      const multipleFilesValid = multiple || list.length <= 1
+
+      return dataTypesValid && multipleFilesValid
+    }
+
     const isSafari = () => (
       /^(?:(?!chrome|android).)*safari/i.test(navigator.userAgent)
       && !('chrome' in window)
@@ -92,6 +103,10 @@ export function useDropZone(
     const handleDragEvent = (event: DragEvent, eventType: 'enter' | 'over' | 'leave' | 'drop') => {
       const dataTransferItemList = event.dataTransfer?.items
       isValid = (dataTransferItemList && checkValidity(dataTransferItemList)) ?? false
+      const fileList = eventType === 'drop' ? getFileList(event) : []
+
+      if (eventType === 'drop' && !isValid && !_options.checkValidity && fileList.length > 0)
+        isValid = checkFileListValidity(fileList)
 
       if (preventDefaultForUnhandled) {
         event.preventDefault()


### PR DESCRIPTION
## Summary

Fixes #3573.

`useDropZone` currently validates `dataTypes` from `dataTransfer.items` for every drag event. Some browsers can expose an empty item list during drag events and only provide usable file metadata on `drop`, which leaves `isValid` false and prevents valid files from reaching `onDrop`.

This adds a drop-time fallback that validates `dataTransfer.files` when item metadata is unavailable and no custom `checkValidity` override is supplied. The existing `multiple` handling is kept intact.

## Validation

- `corepack pnpm exec vitest run packages/core/useDropZone/index.test.ts --project unit`
- `corepack pnpm exec eslint packages/core/useDropZone/index.ts packages/core/useDropZone/index.test.ts`
- `corepack pnpm typecheck`
- `git diff --check origin/main...HEAD`
