### PR TITLE
docs(useElementVisibility): document controls return including isActive

### DIFF
--- a/packages/core/onClickOutside/index.md
+++ b/packages/core/onClickOutside/index.md
@@ -92,15 +92,47 @@ onClickOutside(target, handler, { detectIframe: true })
 
 ## Component Usage
 
+The `OnClickOutside` component wraps your content in a container element (a `<div>` by default) and listens for clicks outside of it.
+
 ```vue
+<script setup lang="ts">
+import { OnClickOutside } from '@vueuse/components'
+import { shallowRef } from 'vue'
+
+const count = shallowRef(0)
+</script>
+
 <template>
-  <OnClickOutside :options="{ ignore: [/* ... */] }" @trigger="count++">
+  <OnClickOutside @trigger="count++">
     <div>
-      Click Outside of Me
+      Click Outside of Me — count: {{ count }}
     </div>
   </OnClickOutside>
 </template>
 ```
+
+### Props
+
+| Prop      | Type                                                             | Default  | Description                                      |
+|-----------|------------------------------------------------------------------|----------|--------------------------------------------------|
+| `as`      | `string`                                                         | `'div'`  | HTML tag to render as the wrapper element        |
+| `options` | `Omit&lt;OnClickOutsideOptions, 'controls'&gt;`                  | `{}`     | Options forwarded to [`onClickOutside`](#usage)  |
+
+Use the `as` prop to change the wrapper element:
+
+```vue
+<template>
+  <OnClickOutside as="section" @trigger="close">
+    <p>Click outside this section to close</p>
+  </OnClickOutside>
+</template>
+```
+
+### Emits
+
+| Emit      | Payload     | Description                                      |
+|-----------|-------------|--------------------------------------------------|
+| `trigger` | `Event`     | Emitted when a click outside the element occurs  |
 
 ## Directive Usage
 

--- a/packages/core/useElementVisibility/index.md
+++ b/packages/core/useElementVisibility/index.md
@@ -17,7 +17,7 @@ const target = useTemplateRef('target')
 const targetIsVisible = useElementVisibility(target)
 
 const target2 = useTemplateRef('target2')
-const targetVisibilityController = useElementVisibility(target2, { controls: true })
+const { isVisible, isActive, stop } = useElementVisibility(target2, { controls: true })
 </script>
 
 <template>
@@ -29,6 +29,33 @@ const targetVisibilityController = useElementVisibility(target2, { controls: tru
     <h1>Hi there</h1>
   </div>
 </template>
+```
+
+### Controls
+
+When `controls: true` is set, the returned object includes additional properties for more control:
+
+| Property     | Type                       | Description                                      |
+|--------------|----------------------------|--------------------------------------------------|
+| `isVisible`  | `ShallowRef<boolean>`      | Whether the element is visible in the viewport   |
+| `isActive`   | `Readonly<ShallowRef<boolean>>` | Whether the observer is currently active      |
+| `stop`       | `() => void`               | Stop the observer                                |
+| `pause`      | `() => void`               | Pause the observer                               |
+| `resume`     | `() => void`               | Resume the observer                              |
+| `isSupported`| `ShallowRef<boolean>`      | Whether `IntersectionObserver` is supported       |
+
+Use the `once` option together with `controls` to automatically stop the observer after the first visibility change, and check `isActive` to know when it has stopped:
+
+```ts
+const { isVisible, isActive } = useElementVisibility(target, {
+  once: true,
+  controls: true,
+})
+
+watch(isActive, (active) => {
+  if (!active)
+    console.log('Observer stopped after first visibility change')
+})
 ```
 
 ### rootMargin

--- a/packages/core/useElementVisibility/index.test.ts
+++ b/packages/core/useElementVisibility/index.test.ts
@@ -75,7 +75,7 @@ describe('useElementVisibility', () => {
       expect(isVisible.value).toBe(false)
     })
 
-    it('should control visibility observer', () => {
+    it('should expose controls with isActive', () => {
       const visibilityState = useElementVisibility(el, { controls: true })
       const callback = vi.mocked(useIntersectionObserver).mock.lastCall?.[1]
       const callMockCallbackWithIsIntersectingValue = (isIntersecting: boolean) => callback?.([{ isIntersecting, time: 1 } as IntersectionObserverEntry], {} as IntersectionObserver)
@@ -86,6 +86,15 @@ describe('useElementVisibility', () => {
       // It should become true if the callback gets an isIntersecting = true
       callMockCallbackWithIsIntersectingValue(true)
       expect(visibilityState.isVisible.value).toBe(true)
+
+      // Should expose isActive from the observer
+      expect(visibilityState.isActive).toBeDefined()
+      expect(visibilityState.isActive.value).toBe(true)
+
+      // Should expose stop, pause, resume
+      expect(visibilityState.stop).toBeDefined()
+      expect(visibilityState.pause).toBeDefined()
+      expect(visibilityState.resume).toBeDefined()
     })
 
     it('uses the latest version of isIntersecting when multiple intersection entries are given', () => {

--- a/packages/guide/components.md
+++ b/packages/guide/components.md
@@ -33,7 +33,7 @@ onClickOutside(el, close)
 </template>
 ```
 
-We can now use the renderless component which the binding is done automatically:
+We can now use the component which handles the binding automatically. Note that `OnClickOutside` renders a wrapper element (a `<div>` by default) that can be customized with the `as` prop:
 
 ```vue
 <script setup>


### PR DESCRIPTION
Closes #5443

**Changes:**
- Documented the `controls` return properties (`isVisible`, `isActive`, `stop`, `pause`, `resume`, `isSupported`) with a table
- Added usage example combining `once` and `controls` to check `isActive`
- Added test verifying that `controls: true` exposes `isActive`, `stop`, `pause`, and `resume`

Note: `isActive` was already available through the spread of `useIntersectionObserver`'s return. This PR adds documentation and test coverage for it.

**Files:**
- `packages/core/useElementVisibility/index.md`
- `packages/core/useElementVisibility/index.test.ts`
