### PR TITLE
fix(nuxt): auto-import VueUse toRef alias

### DIFF
--- a/packages/nuxt/README.md
+++ b/packages/nuxt/README.md
@@ -41,6 +41,9 @@ The following utils are **disabled** from auto-import for Nuxt to avoid conflict
 - `useStorage`
 - `useImage`
 
+VueUse's extended `toRef` is auto-imported as `resolveRef` to avoid conflicting
+with Vue's built-in `toRef`.
+
 You can always use them by explicitly importing from `@vueuse/core`
 
 ## License

--- a/packages/nuxt/index.ts
+++ b/packages/nuxt/index.ts
@@ -35,6 +35,20 @@ const packages = [
 
 const fullPackages = packages.map(p => `@vueuse/${p}`)
 
+const aliasedCoreImports: Import[] = [
+  {
+    from: '@vueuse/core',
+    name: 'toRef',
+    as: 'resolveRef',
+    priority: -1,
+    meta: {
+      description: 'Extended toRef that also accepts MaybeRefOrGetter values.',
+      docsUrl: 'https://vueuse.org/shared/toRef/',
+      category: 'Reactivity',
+    },
+  },
+]
+
 export interface VueUseNuxtOptions {
   /**
    * @default true
@@ -149,6 +163,9 @@ export default defineNuxtModule<VueUseNuxtOptions>({
                 },
               }))
             })
+
+          if (pkg === 'core')
+            imports.push(...aliasedCoreImports)
 
           sources.push({
             from: '@vueuse/core',


### PR DESCRIPTION
### Description

Fixes #5239.

Nuxt already auto-imports Vue's built-in `toRef`, while `@vueuse/nuxt` intentionally disables VueUse's `toRef` under that same name to avoid conflicts. This adds a Nuxt auto-import alias, `resolveRef`, that points to VueUse's extended `toRef`, so Nuxt users can opt into the VueUse type behavior without shadowing Vue's built-in utility.

The README caveat now documents the alias next to the disabled names.

### Additional context

Validation:

- `corepack pnpm install --frozen-lockfile --ignore-scripts`
- `corepack pnpm run update`
- `corepack pnpm --filter @vueuse/nuxt build`
- `corepack pnpm exec eslint packages/nuxt/index.ts packages/nuxt/README.md`
- `corepack pnpm exec vue-tsc --noEmit --pretty false --project tsconfig.json`
- `git diff --check`