### PR TITLE
fix(useRefHistory): clone lastRawValue for shouldCommit comparison

### DIFF
--- a/packages/core/useRefHistory/index.browser.test.ts
+++ b/packages/core/useRefHistory/index.browser.test.ts
@@ -323,6 +323,31 @@ describe('useRefHistory - sync', () => {
     expect(history.value.length).toBe(3)
     expect(history.value[0].snapshot).toBe(4)
   })
+
+  it('sync: shouldCommit with deep should receive cloned old value', () => {
+    const v = deepRef({ foo: 1 })
+    const { history } = useRefHistory(v, {
+      flush: 'sync',
+      deep: true,
+      shouldCommit: (oldValue: { foo: number } | undefined, newValue: { foo: number }) => {
+        if (oldValue === undefined)
+          return true
+        return oldValue.foo !== newValue.foo
+      },
+    })
+
+    expect(history.value.length).toBe(1)
+
+    v.value.foo = 2
+    expect(history.value.length).toBe(2)
+
+    v.value.foo = 3
+    expect(history.value.length).toBe(3)
+
+    // same value should not commit
+    v.value.foo = 3
+    expect(history.value.length).toBe(3)
+  })
 })
 
 describe('useRefHistory - pre', () => {
@@ -628,5 +653,32 @@ describe('useRefHistory - pre', () => {
     await nextTick()
     expect(history.value.length).toBe(3)
     expect(history.value[0].snapshot).toBe(4)
+  })
+
+  it('pre: shouldCommit with deep should receive cloned old value', async () => {
+    const v = deepRef({ foo: 1 })
+    const { history } = useRefHistory(v, {
+      deep: true,
+      shouldCommit: (oldValue: { foo: number } | undefined, newValue: { foo: number }) => {
+        if (oldValue === undefined)
+          return true
+        return oldValue.foo !== newValue.foo
+      },
+    })
+
+    expect(history.value.length).toBe(1)
+
+    v.value.foo = 2
+    await nextTick()
+    expect(history.value.length).toBe(2)
+
+    v.value.foo = 3
+    await nextTick()
+    expect(history.value.length).toBe(3)
+
+    // same value should not commit
+    v.value.foo = 3
+    await nextTick()
+    expect(history.value.length).toBe(3)
   })
 })

--- a/packages/core/useRefHistory/index.ts
+++ b/packages/core/useRefHistory/index.ts
@@ -3,6 +3,7 @@ import type { Ref } from 'vue'
 import type { CloneFn } from '../useCloned'
 import type { UseManualRefHistoryReturn } from '../useManualRefHistory'
 import { pausableFilter, watchIgnorable } from '@vueuse/shared'
+import { cloneFnJSON } from '../useCloned'
 import { useManualRefHistory } from '../useManualRefHistory'
 
 export interface UseRefHistoryOptions<Raw, Serialized = Raw> extends ConfigurableEventFilter, ConfigurableFlush {
@@ -100,8 +101,14 @@ export function useRefHistory<Raw, Serialized = Raw>(
     isActive: isTracking,
   } = pausableFilter(eventFilter)
 
-  // Track the last raw value for shouldCommit comparison
-  let lastRawValue: Raw | undefined = source.value
+  const cloneOption = options.clone || deep
+  const _cloneRaw: (v: Raw) => Raw = cloneOption
+    ? typeof cloneOption === 'function'
+      ? cloneOption
+      : cloneFnJSON
+    : v => v
+
+  let lastRawValue: Raw | undefined = _cloneRaw(source.value)
 
   const {
     ignoreUpdates,
@@ -126,11 +133,11 @@ export function useRefHistory<Raw, Serialized = Raw>(
 
     ignoreUpdates(() => {
       source.value = value
-      lastRawValue = value
+      lastRawValue = _cloneRaw(value)
     })
   }
 
-  const manualHistory = useManualRefHistory(source, { ...options, clone: options.clone || deep, setSource })
+  const manualHistory = useManualRefHistory(source, { ...options, clone: cloneOption, setSource })
 
   const { clear, commit: manualCommit } = manualHistory
 
@@ -143,7 +150,7 @@ export function useRefHistory<Raw, Serialized = Raw>(
     if (!shouldCommit(lastRawValue, source.value))
       return
 
-    lastRawValue = source.value
+    lastRawValue = _cloneRaw(source.value)
     manualCommit()
   }
 

--- a/packages/core/useRefHistory/index.ts
+++ b/packages/core/useRefHistory/index.ts
@@ -147,10 +147,11 @@ export function useRefHistory<Raw, Serialized = Raw>(
     // so we do not trigger an extra commit in the async watcher
     ignorePrevAsyncUpdates()
 
-    if (!shouldCommit(lastRawValue, _cloneRaw(source.value)))
+    const newValue = _cloneRaw(source.value)
+    if (!shouldCommit(lastRawValue, newValue))
       return
 
-    lastRawValue = _cloneRaw(source.value)
+    lastRawValue = newValue
     manualCommit()
   }
 

--- a/packages/core/useRefHistory/index.ts
+++ b/packages/core/useRefHistory/index.ts
@@ -147,7 +147,7 @@ export function useRefHistory<Raw, Serialized = Raw>(
     // so we do not trigger an extra commit in the async watcher
     ignorePrevAsyncUpdates()
 
-    if (!shouldCommit(lastRawValue, source.value))
+    if (!shouldCommit(lastRawValue, _cloneRaw(source.value)))
       return
 
     lastRawValue = _cloneRaw(source.value)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Confirm that this PR is based on your own understanding and review of the project, not solely generated or summarized by AI tools.

> **Note**: If this PR is deemed to be primarily generated by AI tools, it may be closed.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Fixes #4985

`shouldCommit` receives same object reference for both `oldValue` and `newValue` when `deep: true`.
This is because `lastRawValue` holds direct reference to `source.value`.

Clone `lastRawValue` at 3 assignment sites using same clone logic as `useManualRefHistory`.

Added tests for `shouldCommit` + `deep: true` with object values (both `sync` and `pre` flush).

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
