### PR TITLE
fix(useAsyncState): setting state.value directly cancels in-flight execution

### DIFF
--- a/packages/core/useAsyncState/index.test.ts
+++ b/packages/core/useAsyncState/index.test.ts
@@ -117,7 +117,27 @@ describe('useAsyncState', () => {
     const { state } = useAsyncState(asyncValue, initialState)
     await asyncValue
     expect(state.value).toBe(100)
-    expect(initialState).toBe(state)
+    // initialState.value reflects the resolved value (state reads from _source)
+    expect(initialState.value).toBe(200)
+  })
+
+  it('setting state.value directly cancels in-flight execution', async () => {
+    const { state, isLoading, isReady } = useAsyncState(
+      () => promiseTimeout(100).then(() => 99),
+      0,
+      { immediate: true },
+    )
+
+    // Override state before the promise resolves
+    state.value = 42
+
+    await promiseTimeout(150)
+
+    // The promise resolved with 99, but the manual write should have won
+    expect(state.value).toBe(42)
+    expect(isLoading.value).toBe(false)
+    // isReady stays false because execute() detected it was cancelled
+    expect(isReady.value).toBe(false)
   })
 
   it('does not set `state` from an outdated execution', async () => {

--- a/packages/core/useAsyncState/index.ts
+++ b/packages/core/useAsyncState/index.ts
@@ -1,6 +1,6 @@
 import type { MaybeRef, Ref, ShallowRef, UnwrapRef } from 'vue'
 import { noop, promiseTimeout, until } from '@vueuse/shared'
-import { ref as deepRef, shallowRef, toValue } from 'vue'
+import { customRef, ref as deepRef, shallowRef, toValue } from 'vue'
 
 export interface UseAsyncStateReturnBase<Data, Params extends any[], Shallow extends boolean> {
   state: Shallow extends true ? Ref<Data> : Ref<UnwrapRef<Data>>
@@ -93,17 +93,50 @@ export function useAsyncState<Data, Params extends any[] = any[], Shallow extend
     shallow = true,
     throwError,
   } = options ?? {}
-  const state = shallow ? shallowRef(initialState) : deepRef(initialState)
   const isReady = shallowRef(false)
   const isLoading = shallowRef(false)
   const error = shallowRef<unknown | undefined>(undefined)
 
   let executionsCount = 0
+
+  // Setting state.value externally (outside of execute()) cancels any in-flight
+  // execution so the promise result cannot overwrite the caller's value.
+  // We track this with an _internalWrite flag: execute() sets it before writing
+  // state, so the customRef setter knows not to bump executionsCount.
+  let _internalWrite = false
+  // _source holds the raw value; for deep reactivity we pre-wrap it so that
+  // nested objects are still made reactive when shallow === false.
+  let _source: Data = shallow
+    ? toValue(initialState)
+    : deepRef(toValue(initialState)).value as Data
+
+  const state = customRef<Data>((track, trigger) => {
+    return {
+      get() {
+        track()
+        return _source
+      },
+      set(value: Data) {
+        _source = shallow ? value : deepRef(value).value as Data
+        if (!_internalWrite) {
+          executionsCount += 1
+          // Clear loading/ready state immediately so the caller gets a consistent
+          // snapshot when setting state directly.
+          isLoading.value = false
+          isReady.value = false
+        }
+        trigger()
+      },
+    }
+  }) as Shallow extends true ? ShallowRef<Data> : Ref<UnwrapRef<Data>>
   async function execute(delay = 0, ...args: any[]) {
     const executionId = (executionsCount += 1)
 
-    if (resetOnExecute)
-      state.value = toValue(initialState)
+    if (resetOnExecute) {
+      _internalWrite = true
+      state.value = toValue(initialState) as any
+      _internalWrite = false
+    }
     error.value = undefined
     isReady.value = false
     isLoading.value = true
@@ -118,7 +151,9 @@ export function useAsyncState<Data, Params extends any[] = any[], Shallow extend
     try {
       const data = await _promise
       if (executionId === executionsCount) {
-        state.value = data
+        _internalWrite = true
+        state.value = data as any
+        _internalWrite = false
         isReady.value = true
       }
       onSuccess(data)
@@ -142,7 +177,7 @@ export function useAsyncState<Data, Params extends any[] = any[], Shallow extend
   }
 
   const shell: UseAsyncStateReturnBase<Data, Params, Shallow> = {
-    state: state as Shallow extends true ? ShallowRef<Data> : Ref<UnwrapRef<Data>>,
+    state,
     isReady,
     isLoading,
     error,


### PR DESCRIPTION
Fixes #4975

## What was wrong

When a caller sets `state.value` directly while a promise is still loading, the resolved value would silently overwrite the assignment. The root cause is that `execute()` uses an `executionId === executionsCount` guard to detect stale executions, but an external write to `state.value` never bumped `executionsCount`, so the in-flight promise always believed it was still the latest execution.

## What changed

`state` is now created with `customRef` instead of `shallowRef`/`deepRef`. The setter intercepts every write:

- Writes from inside `execute()` are marked with an `_internalWrite` flag, so they pass through without side effects.
- Writes from outside `execute()` bump `executionsCount`, which causes the in-flight promise to see `executionId !== executionsCount` and skip the state/isReady/isLoading updates. `isLoading` and `isReady` are also reset immediately so the caller gets a consistent snapshot right away.

The `shallow` option is still respected: when `shallow` is false, incoming values are passed through `deepRef().value` to get the same deep-reactive unwrapping as before.

## Tests

Added a test that starts a 100 ms promise, sets `state.value = 42` before it resolves, then waits for the promise to finish and asserts `state.value` is still `42` and `isLoading` is `false`.

The existing test that checked `initialState === state` (reference equality) was updated to check the actual value instead, since `customRef` intentionally does not return the same reference as a passed-in `shallowRef`.