### PR TITLE
feat(useFetch): support throwOnFailed option

### DIFF
--- a/packages/core/useFetch/index.md
+++ b/packages/core/useFetch/index.md
@@ -62,6 +62,21 @@ const { execute } = useFetch(url, { immediate: false })
 execute()
 ```
 
+### Throwing failed requests
+
+Setting the `throwOnFailed` option to true will reject the returned promise when the response status is not ok.
+
+```ts
+import { useFetch } from '@vueuse/core'
+// ---cut---
+try {
+  const { data } = await useFetch(url, { throwOnFailed: true })
+}
+catch (error) {
+  // handle the failed response
+}
+```
+
 ### Aborting a request
 
 A request can be aborted by using the `abort` function from the `useFetch` function. The `canAbort` property indicates if the request can be aborted.

--- a/packages/core/useFetch/index.test.ts
+++ b/packages/core/useFetch/index.test.ts
@@ -120,6 +120,31 @@ describe('useFetch', () => {
     expect(error2.message).toBe('Internal Server Error')
   })
 
+  it('should throw error when throwOnFailed option is true', async () => {
+    await expect(
+      useFetch(`${baseUrl}?status=400`, { throwOnFailed: true }),
+    ).rejects.toThrowError('Bad Request')
+  })
+
+  it('should use throwOnFailed option as execute default', async () => {
+    const { execute } = useFetch(`${baseUrl}?status=500`, {
+      immediate: false,
+      throwOnFailed: true,
+    })
+
+    await expect(execute()).rejects.toThrowError('Internal Server Error')
+  })
+
+  it('should allow execute argument to override throwOnFailed option', async () => {
+    const { error, execute } = useFetch(`${baseUrl}?status=400`, {
+      immediate: false,
+      throwOnFailed: true,
+    })
+
+    await expect(execute(false)).resolves.toBeNull()
+    expect(error.value).toBe('Bad Request')
+  })
+
   it('should abort request and set aborted to true', async () => {
     const { aborted, abort, execute } = useFetch(baseUrl)
     setTimeout(abort, 0)

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -181,6 +181,13 @@ export interface UseFetchOptions {
   updateDataOnError?: boolean
 
   /**
+   * Throw an error when the fetch response is not ok
+   *
+   * @default false
+   */
+  throwOnFailed?: boolean
+
+  /**
    * Will run immediately before the fetch request is dispatched
    */
   beforeFetch?: (ctx: BeforeFetchContext) => Promise<Partial<BeforeFetchContext> | void> | Partial<BeforeFetchContext> | void
@@ -228,7 +235,7 @@ export interface CreateFetchOptions {
  * to include the new options
  */
 function isFetchOptions(obj: object): obj is UseFetchOptions {
-  return obj && containsProp(obj, 'immediate', 'refetch', 'initialData', 'timeout', 'beforeFetch', 'afterFetch', 'onFetchError', 'fetch', 'updateDataOnError')
+  return obj && containsProp(obj, 'immediate', 'refetch', 'initialData', 'timeout', 'beforeFetch', 'afterFetch', 'onFetchError', 'fetch', 'updateDataOnError', 'throwOnFailed')
 }
 
 const reAbsolute = /^(?:[a-z][a-z\d+\-.]*:)?\/\//i
@@ -343,6 +350,7 @@ export function useFetch<T>(url: MaybeRefOrGetter<string>, ...args: any[]): UseF
     refetch: false,
     timeout: 0,
     updateDataOnError: false,
+    throwOnFailed: false,
   }
 
   interface InternalConfig {
@@ -415,8 +423,11 @@ export function useFetch<T>(url: MaybeRefOrGetter<string>, ...args: any[]): UseF
     timer = useTimeoutFn(abort, timeout, { immediate: false })
 
   let executeCounter = 0
+  let executePromise: Promise<any> | undefined
+  let rejectOnFailed = false
+  let execute: UseFetchReturn<T>['execute']
 
-  const execute = async (throwOnFailed = false) => {
+  const _execute = async (throwOnFailed = false) => {
     abort()
 
     loading(true)
@@ -539,6 +550,14 @@ export function useFetch<T>(url: MaybeRefOrGetter<string>, ...args: any[]): UseF
       })
   }
 
+  execute = (throwOnFailed = options.throwOnFailed) => {
+    const shouldThrowOnFailed = throwOnFailed ?? false
+
+    rejectOnFailed = shouldThrowOnFailed
+    executePromise = _execute(shouldThrowOnFailed)
+    return executePromise
+  }
+
   const refetch = toRef(options.refetch)
   watch(
     [
@@ -613,7 +632,15 @@ export function useFetch<T>(url: MaybeRefOrGetter<string>, ...args: any[]): UseF
 
   function waitUntilFinished() {
     return new Promise<UseFetchReturn<T>>((resolve, reject) => {
-      until(isFinished).toBe(true).then(() => resolve(shell)).catch(reject)
+      until(isFinished)
+        .toBe(true)
+        .then(() => {
+          if (rejectOnFailed && executePromise)
+            return executePromise.then(() => resolve(shell)).catch(reject)
+
+          resolve(shell)
+        })
+        .catch(reject)
     })
   }
 
@@ -634,7 +661,7 @@ export function useFetch<T>(url: MaybeRefOrGetter<string>, ...args: any[]): UseF
   }
 
   if (options.immediate)
-    Promise.resolve().then(() => execute())
+    Promise.resolve().then(() => execute()).catch(() => {})
 
   return {
     ...shell,


### PR DESCRIPTION
## Summary

- adds `throwOnFailed` to `UseFetchOptions`
- uses that option as the default for automatic and manual `execute()` calls
- keeps the existing per-call `execute(false)` override behavior
- documents the option and adds regression coverage

Fixes #4601.

## Validation

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec vitest run packages/core/useFetch/index.test.ts --project unit`
- `corepack pnpm exec eslint packages/core/useFetch/index.ts packages/core/useFetch/index.test.ts packages/core/useFetch/index.md`
- `git diff --check`
- `node node_modules/tsx/dist/cli.mjs packages/metadata/scripts/update.ts`
- `corepack pnpm typecheck`
- `corepack pnpm lint`