### PR TITLE
feat(useAsyncState): optional initialState param

### DIFF
--- a/packages/core/useAsyncState/index.test.ts
+++ b/packages/core/useAsyncState/index.test.ts
@@ -170,4 +170,18 @@ describe('useAsyncState', () => {
     ])
     expect(error.value).toBeUndefined()
   })
+
+  it('should work with optional initialState omitted', async () => {
+    const { state } = useAsyncState(p1)
+    expect(state.value).toBeUndefined()
+    await promiseTimeout(100)
+    expect(state.value).toBe(1)
+  })
+
+  it('should work with optional initialState passed as undefined', async () => {
+    const { state } = useAsyncState(p1, undefined)
+    expect(state.value).toBeUndefined()
+    await promiseTimeout(100)
+    expect(state.value).toBe(1)
+  })
 })

--- a/packages/core/useAsyncState/index.ts
+++ b/packages/core/useAsyncState/index.ts
@@ -83,7 +83,19 @@ export function useAsyncState<Data, Params extends any[] = any[], Shallow extend
   promise: Promise<Data> | ((...args: Params) => Promise<Data>),
   initialState: MaybeRef<Data>,
   options?: UseAsyncStateOptions<Shallow, Data>,
-): UseAsyncStateReturn<Data, Params, Shallow> {
+): UseAsyncStateReturn<Data, Params, Shallow>
+
+export function useAsyncState<Data, Params extends any[] = any[], Shallow extends boolean = true>(
+  promise: Promise<Data> | ((...args: Params) => Promise<Data>),
+  initialState?: undefined,
+  options?: UseAsyncStateOptions<Shallow, Data>,
+): UseAsyncStateReturn<Data | undefined, Params, Shallow>
+
+export function useAsyncState<Data, Params extends any[] = any[], Shallow extends boolean = true>(
+  promise: Promise<Data> | ((...args: Params) => Promise<Data>),
+  initialState?: MaybeRef<Data>,
+  options?: UseAsyncStateOptions<Shallow, Data>,
+): UseAsyncStateReturn<Data | undefined, Params, Shallow> {
   const {
     immediate = true,
     delay = 0,
@@ -141,8 +153,8 @@ export function useAsyncState<Data, Params extends any[] = any[], Shallow extend
     execute(delay)
   }
 
-  const shell: UseAsyncStateReturnBase<Data, Params, Shallow> = {
-    state: state as Shallow extends true ? ShallowRef<Data> : Ref<UnwrapRef<Data>>,
+  const shell: UseAsyncStateReturnBase<Data | undefined, Params, Shallow> = {
+    state: state as Shallow extends true ? ShallowRef<Data | undefined> : Ref<UnwrapRef<Data | undefined>>,
     isReady,
     isLoading,
     error,
@@ -151,7 +163,7 @@ export function useAsyncState<Data, Params extends any[] = any[], Shallow extend
   }
 
   function waitUntilIsLoaded() {
-    return new Promise<UseAsyncStateReturnBase<Data, Params, Shallow>>((resolve, reject) => {
+    return new Promise<UseAsyncStateReturnBase<Data | undefined, Params, Shallow>>((resolve, reject) => {
       until(isLoading).toBe(false).then(() => resolve(shell)).catch(reject)
     })
   }

--- a/skills/vueuse-functions/references/useAsyncState.md
+++ b/skills/vueuse-functions/references/useAsyncState.md
@@ -22,14 +22,14 @@ const { state, isReady, isLoading, error } = useAsyncState(
 
 ### Return Values
 
-| Property           | Description                                         |
-| ------------------ | --------------------------------------------------- |
-| `state`            | The result of the async function                    |
-| `isReady`          | `true` when the promise has resolved at least once  |
-| `isLoading`        | `true` while the promise is pending                 |
-| `error`            | The error if the promise was rejected               |
-| `execute`          | Re-execute the async function with optional delay   |
-| `executeImmediate` | Re-execute immediately (shorthand for `execute(0)`) |
+| Property           | Description                                                                                                                    |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| `state`            | The result of the async function                                                                                               |
+| `isReady`          | `true` when the latest execution has resolved successfully. Reset to `false` on each execution and stays `false` if it rejects |
+| `isLoading`        | `true` while the promise is pending                                                                                            |
+| `error`            | The error if the promise was rejected                                                                                          |
+| `execute`          | Re-execute the async function with optional delay                                                                              |
+| `executeImmediate` | Re-execute immediately (shorthand for `execute(0)`)                                                                            |
 
 ### Awaiting the Result
 
@@ -182,4 +182,13 @@ export declare function useAsyncState<
   initialState: MaybeRef<Data>,
   options?: UseAsyncStateOptions<Shallow, Data>,
 ): UseAsyncStateReturn<Data, Params, Shallow>
+export declare function useAsyncState<
+  Data,
+  Params extends any[] = any[],
+  Shallow extends boolean = true,
+>(
+  promise: Promise<Data> | ((...args: Params) => Promise<Data>),
+  initialState?: undefined,
+  options?: UseAsyncStateOptions<Shallow, Data>,
+): UseAsyncStateReturn<Data | undefined, Params, Shallow>
 ```

--- a/test/__snapshots__/tsnapi/@vueuse/core/index.snapshot.d.ts
+++ b/test/__snapshots__/tsnapi/@vueuse/core/index.snapshot.d.ts
@@ -1769,6 +1769,7 @@ export declare function useActiveElement<T extends HTMLElement>(_?: UseActiveEle
 export declare function useAnimate(_: MaybeComputedElementRef, _: UseAnimateKeyframes, _?: number | UseAnimateOptions): UseAnimateReturn;
 export declare function useAsyncQueue<T extends any[], S = MapQueueTask<T>>(_: S & Array<UseAsyncQueueTask<any>>, _?: UseAsyncQueueOptions): UseAsyncQueueReturn<{ [P in keyof T]: UseAsyncQueueResult<T[P]> }>;
 export declare function useAsyncState<Data, Params extends any[] = any[], Shallow extends boolean = true>(_: Promise<Data> | ((..._: Params) => Promise<Data>), _: MaybeRef<Data>, _?: UseAsyncStateOptions<Shallow, Data>): UseAsyncStateReturn<Data, Params, Shallow>;
+export declare function useAsyncState<Data, Params extends any[] = any[], Shallow extends boolean = true>(_: Promise<Data> | ((..._: Params) => Promise<Data>), _?: undefined, _?: UseAsyncStateOptions<Shallow, Data>): UseAsyncStateReturn<Data | undefined, Params, Shallow>;
 export declare function useBase64(_: MaybeRefOrGetter<string | undefined>, _?: UseBase64Options): UseBase64Return;
 export declare function useBase64(_: MaybeRefOrGetter<Blob | undefined>, _?: UseBase64Options): UseBase64Return;
 export declare function useBase64(_: MaybeRefOrGetter<ArrayBuffer | undefined>, _?: UseBase64Options): UseBase64Return;


### PR DESCRIPTION
* feat(useAsyncState): make second (initialState) parameter optional

---------

<details>

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Confirm that this PR is based on your own understanding and review of the project, not solely generated or summarized by AI tools.

> **Note**: If this PR is deemed to be primarily generated by AI tools, it may be closed.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

</details>

---

### Description

- Makes the 2nd parameter of `useAsyncState` (intialState) optional, and if omitted makes the returned state ref's type `Data | undefined`.
- Doesn't have any logic changes only typing
- Added tests to cover this requirement.
- Fixed some documentation regarding the `isReady` ref returned by the function.

#5504
