### PR TITLE
fix(onClickOutside): handle dialog backdrop clicks

### DIFF
--- a/packages/core/onClickOutside/index.browser.test.ts
+++ b/packages/core/onClickOutside/index.browser.test.ts
@@ -142,4 +142,62 @@ describe('onClickOutside', () => {
     await userEvent.click(other)
     expect(consoleSpy).toHaveBeenCalled()
   })
+
+  it('should treat dialog backdrop clicks as outside', async () => {
+    const handler = vi.fn()
+
+    const component = defineComponent({
+      template: `
+        <dialog ref="target" open>
+          <button>Inside</button>
+        </dialog>
+      `,
+      setup() {
+        const target = useTemplateRef<HTMLDialogElement>('target')
+        onClickOutside(target, handler)
+        return { target }
+      },
+    })
+
+    const screen = page.render(component)
+    await expect.element(screen.getByText('Inside')).toBeInTheDocument()
+
+    const dialog = document.querySelector('dialog')!
+    vi.spyOn(dialog, 'getBoundingClientRect').mockReturnValue({
+      bottom: 200,
+      height: 100,
+      left: 100,
+      right: 200,
+      top: 100,
+      width: 100,
+      x: 100,
+      y: 100,
+      toJSON: () => {},
+    })
+
+    dialog.dispatchEvent(
+      new MouseEvent('pointerdown', {
+        bubbles: true,
+        clientX: 150,
+        clientY: 150,
+      }),
+    )
+    dialog.dispatchEvent(
+      new MouseEvent('click', { bubbles: true, clientX: 150, clientY: 150 }),
+    )
+    expect(handler).not.toHaveBeenCalled()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    dialog.dispatchEvent(
+      new MouseEvent('pointerdown', {
+        bubbles: true,
+        clientX: 50,
+        clientY: 50,
+      }),
+    )
+    dialog.dispatchEvent(
+      new MouseEvent('click', { bubbles: true, clientX: 50, clientY: 50 }),
+    )
+    expect(handler).toHaveBeenCalledOnce()
+  })
 })

--- a/packages/core/onClickOutside/index.ts
+++ b/packages/core/onClickOutside/index.ts
@@ -132,8 +132,33 @@ export function onClickOutside(
     if (children == null || !Array.isArray(children))
       return false
 
-    // @ts-expect-error should be VNode
-    return children.some((child: VNode) => child.el === event.target || event.composedPath().includes(child.el))
+    return children.some((child) => {
+      const el = (child as VNode).el
+      return el === event.target || (el != null && event.composedPath().includes(el as EventTarget))
+    })
+  }
+
+  function isOutsideDialog(event: Event, el: Element) {
+    const HTMLDialogElement = (window as Window & typeof globalThis).HTMLDialogElement
+
+    if (
+      typeof HTMLDialogElement === 'undefined'
+      || !(el instanceof HTMLDialogElement)
+      || event.target !== el
+      || !('clientX' in event)
+      || !('clientY' in event)
+    ) {
+      return false
+    }
+
+    const rect = el.getBoundingClientRect()
+    const { clientX, clientY } = event as MouseEvent
+    return (
+      clientX < rect.left
+      || clientX > rect.right
+      || clientY < rect.top
+      || clientY > rect.bottom
+    )
   }
 
   const listener = (event: Event) => {
@@ -145,8 +170,13 @@ export function onClickOutside(
     if (!(el instanceof Element) && hasMultipleRoots(target) && checkMultipleRoots(target, event))
       return
 
-    if (!el || el === event.target || event.composedPath().includes(el))
+    if (
+      !el
+      || (!isOutsideDialog(event, el)
+        && (el === event.target || event.composedPath().includes(el)))
+    ) {
       return
+    }
 
     if ('detail' in event && event.detail === 0)
       shouldListen = !shouldIgnore(event)
@@ -173,7 +203,7 @@ export function onClickOutside(
     }, { passive: true, capture }),
     useEventListener(window, 'pointerdown', (e) => {
       const el = unrefElement(target)
-      shouldListen = !shouldIgnore(e) && !!(el && !e.composedPath().includes(el))
+      shouldListen = !shouldIgnore(e) && !!(el && (isOutsideDialog(e, el) || !e.composedPath().includes(el)))
     }, { passive: true }),
     detectIframe && useEventListener(window, 'blur', (event) => {
       setTimeout(() => {


### PR DESCRIPTION
Fixes #5355

## Summary
- treat native `<dialog>` backdrop clicks as outside clicks when the click target is the dialog but the pointer coordinates are outside its bounding rect
- apply the same dialog-backdrop check during `pointerdown` so the existing click gating allows the handler to run
- add browser regression coverage that verifies inside dialog clicks are ignored and backdrop clicks trigger the handler

## Tests
- `corepack pnpm exec vitest run --project="browser (chromium)" packages/core/onClickOutside/index.browser.test.ts`
- `corepack pnpm exec vitest run --project="browser (webkit)" packages/core/onClickOutside/index.browser.test.ts`
- `corepack pnpm exec eslint packages/core/onClickOutside/index.ts packages/core/onClickOutside/index.browser.test.ts`
- `corepack pnpm exec vue-tsc --noEmit --pretty false`
- `git diff --check`
