### PR TITLE
fix: accept array template ref bound to v-for as observer target

### DIFF
--- a/packages/core/unrefElement/index.ts
+++ b/packages/core/unrefElement/index.ts
@@ -5,6 +5,7 @@ export type VueInstance = ComponentPublicInstance
 export type MaybeElementRef<T extends MaybeElement = MaybeElement> = MaybeRef<T>
 export type MaybeComputedElementRef<T extends MaybeElement = MaybeElement> = MaybeRefOrGetter<T>
 export type MaybeElement = HTMLElement | SVGElement | VueInstance | undefined | null
+export type MaybeComputedElementRefOrArray<T extends MaybeElement = MaybeElement> = MaybeComputedElementRef<T> | MaybeComputedElementRef<T>[] | MaybeRefOrGetter<T[] | null>
 
 export type UnRefElementReturn<T extends MaybeElement = MaybeElement> = T extends VueInstance ? Exclude<MaybeElement, VueInstance> : T | undefined
 

--- a/packages/core/useIntersectionObserver/index.browser.test.ts
+++ b/packages/core/useIntersectionObserver/index.browser.test.ts
@@ -1,5 +1,6 @@
+import type { ShallowRef } from 'vue'
 import type { UseIntersectionObserverReturn } from '.'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest'
 import { cleanup } from 'vitest-browser-vue'
 import { page } from 'vitest/browser'
 import { defineComponent, shallowRef, toValue, useTemplateRef } from 'vue'
@@ -8,6 +9,11 @@ import { useIntersectionObserver } from '.'
 describe('useIntersectionObserver', () => {
   beforeEach(() => {
     window.scrollTo(0, 0)
+  })
+
+  it('accepts an array template ref bound to v-for as target', () => {
+    expectTypeOf<Readonly<ShallowRef<HTMLElement[] | null>>>()
+      .toExtend<Parameters<typeof useIntersectionObserver>[0]>()
   })
 
   const expectFunctionHasNotBeenCalled = async (callbackMock: any) => {

--- a/packages/core/useIntersectionObserver/index.ts
+++ b/packages/core/useIntersectionObserver/index.ts
@@ -2,7 +2,7 @@ import type { Pausable } from '@vueuse/shared'
 import type { MaybeRefOrGetter } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
 import type { Supportable } from '../types'
-import type { MaybeComputedElementRef, MaybeElement } from '../unrefElement'
+import type { MaybeComputedElementRef, MaybeComputedElementRefOrArray } from '../unrefElement'
 import { noop, notNullish, toArray, tryOnScopeDispose } from '@vueuse/shared'
 import { computed, shallowRef, toValue, watch } from 'vue'
 import { defaultWindow } from '../_configurable'
@@ -47,7 +47,7 @@ export interface UseIntersectionObserverReturn extends Supportable, Pausable {
  * @param options
  */
 export function useIntersectionObserver(
-  target: MaybeComputedElementRef | MaybeRefOrGetter<MaybeElement[]> | MaybeComputedElementRef[],
+  target: MaybeComputedElementRefOrArray,
   callback: IntersectionObserverCallback,
   options: UseIntersectionObserverOptions = {},
 ): UseIntersectionObserverReturn {

--- a/packages/core/useMutationObserver/index.browser.test.ts
+++ b/packages/core/useMutationObserver/index.browser.test.ts
@@ -1,10 +1,16 @@
-import { describe, expect, it, vi } from 'vitest'
+import type { ShallowRef } from 'vue'
+import { describe, expect, expectTypeOf, it, vi } from 'vitest'
 import { computed, ref as deepRef, nextTick } from 'vue'
 import { useMutationObserver } from './index'
 
 describe('useMutationObserver', () => {
   it('should be defined', () => {
     expect(useMutationObserver).toBeDefined()
+  })
+
+  it('accepts an array template ref bound to v-for as target', () => {
+    expectTypeOf<Readonly<ShallowRef<HTMLElement[] | null>>>()
+      .toExtend<Parameters<typeof useMutationObserver>[0]>()
   })
 
   it('should work with attributes', async () => {

--- a/packages/core/useMutationObserver/index.ts
+++ b/packages/core/useMutationObserver/index.ts
@@ -1,7 +1,6 @@
-import type { MaybeRefOrGetter } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
 import type { Supportable } from '../types'
-import type { MaybeComputedElementRef, MaybeElement } from '../unrefElement'
+import type { MaybeComputedElementRefOrArray } from '../unrefElement'
 import { notNullish, toArray, tryOnScopeDispose } from '@vueuse/shared'
 import { computed, toValue, watch } from 'vue'
 import { defaultWindow } from '../_configurable'
@@ -25,7 +24,7 @@ export interface UseMutationObserverReturn extends Supportable {
  * @param options
  */
 export function useMutationObserver(
-  target: MaybeComputedElementRef | MaybeComputedElementRef[] | MaybeRefOrGetter<MaybeElement[]>,
+  target: MaybeComputedElementRefOrArray,
   callback: MutationCallback,
   options: UseMutationObserverOptions = {},
 ): UseMutationObserverReturn {

--- a/packages/core/useResizeObserver/index.test.ts
+++ b/packages/core/useResizeObserver/index.test.ts
@@ -1,0 +1,10 @@
+import type { ShallowRef } from 'vue'
+import type { useResizeObserver } from './index'
+import { describe, expectTypeOf, it } from 'vitest'
+
+describe('useResizeObserver', () => {
+  it('accepts an array template ref bound to v-for as target', () => {
+    expectTypeOf<Readonly<ShallowRef<HTMLElement[] | null>>>()
+      .toExtend<Parameters<typeof useResizeObserver>[0]>()
+  })
+})

--- a/packages/core/useResizeObserver/index.ts
+++ b/packages/core/useResizeObserver/index.ts
@@ -1,7 +1,6 @@
-import type { MaybeRefOrGetter } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
 import type { Supportable } from '../types'
-import type { MaybeComputedElementRef, MaybeElement } from '../unrefElement'
+import type { MaybeComputedElementRefOrArray } from '../unrefElement'
 import { tryOnScopeDispose } from '@vueuse/shared'
 import { computed, toValue, watch } from 'vue'
 import { defaultWindow } from '../_configurable'
@@ -51,7 +50,7 @@ export interface UseResizeObserverReturn extends Supportable {
  * @param options
  */
 export function useResizeObserver(
-  target: MaybeComputedElementRef | MaybeComputedElementRef[] | MaybeRefOrGetter<MaybeElement[]>,
+  target: MaybeComputedElementRefOrArray,
   callback: globalThis.ResizeObserverCallback,
   options: UseResizeObserverOptions = {},
 ): UseResizeObserverReturn {

--- a/test/__snapshots__/tsnapi/@vueuse/core/index.snapshot.d.ts
+++ b/test/__snapshots__/tsnapi/@vueuse/core/index.snapshot.d.ts
@@ -1543,6 +1543,7 @@ export type KeyModifier = 'Alt' | 'AltGraph' | 'CapsLock' | 'Control' | 'Fn' | '
 export type KeyPredicate = (_: KeyboardEvent) => boolean;
 export type KeyStrokeEventName = 'keydown' | 'keypress' | 'keyup';
 export type MaybeComputedElementRef<T extends MaybeElement = MaybeElement> = MaybeRefOrGetter<T>;
+export type MaybeComputedElementRefOrArray<T extends MaybeElement = MaybeElement> = MaybeComputedElementRef<T> | MaybeComputedElementRef<T>[] | MaybeRefOrGetter<T[] | null>;
 export type MaybeElement = HTMLElement | SVGElement | VueInstance | undefined | null;
 export type MaybeElementRef<T extends MaybeElement = MaybeElement> = MaybeRef<T>;
 export type MousePressedOptions = UseMousePressedOptions;
@@ -1851,7 +1852,7 @@ export declare function useGeolocation(_?: UseGeolocationOptions): UseGeolocatio
 export declare function useIdle(_?: number, _?: UseIdleOptions): UseIdleReturn;
 export declare function useImage<Shallow extends true>(_: MaybeRefOrGetter<UseImageOptions>, _?: UseAsyncStateOptions<Shallow>): UseImageReturn;
 export declare function useInfiniteScroll<T extends InfiniteScrollElement>(_: MaybeRefOrGetter<T>, _: (_: UnwrapNestedRefs<UseScrollReturn>) => Awaitable<void>, _?: UseInfiniteScrollOptions<T>): UseInfiniteScrollReturn;
-export declare function useIntersectionObserver(_: MaybeComputedElementRef | MaybeRefOrGetter<MaybeElement[]> | MaybeComputedElementRef[], _: IntersectionObserverCallback, _?: UseIntersectionObserverOptions): UseIntersectionObserverReturn;
+export declare function useIntersectionObserver(_: MaybeComputedElementRefOrArray, _: IntersectionObserverCallback, _?: UseIntersectionObserverOptions): UseIntersectionObserverReturn;
 export declare function useKeyModifier<Initial extends boolean | null>(_: KeyModifier, _?: UseModifierOptions<Initial>): UseKeyModifierReturn<Initial>;
 export declare function useLocalStorage(_: MaybeRefOrGetter<string>, _: MaybeRefOrGetter<string>, _?: UseStorageOptions<string>): RemovableRef<string>;
 export declare function useLocalStorage(_: MaybeRefOrGetter<string>, _: MaybeRefOrGetter<boolean>, _?: UseStorageOptions<boolean>): RemovableRef<boolean>;
@@ -1882,7 +1883,7 @@ export declare function useMouseInElement(_?: MaybeElementRef, _?: MouseInElemen
   stop: () => void;
 };
 export declare function useMousePressed(_?: UseMousePressedOptions): UseMousePressedReturn;
-export declare function useMutationObserver(_: MaybeComputedElementRef | MaybeComputedElementRef[] | MaybeRefOrGetter<MaybeElement[]>, _: MutationCallback, _?: UseMutationObserverOptions): UseMutationObserverReturn;
+export declare function useMutationObserver(_: MaybeComputedElementRefOrArray, _: MutationCallback, _?: UseMutationObserverOptions): UseMutationObserverReturn;
 export declare function useNavigatorLanguage(_?: UseNavigatorLanguageOptions): UseNavigatorLanguageReturn;
 export declare function useNetwork(_?: UseNetworkOptions): UseNetworkReturn;
 export declare function useNow(_?: UseNowOptions<false>): ShallowRef<Date>;
@@ -1916,7 +1917,7 @@ export declare function usePrevious<T>(_: MaybeRefOrGetter<T>): Readonly<Shallow
 export declare function usePrevious<T>(_: MaybeRefOrGetter<T>, _: T): Readonly<ShallowRef<T>>;
 export declare function useRafFn(_: (_: UseRafFnCallbackArguments) => void, _?: UseRafFnOptions): Pausable;
 export declare function useRefHistory<Raw, Serialized = Raw>(_: Ref<Raw>, _?: UseRefHistoryOptions<Raw, Serialized>): UseRefHistoryReturn<Raw, Serialized>;
-export declare function useResizeObserver(_: MaybeComputedElementRef | MaybeComputedElementRef[] | MaybeRefOrGetter<MaybeElement[]>, _: globalThis.ResizeObserverCallback, _?: UseResizeObserverOptions): UseResizeObserverReturn;
+export declare function useResizeObserver(_: MaybeComputedElementRefOrArray, _: globalThis.ResizeObserverCallback, _?: UseResizeObserverOptions): UseResizeObserverReturn;
 export declare function useScreenOrientation(_?: UseScreenOrientationOptions): UseScreenOrientationReturn;
 export declare function useScreenSafeArea(): UseScreenSafeAreaReturn;
 export declare function useScriptTag(_: MaybeRefOrGetter<string>, _?: (_: HTMLScriptElement) => void, _?: UseScriptTagOptions): UseScriptTagReturn;


### PR DESCRIPTION
Fixes #4712

`useTemplateRef` on an element rendered with `v-for` is typed as
`Readonly<ShallowRef<HTMLElement[] | null>>` in Vue 3.5. Passing that into
`useIntersectionObserver` doesn't type-check, because the `target` type didn't
allow `null` inside the array ref:

```ts
const items = useTemplateRef('items') // ShallowRef<HTMLElement[] | null>
useIntersectionObserver(items, () => {}) // type error
```

`useResizeObserver` and `useMutationObserver` share the same `target` type, so
they had it too. Rather than patch one signature, I moved the union into a
`MaybeComputedElementRefOrArray` type in `unrefElement` and reused it across all
three. It allows a `null` array value, which is what a `v-for` template ref
produces.

The runtime stays the same: these composables already drop nullish entries via
`toArray(...).map(unrefElement).filter(notNullish)`, so only the type needed
widening.
