### PR TITLE
fix(useFetch): ignore stale abort error after refetch succeeds

### DIFF
--- a/packages/core/useFetch/index.test.ts
+++ b/packages/core/useFetch/index.test.ts
@@ -731,6 +731,17 @@ describe('useFetch', () => {
     })
   })
 
+  it('should clear error when refetch succeeds after aborting previous request', async () => {
+    const url = shallowRef(`${baseUrl}?delay=50`)
+    const { data, error } = useFetch(url, { refetch: true }).json()
+    await nextTick()
+    url.value = jsonUrl
+    await vi.waitFor(() => {
+      expect(data.value).toEqual(jsonMessage)
+    })
+    expect(error.value).toBeNull()
+  })
+
   it('should be generated payloadType on execute', async () => {
     const form = deepRef()
     const { execute } = useFetch(baseUrl).post(form)

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -521,9 +521,11 @@ export function useFetch<T>(url: MaybeRefOrGetter<string>, ...args: any[]): UseF
           }))
         }
 
-        error.value = errorData
-        if (options.updateDataOnError)
-          data.value = responseData
+        if (currentExecuteCounter === executeCounter) {
+          error.value = errorData
+          if (options.updateDataOnError)
+            data.value = responseData
+        }
 
         errorEvent.trigger(fetchError)
         if (throwOnFailed)


### PR DESCRIPTION
When the reactive URL changes while a request is in flight, useFetch aborts the previous request, but its `.catch` handler still wrote the abort error into `error` even after a newer request had reset the state and succeeded, leaving `error` stuck. This guards the error/data assignment with the same execute-counter check already used in `.finally`, so a stale aborted request no longer overwrites the latest result.

Fixes #5516
