### PR TITLE
feat(useDebounceFn): add leading option for immediate first execution

### DIFF
--- a/packages/shared/useDebounceFn/index.browser.test.ts
+++ b/packages/shared/useDebounceFn/index.browser.test.ts
@@ -112,17 +112,17 @@ describe('useDebounceFn', () => {
     expect(debounced.isPending.value).toBe(false)
   })
 
-  it('should execute immediately when debounceInitialExecution is false', async () => {
+  it('should execute immediately when leading is false', async () => {
     const fn = vi.fn()
-    const debounced = useDebounceFn(fn, 100, { debounceInitialExecution: false })
+    const debounced = useDebounceFn(fn, 100, { leading: false })
 
     debounced()
     expect(fn).toHaveBeenCalledTimes(1)
   })
 
-  it('should debounce subsequent calls when debounceInitialExecution is false', async () => {
+  it('should debounce subsequent calls when leading is false', async () => {
     const fn = vi.fn()
-    const debounced = useDebounceFn(fn, 100, { debounceInitialExecution: false })
+    const debounced = useDebounceFn(fn, 100, { leading: false })
 
     // First call executes immediately
     debounced()
@@ -136,9 +136,9 @@ describe('useDebounceFn', () => {
     expect(fn).toHaveBeenCalledTimes(2)
   })
 
-  it('should debounce by default (debounceInitialExecution defaults to true)', async () => {
+  it('should debounce by default (leading defaults to true)', async () => {
     const fn = vi.fn()
-    const debounced = useDebounceFn(fn, 100, { debounceInitialExecution: true })
+    const debounced = useDebounceFn(fn, 100, { leading: true })
 
     debounced()
     expect(fn).not.toHaveBeenCalled()
@@ -147,9 +147,9 @@ describe('useDebounceFn', () => {
     expect(fn).toHaveBeenCalledTimes(1)
   })
 
-  it('should reset debounceInitialExecution behavior after cancel', async () => {
+  it('should reset leading behavior after cancel', async () => {
     const fn = vi.fn()
-    const debounced = useDebounceFn(fn, 100, { debounceInitialExecution: false })
+    const debounced = useDebounceFn(fn, 100, { leading: false })
 
     // First call executes immediately
     debounced()
@@ -195,10 +195,10 @@ describe('useDebounceFn', () => {
     await expect(promise).rejects.toBeUndefined()
   })
 
-  it('should combine debounceInitialExecution with maxWait', async () => {
+  it('should combine leading with maxWait', async () => {
     const fn = vi.fn()
     const debounced = useDebounceFn(fn, 100, {
-      debounceInitialExecution: false,
+      leading: false,
       maxWait: 200,
     })
 

--- a/packages/shared/useDebounceFn/index.browser.test.ts
+++ b/packages/shared/useDebounceFn/index.browser.test.ts
@@ -112,17 +112,17 @@ describe('useDebounceFn', () => {
     expect(debounced.isPending.value).toBe(false)
   })
 
-  it('should execute immediately when leading is false', async () => {
+  it('should execute immediately when leading is true', async () => {
     const fn = vi.fn()
-    const debounced = useDebounceFn(fn, 100, { leading: false })
+    const debounced = useDebounceFn(fn, 100, { leading: true })
 
     debounced()
     expect(fn).toHaveBeenCalledTimes(1)
   })
 
-  it('should debounce subsequent calls when leading is false', async () => {
+  it('should debounce subsequent calls when leading is true', async () => {
     const fn = vi.fn()
-    const debounced = useDebounceFn(fn, 100, { leading: false })
+    const debounced = useDebounceFn(fn, 100, { leading: true })
 
     // First call executes immediately
     debounced()
@@ -136,9 +136,9 @@ describe('useDebounceFn', () => {
     expect(fn).toHaveBeenCalledTimes(2)
   })
 
-  it('should debounce by default (leading defaults to true)', async () => {
+  it('should debounce by default (leading defaults to false)', async () => {
     const fn = vi.fn()
-    const debounced = useDebounceFn(fn, 100, { leading: true })
+    const debounced = useDebounceFn(fn, 100, { leading: false })
 
     debounced()
     expect(fn).not.toHaveBeenCalled()
@@ -149,7 +149,7 @@ describe('useDebounceFn', () => {
 
   it('should reset leading behavior after cancel', async () => {
     const fn = vi.fn()
-    const debounced = useDebounceFn(fn, 100, { leading: false })
+    const debounced = useDebounceFn(fn, 100, { leading: true })
 
     // First call executes immediately
     debounced()
@@ -198,7 +198,7 @@ describe('useDebounceFn', () => {
   it('should combine leading with maxWait', async () => {
     const fn = vi.fn()
     const debounced = useDebounceFn(fn, 100, {
-      leading: false,
+      leading: true,
       maxWait: 200,
     })
 

--- a/packages/shared/useDebounceFn/index.md
+++ b/packages/shared/useDebounceFn/index.md
@@ -130,6 +130,39 @@ debouncedFn.flush()
 
 This is useful when you need to ensure the debounced function runs right away, for example, before navigating away from a page or submitting a form.
 
+## Immediate Initial Execution
+
+By default, even the first call to a debounced function is delayed. If you want the first call to execute immediately (without delay) and only debounce subsequent calls, set `debounceInitialExecution` to `false`.
+
+```ts
+import { useDebounceFn, useEventListener } from '@vueuse/core'
+
+const debouncedFn = useDebounceFn(() => {
+  // do something
+}, 1000, { debounceInitialExecution: false })
+
+// The first call executes immediately
+debouncedFn()
+
+// Subsequent calls within the debounce window are delayed
+debouncedFn() // This will be debounced
+```
+
+This is useful for scenarios like search-as-you-type, where you want the initial query to execute right away but debounce rapid subsequent keystrokes.
+
+```ts
+import { useDebounceFn } from '@vueuse/core'
+
+const search = useDebounceFn(async (query: string) => {
+  const results = await fetchSearchResults(query)
+  updateResults(results)
+}, 300, { debounceInitialExecution: false })
+
+// First keystroke triggers immediate search
+// Rapid subsequent keystrokes are debounced at 300ms
+watch(searchInput, value => search(value))
+```
+
 ## Recommended Reading
 
 - [**Debounce vs Throttle**: Definitive Visual Guide](https://kettanaito.com/blog/debounce-vs-throttle)

--- a/packages/shared/useDebounceFn/index.md
+++ b/packages/shared/useDebounceFn/index.md
@@ -132,14 +132,14 @@ This is useful when you need to ensure the debounced function runs right away, f
 
 ## Immediate Initial Execution
 
-By default, even the first call to a debounced function is delayed. If you want the first call to execute immediately (without delay) and only debounce subsequent calls, set `leading` to `false`.
+By default, even the first call to a debounced function is delayed. If you want the first call to execute immediately (without delay) and only debounce subsequent calls, set `leading` to `true`.
 
 ```ts
 import { useDebounceFn, useEventListener } from '@vueuse/core'
 
 const debouncedFn = useDebounceFn(() => {
   // do something
-}, 1000, { leading: false })
+}, 1000, { leading: true })
 
 // The first call executes immediately
 debouncedFn()
@@ -156,7 +156,7 @@ import { useDebounceFn } from '@vueuse/core'
 const search = useDebounceFn(async (query: string) => {
   const results = await fetchSearchResults(query)
   updateResults(results)
-}, 300, { leading: false })
+}, 300, { leading: true })
 
 // First keystroke triggers immediate search
 // Rapid subsequent keystrokes are debounced at 300ms

--- a/packages/shared/useDebounceFn/index.md
+++ b/packages/shared/useDebounceFn/index.md
@@ -132,14 +132,14 @@ This is useful when you need to ensure the debounced function runs right away, f
 
 ## Immediate Initial Execution
 
-By default, even the first call to a debounced function is delayed. If you want the first call to execute immediately (without delay) and only debounce subsequent calls, set `debounceInitialExecution` to `false`.
+By default, even the first call to a debounced function is delayed. If you want the first call to execute immediately (without delay) and only debounce subsequent calls, set `leading` to `false`.
 
 ```ts
 import { useDebounceFn, useEventListener } from '@vueuse/core'
 
 const debouncedFn = useDebounceFn(() => {
   // do something
-}, 1000, { debounceInitialExecution: false })
+}, 1000, { leading: false })
 
 // The first call executes immediately
 debouncedFn()
@@ -156,7 +156,7 @@ import { useDebounceFn } from '@vueuse/core'
 const search = useDebounceFn(async (query: string) => {
   const results = await fetchSearchResults(query)
   updateResults(results)
-}, 300, { debounceInitialExecution: false })
+}, 300, { leading: false })
 
 // First keystroke triggers immediate search
 // Rapid subsequent keystrokes are debounced at 300ms

--- a/packages/shared/useDebounceFn/index.test.ts
+++ b/packages/shared/useDebounceFn/index.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useDebounceFn } from './index'
+
+describe('useDebounceFn', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('should be defined', () => {
+    expect(useDebounceFn).toBeDefined()
+  })
+
+  it('should debounce the function execution', async () => {
+    const fn = vi.fn()
+    const debounced = useDebounceFn(fn, 100)
+
+    debounced()
+    expect(fn).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(50)
+    expect(fn).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(50)
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('should reset the debounce timer on subsequent calls', async () => {
+    const fn = vi.fn()
+    const debounced = useDebounceFn(fn, 100)
+
+    debounced()
+    await vi.advanceTimersByTimeAsync(50)
+    debounced()
+    await vi.advanceTimersByTimeAsync(50)
+    expect(fn).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(50)
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('should pass arguments to the debounced function', async () => {
+    const fn = vi.fn()
+    const debounced = useDebounceFn(fn, 100)
+
+    debounced('a', 'b')
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(fn).toHaveBeenCalledWith('a', 'b')
+  })
+
+  it('should use default delay of 200ms', async () => {
+    const fn = vi.fn()
+    const debounced = useDebounceFn(fn)
+
+    debounced()
+    await vi.advanceTimersByTimeAsync(100)
+    expect(fn).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(100)
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('should return a promise that resolves with the function result', async () => {
+    const fn = vi.fn(() => 'result')
+    const debounced = useDebounceFn(fn, 100)
+
+    const promise = debounced()
+    await vi.advanceTimersByTimeAsync(100)
+    const result = await promise
+
+    expect(result).toBe('result')
+  })
+
+  it('should expose isPending ref', async () => {
+    const fn = vi.fn()
+    const debounced = useDebounceFn(fn, 100)
+
+    expect(debounced.isPending.value).toBe(false)
+
+    debounced()
+    expect(debounced.isPending.value).toBe(true)
+
+    await vi.advanceTimersByTimeAsync(100)
+    expect(debounced.isPending.value).toBe(false)
+  })
+
+  it('should support cancel', async () => {
+    const fn = vi.fn()
+    const debounced = useDebounceFn(fn, 100)
+
+    debounced()
+    debounced.cancel()
+
+    await vi.advanceTimersByTimeAsync(200)
+    expect(fn).not.toHaveBeenCalled()
+    expect(debounced.isPending.value).toBe(false)
+  })
+
+  it('should support flush', async () => {
+    const fn = vi.fn()
+    const debounced = useDebounceFn(fn, 100)
+
+    debounced()
+    expect(fn).not.toHaveBeenCalled()
+
+    debounced.flush()
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(debounced.isPending.value).toBe(false)
+  })
+
+  it('should execute immediately when debounceInitialExecution is false', async () => {
+    const fn = vi.fn()
+    const debounced = useDebounceFn(fn, 100, { debounceInitialExecution: false })
+
+    debounced()
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('should debounce subsequent calls when debounceInitialExecution is false', async () => {
+    const fn = vi.fn()
+    const debounced = useDebounceFn(fn, 100, { debounceInitialExecution: false })
+
+    // First call executes immediately
+    debounced()
+    expect(fn).toHaveBeenCalledTimes(1)
+
+    // Second call should be debounced
+    debounced()
+    expect(fn).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(100)
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it('should debounce by default (debounceInitialExecution defaults to true)', async () => {
+    const fn = vi.fn()
+    const debounced = useDebounceFn(fn, 100, { debounceInitialExecution: true })
+
+    debounced()
+    expect(fn).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(100)
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('should reset debounceInitialExecution behavior after cancel', async () => {
+    const fn = vi.fn()
+    const debounced = useDebounceFn(fn, 100, { debounceInitialExecution: false })
+
+    // First call executes immediately
+    debounced()
+    expect(fn).toHaveBeenCalledTimes(1)
+
+    // Cancel pending state
+    debounced.cancel()
+
+    // After cancel, the function has already executed once,
+    // so subsequent calls should still be debounced
+    debounced()
+    expect(fn).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(100)
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it('should work with maxWait option', async () => {
+    const fn = vi.fn()
+    const debounced = useDebounceFn(fn, 100, { maxWait: 200 })
+
+    debounced()
+    await vi.advanceTimersByTimeAsync(50)
+    debounced()
+    await vi.advanceTimersByTimeAsync(50)
+    debounced()
+    await vi.advanceTimersByTimeAsync(50)
+    debounced()
+    await vi.advanceTimersByTimeAsync(50)
+
+    expect(fn).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(100)
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('should work with rejectOnCancel option', async () => {
+    const fn = vi.fn()
+    const debounced = useDebounceFn(fn, 100, { rejectOnCancel: true })
+
+    const promise = debounced()
+    debounced.cancel()
+
+    await expect(promise).rejects.toBeUndefined()
+  })
+
+  it('should combine debounceInitialExecution with maxWait', async () => {
+    const fn = vi.fn()
+    const debounced = useDebounceFn(fn, 100, {
+      debounceInitialExecution: false,
+      maxWait: 200,
+    })
+
+    // First call executes immediately
+    debounced()
+    expect(fn).toHaveBeenCalledTimes(1)
+
+    // Subsequent calls should be debounced
+    debounced()
+    await vi.advanceTimersByTimeAsync(50)
+    debounced()
+    await vi.advanceTimersByTimeAsync(50)
+
+    expect(fn).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(100)
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/shared/utils/filters.ts
+++ b/packages/shared/utils/filters.ts
@@ -46,6 +46,15 @@ export interface DebounceFilterOptions {
    * @default false
    */
   rejectOnCancel?: boolean
+
+  /**
+   * Whether to delay the initial execution as well.
+   * When `false`, the first call will be executed immediately without delay,
+   * and subsequent calls will be debounced as usual.
+   *
+   * @default true
+   */
+  debounceInitialExecution?: boolean
 }
 
 export type CancelablePromisifyFn<T extends AnyFn> = PromisifyFn<T> & {
@@ -93,6 +102,7 @@ export function debounceFilter(ms: MaybeRefOrGetter<number>, options: DebounceFi
   let lastRejector: AnyFn = noop
   let lastResolve: AnyFn = noop
   const _pending = shallowRef(false)
+  const _debounceInitialExecution = options.debounceInitialExecution !== false
 
   const _clearTimeout = (timer: TimerHandle) => {
     clearTimeout(timer)
@@ -101,6 +111,7 @@ export function debounceFilter(ms: MaybeRefOrGetter<number>, options: DebounceFi
   }
 
   let lastInvoker: () => void
+  let hasExecuted = false
 
   const handler = (invoke: AnyFn) => {
     const duration = toValue(ms)
@@ -110,6 +121,18 @@ export function debounceFilter(ms: MaybeRefOrGetter<number>, options: DebounceFi
       _clearTimeout(timer)
 
     if (duration <= 0 || (maxDuration !== undefined && maxDuration <= 0)) {
+      if (maxTimer) {
+        _clearTimeout(maxTimer)
+        maxTimer = undefined
+      }
+      _pending.value = false
+      return Promise.resolve(invoke())
+    }
+
+    // If debounceInitialExecution is false and this is the first call,
+    // execute immediately without delay
+    if (!_debounceInitialExecution && !hasExecuted) {
+      hasExecuted = true
       if (maxTimer) {
         _clearTimeout(maxTimer)
         maxTimer = undefined

--- a/packages/shared/utils/filters.ts
+++ b/packages/shared/utils/filters.ts
@@ -54,7 +54,7 @@ export interface DebounceFilterOptions {
    *
    * @default true
    */
-  debounceInitialExecution?: boolean
+  leading?: boolean
 }
 
 export type CancelablePromisifyFn<T extends AnyFn> = PromisifyFn<T> & {
@@ -102,7 +102,7 @@ export function debounceFilter(ms: MaybeRefOrGetter<number>, options: DebounceFi
   let lastRejector: AnyFn = noop
   let lastResolve: AnyFn = noop
   const _pending = shallowRef(false)
-  const _debounceInitialExecution = options.debounceInitialExecution !== false
+  const _leading = options.leading !== false
 
   const _clearTimeout = (timer: TimerHandle) => {
     clearTimeout(timer)
@@ -129,9 +129,9 @@ export function debounceFilter(ms: MaybeRefOrGetter<number>, options: DebounceFi
       return Promise.resolve(invoke())
     }
 
-    // If debounceInitialExecution is false and this is the first call,
+    // If leading is false and this is the first call,
     // execute immediately without delay
-    if (!_debounceInitialExecution && !hasExecuted) {
+    if (!_leading && !hasExecuted) {
       hasExecuted = true
       if (maxTimer) {
         _clearTimeout(maxTimer)

--- a/packages/shared/utils/filters.ts
+++ b/packages/shared/utils/filters.ts
@@ -48,11 +48,11 @@ export interface DebounceFilterOptions {
   rejectOnCancel?: boolean
 
   /**
-   * Whether to delay the initial execution as well.
-   * When `false`, the first call will be executed immediately without delay,
+   * Whether to execute on the leading edge.
+   * When `true`, the first call will be executed immediately without delay,
    * and subsequent calls will be debounced as usual.
    *
-   * @default true
+   * @default false
    */
   leading?: boolean
 }
@@ -102,7 +102,7 @@ export function debounceFilter(ms: MaybeRefOrGetter<number>, options: DebounceFi
   let lastRejector: AnyFn = noop
   let lastResolve: AnyFn = noop
   const _pending = shallowRef(false)
-  const _leading = options.leading !== false
+  const _leading = options.leading === true
 
   const _clearTimeout = (timer: TimerHandle) => {
     clearTimeout(timer)
@@ -129,9 +129,9 @@ export function debounceFilter(ms: MaybeRefOrGetter<number>, options: DebounceFi
       return Promise.resolve(invoke())
     }
 
-    // If leading is false and this is the first call,
-    // execute immediately without delay
-    if (!_leading && !hasExecuted) {
+    // If leading is true and this is the first call,
+    // execute immediately without delay (leading edge)
+    if (_leading && !hasExecuted) {
       hasExecuted = true
       if (maxTimer) {
         _clearTimeout(maxTimer)


### PR DESCRIPTION
Closes #4282

I wanted `useDebounceFn` to fire immediately on the first call for a search-as-you-type pattern, but it always delays even the first invocation. This PR adds a `leading` option that controls this.

When `leading: true`, the first call executes immediately on the leading edge, and subsequent calls are debounced as usual. Default is `false` (standard debounce behavior, nothing changes).

```ts
const search = useDebounceFn(fetchResults, 300, { leading: true })
// First keystroke -> immediate search
// Rapid typing -> debounced at 300ms
```

Also added 16 tests for `useDebounceFn` which previously had zero dedicated tests. Happy to adjust anything!