### PR TITLE
fix(core): resolve useStorageAsync awaitable ref

### DIFF
--- a/packages/core/useStorageAsync/index.test.ts
+++ b/packages/core/useStorageAsync/index.test.ts
@@ -1,6 +1,7 @@
 import type { Awaitable, StorageLikeAsync } from '@vueuse/core'
 import { createEventHook, useStorageAsync } from '@vueuse/core'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { isRef } from 'vue'
 
 const KEY = 'custom-key'
 const KEY2 = 'custom-key2'
@@ -65,7 +66,7 @@ describe('useStorageAsync', () => {
     )
 
     expect(storage.value).toBe('')
-    vi.waitFor(async () => {
+    await vi.waitFor(async () => {
       await expect(promise).resolves.toBe('CurrentValue')
     })
   })
@@ -81,9 +82,14 @@ describe('useStorageAsync', () => {
 
     expect(storage.value).toBe('')
 
-    vi.waitFor(async () => {
+    const result = await vi.waitFor(async () => {
       const result = await storage
+      expect(isRef(result)).toBe(true)
       expect(result.value).toBe('AnotherValue')
+      return result
     })
+
+    result.value = 'UpdatedValue'
+    expect(storage.value).toBe('UpdatedValue')
   })
 })

--- a/packages/core/useStorageAsync/index.ts
+++ b/packages/core/useStorageAsync/index.ts
@@ -101,10 +101,12 @@ export function useStorageAsync<T extends(string | number | boolean | object | n
     }
   }
 
-  const promise = new Promise((resolve) => {
+  let awaitableData = data
+
+  const promise = new Promise<RemovableRef<T>>((resolve) => {
     read().then(() => {
       onReady?.(data.value)
-      resolve(data)
+      resolve(awaitableData)
     })
   })
 
@@ -132,6 +134,17 @@ export function useStorageAsync<T extends(string | number | boolean | object | n
       },
     )
   }
+
+  awaitableData = new Proxy(data, {
+    get(target, prop, receiver) {
+      // Promise resolution assimilates thenables. Hide the promise methods on
+      // the resolved ref so `await useStorageAsync()` can settle with the ref.
+      if (prop === 'then' || prop === 'catch')
+        return undefined
+
+      return Reflect.get(target, prop, receiver)
+    },
+  })
 
   Object.assign(data, {
     then: promise.then.bind(promise),


### PR DESCRIPTION
### Description

Fixes `useStorageAsync` so `await useStorageAsync(...)` resolves after the initial async read instead of hanging indefinitely.

The returned ref is made awaitable through `then`/`catch`, but resolving a promise with that same thenable ref causes promise assimilation to follow itself. This change resolves the internal promise with a ref proxy that hides only `then`/`catch`, preserving the reactive ref shape for awaited consumers.

The regression test now awaits `vi.waitFor` and verifies the awaited result is still a Vue ref backed by the same storage state.

Fixes #5195.

### Validation

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec vitest run packages/core/useStorageAsync/index.test.ts --project unit`
- `corepack pnpm exec eslint packages/core/useStorageAsync/index.ts packages/core/useStorageAsync/index.test.ts`
- `git diff --check`
- `node node_modules/tsx/dist/cli.mjs packages/metadata/scripts/update.ts`
- `corepack pnpm typecheck`
- `corepack pnpm lint`