### PR TITLE
docs(useAsyncState): correct `isReady` description to match actual behavior

### DIFF
--- a/packages/core/useAsyncState/index.md
+++ b/packages/core/useAsyncState/index.md
@@ -22,14 +22,14 @@ const { state, isReady, isLoading, error } = useAsyncState(
 
 ### Return Values
 
-| Property           | Description                                         |
-| ------------------ | --------------------------------------------------- |
-| `state`            | The result of the async function                    |
-| `isReady`          | `true` when the promise has resolved at least once  |
-| `isLoading`        | `true` while the promise is pending                 |
-| `error`            | The error if the promise was rejected               |
-| `execute`          | Re-execute the async function with optional delay   |
-| `executeImmediate` | Re-execute immediately (shorthand for `execute(0)`) |
+| Property           | Description                                                                                                                    |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| `state`            | The result of the async function                                                                                               |
+| `isReady`          | `true` when the latest execution has resolved successfully. Reset to `false` on each execution and stays `false` if it rejects |
+| `isLoading`        | `true` while the promise is pending                                                                                            |
+| `error`            | The error if the promise was rejected                                                                                          |
+| `execute`          | Re-execute the async function with optional delay                                                                              |
+| `executeImmediate` | Re-execute immediately (shorthand for `execute(0)`)                                                                            |
 
 ### Awaiting the Result
 

--- a/packages/core/useAsyncState/index.test.ts
+++ b/packages/core/useAsyncState/index.test.ts
@@ -56,6 +56,23 @@ describe('useAsyncState', () => {
     expect(isReady.value).toBeTruthy()
   })
 
+  it('should reset isReady on re-execution', async () => {
+    const { execute, isReady } = useAsyncState(p1, 0, { immediate: false })
+    await execute()
+    expect(isReady.value).toBeTruthy()
+    const promise = execute()
+    expect(isReady.value).toBeFalsy()
+    await promise
+    expect(isReady.value).toBeTruthy()
+  })
+
+  it('should keep isReady false when the promise rejects', async () => {
+    const { execute, isReady, isLoading } = useAsyncState(p2, '0', { immediate: false })
+    await execute()
+    expect(isReady.value).toBeFalsy()
+    expect(isLoading.value).toBeFalsy()
+  })
+
   it('should work with error', async () => {
     const { execute, error } = useAsyncState(p2, '0', { immediate: false })
     expect(error.value).toBeUndefined()


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Confirm that this PR is based on your own understanding and review of the project, not solely generated or summarized by AI tools.

### Description

fixes #5499

The docs describe `isReady` as "`true` when the promise has resolved at least once", but the actual behavior is: `execute()` resets it to `false` on every execution, and it stays `false` when the promise rejects — i.e. "the latest execution has resolved successfully". The implementation has always worked this way; the inaccurate wording was introduced by the docs sync in 23921315.

This PR corrects the description and adds tests locking in the current behavior.

No behavior change — docs and tests only.
