### PR TITLE
fix(useFocusTrap): clean up containers to prevent a memory leak

### DIFF
--- a/packages/integrations/useFocusTrap/index.ts
+++ b/packages/integrations/useFocusTrap/index.ts
@@ -100,8 +100,14 @@ export function useFocusTrap(
   watch(
     targets,
     (els) => {
-      if (!els.length)
+      if (!els.length) {
+        // Clean up to prevent a memory leak
+        if (trap) {
+          trap.updateContainerElements([])
+          trap.deactivate()
+        }
         return
+      }
       if (!trap) {
         // create the trap
         trap = createFocusTrap(els, {

--- a/packages/integrations/useFocusTrap/index.ts
+++ b/packages/integrations/useFocusTrap/index.ts
@@ -71,7 +71,14 @@ export function useFocusTrap(
   const isPaused = shallowRef(false)
 
   const activate = (opts?: ActivateOptions) => trap && trap.activate(opts)
-  const deactivate = (opts?: DeactivateOptions) => trap && trap.deactivate(opts)
+
+  const deactivate = (opts?: DeactivateOptions) => {
+    if (trap) {
+      trap.deactivate(opts);
+      // Clear trap reference to avoid memory leaks
+      trap = undefined;
+    }
+  }
 
   const pause = () => {
     if (trap) {
@@ -101,11 +108,8 @@ export function useFocusTrap(
     targets,
     (els) => {
       if (!els.length) {
-        // Clean up to prevent a memory leak
-        if (trap) {
-          trap.updateContainerElements([])
-          trap.deactivate()
-        }
+        // Reset trap when targets array becomes empty ("v-if" case)
+        deactivate()
         return
       }
       if (!trap) {

--- a/packages/integrations/useFocusTrap/index.ts
+++ b/packages/integrations/useFocusTrap/index.ts
@@ -74,9 +74,9 @@ export function useFocusTrap(
 
   const deactivate = (opts?: DeactivateOptions) => {
     if (trap) {
-      trap.deactivate(opts);
+      trap.deactivate(opts)
       // Clear trap reference to avoid memory leaks
-      trap = undefined;
+      trap = undefined
     }
   }
 


### PR DESCRIPTION
This PR fixes a memory leak inside `useFocusTrap` where detached DOM element references are permanently retained in memory when a trapped element is removed from the DOM (e.g., via `v-if`).

When the reactive target becomes empty (els.length === 0), the watch implementation returns early. This skips notifying the underlying focus-trap instance. Its internal `state.containers` and `state.containerGroups` arrays hold onto hard references of the detached HTMLElements indefinitely.