### PR TITLE
feat(useMagicKeys): add useHotkey composable for string-based keyboard shortcuts

### DIFF
--- a/packages/core/useMagicKeys/index.md
+++ b/packages/core/useMagicKeys/index.md
@@ -164,6 +164,28 @@ whenever(ctrl_s, () => console.log('Ctrl+S have been pressed'))
 
 > ⚠️ This usage is NOT recommended, please use with caution.
 
+### useHotkey
+
+For simpler cases, you can use `useHotkey` which wraps `useMagicKeys` with a string-based API:
+
+```ts
+import { useHotkey } from '@vueuse/core'
+
+useHotkey('Alt+ArrowRight', () => {
+  x += 10
+})
+```
+
+You can also configure it to fire only once, or on keyup:
+
+```ts
+useHotkey('Ctrl+S', handler, { once: true })
+
+useHotkey('Shift+A', handler, { trigger: 'keyup' })
+```
+
+The function returns a `cleanup` function to manually stop listening.
+
 ### Reactive Mode
 
 By default, the values of `useMagicKeys()` are `Ref<boolean>`. If you want to use the object in the template, you can set it to reactive mode.

--- a/packages/core/useMagicKeys/index.md
+++ b/packages/core/useMagicKeys/index.md
@@ -166,25 +166,33 @@ whenever(ctrl_s, () => console.log('Ctrl+S have been pressed'))
 
 ### useHotkey
 
-For simpler cases, you can use `useHotkey` which wraps `useMagicKeys` with a string-based API:
+For simpler cases, you can use `useHotkey` which accepts a human-readable combo string:
 
 ```ts
 import { useHotkey } from '@vueuse/core'
 
-useHotkey('Alt+ArrowRight', () => {
+useHotkey('Alt+ArrowRight', (e) => {
   x += 10
 })
 ```
 
-You can also configure it to fire only once, or on keyup:
+The handler receives the native `KeyboardEvent`, so you can call `e.preventDefault()` when needed. You can also pass `preventDefault: true` in options to do it automatically:
 
 ```ts
+useHotkey('Ctrl+S', handler, { preventDefault: true })
+```
+
+Other options:
+
+```ts
+// Fire only once, then auto-cleanup
 useHotkey('Ctrl+S', handler, { once: true })
 
+// Fire on keyup instead of keydown
 useHotkey('Shift+A', handler, { trigger: 'keyup' })
 ```
 
-The function returns a `cleanup` function to manually stop listening.
+The function returns a `cleanup` function to manually stop listening. Listeners are also automatically cleaned up when the enclosing Vue scope is disposed.
 
 ### Reactive Mode
 

--- a/packages/core/useMagicKeys/index.test.ts
+++ b/packages/core/useMagicKeys/index.test.ts
@@ -190,7 +190,7 @@ describe('useHotkey', () => {
     target = document.createElement('input')
   })
 
-  it('fires handler when combo is pressed', async () => {
+  it('fires handler when combo is pressed', () => {
     const handler = vi.fn()
     useHotkey('Alt+ArrowRight', handler, { target })
 
@@ -199,9 +199,10 @@ describe('useHotkey', () => {
 
     dispatchKeyboardEvent({ target, key: 'ArrowRight', altKey: true })
     expect(handler).toHaveBeenCalledTimes(1)
+    expect(handler).toHaveBeenCalledWith(expect.any(KeyboardEvent))
   })
 
-  it('does not fire on partial combo', async () => {
+  it('does not fire on partial combo', () => {
     const handler = vi.fn()
     useHotkey('Ctrl+A', handler, { target })
 
@@ -209,7 +210,7 @@ describe('useHotkey', () => {
     expect(handler).not.toHaveBeenCalled()
   })
 
-  it('fires once with once: true', async () => {
+  it('fires once then stops listening', () => {
     const handler = vi.fn()
     useHotkey('Shift+A', handler, { target, once: true })
 
@@ -217,13 +218,13 @@ describe('useHotkey', () => {
     dispatchKeyboardEvent({ target, key: 'A', shiftKey: true })
     expect(handler).toHaveBeenCalledTimes(1)
 
-    // Release and press again
-    dispatchKeyboardEvent({ target, key: 'A', shiftKey: true, eventType: 'keyup' })
+    // Press again — listener was removed after first fire
+    dispatchKeyboardEvent({ target, key: 'Shift', shiftKey: true })
     dispatchKeyboardEvent({ target, key: 'A', shiftKey: true })
     expect(handler).toHaveBeenCalledTimes(1)
   })
 
-  it('fires on keyup with trigger: keyup', async () => {
+  it('fires on keyup with trigger: keyup', () => {
     const handler = vi.fn()
     useHotkey('Ctrl+S', handler, { target, trigger: 'keyup' })
 
@@ -235,7 +236,7 @@ describe('useHotkey', () => {
     expect(handler).toHaveBeenCalledTimes(1)
   })
 
-  it('cleanup stops listening', async () => {
+  it('cleanup stops listening', () => {
     const handler = vi.fn()
     const { cleanup } = useHotkey('Space', handler, { target })
 
@@ -245,7 +246,7 @@ describe('useHotkey', () => {
     expect(handler).not.toHaveBeenCalled()
   })
 
-  it('handles triple-key combo', async () => {
+  it('handles triple-key combo', () => {
     const handler = vi.fn()
     useHotkey('Ctrl+Shift+A', handler, { target })
 
@@ -253,6 +254,15 @@ describe('useHotkey', () => {
     dispatchKeyboardEvent({ target, key: 'Shift', ctrlKey: true, shiftKey: true })
     expect(handler).not.toHaveBeenCalled()
 
+    dispatchKeyboardEvent({ target, key: 'A', ctrlKey: true, shiftKey: true })
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires when combo keys are held even with extra modifiers', () => {
+    const handler = vi.fn()
+    useHotkey('Ctrl+A', handler, { target })
+
+    dispatchKeyboardEvent({ target, key: 'Control', ctrlKey: true })
     dispatchKeyboardEvent({ target, key: 'A', ctrlKey: true, shiftKey: true })
     expect(handler).toHaveBeenCalledTimes(1)
   })

--- a/packages/core/useMagicKeys/index.test.ts
+++ b/packages/core/useMagicKeys/index.test.ts
@@ -1,6 +1,6 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { dispatchKeyboardEvent } from '../../.test'
-import { useMagicKeys } from './index'
+import { useHotkey, useMagicKeys } from './index'
 
 describe('useMagicKeys', () => {
   let target: HTMLInputElement
@@ -180,5 +180,80 @@ describe('useMagicKeys', () => {
     expect(() => {
       target.dispatchEvent(event)
     }).not.toThrow()
+  })
+})
+
+describe('useHotkey', () => {
+  let target: HTMLInputElement
+
+  beforeEach(() => {
+    target = document.createElement('input')
+  })
+
+  it('fires handler when combo is pressed', async () => {
+    const handler = vi.fn()
+    useHotkey('Alt+ArrowRight', handler, { target })
+
+    dispatchKeyboardEvent({ target, key: 'Alt', altKey: true })
+    expect(handler).not.toHaveBeenCalled()
+
+    dispatchKeyboardEvent({ target, key: 'ArrowRight', altKey: true })
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not fire on partial combo', async () => {
+    const handler = vi.fn()
+    useHotkey('Ctrl+A', handler, { target })
+
+    dispatchKeyboardEvent({ target, key: 'Control', ctrlKey: true })
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('fires once with once: true', async () => {
+    const handler = vi.fn()
+    useHotkey('Shift+A', handler, { target, once: true })
+
+    dispatchKeyboardEvent({ target, key: 'Shift', shiftKey: true })
+    dispatchKeyboardEvent({ target, key: 'A', shiftKey: true })
+    expect(handler).toHaveBeenCalledTimes(1)
+
+    // Release and press again
+    dispatchKeyboardEvent({ target, key: 'A', shiftKey: true, eventType: 'keyup' })
+    dispatchKeyboardEvent({ target, key: 'A', shiftKey: true })
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires on keyup with trigger: keyup', async () => {
+    const handler = vi.fn()
+    useHotkey('Ctrl+S', handler, { target, trigger: 'keyup' })
+
+    dispatchKeyboardEvent({ target, key: 'Control', ctrlKey: true })
+    dispatchKeyboardEvent({ target, key: 'S', ctrlKey: true })
+    expect(handler).not.toHaveBeenCalled()
+
+    dispatchKeyboardEvent({ target, key: 'S', ctrlKey: true, eventType: 'keyup' })
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  it('cleanup stops listening', async () => {
+    const handler = vi.fn()
+    const { cleanup } = useHotkey('Space', handler, { target })
+
+    cleanup()
+
+    dispatchKeyboardEvent({ target, key: ' ' })
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('handles triple-key combo', async () => {
+    const handler = vi.fn()
+    useHotkey('Ctrl+Shift+A', handler, { target })
+
+    dispatchKeyboardEvent({ target, key: 'Control', ctrlKey: true })
+    dispatchKeyboardEvent({ target, key: 'Shift', ctrlKey: true, shiftKey: true })
+    expect(handler).not.toHaveBeenCalled()
+
+    dispatchKeyboardEvent({ target, key: 'A', ctrlKey: true, shiftKey: true })
+    expect(handler).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/core/useMagicKeys/index.ts
+++ b/packages/core/useMagicKeys/index.ts
@@ -1,6 +1,6 @@
 import type { ComputedRef, MaybeRefOrGetter } from 'vue'
 import { noop } from '@vueuse/shared'
-import { computed, reactive, shallowRef, toValue } from 'vue'
+import { computed, reactive, shallowRef, toValue, watch } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 import { DefaultMagicKeysAliasMap } from './aliasMap'
@@ -213,6 +213,59 @@ export function useMagicKeys<T extends boolean = false>(options: UseMagicKeysOpt
   )
 
   return proxy as UseMagicKeysReturn<T>
+}
+
+export interface UseHotkeyOptions {
+  /**
+   * Only trigger once, then clean up
+   *
+   * @default false
+   */
+  once?: boolean
+
+  /**
+   * Trigger on keydown or keyup
+   *
+   * @default 'keydown'
+   */
+  trigger?: 'keydown' | 'keyup'
+
+  /**
+   * Target for listening events
+   *
+   * @default window
+   */
+  target?: MaybeRefOrGetter<EventTarget>
+}
+
+/**
+ * Register a keyboard shortcut with a human-readable combo string.
+ *
+ * @see https://vueuse.org/useMagicKeys#usehotkey
+ */
+export function useHotkey(
+  combo: string,
+  handler: () => void,
+  options: UseHotkeyOptions = {},
+): { cleanup: () => void } {
+  const { once = false, trigger: triggerOn = 'keydown', target = defaultWindow } = options
+
+  const keys = combo.split('+').map(k => k.trim().toLowerCase())
+  const magicKeys = useMagicKeys({ target })
+  const isPressed = computed(() => toValue(magicKeys[keys.join('_')]))
+
+  let prev = false
+  const stop = watch(isPressed, (curr) => {
+    const fire = triggerOn === 'keyup' ? (!curr && prev) : (curr && !prev)
+    if (fire) {
+      handler()
+      if (once)
+        stop()
+    }
+    prev = curr
+  }, { flush: 'sync' })
+
+  return { cleanup: stop }
 }
 
 export { DefaultMagicKeysAliasMap } from './aliasMap'

--- a/packages/core/useMagicKeys/index.ts
+++ b/packages/core/useMagicKeys/index.ts
@@ -1,6 +1,6 @@
 import type { ComputedRef, MaybeRefOrGetter } from 'vue'
-import { noop } from '@vueuse/shared'
-import { computed, reactive, shallowRef, toValue, watch } from 'vue'
+import { noop, tryOnScopeDispose } from '@vueuse/shared'
+import { computed, reactive, shallowRef, toValue } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 import { DefaultMagicKeysAliasMap } from './aliasMap'
@@ -236,6 +236,13 @@ export interface UseHotkeyOptions {
    * @default window
    */
   target?: MaybeRefOrGetter<EventTarget>
+
+  /**
+   * Whether to call `event.preventDefault()` on match
+   *
+   * @default false
+   */
+  preventDefault?: boolean
 }
 
 /**
@@ -245,27 +252,69 @@ export interface UseHotkeyOptions {
  */
 export function useHotkey(
   combo: string,
-  handler: () => void,
+  handler: (event: KeyboardEvent) => void,
   options: UseHotkeyOptions = {},
 ): { cleanup: () => void } {
-  const { once = false, trigger: triggerOn = 'keydown', target = defaultWindow } = options
+  const {
+    once = false,
+    trigger: triggerOn = 'keydown',
+    target = defaultWindow,
+    preventDefault = false,
+  } = options
 
   const keys = combo.split('+').map(k => k.trim().toLowerCase())
-  const magicKeys = useMagicKeys({ target })
-  const isPressed = computed(() => toValue(magicKeys[keys.join('_')]))
+  const held = new Set<string>()
+  let disposed = false
 
-  let prev = false
-  const stop = watch(isPressed, (curr) => {
-    const fire = triggerOn === 'keyup' ? (!curr && prev) : (curr && !prev)
-    if (fire) {
-      handler()
-      if (once)
-        stop()
+  const stop: Array<() => void> = []
+
+  function cleanup() {
+    if (disposed)
+      return
+    disposed = true
+    held.clear()
+    stop.forEach(fn => fn())
+  }
+
+  function matches(e: KeyboardEvent): boolean {
+    const mainKey = keys[keys.length - 1]
+    const eventKey = e.key?.toLowerCase()
+    if (eventKey !== mainKey && e.code?.toLowerCase() !== mainKey)
+      return false
+    for (let i = 0; i < keys.length - 1; i++) {
+      if (!held.has(keys[i]))
+        return false
     }
-    prev = curr
-  }, { flush: 'sync' })
+    return true
+  }
 
-  return { cleanup: stop }
+  stop.push(
+    useEventListener(target, 'keydown', (e: KeyboardEvent) => {
+      held.add(e.key?.toLowerCase() ?? '')
+      if (triggerOn === 'keydown' && matches(e)) {
+        if (preventDefault)
+          e.preventDefault()
+        handler(e)
+        if (once)
+          cleanup()
+      }
+    }),
+    useEventListener(target, 'keyup', (e: KeyboardEvent) => {
+      if (triggerOn === 'keyup' && matches(e)) {
+        if (preventDefault)
+          e.preventDefault()
+        handler(e)
+        if (once)
+          cleanup()
+      }
+      held.delete(e.key?.toLowerCase() ?? '')
+    }),
+    useEventListener(target, 'blur', () => held.clear()),
+  )
+
+  tryOnScopeDispose(cleanup)
+
+  return { cleanup }
 }
 
 export { DefaultMagicKeysAliasMap } from './aliasMap'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10142,7 +10142,7 @@ snapshots:
 
   '@babel/helper-builder-binary-assignment-operator-visitor@7.21.5':
     dependencies:
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.0
 
   '@babel/helper-compilation-targets@7.28.6':
     dependencies:
@@ -10186,18 +10186,18 @@ snapshots:
 
   '@babel/helper-environment-visitor@7.24.7':
     dependencies:
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.0
 
   '@babel/helper-function-name@7.24.7':
     dependencies:
       '@babel/template': 7.28.6
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.0
 
   '@babel/helper-globals@7.28.0': {}
 
   '@babel/helper-hoist-variables@7.24.7':
     dependencies:
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.0
 
   '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
@@ -10234,7 +10234,7 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-environment-visitor': 7.24.7
       '@babel/helper-wrap-function': 7.20.5
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -10250,7 +10250,7 @@ snapshots:
   '@babel/helper-simple-access@7.24.7':
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -10263,7 +10263,7 @@ snapshots:
 
   '@babel/helper-split-export-declaration@7.24.7':
     dependencies:
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.0
 
   '@babel/helper-string-parser@7.27.1': {}
 
@@ -10288,7 +10288,7 @@ snapshots:
       '@babel/helper-function-name': 7.24.7
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -10640,7 +10640,7 @@ snapshots:
       '@babel/helper-hoist-variables': 7.24.7
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/helper-validator-identifier': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -10815,7 +10815,7 @@ snapshots:
       '@babel/plugin-transform-unicode-escapes': 7.21.5(@babel/core@7.29.0)
       '@babel/plugin-transform-unicode-regex': 7.18.6(@babel/core@7.29.0)
       '@babel/preset-modules': 0.1.5(@babel/core@7.29.0)
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.0
       babel-plugin-polyfill-corejs2: 0.3.3(@babel/core@7.29.0)
       babel-plugin-polyfill-corejs3: 0.6.0(@babel/core@7.29.0)
       babel-plugin-polyfill-regenerator: 0.4.1(@babel/core@7.29.0)
@@ -10830,7 +10830,7 @@ snapshots:
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/plugin-proposal-unicode-property-regex': 7.18.6(@babel/core@7.29.0)
       '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.29.0)
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.0
       esutils: 2.0.3
 
   '@babel/regjsgen@0.8.0': {}
@@ -12348,7 +12348,7 @@ snapshots:
       scule: 1.3.0
       semver: 7.8.1
       std-env: 3.10.0
-      tinyglobby: 0.2.17
+      tinyglobby: 0.2.16
       ufo: 1.6.4
       unctx: 2.5.0
       unimport: 5.6.0
@@ -13656,7 +13656,7 @@ snapshots:
 
   '@types/resolve@1.17.1':
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 25.6.0
 
   '@types/resolve@1.20.2': {}
 
@@ -16582,7 +16582,7 @@ snapshots:
 
   jest-worker@26.6.2:
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 25.6.0
       merge-stream: 2.0.0
       supports-color: 7.2.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10142,7 +10142,7 @@ snapshots:
 
   '@babel/helper-builder-binary-assignment-operator-visitor@7.21.5':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/helper-compilation-targets@7.28.6':
     dependencies:
@@ -10186,18 +10186,18 @@ snapshots:
 
   '@babel/helper-environment-visitor@7.24.7':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/helper-function-name@7.24.7':
     dependencies:
       '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/helper-globals@7.28.0': {}
 
   '@babel/helper-hoist-variables@7.24.7':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
@@ -10234,7 +10234,7 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-environment-visitor': 7.24.7
       '@babel/helper-wrap-function': 7.20.5
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -10250,7 +10250,7 @@ snapshots:
   '@babel/helper-simple-access@7.24.7':
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -10263,7 +10263,7 @@ snapshots:
 
   '@babel/helper-split-export-declaration@7.24.7':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/helper-string-parser@7.27.1': {}
 
@@ -10288,7 +10288,7 @@ snapshots:
       '@babel/helper-function-name': 7.24.7
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -10640,7 +10640,7 @@ snapshots:
       '@babel/helper-hoist-variables': 7.24.7
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -10815,7 +10815,7 @@ snapshots:
       '@babel/plugin-transform-unicode-escapes': 7.21.5(@babel/core@7.29.0)
       '@babel/plugin-transform-unicode-regex': 7.18.6(@babel/core@7.29.0)
       '@babel/preset-modules': 0.1.5(@babel/core@7.29.0)
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       babel-plugin-polyfill-corejs2: 0.3.3(@babel/core@7.29.0)
       babel-plugin-polyfill-corejs3: 0.6.0(@babel/core@7.29.0)
       babel-plugin-polyfill-regenerator: 0.4.1(@babel/core@7.29.0)
@@ -10830,7 +10830,7 @@ snapshots:
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/plugin-proposal-unicode-property-regex': 7.18.6(@babel/core@7.29.0)
       '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.29.0)
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       esutils: 2.0.3
 
   '@babel/regjsgen@0.8.0': {}
@@ -12348,7 +12348,7 @@ snapshots:
       scule: 1.3.0
       semver: 7.8.1
       std-env: 3.10.0
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       ufo: 1.6.4
       unctx: 2.5.0
       unimport: 5.6.0
@@ -13656,7 +13656,7 @@ snapshots:
 
   '@types/resolve@1.17.1':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.1
 
   '@types/resolve@1.20.2': {}
 
@@ -16582,7 +16582,7 @@ snapshots:
 
   jest-worker@26.6.2:
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.1
       merge-stream: 2.0.0
       supports-color: 7.2.0
 


### PR DESCRIPTION
### Summary

  Closes #5371

  ### Problem

  useMagicKeys requires destructuring or proxy access to create keyboard shortcuts. For simple hotkey use-cases like
  Alt+ArrowRight or Ctrl+S, users need a more concise API.

  ### Solution

  Added `useHotkey(combo, handler, options)` — a wrapper around useMagicKeys that accepts a human-readable combo string:

  ```ts
  useHotkey('Alt+ArrowRight', () => (x += 10))

  - Supports trigger: 'keydown' (default) or 'keyup'
  - Supports once: true for single-fire shortcuts
  - Returns { cleanup } for manual teardown
  - Leverages existing useMagicKeys proxy for combo detection

  Testing

  - Added 6 new tests covering: basic combo, partial combo, once, keyup trigger, cleanup, triple-key combo
  - All 19 tests pass