### PR TITLE
fix(useElementSize): prefill size based on box option

### DIFF
--- a/packages/core/useElementSize/directive.browser.test.ts
+++ b/packages/core/useElementSize/directive.browser.test.ts
@@ -1,0 +1,44 @@
+import { promiseTimeout } from '@vueuse/shared'
+import { describe, expect, it, vi } from 'vitest'
+import { page } from 'vitest/browser'
+import { defineComponent } from 'vue'
+import { vElementSize } from './directive'
+
+// The element uses `box-sizing: border-box` with a 200x100 outer size,
+// 10px padding and 5px border on each side, so:
+//   - border-box measurement => 200 x 100
+//   - content-box measurement => 200 - 20 - 10 = 170 wide, 100 - 20 - 10 = 70 tall
+const Component = defineComponent({
+  props: ['onResize', 'options'],
+  directives: {
+    elementSize: vElementSize,
+  },
+  template: `<div
+    data-testid="target"
+    style="width: 200px; height: 100px; padding: 10px; border: 5px solid black; box-sizing: border-box;"
+    v-element-size="[onResize, { width: 0, height: 0 }, options]"
+  >Hello world!</div>`,
+})
+
+describe('vElementSize', () => {
+  it('should call the handler once with border-box dimensions', async () => {
+    const onResize = vi.fn()
+    const screen = page.render(Component, { props: { onResize, options: { box: 'border-box' } } })
+    await expect.element(screen.getByTestId('target')).toBeVisible()
+    // give the ResizeObserver a chance to report so a double-fire would surface
+    await promiseTimeout(50)
+
+    expect(onResize).toHaveBeenCalledTimes(1)
+    expect(onResize).toHaveBeenCalledWith({ width: 200, height: 100 })
+  })
+
+  it('should call the handler once with content-box dimensions', async () => {
+    const onResize = vi.fn()
+    const screen = page.render(Component, { props: { onResize, options: { box: 'content-box' } } })
+    await expect.element(screen.getByTestId('target')).toBeVisible()
+    await promiseTimeout(50)
+
+    expect(onResize).toHaveBeenCalledTimes(1)
+    expect(onResize).toHaveBeenCalledWith({ width: 170, height: 70 })
+  })
+})

--- a/packages/core/useElementSize/directive.ts
+++ b/packages/core/useElementSize/directive.ts
@@ -21,7 +21,7 @@ export const vElementSize = createDisposableDirective<
       const options = (typeof binding.value === 'function' ? [] : binding.value.slice(1)) as RemoveFirstFromTuple<BindingValueArray>
 
       const { width, height } = useElementSize(el, ...options)
-      watch([width, height], ([width, height]) => handler({ width, height }))
+      watch([width, height], ([width, height]) => handler({ width, height }), { immediate: true })
     },
   },
 )

--- a/packages/core/useElementSize/index.browser.test.ts
+++ b/packages/core/useElementSize/index.browser.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { useElementSize } from './index'
+
+// The element uses `box-sizing: border-box` with a 200x100 outer size,
+// 10px padding and 5px border on each side, so:
+//   - border-box measurement => 200 x 100
+//   - content-box measurement => 200 - 20 - 10 = 170 wide, 100 - 20 - 10 = 70 tall
+describe('useElementSize', () => {
+  let el: HTMLDivElement
+
+  beforeEach(() => {
+    el = document.createElement('div')
+    el.style.cssText = 'width: 200px; height: 100px; padding: 10px; border: 5px solid black; box-sizing: border-box;'
+    document.body.appendChild(el)
+  })
+
+  afterEach(() => {
+    el.remove()
+  })
+
+  it('should prefill with border-box dimensions when box is border-box', () => {
+    const { width, height } = useElementSize(el, { width: 0, height: 0 }, { box: 'border-box' })
+    expect(width.value).toBe(200)
+    expect(height.value).toBe(100)
+  })
+
+  it('should prefill with content-box dimensions when box is content-box', () => {
+    const { width, height } = useElementSize(el, { width: 0, height: 0 }, { box: 'content-box' })
+    expect(width.value).toBe(170)
+    expect(height.value).toBe(70)
+  })
+
+  it('should prefill with content-box dimensions by default', () => {
+    const { width, height } = useElementSize(el)
+    expect(width.value).toBe(170)
+    expect(height.value).toBe(70)
+  })
+})

--- a/packages/core/useElementSize/index.ts
+++ b/packages/core/useElementSize/index.ts
@@ -71,9 +71,24 @@ export function useElementSize(
 
   tryOnMounted(() => {
     const ele = unrefElement(target)
-    if (ele) {
-      width.value = 'offsetWidth' in ele ? ele.offsetWidth : initialSize.width
-      height.value = 'offsetHeight' in ele ? ele.offsetHeight : initialSize.height
+    if (ele && 'offsetWidth' in ele) {
+      if (box === 'content-box' && window) {
+        const cs = window.getComputedStyle(ele)
+        const padX = Number.parseFloat(cs.paddingLeft) + Number.parseFloat(cs.paddingRight)
+        const padY = Number.parseFloat(cs.paddingTop) + Number.parseFloat(cs.paddingBottom)
+        const bdX = Number.parseFloat(cs.borderLeftWidth) + Number.parseFloat(cs.borderRightWidth)
+        const bdY = Number.parseFloat(cs.borderTopWidth) + Number.parseFloat(cs.borderBottomWidth)
+        width.value = ele.offsetWidth - padX - bdX
+        height.value = ele.offsetHeight - padY - bdY
+      }
+      else {
+        width.value = ele.offsetWidth
+        height.value = ele.offsetHeight
+      }
+    }
+    else if (ele) {
+      width.value = initialSize.width
+      height.value = initialSize.height
     }
   })
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Confirm that this PR is based on your own understanding and review of the project, not solely generated or summarized by AI tools.

> **Note**: If this PR is deemed to be primarily generated by AI tools, it may be closed.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Fix `v-element-size` handler not being called when `box: 'border-box'` is set.

`tryOnMounted` pre-fills width/height with `offsetWidth`/`offsetHeight` (always border-box). When `box: 'border-box'` is requested,
ResizeObserver reports the same values — the watch sees no change and the handler never fires.

This PR makes the pre-fill box-aware and adds `{ immediate: true }` to the directive watcher, as discussed in #5347.

| Scenario | content-box | border-box |
|---|---|---|
| Before (bug) | 1× ✅ | **0× ❌** |
| `immediate` only | 2× ❌ (double-fire) | 1× ✅ |
| **This PR** | **1× ✅** | **1× ✅** |

Fixes #5347
### Additional context

Design was discussed and agreed upon with @9romise in #5347.