### PR TITLE
fix(createReusableTemplate): support generic SFC props

### DIFF
--- a/packages/core/createReusableTemplate/index.test-d.vue
+++ b/packages/core/createReusableTemplate/index.test-d.vue
@@ -1,0 +1,22 @@
+<script lang="ts">
+import { createReusableTemplate } from './index'
+
+type AcceptableValue
+  = | string
+    | { label: string, value: string | number | null }
+    | null
+</script>
+
+<script setup lang="ts" generic="T extends AcceptableValue = AcceptableValue">
+const [DefineTemplate, ReuseTemplate] = createReusableTemplate<{
+  option: T
+}>()
+</script>
+
+<template>
+  <DefineTemplate #="{ option }">
+    <div>{{ option }}</div>
+  </DefineTemplate>
+
+  <ReuseTemplate option="value" />
+</template>

--- a/packages/core/createReusableTemplate/index.ts
+++ b/packages/core/createReusableTemplate/index.ts
@@ -18,8 +18,11 @@ export type DefineTemplateComponent<
 export type ReuseTemplateComponent<
   Bindings extends Record<string, any>,
   MapSlotNameToSlotProps extends ObjectLiteralWithPotentialObjectLiterals,
-> = DefineComponent<Bindings> & {
-  new(): { $slots: GenerateSlotsFromSlotMap<MapSlotNameToSlotProps> }
+> = DefineComponent & {
+  new(): {
+    $props: { [K in keyof Bindings]: any }
+    $slots: GenerateSlotsFromSlotMap<MapSlotNameToSlotProps>
+  }
 }
 
 export type ReusableTemplatePair<


### PR DESCRIPTION
### Description

Fixes #5354.

`ReuseTemplateComponent` previously used `DefineComponent<Bindings>`, which lets Vue treat the binding object as runtime prop options. In a generic `<script setup>` component, a binding like `{ option: T }` can then be interpreted as a prop-options shape instead of a plain prop type, producing the reported template type error.

This keeps the reuse component as a plain component and exposes the binding keys through its public `$props` constructor type, so generic SFC bindings can be used in templates without tripping Vue's prop-options inference.

### Validation

- `corepack pnpm vitest run packages/core/createReusableTemplate/index.test.ts --project unit`
- `corepack pnpm exec eslint packages/core/createReusableTemplate/index.ts packages/core/createReusableTemplate/index.test.ts packages/core/createReusableTemplate/index.test-d.vue`
- `corepack pnpm exec vue-tsc --noEmit --pretty false --project tsconfig.json`
- `git diff --check origin/main...HEAD`
