### PR TITLE
fix(useTextareaAutosize): wire demo textarea ref

### DIFF
--- a/packages/core/useTextareaAutosize/demo.vue
+++ b/packages/core/useTextareaAutosize/demo.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { useTextareaAutosize } from '@vueuse/core'
+import { useTemplateRef } from 'vue'
 
-const { input } = useTextareaAutosize()
+const textarea = useTemplateRef<HTMLTextAreaElement>('textarea')
+const { input } = useTextareaAutosize({ element: textarea })
 </script>
 
 <template>


### PR DESCRIPTION
Fixes #5380

### Description

The live `useTextareaAutosize` demo bound `ref=textarea`, but the demo only kept `input` from `useTextareaAutosize()`. That left the composable without a textarea element, so typing in the docs demo no longer triggered autosizing.

This uses Vue's explicit `useTemplateRef` pattern and passes the element into `useTextareaAutosize`, matching the pattern used by other VueUse demos.

### Additional context

### Checklist

- [x] `corepack pnpm exec eslint packages/core/useTextareaAutosize/demo.vue`
- [x] `corepack pnpm exec vitest run packages/core/useTextareaAutosize/index.test.ts --project unit`
- [x] `corepack pnpm typecheck`
- [x] `git diff --check`
- [x] Local VitePress/Playwright smoke test on `/core/useTextareaAutosize/`: typed six lines and verified the textarea height grew from 39px to 159px