### PR TITLE
feat(shared): support leading debounce

### DIFF
--- a/packages/shared/useDebounceFn/index.md
+++ b/packages/shared/useDebounceFn/index.md
@@ -35,6 +35,16 @@ const debouncedFn = useDebounceFn(() => {
 useEventListener(window, 'resize', debouncedFn)
 ```
 
+Set `leading: true` to invoke the function immediately on the first call, and keep `trailing` enabled to run the latest call at the end of the debounce window.
+
+```ts
+import { useDebounceFn } from '@vueuse/core'
+
+const debouncedFn = useDebounceFn(() => {
+  // do something
+}, 1000, { leading: true })
+```
+
 Optionally, you can get the return value of the function using promise operations.
 
 ```ts

--- a/packages/shared/utils/filters.ts
+++ b/packages/shared/utils/filters.ts
@@ -34,6 +34,20 @@ export interface DebounceFilterOptions {
   maxWait?: MaybeRefOrGetter<number>
 
   /**
+   * Whether to invoke on the leading edge of the timeout.
+   *
+   * @default false
+   */
+  leading?: boolean
+
+  /**
+   * Whether to invoke on the trailing edge of the timeout.
+   *
+   * @default true
+   */
+  trailing?: boolean
+
+  /**
    * Whether to reject the last call if it's been cancel.
    *
    * @default false
@@ -68,51 +82,95 @@ export function debounceFilter(ms: MaybeRefOrGetter<number>, options: DebounceFi
   let timer: TimerHandle
   let maxTimer: TimerHandle
   let lastRejector: AnyFn = noop
+  let lastResolver: AnyFn = noop
+  let lastValue: any
+  let leadingInvoked = false
+  let trailingPending = false
 
   const _clearTimeout = (timer: TimerHandle) => {
     clearTimeout(timer)
     lastRejector()
     lastRejector = noop
+    lastResolver = noop
   }
 
   let lastInvoker: () => void
 
+  const reset = () => {
+    if (timer) {
+      clearTimeout(timer)
+      timer = undefined
+    }
+    if (maxTimer) {
+      clearTimeout(maxTimer)
+      maxTimer = undefined
+    }
+    lastRejector = noop
+    lastResolver = noop
+    leadingInvoked = false
+    trailingPending = false
+  }
+
+  const invokeTrailing = () => {
+    if (timer) {
+      clearTimeout(timer)
+      timer = undefined
+    }
+    if (maxTimer) {
+      clearTimeout(maxTimer)
+      maxTimer = undefined
+    }
+
+    if (trailingPending) {
+      lastValue = lastInvoker()
+      lastResolver(lastValue)
+    }
+
+    lastRejector = noop
+    lastResolver = noop
+    leadingInvoked = false
+    trailingPending = false
+  }
+
   const filter: EventFilter = (invoke) => {
     const duration = toValue(ms)
     const maxDuration = toValue(options.maxWait)
+    const leading = options.leading ?? false
+    const trailing = options.trailing ?? true
+    const isLeadingCall = leading && !leadingInvoked
 
     if (timer)
       _clearTimeout(timer)
 
     if (duration <= 0 || (maxDuration !== undefined && maxDuration <= 0)) {
-      if (maxTimer) {
-        _clearTimeout(maxTimer)
-        maxTimer = undefined
-      }
+      reset()
       return Promise.resolve(invoke())
     }
 
-    return new Promise((resolve, reject) => {
-      lastRejector = options.rejectOnCancel ? reject : resolve
-      lastInvoker = invoke
-      // Create the maxTimer. Clears the regular timer on invoke
-      if (maxDuration && !maxTimer) {
-        maxTimer = setTimeout(() => {
-          if (timer)
-            _clearTimeout(timer)
-          maxTimer = undefined
-          resolve(lastInvoker())
-        }, maxDuration)
-      }
+    if (isLeadingCall) {
+      lastValue = invoke()
+      leadingInvoked = true
+      trailingPending = false
+    }
+    else {
+      trailingPending = trailing
+    }
 
-      // Create the regular timer. Clears the max timer on invoke
-      timer = setTimeout(() => {
-        if (maxTimer)
-          _clearTimeout(maxTimer)
-        maxTimer = undefined
-        resolve(invoke())
-      }, duration)
-    })
+    lastInvoker = invoke
+
+    if (maxDuration && !maxTimer)
+      maxTimer = setTimeout(invokeTrailing, maxDuration)
+
+    timer = setTimeout(invokeTrailing, duration)
+
+    if (trailingPending) {
+      return new Promise((resolve, reject) => {
+        lastRejector = options.rejectOnCancel ? reject : resolve
+        lastResolver = resolve
+      })
+    }
+
+    return Promise.resolve(lastValue)
   }
 
   return filter

--- a/packages/shared/utils/index.test.ts
+++ b/packages/shared/utils/index.test.ts
@@ -175,6 +175,46 @@ describe('filters', () => {
 
       expect(debouncedFilterSpy).toHaveBeenCalledTimes(2)
     })
+
+    it('should support leading debounce', async () => {
+      const debouncedFilterSpy = vi.fn((value: number) => value)
+      const filter = createFilterWrapper(
+        debounceFilter(500, { leading: true }),
+        debouncedFilterSpy,
+      )
+
+      await expect(filter(1)).resolves.toBe(1)
+      expect(debouncedFilterSpy).toHaveBeenCalledOnce()
+
+      const second = filter(2)
+      vi.advanceTimersByTime(500)
+
+      await expect(second).resolves.toBe(2)
+      expect(debouncedFilterSpy).toHaveBeenCalledTimes(2)
+      expect(debouncedFilterSpy).toHaveBeenLastCalledWith(2)
+
+      await expect(filter(3)).resolves.toBe(3)
+      expect(debouncedFilterSpy).toHaveBeenCalledTimes(3)
+      expect(debouncedFilterSpy).toHaveBeenLastCalledWith(3)
+    })
+
+    it('should support leading-only debounce', async () => {
+      const debouncedFilterSpy = vi.fn((value: number) => value)
+      const filter = createFilterWrapper(
+        debounceFilter(500, { leading: true, trailing: false }),
+        debouncedFilterSpy,
+      )
+
+      await expect(filter(1)).resolves.toBe(1)
+      await expect(filter(2)).resolves.toBe(1)
+      vi.advanceTimersByTime(500)
+
+      expect(debouncedFilterSpy).toHaveBeenCalledOnce()
+
+      await expect(filter(3)).resolves.toBe(3)
+      expect(debouncedFilterSpy).toHaveBeenCalledTimes(2)
+      expect(debouncedFilterSpy).toHaveBeenLastCalledWith(3)
+    })
   })
 
   describe('throttleFilter', () => {

--- a/packages/shared/watchDebounced/index.ts
+++ b/packages/shared/watchDebounced/index.ts
@@ -40,7 +40,10 @@ export function watchDebounced<Immediate extends Readonly<boolean> = false>(
 ): WatchHandle {
   const {
     debounce = 0,
+    leading = false,
     maxWait = undefined,
+    rejectOnCancel = false,
+    trailing = true,
     ...watchOptions
   } = options
 
@@ -49,7 +52,7 @@ export function watchDebounced<Immediate extends Readonly<boolean> = false>(
     cb,
     {
       ...watchOptions,
-      eventFilter: debounceFilter(debounce, { maxWait }),
+      eventFilter: debounceFilter(debounce, { leading, maxWait, rejectOnCancel, trailing }),
     },
   )
 }


### PR DESCRIPTION
### Description

Adds leading/trailing debounce support to the shared debounce filter so `useDebounceFn` can invoke immediately on the first call while still optionally running the latest call at the end of the debounce window.

This also passes the debounce filter options through `watchDebounced`, documents the `leading` option for `useDebounceFn`, and covers the new behavior with focused tests.

Fixes #4282.

### Validation

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec vitest run packages/shared/utils/index.test.ts packages/shared/watchDebounced/index.test.ts --project unit`
- `corepack pnpm exec eslint packages/shared/utils/filters.ts packages/shared/utils/index.test.ts packages/shared/watchDebounced/index.ts packages/shared/useDebounceFn/index.md`
- `git diff --check`
- `node node_modules/tsx/dist/cli.mjs packages/metadata/scripts/update.ts`
- `corepack pnpm typecheck`
- `corepack pnpm lint`