### PR TITLE
fix(useConfirmDialog): preserve onReveal data type

### DIFF
--- a/packages/core/useConfirmDialog/index.test.ts
+++ b/packages/core/useConfirmDialog/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, expectTypeOf, it } from 'vitest'
 import { nextTick, shallowRef } from 'vue'
 import { useConfirmDialog } from './index'
 
@@ -139,6 +139,16 @@ describe('useConfirmDialog', () => {
     cancel(data)
 
     expect(message.value).toBe('confirm')
+  })
+
+  it('should keep array reveal data type in `onReveal` hook', () => {
+    const show = shallowRef(false)
+
+    const { onReveal } = useConfirmDialog<number[], number>(show)
+
+    onReveal((data) => {
+      expectTypeOf(data).toEqualTypeOf<number[]>()
+    })
   })
 
   it('should return promise that will be resolved on `confirm()`', async () => {

--- a/packages/core/useConfirmDialog/index.ts
+++ b/packages/core/useConfirmDialog/index.ts
@@ -41,7 +41,7 @@ export interface UseConfirmDialogReturn<RevealData, ConfirmData, CancelData> {
   /**
    * Event Hook to be triggered right before dialog creating.
    */
-  onReveal: EventHookOn<RevealData>
+  onReveal: EventHookOn<[RevealData]>
 
   /**
    * Event Hook to be called on `confirm()`.
@@ -75,10 +75,17 @@ export function useConfirmDialog<
   const cancelHook: EventHook = createEventHook<CancelData>()
   const revealHook: EventHook = createEventHook<RevealData>()
 
+  const onReveal: EventHookOn<[RevealData]> = (callback) => {
+    return revealHook.on((...data: any[]) => callback(data[0] as RevealData))
+  }
+
   let _resolve: (arg0: UseConfirmDialogRevealResult<ConfirmData, CancelData>) => void = noop
 
   const reveal = (data?: RevealData) => {
-    revealHook.trigger(data)
+    if (data === undefined)
+      revealHook.trigger()
+    else
+      revealHook.trigger(data)
     revealed.value = true
 
     return new Promise<UseConfirmDialogRevealResult<ConfirmData, CancelData>>((resolve) => {
@@ -104,7 +111,7 @@ export function useConfirmDialog<
     reveal,
     confirm,
     cancel,
-    onReveal: revealHook.on,
+    onReveal,
     onConfirm: confirmHook.on,
     onCancel: cancelHook.on,
   }

--- a/packages/integrations/useIDBKeyval/index.server.test.ts
+++ b/packages/integrations/useIDBKeyval/index.server.test.ts
@@ -1,0 +1,28 @@
+import { get, set, update } from 'idb-keyval'
+import { describe, expect, it, vi } from 'vitest'
+import { useIDBKeyval } from './index'
+
+vi.mock('idb-keyval', () => ({
+  get: vi.fn(),
+  set: vi.fn(),
+  update: vi.fn(),
+  del: vi.fn(),
+}))
+
+describe('useIDBKeyval SSR', () => {
+  it('does not access IndexedDB when it is unavailable', async () => {
+    const { data, isFinished, set: setData } = useIDBKeyval('key', 'initial')
+
+    expect(data.value).toBe('initial')
+    expect(isFinished.value).toBe(true)
+    expect(get).not.toHaveBeenCalled()
+    expect(set).not.toHaveBeenCalled()
+    expect(update).not.toHaveBeenCalled()
+
+    await setData('updated')
+
+    expect(data.value).toBe('updated')
+    expect(set).not.toHaveBeenCalled()
+    expect(update).not.toHaveBeenCalled()
+  })
+})

--- a/packages/integrations/useIDBKeyval/index.test.ts
+++ b/packages/integrations/useIDBKeyval/index.test.ts
@@ -46,6 +46,7 @@ describe('useIDBKeyval', () => {
 
   beforeEach(async () => {
     console.error = vi.fn()
+    vi.stubGlobal('indexedDB', {})
 
     await set(KEY3, 'hello');
 
@@ -56,6 +57,7 @@ describe('useIDBKeyval', () => {
 
   afterEach(() => {
     vi.clearAllMocks()
+    vi.unstubAllGlobals()
     cache.clear()
   })
 

--- a/packages/integrations/useIDBKeyval/index.ts
+++ b/packages/integrations/useIDBKeyval/index.ts
@@ -79,6 +79,18 @@ export function useIDBKeyval<T>(
 
   const rawInit: T = toValue(initialValue)
 
+  if (typeof indexedDB === 'undefined') {
+    isFinished.value = true
+
+    return {
+      set: async (value: T) => {
+        data.value = value
+      },
+      isFinished,
+      data: data as RemovableRef<T>,
+    }
+  }
+
   async function read() {
     try {
       const rawValue = await get<T>(key)


### PR DESCRIPTION
### Description

This fixes the `useConfirmDialog` `onReveal` callback type when `RevealData` itself is an array, for example `useConfirmDialog<number[], number>()`.

`createEventHook<T>()` intentionally treats array `T` as variadic callback arguments. That is useful for the shared hook, but `useConfirmDialog` exposes `reveal(data)` as a single payload. This wraps the internal reveal hook so `onReveal` receives that payload as one argument without changing `createEventHook` globally.

This is a narrower alternative to #5182.

Fixes #5176.

### Validation

- `corepack pnpm exec vitest run packages/core/useConfirmDialog/index.test.ts`
- `corepack pnpm exec vue-tsc --noEmit --pretty false`
- `corepack pnpm exec eslint packages/core/useConfirmDialog/index.ts packages/core/useConfirmDialog/index.test.ts`