### PR TITLE
fix(useFuse): trigger search when reactive collection changes

### DIFF
--- a/packages/integrations/useFuse/index.test.ts
+++ b/packages/integrations/useFuse/index.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import { ref as deepRef, nextTick } from 'vue'
+import { useFuse } from './index'
+
+describe('useFuse', () => {
+  it('should be defined', () => {
+    expect(useFuse).toBeDefined()
+  })
+
+  it('returns results for a static collection', () => {
+    const data = ['apple', 'banana', 'cherry']
+    const { results } = useFuse('apple', data)
+    expect(results.value.length).toBeGreaterThan(0)
+    expect(results.value[0].item).toBe('apple')
+  })
+
+  it('reacts to reactive query changes', async () => {
+    const query = deepRef('apple')
+    const data = ['apple', 'banana', 'cherry']
+    const { results } = useFuse(query, data)
+    expect(results.value[0].item).toBe('apple')
+    query.value = 'banana'
+    await nextTick()
+    expect(results.value[0].item).toBe('banana')
+  })
+
+  it('reacts to reactive collection changes', async () => {
+    const query = deepRef('mango')
+    const data = deepRef(['apple', 'banana', 'cherry'])
+    const { results } = useFuse(query, data, {
+      fuseOptions: { threshold: 0.3 },
+    })
+
+    // Initially 'mango' is not in the collection
+    expect(results.value.length).toBe(0)
+
+    // Add 'mango' to the collection
+    data.value = [...data.value, 'mango']
+    await nextTick()
+
+    // Results should now include 'mango'
+    expect(results.value.length).toBeGreaterThan(0)
+    expect(results.value[0].item).toBe('mango')
+  })
+
+  it('matchAllWhenSearchEmpty returns all items', () => {
+    const data = ['apple', 'banana', 'cherry']
+    const { results } = useFuse('', data, { matchAllWhenSearchEmpty: true })
+    expect(results.value.length).toBe(3)
+  })
+
+  it('matchAllWhenSearchEmpty reacts to reactive collection changes', async () => {
+    const query = deepRef('')
+    const data = deepRef(['apple', 'banana', 'cherry'])
+    const { results } = useFuse(query, data, { matchAllWhenSearchEmpty: true })
+
+    expect(results.value.length).toBe(3)
+
+    data.value = [...data.value, 'mango']
+    await nextTick()
+
+    expect(results.value.length).toBe(4)
+    expect(results.value.map(r => r.item)).toContain('mango')
+  })
+
+  it('respects resultLimit option', () => {
+    const data = ['apple', 'apricot', 'avocado']
+    const { results } = useFuse('a', data, { resultLimit: 2 })
+    expect(results.value.length).toBeLessThanOrEqual(2)
+  })
+})

--- a/packages/integrations/useFuse/index.ts
+++ b/packages/integrations/useFuse/index.ts
@@ -1,7 +1,7 @@
 import type { FuseResult, IFuseOptions } from 'fuse.js'
 import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue'
 import Fuse from 'fuse.js'
-import { computed, shallowRef, toValue, watch } from 'vue'
+import { computed, shallowRef, toValue, triggerRef, watch } from 'vue'
 
 export type FuseOptions<T> = IFuseOptions<T>
 export interface UseFuseOptions<T> {
@@ -37,7 +37,10 @@ export function useFuse<DataItem>(
 
   watch(
     () => toValue(data),
-    (newData) => { fuse.value.setCollection(newData) },
+    (newData) => {
+      fuse.value.setCollection(newData)
+      triggerRef(fuse)
+    },
     { deep: true },
   )
 


### PR DESCRIPTION
Closes #5477

## Root Cause

`useFuse` stores the `Fuse` instance in a `shallowRef`. When the `data` collection changes, the existing `watch` correctly calls `fuse.value.setCollection(newData)`, but this only mutates the internal state of the Fuse object — it does **not** change the `shallowRef`'s identity. Since `shallowRef` tracks by reference equality, the `results` computed never sees a dependency change and never re-runs.

## Fix

After calling `setCollection`, call `triggerRef(fuse)` to manually notify Vue that the shallow ref's dependencies should re-evaluate. This is exactly the workaround the issue author identified, now applied internally.

```diff
-import { computed, shallowRef, toValue, watch } from 'vue'
+import { computed, shallowRef, toValue, triggerRef, watch } from 'vue'

 watch(
   () => toValue(data),
   (newData) => {
     fuse.value.setCollection(newData)
+    triggerRef(fuse)
   },
   { deep: true },
 )
```

## Tests

Added `packages/integrations/useFuse/index.test.ts` with 7 test cases covering:

- Basic search on a static collection
- Reactive query changes
- **Reactive collection changes** (the failing case — confirms the bug and fix)
- `matchAllWhenSearchEmpty` static and reactive
- `resultLimit` option

Verified:
- **With fix**: all 7 tests pass
- **Without fix** (`git stash`): test `reacts to reactive collection changes` fails with `expected 0 to be greater than 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)