### PR TITLE
fix(useFuse): trigger fuse ref after setCollection

### DIFF
--- a/packages/integrations/useFuse/index.test.ts
+++ b/packages/integrations/useFuse/index.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { ref as deepRef, nextTick } from 'vue'
+import { useFuse } from './index'
+
+describe('useFuse', () => {
+  it('updates results when data changes', async () => {
+    const search = deepRef('')
+    const data = deepRef([{ name: 'foo' }])
+    const { results } = useFuse(search, data, { matchAllWhenSearchEmpty: true })
+
+    expect(results.value).toHaveLength(1)
+    expect(results.value[0].item.name).toBe('foo')
+
+    data.value = [{ name: 'bar' }, { name: 'baz' }]
+    await nextTick()
+
+    expect(results.value).toHaveLength(2)
+    expect(results.value[0].item.name).toBe('bar')
+    expect(results.value[1].item.name).toBe('baz')
+  })
+
+  it('searches updated data', async () => {
+    const search = deepRef('bar')
+    const data = deepRef([{ name: 'foo' }])
+    const { results } = useFuse(search, data, { fuseOptions: { keys: ['name'] } })
+
+    expect(results.value).toHaveLength(0)
+
+    data.value = [{ name: 'bar' }]
+    await nextTick()
+
+    expect(results.value).toHaveLength(1)
+    expect(results.value[0].item.name).toBe('bar')
+  })
+})

--- a/packages/integrations/useFuse/index.ts
+++ b/packages/integrations/useFuse/index.ts
@@ -30,14 +30,8 @@ export function useFuse<DataItem>(
   const fuse = shallowRef(createFuse())
 
   watch(
-    () => toValue(options)?.fuseOptions,
+    [() => toValue(data), () => toValue(options)?.fuseOptions],
     () => { fuse.value = createFuse() },
-    { deep: true },
-  )
-
-  watch(
-    () => toValue(data),
-    (newData) => { fuse.value.setCollection(newData) },
     { deep: true },
   )
 

--- a/packages/integrations/useFuse/index.ts
+++ b/packages/integrations/useFuse/index.ts
@@ -20,18 +20,16 @@ export function useFuse<DataItem>(
   data: MaybeRefOrGetter<DataItem[]>,
   options?: MaybeRefOrGetter<UseFuseOptions<DataItem>>,
 ): UseFuseReturn<DataItem> {
-  const createFuse = () => {
-    return new Fuse(
-      toValue(data) ?? [],
-      toValue(options)?.fuseOptions,
-    )
-  }
+  const createFuse = (
+    d = toValue(data) ?? [],
+    fuseOpts = toValue(options)?.fuseOptions,
+  ) => new Fuse(d, fuseOpts)
 
   const fuse = shallowRef(createFuse())
 
   watch(
     [() => toValue(data), () => toValue(options)?.fuseOptions],
-    () => { fuse.value = createFuse() },
+    ([newData, newFuseOptions]) => { fuse.value = createFuse(newData ?? [], newFuseOptions) },
     { deep: true },
   )
 

--- a/packages/integrations/useFuse/index.ts
+++ b/packages/integrations/useFuse/index.ts
@@ -1,7 +1,7 @@
 import type { FuseResult, IFuseOptions } from 'fuse.js'
 import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue'
 import Fuse from 'fuse.js'
-import { computed, shallowRef, toValue, watch } from 'vue'
+import { computed, shallowRef, toValue, triggerRef, watch } from 'vue'
 
 export type FuseOptions<T> = IFuseOptions<T>
 export interface UseFuseOptions<T> {
@@ -20,16 +20,27 @@ export function useFuse<DataItem>(
   data: MaybeRefOrGetter<DataItem[]>,
   options?: MaybeRefOrGetter<UseFuseOptions<DataItem>>,
 ): UseFuseReturn<DataItem> {
-  const createFuse = (
-    d = toValue(data) ?? [],
-    fuseOpts = toValue(options)?.fuseOptions,
-  ) => new Fuse(d, fuseOpts)
+  const createFuse = () => {
+    return new Fuse(
+      toValue(data) ?? [],
+      toValue(options)?.fuseOptions,
+    )
+  }
 
   const fuse = shallowRef(createFuse())
 
   watch(
-    [() => toValue(data), () => toValue(options)?.fuseOptions],
-    ([newData, newFuseOptions]) => { fuse.value = createFuse(newData ?? [], newFuseOptions) },
+    () => toValue(options)?.fuseOptions,
+    () => { fuse.value = createFuse() },
+    { deep: true },
+  )
+
+  watch(
+    () => toValue(data),
+    (newData) => {
+      fuse.value.setCollection(newData)
+      triggerRef(fuse)
+    },
     { deep: true },
   )
 


### PR DESCRIPTION
This PR fixes `useFuse` not updating `results` on data changes by calling `triggerRef(fuse)` after `setCollection`, so the `shallowRef` notifies its subscribers and `results` recomputes.

The root cause was `setCollection` mutating the Fuse instance in place without changing the reference, which a shallow ref can't detect.

Closes #5477