### PR TITLE
fix(useAsyncState): ignore onSuccess and onError for stale executions

### DIFF
--- a/packages/core/useAsyncState/index.test.ts
+++ b/packages/core/useAsyncState/index.test.ts
@@ -129,6 +129,17 @@ describe('useAsyncState', () => {
     expect(state.value).toBe('bar')
   })
 
+  it('does not call `onSuccess` from an outdated execution', async () => {
+    const onSuccess = vi.fn()
+    const { execute } = useAsyncState((returnValue: string, timeout: number) => promiseTimeout(timeout).then(() => returnValue), '', { immediate: false, onSuccess })
+    await Promise.all([
+      execute(0, 'foo', 100),
+      execute(0, 'bar', 50),
+    ])
+    expect(onSuccess).toHaveBeenCalledOnce()
+    expect(onSuccess).toHaveBeenCalledWith('bar')
+  })
+
   it('does not set `isReady` from an outdated execution', async () => {
     const { execute, isReady } = useAsyncState(promiseTimeout, shallowRef<void>())
     void execute(0, 0)
@@ -152,5 +163,15 @@ describe('useAsyncState', () => {
       execute(0, 0),
     ])
     expect(error.value).toBeUndefined()
+  })
+
+  it('does not call `onError` from an outdated execution', async () => {
+    const onError = vi.fn()
+    const { execute } = useAsyncState(promiseTimeout, shallowRef<void>(), { immediate: false, onError })
+    await Promise.all([
+      execute(0, 100, true),
+      execute(0, 0),
+    ])
+    expect(onError).not.toHaveBeenCalled()
   })
 })

--- a/packages/core/useAsyncState/index.ts
+++ b/packages/core/useAsyncState/index.ts
@@ -120,14 +120,15 @@ export function useAsyncState<Data, Params extends any[] = any[], Shallow extend
       if (executionId === executionsCount) {
         state.value = data
         isReady.value = true
+        onSuccess(data)
       }
-      onSuccess(data)
       return data
     }
     catch (e) {
-      if (executionId === executionsCount)
+      if (executionId === executionsCount) {
         error.value = e
-      onError(e)
+        onError(e)
+      }
       if (throwError)
         throw e
     }


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<br />
<br />
<br />
<br />

## Summary

Currently, the results of stale `execute` are not written to the Signal, yet `onSuccess` or `onError` are still being invoked. This is counterintuitive, they should be ignored as well.

Why?

1. It is more intuitive
2. `onSuccess` and `onError` themselves do not provide any indicators regarding whether they are stale. If users use them to execute side effects, a late-arriving stale request will cause race conditions
3. Both SWR and `ahooks/useRequest` ignore `onSuccess` and `onError` for stale operations

> Note: Executing side effects in `onSuccess` and `onError` (e.g., mutating Signals) is a great timing because it runs earlier than `watch` and reduces the unnecessary use of `effect`.