### PR TITLE
fix(core): emit vElementSize border-box size on mount

### DIFF
--- a/packages/core/useElementSize/directive.test.ts
+++ b/packages/core/useElementSize/directive.test.ts
@@ -1,6 +1,6 @@
 import type { VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent } from 'vue'
 import { vElementSize } from './directive'
 
@@ -17,7 +17,7 @@ const App = defineComponent({
   },
 
   template: `<template>
-  <div v-if="options" v-element-size="[onResize,options]">Hello world!</div>
+  <div v-if="options" v-element-size="[onResize,...options]">Hello world!</div>
   <div v-else v-element-size="onResize">Hello world!</div>
   </template>
   `,
@@ -26,6 +26,10 @@ const App = defineComponent({
 describe('vElementSize', () => {
   let onResize = vi.fn()
   let wrapper: VueWrapper<any>
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
 
   describe('given no options', () => {
     beforeEach(() => {
@@ -67,6 +71,36 @@ describe('vElementSize', () => {
 
     it('should be defined', () => {
       expect(wrapper).toBeDefined()
+    })
+  })
+
+  describe('given border-box options', () => {
+    beforeEach(() => {
+      vi.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockReturnValue(45)
+      vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockReturnValue(
+        35,
+      )
+
+      onResize = vi.fn()
+      const options = [{ width: 0, height: 0 }, { box: 'border-box' }]
+
+      wrapper = mount(App, {
+        props: {
+          onResize,
+          options,
+        },
+        global: {
+          directives: {
+            ElementSize: vElementSize,
+          },
+        },
+      })
+    })
+
+    it('calls the handler with the mounted border-box size', () => {
+      expect(wrapper).toBeDefined()
+      expect(onResize).toHaveBeenCalledTimes(1)
+      expect(onResize).toHaveBeenCalledWith({ width: 45, height: 35 })
     })
   })
 })

--- a/packages/core/useElementSize/directive.ts
+++ b/packages/core/useElementSize/directive.ts
@@ -22,6 +22,9 @@ export const vElementSize = createDisposableDirective<
 
       const { width, height } = useElementSize(el, ...options)
       watch([width, height], ([width, height]) => handler({ width, height }))
+
+      if (options[1]?.box === 'border-box')
+        handler({ width: width.value, height: height.value })
     },
   },
 )


### PR DESCRIPTION
## Summary

Fixes #5347.

`vElementSize` now forwards the already-measured mount size when the directive is configured with `{ box: 'border-box' }`. This keeps the existing content-box path unchanged, avoiding an unconditional immediate watcher callback, while ensuring the border-box case does not wait for a ResizeObserver value that may be identical to the mount measurement.

The directive test now spreads tuple options the same way the docs show and covers the border-box mount callback with mocked `offsetWidth`/`offsetHeight`.

## Testing

- `corepack pnpm exec vitest run packages/core/useElementSize/directive.test.ts`
- `corepack pnpm exec eslint packages/core/useElementSize/directive.ts packages/core/useElementSize/directive.test.ts`
- `corepack pnpm exec vue-tsc --noEmit --pretty false`
- `git diff origin/main...HEAD --check`