### PR TITLE
fix(useElementSize): prefer SVG content rect

### DIFF
--- a/packages/core/useElementSize/index.test.ts
+++ b/packages/core/useElementSize/index.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { shallowRef } from 'vue'
+import { useResizeObserver } from '../useResizeObserver'
+import { useElementSize } from './index'
+
+vi.mock('../useResizeObserver', () => ({
+  useResizeObserver: vi.fn(() => ({
+    stop: vi.fn(),
+  })),
+}))
+
+describe('useElementSize', () => {
+  beforeEach(() => {
+    vi.mocked(useResizeObserver).mockClear()
+  })
+
+  it('uses contentRect for SVG elements instead of transformed bounds', () => {
+    const target = shallowRef(document.createElementNS('http://www.w3.org/2000/svg', 'svg'))
+    target.value.getBoundingClientRect = vi.fn(() => ({
+      bottom: 200,
+      height: 200,
+      left: 0,
+      right: 200,
+      top: 0,
+      width: 200,
+      x: 0,
+      y: 0,
+      toJSON: vi.fn(),
+    }))
+
+    const size = useElementSize(target)
+    const callback = vi.mocked(useResizeObserver).mock.lastCall?.[1]
+
+    callback?.([
+      {
+        contentRect: {
+          height: 100,
+          width: 100,
+        },
+      } as ResizeObserverEntry,
+    ], {} as ResizeObserver)
+
+    expect(size.width.value).toBe(100)
+    expect(size.height.value).toBe(100)
+    expect(target.value.getBoundingClientRect).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/useElementSize/index.ts
+++ b/packages/core/useElementSize/index.ts
@@ -45,13 +45,9 @@ export function useElementSize(
           ? entry.contentBoxSize
           : entry.devicePixelContentBoxSize
 
-      if (window && isSVG.value) {
-        const $elem = unrefElement(target)
-        if ($elem) {
-          const rect = $elem.getBoundingClientRect()
-          width.value = rect.width
-          height.value = rect.height
-        }
+      if (window && isSVG.value && entry.contentRect) {
+        width.value = entry.contentRect.width
+        height.value = entry.contentRect.height
       }
       else {
         if (boxSize) {


### PR DESCRIPTION
### Description

Fixes #5326.

`useElementSize` was special-casing SVG targets by reading `getBoundingClientRect()`. That means CSS transforms, such as `transform: scale()`, affected the reported size for SVG elements while HTML elements continued to report layout size from ResizeObserver entries.

This makes SVG targets prefer the ResizeObserver `contentRect`, matching the layout-size behavior used for non-SVG elements and leaving transformed bounds to `useElementBounding`.

### Validation

- `corepack pnpm vitest run packages/core/useElementSize/index.test.ts --project unit`
- `corepack pnpm exec eslint packages/core/useElementSize/index.ts packages/core/useElementSize/index.test.ts`
- `corepack pnpm exec vue-tsc --noEmit --pretty false --project tsconfig.json`
- `git diff --check origin/main...HEAD`
