### PR TITLE
fix(useTextareaAutosize): wire demo textarea ref

### DIFF
--- a/packages/core/useTextareaAutosize/demo.vue
+++ b/packages/core/useTextareaAutosize/demo.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { useTextareaAutosize } from '@vueuse/core'
+import { useTemplateRef } from 'vue'
 
-const { input } = useTextareaAutosize()
+const textarea = useTemplateRef('textarea')
+const { input } = useTextareaAutosize({ element: textarea })
 </script>
 
 <template>


### PR DESCRIPTION
## Summary

Fixes #5380.

The `useTextareaAutosize` demo already renders a `ref=textarea`, but the composable was created without receiving that element ref. As a result, typing in the live demo only updated `input` and never resized the textarea. This wires the template ref into `useTextareaAutosize` so the documented demo grows as users type.

## Testing

- `corepack pnpm exec eslint packages/core/useTextareaAutosize/demo.vue`
- `corepack pnpm exec vue-tsc --noEmit --pretty false`
- `corepack pnpm exec vitest run packages/core/useTextareaAutosize/index.test.ts`
- `git diff origin/main...HEAD --check`