### PR TITLE
fix(useWebSocket): sync status to 'CLOSED' after explicit close()

### DIFF
--- a/packages/core/useWebSocket/index.test.ts
+++ b/packages/core/useWebSocket/index.test.ts
@@ -153,6 +153,29 @@ describe('useWebSocket', () => {
 
       expect(mockWebSocket.prototype.close).toBeCalledWith(1000, undefined)
     })
+
+    it('should sync status to CLOSED after close() when onclose fires', () => {
+      vm = useSetup(() => {
+        const ref = useWebSocket('ws://localhost')
+
+        return {
+          ref,
+        }
+      })
+
+      const ws = vm.ref.ws.value
+      ws?.onopen?.(new Event('open'))
+      expect(vm.ref.status.value).toBe('OPEN')
+
+      vm.ref.close()
+
+      // Real browsers fire onclose asynchronously after WebSocket.close().
+      // Simulate that here: at this point close() has already nulled wsRef.value,
+      // so the handler must still transition status to CLOSED.
+      ws?.onclose?.(new CloseEvent('close'))
+
+      expect(vm.ref.status.value).toBe('CLOSED')
+    })
   })
 
   describe('autoClose', () => {

--- a/packages/core/useWebSocket/index.ts
+++ b/packages/core/useWebSocket/index.ts
@@ -232,6 +232,7 @@ export function useWebSocket<Data = any>(
     heartbeatPause?.()
     wsRef.value.close(code, reason)
     wsRef.value = undefined
+    status.value = 'CLOSED'
   }
 
   const send = (data: string | ArrayBuffer | Blob, useBuffer = true) => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ - ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

#### Problem
When close() is called on an active useWebSocket connection, status is never updated to 'CLOSED' and remains stuck at 'OPEN'.

Root cause — in [packages/core/useWebSocket/index.ts](vscode-webview://0c4posqkk3ujuvkj07vbnqbcva9isbijoiag5htrgu041t7lmnu6/packages/core/useWebSocket/index.ts):

The close() function synchronously sets wsRef.value = undefined right after requesting the socket to close:


```
wsRef.value.close(code, reason)
wsRef.value = undefined
The browser later fires onclose asynchronously, where the handler uses an identity guard before updating status:


ws.onclose = (ev) => {
  if (wsRef.value === ws)
    status.value = 'CLOSED'
  ...
}
```

By the time onclose runs, wsRef.value is already undefined, so the guard fails and the status assignment is skipped. The guard itself is correct — it protects against a stale socket overwriting a newer connection during auto-reconnect — but it leaves the explicit-close path without any code that sets 'CLOSED'.

Fix
Set status.value = 'CLOSED' synchronously inside close(), so the explicit-close path doesn't depend on the async onclose handler at all:


  wsRef.value.close(code, reason)
  wsRef.value = undefined
+ status.value = 'CLOSED'
This keeps the existing onclose guard intact (auto-reconnect logic is unaffected) and aligns with the library's status machine, which only models 'OPEN' | 'CONNECTING' | 'CLOSED' (no intermediate 'CLOSING' state).

Test
Added a regression test that reproduces the original timing: capture the socket reference, call close(), then dispatch onclose against the captured reference (mirroring how a real browser fires the event after wsRef.value has already been cleared). The test fails before the fix (expected 'OPEN' to be 'CLOSED') and passes after.



<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

fix: #5450 

<!-- e.g. is there anything you'd like reviewers to focus on? -->
