### PR TITLE
fix(useStyleTag): avoid error when multiple components share the same id

### DIFF
--- a/packages/core/useStyleTag/index.test.ts
+++ b/packages/core/useStyleTag/index.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest'
+import { effectScope, nextTick, shallowRef } from 'vue'
+import { useStyleTag } from './index'
+
+describe('useStyleTag', () => {
+  it('should create a style element', async () => {
+    const { css, isLoaded } = useStyleTag('body { color: red; }', { id: 'test-1' })
+
+    await nextTick()
+
+    expect(isLoaded.value).toBe(true)
+    const el = document.getElementById('test-1') as HTMLStyleElement
+    expect(el).not.toBeNull()
+    expect(el.textContent).toBe('body { color: red; }')
+  })
+
+  it('should update css when ref changes', async () => {
+    const css = shallowRef('body { color: red; }')
+    useStyleTag(css, { id: 'test-2' })
+
+    await nextTick()
+    expect(document.getElementById('test-2')?.textContent).toBe('body { color: red; }')
+
+    css.value = 'body { color: blue; }'
+    await nextTick()
+    expect(document.getElementById('test-2')?.textContent).toBe('body { color: blue; }')
+  })
+
+  it('should remove style element on unload', async () => {
+    const { unload, isLoaded } = useStyleTag('body { color: red; }', { id: 'test-3' })
+
+    await nextTick()
+    expect(document.getElementById('test-3')).not.toBeNull()
+
+    unload()
+    expect(isLoaded.value).toBe(false)
+    expect(document.getElementById('test-3')).toBeNull()
+  })
+
+  it('should not error when unload is called twice', async () => {
+    const { unload } = useStyleTag('body { color: red; }', { id: 'test-4' })
+
+    await nextTick()
+    unload()
+    expect(() => unload()).not.toThrow()
+  })
+
+  it('should not error when unload is called without load', () => {
+    const { unload } = useStyleTag('body { color: red; }', { id: 'test-5', manual: true })
+
+    expect(() => unload()).not.toThrow()
+  })
+
+  it('should not error when two instances share the same id and both unmount', async () => {
+    const scope1 = effectScope()
+    const scope2 = effectScope()
+
+    await nextTick()
+
+    scope1.run(() => {
+      useStyleTag('body { color: red; }', { id: 'shared-test' })
+    })
+
+    await nextTick()
+
+    scope2.run(() => {
+      useStyleTag('body { color: blue; }', { id: 'shared-test' })
+    })
+
+    await nextTick()
+    expect(document.getElementById('shared-test')).not.toBeNull()
+
+    // First scope unmounts - should remove the element
+    scope1.stop()
+    expect(document.getElementById('shared-test')).toBeNull()
+
+    // Second scope unmounts - should not error (element already gone)
+    expect(() => scope2.stop()).not.toThrow()
+  })
+
+  it('should not error when one component unloads and the other stays loaded with shared id', async () => {
+    const scope1 = effectScope()
+    const scope2 = effectScope()
+    const css2 = shallowRef('body { color: blue; }')
+
+    scope1.run(() => {
+      useStyleTag('body { color: red; }', { id: 'shared-test-2' })
+    })
+
+    scope2.run(() => {
+      useStyleTag(css2, { id: 'shared-test-2' })
+    })
+
+    await nextTick()
+
+    // First scope unmounts
+    scope1.stop()
+
+    // Second scope is still active, should not error
+    expect(() => scope2.stop()).not.toThrow()
+  })
+
+  it('should create element with media attribute', async () => {
+    useStyleTag('body { color: red; }', { id: 'test-media', media: 'print' })
+
+    await nextTick()
+    const el = document.getElementById('test-media') as HTMLStyleElement
+    expect(el).not.toBeNull()
+    expect(el.media).toBe('print')
+  })
+
+  it('should not create element when manual is true', async () => {
+    const { load, isLoaded } = useStyleTag('body { color: red; }', { id: 'test-manual', manual: true })
+
+    await nextTick()
+    expect(isLoaded.value).toBe(false)
+    expect(document.getElementById('test-manual')).toBeNull()
+
+    load()
+    expect(isLoaded.value).toBe(true)
+    expect(document.getElementById('test-manual')).not.toBeNull()
+  })
+
+  it('should not create element when immediate is false', async () => {
+    const { isLoaded } = useStyleTag('body { color: red; }', { id: 'test-no-immediate', immediate: false })
+
+    await nextTick()
+    expect(isLoaded.value).toBe(false)
+    expect(document.getElementById('test-no-immediate')).toBeNull()
+  })
+})

--- a/packages/core/useStyleTag/index.test.ts
+++ b/packages/core/useStyleTag/index.test.ts
@@ -4,7 +4,7 @@ import { useStyleTag } from './index'
 
 describe('useStyleTag', () => {
   it('should create a style element', async () => {
-    const { css, isLoaded } = useStyleTag('body { color: red; }', { id: 'test-1' })
+    const { isLoaded } = useStyleTag('body { color: red; }', { id: 'test-1' })
 
     await nextTick()
 

--- a/packages/core/useStyleTag/index.test.ts
+++ b/packages/core/useStyleTag/index.test.ts
@@ -51,7 +51,7 @@ describe('useStyleTag', () => {
     expect(() => unload()).not.toThrow()
   })
 
-  it('should not error when two instances share the same id and both unmount', async () => {
+  it('should keep style element when two instances share the same id and only one unmounts', async () => {
     const scope1 = effectScope()
     const scope2 = effectScope()
 
@@ -70,12 +70,13 @@ describe('useStyleTag', () => {
     await nextTick()
     expect(document.getElementById('shared-test')).not.toBeNull()
 
-    // First scope unmounts - should remove the element
+    // First scope unmounts - element should still exist (scope2 still holds it)
     scope1.stop()
-    expect(document.getElementById('shared-test')).toBeNull()
+    expect(document.getElementById('shared-test')).not.toBeNull()
 
-    // Second scope unmounts - should not error (element already gone)
-    expect(() => scope2.stop()).not.toThrow()
+    // Second scope unmounts - last reference, element should be removed
+    scope2.stop()
+    expect(document.getElementById('shared-test')).toBeNull()
   })
 
   it('should not error when one component unloads and the other stays loaded with shared id', async () => {
@@ -93,11 +94,13 @@ describe('useStyleTag', () => {
 
     await nextTick()
 
-    // First scope unmounts
+    // First scope unmounts - element should still exist
     scope1.stop()
+    expect(document.getElementById('shared-test-2')).not.toBeNull()
 
     // Second scope is still active, should not error
     expect(() => scope2.stop()).not.toThrow()
+    expect(document.getElementById('shared-test-2')).toBeNull()
   })
 
   it('should create element with media attribute', async () => {

--- a/packages/core/useStyleTag/index.ts
+++ b/packages/core/useStyleTag/index.ts
@@ -107,7 +107,9 @@ export function useStyleTag(
     if (!document || !isLoaded.value)
       return
     stop()
-    document.head.removeChild(document.getElementById(id) as HTMLStyleElement)
+    const el = document.getElementById(id)
+    if (el)
+      document.head.removeChild(el)
     isLoaded.value = false
   }
 

--- a/packages/core/useStyleTag/index.ts
+++ b/packages/core/useStyleTag/index.ts
@@ -48,7 +48,7 @@ export interface UseStyleTagReturn {
 }
 
 let _id = 0
-const _count = new Map<string, number>()
+const _refCount = new WeakMap<HTMLStyleElement, number>()
 
 /**
  * Inject <style> element in head.
@@ -93,7 +93,7 @@ export function useStyleTag(
     if (isLoaded.value)
       return
 
-    _count.set(id, (_count.get(id) ?? 0) + 1)
+    _refCount.set(el, (_refCount.get(el) ?? 0) + 1)
 
     stop = watch(
       cssRef,
@@ -111,15 +111,16 @@ export function useStyleTag(
       return
     stop()
 
-    const count = (_count.get(id) ?? 1) - 1
-    if (count <= 0) {
-      _count.delete(id)
-      const el = document.getElementById(id)
-      if (el)
+    const el = document.getElementById(id) as HTMLStyleElement | null
+    if (el) {
+      const count = (_refCount.get(el) ?? 1) - 1
+      if (count <= 0) {
+        _refCount.delete(el)
         document.head.removeChild(el)
-    }
-    else {
-      _count.set(id, count)
+      }
+      else {
+        _refCount.set(el, count)
+      }
     }
 
     isLoaded.value = false

--- a/packages/core/useStyleTag/index.ts
+++ b/packages/core/useStyleTag/index.ts
@@ -48,6 +48,7 @@ export interface UseStyleTagReturn {
 }
 
 let _id = 0
+const _count = new Map<string, number>()
 
 /**
  * Inject <style> element in head.
@@ -92,6 +93,8 @@ export function useStyleTag(
     if (isLoaded.value)
       return
 
+    _count.set(id, (_count.get(id) ?? 0) + 1)
+
     stop = watch(
       cssRef,
       (value) => {
@@ -107,9 +110,18 @@ export function useStyleTag(
     if (!document || !isLoaded.value)
       return
     stop()
-    const el = document.getElementById(id)
-    if (el)
-      document.head.removeChild(el)
+
+    const count = (_count.get(id) ?? 1) - 1
+    if (count <= 0) {
+      _count.delete(id)
+      const el = document.getElementById(id)
+      if (el)
+        document.head.removeChild(el)
+    }
+    else {
+      _count.set(id, count)
+    }
+
     isLoaded.value = false
   }
 


### PR DESCRIPTION
### Description

`useStyleTag` injects a `<style>` element into `<head>`, and supports specifying a DOM `id` via the `id` option. When multiple components pass the same `id`, they reuse the same `<style>` element — which is the intended behavior.

When multiple components share the same `id`, two issues occur during unmount:

**1. Style loss**

Component A and Component B both use `id: 'my-style'`. When Component A unmounts, `unload()` removes `<style id="my-style">` from the DOM entirely. Component B is still active, but its styles disappear from the page.

**2. Runtime error**

After Component A removes the element, Component B's `unload()` calls `document.getElementById('my-style')` which returns `null`. Calling `removeChild(null)` throws:

```
NotFoundError: Failed to execute 'removeChild' on 'Node': parameter 1 is not of type 'Node'.
```

**Root cause**: `unload()` unconditionally removes the `<style>` element without checking if other components are still using it.


### Solution

Introduce a module-level reference counter (`Map<string, number>`) that tracks how many instances are using each style tag by `id`:

- `load()` increments the count on each successful load
- `unload()` decrements the count; only removes the `<style>` element from the DOM when the count reaches zero (i.e. the last consumer unmounts)

This ensures that in the shared `id` scenario:

- Component A unmounts → style stays in DOM, Component B is unaffected
- Component B unmounts → last consumer leaves, style is removed
- No exceptions are thrown regardless of unmount order

### Changes

- `packages/core/useStyleTag/index.ts` — add reference counting in `load`/`unload`
- `packages/core/useStyleTag/index.test.ts` — new test file with 10 tests covering basic usage, edge cases, and shared id scenarios

### Test plan

- [x] `pnpm vitest run packages/core/useStyleTag/index.test.ts --project unit` — 10/10 passed
