### PR TITLE
fix(useEventSource): reset autoReconnect retry budget after a successful reconnection

### DIFF
--- a/packages/core/useEventSource/index.browser.test.ts
+++ b/packages/core/useEventSource/index.browser.test.ts
@@ -175,4 +175,29 @@ describe('useEventSource', () => {
 
     expect(data.value).toBeNull()
   })
+
+  it('resets the autoReconnect retry budget after a successful reconnection', () => {
+    vi.useFakeTimers()
+
+    const onFailed = vi.fn()
+    const { eventSource } = useEventSource('https://localhost', [], {
+      autoReconnect: { retries: 3, delay: 100, onFailed },
+    })
+
+    // Three independent disconnect episodes, each immediately recovered by a
+    // successful reconnection. Since every reconnection succeeds, the retry
+    // budget should be refreshed each time and never run out.
+    for (let i = 0; i < 3; i++) {
+      const source = eventSource.value as unknown as MockEventSource
+      source.readyState = 2
+      source.onerror(new Event('error'))
+      vi.advanceTimersByTime(100)
+      const reconnected = eventSource.value as unknown as MockEventSource
+      reconnected.onopen(new Event('open'))
+    }
+
+    expect(onFailed).not.toHaveBeenCalled()
+
+    vi.useRealTimers()
+  })
 })

--- a/packages/core/useEventSource/index.ts
+++ b/packages/core/useEventSource/index.ts
@@ -164,6 +164,7 @@ export function useEventSource<Events extends string[], Data = any>(
 
     es.onopen = () => {
       status.value = 'OPEN'
+      retried = 0
       error.value = null
     }
 


### PR DESCRIPTION
`useEventSource`'s `autoReconnect` bumps `retried` on every reconnect attempt but never resets it once a reconnection actually succeeds. The only place `retried` goes back to `0` is the manual `open()`. So on a long-lived stream that drops and recovers a few times, the counter keeps climbing across unrelated disconnects until `retried < retries` is false, and it stops retrying (or calls `onFailed`) even though every previous reconnect worked.

`useWebSocket` already handles this by resetting the counter inside `onopen`, and `useEventSource` was built to mirror its reconnect options (same `retries` / `delay` / `onFailed` shape). With that shared API, `retries: 3` reads as "up to 3 attempts per disconnection", not "3 for the whole lifetime of the composable".

The fix is the same line `useWebSocket` uses:

```ts
es.onopen = () => {
  status.value = 'OPEN'
  retried = 0
  error.value = null
}
```

The added test runs three separate disconnect/reconnect cycles with `retries: 3`. Before the change, `onFailed` fires on the third drop; after it, a successful reconnection refreshes the budget each time so reconnection keeps working.
