### PR TITLE
fix(useDraggable): capture pointer during drag

### DIFF
--- a/packages/core/useDraggable/index.test.ts
+++ b/packages/core/useDraggable/index.test.ts
@@ -70,6 +70,50 @@ describe('useDraggable', () => {
     expect(wrapper.get('div').element.dataset.isDragging).toBe('false')
   })
 
+  it('captures pointer events on the drag handle', async () => {
+    const setPointerCapture = vi.fn()
+    const releasePointerCapture = vi.fn()
+
+    const wrapper = mount({
+      setup() {
+        const el = useTemplateRef<HTMLElement>('el')
+        const { isDragging } = useDraggable(el)
+
+        return () => h('div', {
+          'data-is-dragging': isDragging.value,
+          'ref': 'el',
+        })
+      },
+    })
+
+    await nextTick()
+
+    Object.assign(wrapper.get('div').element, {
+      releasePointerCapture,
+      setPointerCapture,
+    })
+
+    wrapper.get('div').element.dispatchEvent(new PointerEvent('pointerdown', {
+      clientX: 0,
+      clientY: 0,
+      pointerId: 12,
+    }))
+
+    await nextTick()
+
+    expect(setPointerCapture).toHaveBeenCalledWith(12)
+    expect(wrapper.get('div').element.dataset.isDragging).toBe('true')
+
+    window.dispatchEvent(new PointerEvent('pointerup', {
+      pointerId: 12,
+    }))
+
+    await nextTick()
+
+    expect(releasePointerCapture).toHaveBeenCalledWith(12)
+    expect(wrapper.get('div').element.dataset.isDragging).toBe('false')
+  })
+
   it('component', async () => {
     const onStart = vi.fn()
     const onMove = vi.fn()

--- a/packages/core/useDraggable/index.ts
+++ b/packages/core/useDraggable/index.ts
@@ -202,6 +202,7 @@ export function useDraggable(
   )
 
   const pressedDelta = deepRef<Position>()
+  let capturedPointer: { element: Element, pointerId: number } | undefined
 
   const filterEvent = (e: PointerEvent) => {
     if (pointerTypes)
@@ -214,6 +215,37 @@ export function useDraggable(
       e.preventDefault()
     if (toValue(stopPropagation))
       e.stopPropagation()
+  }
+
+  const capturePointer = (e: PointerEvent) => {
+    if (!(e.currentTarget instanceof Element))
+      return
+
+    try {
+      e.currentTarget.setPointerCapture(e.pointerId)
+      capturedPointer = {
+        element: e.currentTarget,
+        pointerId: e.pointerId,
+      }
+    }
+    catch {
+      // Ignore browsers that reject capturing inactive pointers.
+    }
+  }
+
+  const releasePointer = () => {
+    if (!capturedPointer)
+      return
+
+    const { element, pointerId } = capturedPointer
+    capturedPointer = undefined
+
+    try {
+      element.releasePointerCapture(pointerId)
+    }
+    catch {
+      // The browser may already release capture before pointerup finishes.
+    }
   }
 
   const scrollConfig = toValue(autoScroll)
@@ -339,6 +371,7 @@ export function useDraggable(
     if (onStart?.(pos, e) === false)
       return
     pressedDelta.value = pos
+    capturePointer(e)
     handleEvent(e)
   }
 
@@ -404,7 +437,12 @@ export function useDraggable(
     pressedDelta.value = undefined
     if (autoScroll)
       stopAutoScroll()
-    onEnd?.(position.value, e)
+    try {
+      onEnd?.(position.value, e)
+    }
+    finally {
+      releasePointer()
+    }
     handleEvent(e)
   }
 


### PR DESCRIPTION
Fixes #5325

### Description

`useDraggable` currently listens for `pointermove` / `pointerup` on `window` by default. When a drag crosses an iframe, the iframe can consume the pointer stream and leave the draggable stuck.

This captures the active pointer on the drag handle after `onStart` accepts the drag, then releases it when the drag ends. Captured pointer events continue to bubble to the existing listeners, so the current `draggingElement` option remains compatible while default dragging keeps receiving events across iframes.

### Additional context

### Checklist

- [x] corepack pnpm exec vitest run packages/core/useDraggable/index.test.ts --project unit
- [x] corepack pnpm exec vitest run packages/core/useDraggable/index.browser.test.ts --project browser (chromium)
- [x] corepack pnpm exec eslint packages/core/useDraggable/index.ts packages/core/useDraggable/index.test.ts
- [x] corepack pnpm typecheck
- [x] git diff --check
