### PR TITLE
fix(useElementVisibility): 修复 `once` 选项导致重复创建 watcher 的问题

### DIFF
--- a/packages/core/useElementVisibility/index.ts
+++ b/packages/core/useElementVisibility/index.ts
@@ -2,7 +2,6 @@ import type { ShallowRef } from 'vue'
 import type { ConfigurableWindow } from '../_configurable'
 import type { MaybeComputedElementRef } from '../unrefElement'
 import type { UseIntersectionObserverOptions, UseIntersectionObserverReturn } from '../useIntersectionObserver'
-import { watchOnce } from '@vueuse/shared'
 import { shallowRef } from 'vue'
 import { defaultWindow } from '../_configurable'
 import { useIntersectionObserver } from '../useIntersectionObserver'
@@ -84,9 +83,7 @@ export function useElementVisibility(
       isVisible.value = isIntersecting
 
       if (once) {
-        watchOnce(isVisible, () => {
-          observerController.stop()
-        })
+        observerController.stop()
       }
     },
     {


### PR DESCRIPTION
## 问题描述

`useElementVisibility` 的 `once` 选项中，`watchOnce` 被错误地放在了 `useIntersectionObserver` 的回调函数内部（第60-64行）。

这会导致：
1. 每次 observer 触发都会创建一个新的 watcher
2. 多个 watcher 不断堆叠
3. watcher 脱离了正常的 effect scope

## 修复方案

直接在回调中调用 `observerController.stop()`，移除多余的 `watchOnce` 包装。同时也移除了不再使用的 `watchOnce` import。

## 关联 Issue

Fixes #4704

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)