### PR TITLE
docs(onClickOutside): clarify component is not renderless and document props

### DIFF
--- a/packages/core/onClickOutside/index.md
+++ b/packages/core/onClickOutside/index.md
@@ -92,15 +92,47 @@ onClickOutside(target, handler, { detectIframe: true })
 
 ## Component Usage
 
+The `OnClickOutside` component wraps your content in a container element (a `<div>` by default) and listens for clicks outside of it.
+
 ```vue
+<script setup lang="ts">
+import { OnClickOutside } from '@vueuse/components'
+import { shallowRef } from 'vue'
+
+const count = shallowRef(0)
+</script>
+
 <template>
-  <OnClickOutside :options="{ ignore: [/* ... */] }" @trigger="count++">
+  <OnClickOutside @trigger="count++">
     <div>
-      Click Outside of Me
+      Click Outside of Me — count: {{ count }}
     </div>
   </OnClickOutside>
 </template>
 ```
+
+### Props
+
+| Prop      | Type                                                             | Default  | Description                                      |
+|-----------|------------------------------------------------------------------|----------|--------------------------------------------------|
+| `as`      | `string`                                                         | `'div'`  | HTML tag to render as the wrapper element        |
+| `options` | `Omit&lt;OnClickOutsideOptions, 'controls'&gt;`                  | `{}`     | Options forwarded to [`onClickOutside`](#usage)  |
+
+Use the `as` prop to change the wrapper element:
+
+```vue
+<template>
+  <OnClickOutside as="section" @trigger="close">
+    <p>Click outside this section to close</p>
+  </OnClickOutside>
+</template>
+```
+
+### Emits
+
+| Emit      | Payload     | Description                                      |
+|-----------|-------------|--------------------------------------------------|
+| `trigger` | `Event`     | Emitted when a click outside the element occurs  |
 
 ## Directive Usage
 

--- a/packages/guide/components.md
+++ b/packages/guide/components.md
@@ -33,7 +33,7 @@ onClickOutside(el, close)
 </template>
 ```
 
-We can now use the renderless component which the binding is done automatically:
+We can now use the component which handles the binding automatically. Note that `OnClickOutside` renders a wrapper element (a `<div>` by default) that can be customized with the `as` prop:
 
 ```vue
 <script setup>


### PR DESCRIPTION
### Title
docs(onClickOutside): clarify component is not renderless and document props

### Description
Closes #5253

**Changes:**
1. Clarified that `OnClickOutside` wraps content in a container element (not renderless), customizable via the `as` prop
2. Added props table (`as`, `options`) and emits table (`trigger`)
3. Updated `guide/components.md` wording

**Files:**
- `packages/core/onClickOutside/index.md`
- `packages/guide/components.md`