### PR TITLE
feat(nuxt): allow user to disable VueUse functions inside `nuxt.config`

### DIFF
--- a/packages/guide/index.md
+++ b/packages/guide/index.md
@@ -79,11 +79,13 @@ You may also disable certain functions if there are name conflicts with other nu
 // nuxt.config.ts
 export default defineNuxtConfig({
   vueuse: {
-    disableFunctions: [
-      'useColorMode',
-      'useDark',
-      // Any other VueUse functions
-    ],
+    autoImports: {
+      disableFunctions: [
+        'useColorMode',
+        'useDark',
+        // Any other VueUse functions
+      ],
+    }
   },
 })
 ```

--- a/packages/guide/index.md
+++ b/packages/guide/index.md
@@ -73,6 +73,21 @@ const { x, y } = useMouse()
 </template>
 ```
 
+You may also disable certain functions if there are name conflicts with other nuxt modules.
+
+```ts
+// nuxt.config.ts
+export default defineNuxtConfig({
+  vueuse: {
+    disableFunctions: [
+      'useColorMode',
+      'useDark',
+      // Any other VueUse functions
+    ],
+  },
+})
+```
+
 ## Usage Example
 
 Simply importing the functions you need from `@vueuse/core`

--- a/packages/nuxt/index.ts
+++ b/packages/nuxt/index.ts
@@ -46,6 +46,8 @@ export interface VueUseNuxtOptions {
    * @default false
    */
   ssrHandlers?: boolean
+
+  disableFunctions?: string[]
 }
 
 /**
@@ -116,6 +118,9 @@ export default defineNuxtModule<VueUseNuxtOptions>({
           if (i.package === 'shared')
             i.package = 'core'
         })
+
+        // disable the functions specified in options provided by user
+        disabledFunctions.push(...(options.disableFunctions || []))
 
         for (const pkg of packages) {
           if (pkg === 'shared')

--- a/packages/nuxt/index.ts
+++ b/packages/nuxt/index.ts
@@ -35,19 +35,21 @@ const packages = [
 
 const fullPackages = packages.map(p => `@vueuse/${p}`)
 
+interface AutoImportOptions {
+  disableFunctions?: string[]
+}
+
 export interface VueUseNuxtOptions {
   /**
    * @default true
    */
-  autoImports?: boolean
+  autoImports?: boolean | AutoImportOptions
 
   /**
    * @experimental
    * @default false
    */
   ssrHandlers?: boolean
-
-  disableFunctions?: string[]
 }
 
 /**
@@ -120,7 +122,9 @@ export default defineNuxtModule<VueUseNuxtOptions>({
         })
 
         // disable the functions specified in options provided by user
-        disabledFunctions.push(...(options.disableFunctions || []))
+        if (typeof options.autoImports === 'object') {
+          disabledFunctions.push(...(options.autoImports.disableFunctions || []))
+        }
 
         for (const pkg of packages) {
           if (pkg === 'shared')


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Inspired by #5475 

Apart from `@nuxtjs/color-mode`, we cannot tell if there would be more VueUse functions having name conflicts with any other Nuxt modules now or in the future, and it is obviously not effective to create PRs one by one for each case.

I believe that providing a simple config for users to disable certain functions inside `nuxt.config` would help.

This PR should make users able to disable function by:
```ts
// nuxt.config.ts
export default defineNuxtConfig({
  vueuse: {
    disableFunctions: [
      'useColorMode',
      'useDark',
      // Any other VueUse functions
    ],
  },
}
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
