### PR TITLE
fix(useVibrate): make interval option optional

### DIFF
--- a/packages/core/useVibrate/index.test.ts
+++ b/packages/core/useVibrate/index.test.ts
@@ -1,0 +1,21 @@
+import type { UseVibrateOptions } from './index'
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import { useVibrate } from './index'
+
+describe('useVibrate', () => {
+  it('allows omitting deprecated interval option', () => {
+    expectTypeOf({ pattern: [300, 100, 300] }).toExtend<UseVibrateOptions>()
+  })
+
+  it('does not create interval controls without interval or scheduler', () => {
+    const { intervalControls } = useVibrate({ pattern: [300, 100, 300] })
+
+    expect(intervalControls).toBeUndefined()
+  })
+
+  it('keeps interval option for backwards compatibility', () => {
+    const { intervalControls } = useVibrate({ interval: 1000 })
+
+    expect(intervalControls).toBeDefined()
+  })
+})

--- a/packages/core/useVibrate/index.ts
+++ b/packages/core/useVibrate/index.ts
@@ -6,9 +6,9 @@ import { toRef, useIntervalFn } from '@vueuse/shared'
 import { defaultNavigator } from '../_configurable'
 import { useSupported } from '../useSupported'
 
-function getDefaultScheduler(options: UseVibrateOptions = { interval: 0 }) {
+function getDefaultScheduler(options: UseVibrateOptions = {}) {
   const {
-    interval,
+    interval = 0,
   } = options
 
   if (interval === 0)
@@ -44,7 +44,7 @@ export interface UseVibrateOptions extends ConfigurableNavigator, ConfigurableSc
    * @default 0
    *
    */
-  interval: number
+  interval?: number
 }
 
 export interface UseVibrateReturn extends Supportable {

--- a/test/__snapshots__/tsnapi/@vueuse/core/index.snapshot.d.ts
+++ b/test/__snapshots__/tsnapi/@vueuse/core/index.snapshot.d.ts
@@ -1347,7 +1347,7 @@ export interface UseVerticalVirtualListOptions extends UseVirtualListOptionsBase
 }
 export interface UseVibrateOptions extends ConfigurableNavigator, ConfigurableScheduler {
   pattern?: MaybeRefOrGetter<Arrayable<number>>;
-  interval: number;
+  interval?: number;
 }
 export interface UseVibrateReturn extends Supportable {
   pattern: MaybeRefOrGetter<Arrayable<number>>;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Confirm that this PR is based on your own understanding and review of the project, not solely generated or summarized by AI tools.

> **Note**: If this PR is deemed to be primarily generated by AI tools, it may be closed.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

`UseVibrateOptions.interval` is deprecated and documented with `@default 0`, but it is currently required. This makes documented usage such as `useVibrate({ pattern: [...] })` fail type checking.

It also means that when options are provided without `interval`, `getDefaultScheduler` receives `interval` as `undefined`, which can fall through to `useIntervalFn`'s default interval instead of disabling the interval scheduler.

This PR makes `interval` optional, defaults it to `0` inside `getDefaultScheduler`, and adds tests for the default behavior and backwards compatibility.

### Additional context

No breaking change: this only relaxes the option type and preserves the deprecated `interval` behavior.