### PR TITLE
feat(useStorage&useAsyncStorage): allow disabling serialization via `serializer: false` option

### DIFF
--- a/packages/core/ssr-handlers.ts
+++ b/packages/core/ssr-handlers.ts
@@ -2,15 +2,15 @@
 import type { Awaitable } from '@vueuse/shared'
 import type { MaybeElementRef } from './unrefElement'
 
-export interface StorageLikeAsync {
-  getItem: (key: string) => Awaitable<string | null>
-  setItem: (key: string, value: string) => Awaitable<void>
+export interface StorageLikeAsync<T = string> {
+  getItem: (key: string) => Awaitable<T | null>
+  setItem: (key: string, value: T) => Awaitable<void>
   removeItem: (key: string) => Awaitable<void>
 }
 
-export interface StorageLike {
-  getItem: (key: string) => string | null
-  setItem: (key: string, value: string) => void
+export interface StorageLike<T = string> {
+  getItem: (key: string) => T | null
+  setItem: (key: string, value: T) => void
   removeItem: (key: string) => void
 }
 

--- a/packages/core/useStorage/index.browser.test.ts
+++ b/packages/core/useStorage/index.browser.test.ts
@@ -1,3 +1,4 @@
+import type { StorageLike } from '../ssr-handlers'
 import { debounceFilter } from '@vueuse/shared'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref as deepRef, defineComponent, nextTick, toRaw } from 'vue'
@@ -7,6 +8,31 @@ import { customStorageEventName, StorageSerializers, useStorage } from './index'
 const KEY = 'custom-key'
 const ANOTHER_KEY = 'another-key'
 
+interface RawStorageValue {
+  name: string
+  createdAt: Date
+  nested: {
+    map: Map<string, Set<number>>
+  }
+  self?: RawStorageValue
+}
+
+function createRawStorageValue(name: string): RawStorageValue {
+  const value: RawStorageValue = {
+    name,
+    createdAt: new Date('2024-01-01T00:00:00.000Z'),
+    nested: {
+      map: new Map([
+        ['numbers', new Set([1, 2, 3])],
+      ]),
+    },
+  }
+
+  value.self = value
+
+  return value
+}
+
 vi.mock('../ssr-handlers', () => ({
   getSSRHandler: vi.fn().mockImplementationOnce((_, cb) => () => cb()).mockImplementationOnce(() => () => {
     throw new Error('getDefaultStorage error')
@@ -15,7 +41,7 @@ vi.mock('../ssr-handlers', () => ({
 
 describe('useStorage', () => {
   console.error = vi.fn()
-  const storageState = new Map<string, string | number | undefined>()
+  const storageState = new Map<string, unknown>()
   const storageMock = {
     getItem: vi.fn(x => storageState.get(x)),
     setItem: vi.fn((x, v) => storageState.set(x, v)),
@@ -356,6 +382,61 @@ describe('useStorage', () => {
     expect(storage.removeItem).toBeCalledWith(KEY)
   })
 
+  it('stores values as-is when serializer is false', async () => {
+    const initial = createRawStorageValue('initial')
+    const objectStorage = storageMock as StorageLike<RawStorageValue>
+    const store = useStorage(KEY, initial, objectStorage, { serializer: false })
+
+    expect(toRaw(store.value)).toBe(initial)
+    expect(objectStorage.getItem(KEY)).toBe(initial)
+
+    const next = createRawStorageValue('next')
+    store.value = next
+    await nextTwoTick()
+
+    const storedValue = objectStorage.getItem(KEY)
+    expect(storedValue).toBe(store.value)
+    expect(toRaw(storedValue!)).toBe(next)
+
+    store.value = null
+    await nextTwoTick()
+
+    expect(storage.removeItem).toHaveBeenCalledWith(KEY)
+  })
+
+  it('stores vm values as-is when serializer is false', async () => {
+    const initial = createRawStorageValue('initial')
+    const objectStorage = storageMock as StorageLike<RawStorageValue>
+    const vm = useSetup(() => {
+      const ref = useStorage(KEY, initial, objectStorage, { serializer: false })
+
+      return {
+        ref,
+      }
+    })
+
+    expect(toRaw(vm.ref)).toBe(initial)
+    expect(objectStorage.getItem(KEY)).toBe(initial)
+
+    const next = createRawStorageValue('next')
+    vm.ref = next
+    await nextTwoTick()
+
+    const storedValue = objectStorage.getItem(KEY)
+    expect(storedValue).toBe(vm.ref)
+    expect(toRaw(storedValue!)).toBe(next)
+  })
+
+  it('reads existing values as-is when serializer is false', () => {
+    const storedValue = createRawStorageValue('stored')
+    storageMock.setItem(KEY, storedValue)
+
+    const objectStorage = storageMock as StorageLike<RawStorageValue>
+    const store = useStorage(KEY, createRawStorageValue('default'), objectStorage, { serializer: false })
+
+    expect(toRaw(store.value)).toBe(storedValue)
+  })
+
   it('mergeDefaults option', async () => {
     // basic
     storage.setItem(KEY, '0')
@@ -553,6 +634,24 @@ describe('useStorage', () => {
     state1.value = 1
     await nextTick()
     expect(state2.value).toBe(1)
+  })
+
+  it('updates from custom storage events when serializer is false', async () => {
+    const customStorage = storageMock as StorageLike<RawStorageValue>
+    const state = useStorage(KEY, createRawStorageValue('initial'), customStorage, { serializer: false })
+    const nextValue = createRawStorageValue('event')
+
+    window.dispatchEvent(new CustomEvent(customStorageEventName, {
+      detail: {
+        storageArea: customStorage,
+        key: KEY,
+        oldValue: createRawStorageValue('previous'),
+        newValue: nextValue,
+      },
+    }))
+    await nextTick()
+
+    expect(toRaw(state.value)).toBe(nextValue)
   })
 
   it('updates on key change when thew new storage value is presented', async () => {

--- a/packages/core/useStorage/index.md
+++ b/packages/core/useStorage/index.md
@@ -101,6 +101,23 @@ useStorage(
 )
 ```
 
+If your storage backend can store JavaScript values directly, set `serializer` to `false` to skip serialization. This is useful for storage wrappers around APIs such as `chrome.storage` or IndexedDB, where values do not need to be converted to strings.
+
+```ts
+import { useStorage } from '@vueuse/core'
+
+const state = useStorage(
+  'key',
+  { count: 0 },
+  objectStorage,
+  { serializer: false },
+)
+
+state.value = { count: 1 } // stored as the object itself
+```
+
+Native `localStorage` and `sessionStorage` only store strings, so `serializer: false` should be used with a compatible custom storage backend.
+
 Please note when you provide `null` as the default value, `useStorage` can't assume the data type from it. In this case, you can provide a custom serializer or reuse the built-in ones explicitly.
 
 ```ts

--- a/packages/core/useStorage/index.ts
+++ b/packages/core/useStorage/index.ts
@@ -57,10 +57,10 @@ export const StorageSerializers: Record<'boolean' | 'object' | 'number' | 'any' 
 export const customStorageEventName = 'vueuse-storage'
 
 export interface StorageEventLike {
-  storageArea: StorageLike | null
+  storageArea: StorageLike<unknown> | null
   key: StorageEvent['key']
-  oldValue: StorageEvent['oldValue']
-  newValue: StorageEvent['newValue']
+  oldValue: unknown
+  newValue: unknown
 }
 
 export interface UseStorageOptions<T> extends ConfigurableEventFilter, ConfigurableWindow, ConfigurableFlush {
@@ -96,7 +96,9 @@ export interface UseStorageOptions<T> extends ConfigurableEventFilter, Configura
   mergeDefaults?: boolean | ((storageValue: T, defaults: T) => T)
 
   /**
-   * Custom data serialization
+   * Custom data serialization.
+   *
+   * `false` can be passed to store values as-is without serialization.
    */
   serializer?: Serializer<T>
 
@@ -122,11 +124,19 @@ export interface UseStorageOptions<T> extends ConfigurableEventFilter, Configura
   initOnMounted?: boolean
 }
 
+export interface UseStorageRawOptions<T> extends Omit<UseStorageOptions<T>, 'serializer'> {
+  /**
+   * Store values as-is without serialization.
+   */
+  serializer: false
+}
+
+export function useStorage<T>(key: MaybeRefOrGetter<string>, defaults: MaybeRefOrGetter<T>, storage: StorageLike<T>, options: UseStorageRawOptions<T>): RemovableRef<T>
 export function useStorage(key: MaybeRefOrGetter<string>, defaults: MaybeRefOrGetter<string>, storage?: StorageLike, options?: UseStorageOptions<string>): RemovableRef<string>
 export function useStorage(key: MaybeRefOrGetter<string>, defaults: MaybeRefOrGetter<boolean>, storage?: StorageLike, options?: UseStorageOptions<boolean>): RemovableRef<boolean>
 export function useStorage(key: MaybeRefOrGetter<string>, defaults: MaybeRefOrGetter<number>, storage?: StorageLike, options?: UseStorageOptions<number>): RemovableRef<number>
 export function useStorage<T>(key: MaybeRefOrGetter<string>, defaults: MaybeRefOrGetter<T>, storage?: StorageLike, options?: UseStorageOptions<T>): RemovableRef<T>
-export function useStorage<T = unknown>(key: MaybeRefOrGetter<string>, defaults: MaybeRefOrGetter<null>, storage?: StorageLike, options?: UseStorageOptions<T>): RemovableRef<T>
+export function useStorage<T = unknown>(key: MaybeRefOrGetter<string>, defaults: MaybeRefOrGetter<null>, storage?: StorageLike<T>, options?: UseStorageOptions<T> | UseStorageRawOptions<T>): RemovableRef<T>
 
 /**
  * Reactive LocalStorage/SessionStorage.
@@ -136,8 +146,8 @@ export function useStorage<T = unknown>(key: MaybeRefOrGetter<string>, defaults:
 export function useStorage<T extends (string | number | boolean | object | null)>(
   key: MaybeRefOrGetter<string>,
   defaults: MaybeRefOrGetter<T>,
-  storage: StorageLike | undefined,
-  options: UseStorageOptions<T> = {},
+  storage: StorageLike<T> | StorageLike | undefined,
+  options: UseStorageOptions<T> | UseStorageRawOptions<T> = {},
 ): RemovableRef<T> {
   const {
     flush = 'pre',
@@ -172,6 +182,9 @@ export function useStorage<T extends (string | number | boolean | object | null)
   const rawInit: T = toValue(defaults)
   const type = guessSerializerType<T>(rawInit)
   const serializer = options.serializer ?? StorageSerializers[type]
+
+  const readValue = (raw: any): T => serializer === false ? raw : serializer.read(raw)
+  const writeValue = (value: T): any => serializer === false ? value : serializer.write(value)
 
   const { pause: pauseWatch, resume: resumeWatch } = watchPausable(
     data,
@@ -220,19 +233,24 @@ export function useStorage<T extends (string | number | boolean | object | null)
     update()
   }
 
-  function dispatchWriteEvent(oldValue: string | null, newValue: string | null) {
+  function dispatchWriteEvent(oldValue: T | string | null, newValue: T | string | null) {
     // send custom event to communicate within same page
     if (window) {
       const payload = {
         key: keyComputed.value,
         oldValue,
         newValue,
-        storageArea: storage as Storage,
+        storageArea: storage as StorageLike<unknown>,
       }
       // We also use a CustomEvent since StorageEvent cannot
       // be constructed with a non-built-in storage area
       window.dispatchEvent(storage instanceof Storage
-        ? new StorageEvent('storage', payload)
+        ? new StorageEvent('storage', {
+            key: payload.key,
+            oldValue: payload.oldValue as string | null,
+            newValue: payload.newValue as string | null,
+            storageArea: storage,
+          })
         : new CustomEvent<StorageEventLike>(customStorageEventName, {
             detail: payload,
           }))
@@ -248,10 +266,10 @@ export function useStorage<T extends (string | number | boolean | object | null)
         storage!.removeItem(keyComputed.value)
       }
       else {
-        const serialized = serializer.write(v as any)
-        if (oldValue !== serialized) {
-          storage!.setItem(keyComputed.value, serialized)
-          dispatchWriteEvent(oldValue, serialized)
+        const newValue = writeValue(v as T)
+        if (oldValue !== newValue) {
+          storage!.setItem(keyComputed.value, newValue)
+          dispatchWriteEvent(oldValue, newValue)
         }
       }
     }
@@ -260,33 +278,36 @@ export function useStorage<T extends (string | number | boolean | object | null)
     }
   }
 
-  function read(event?: StorageEventLike) {
+  function read(event?: StorageEvent | StorageEventLike) {
     const rawValue = event
       ? event.newValue
       : storage!.getItem(keyComputed.value)
 
     if (rawValue == null) {
       if (writeDefaults && rawInit != null)
-        storage!.setItem(keyComputed.value, serializer.write(rawInit))
+        storage!.setItem(keyComputed.value, writeValue(rawInit))
       return rawInit
     }
+    else if (serializer === false) {
+      return rawValue
+    }
     else if (!event && mergeDefaults) {
-      const value = serializer.read(rawValue)
+      const value = readValue(rawValue)
       if (typeof mergeDefaults === 'function')
         return mergeDefaults(value, rawInit)
       else if (type === 'object' && !Array.isArray(value))
-        return { ...rawInit as any, ...value }
+        return { ...(rawInit as any), ...(value as any) }
       return value
     }
     else if (typeof rawValue !== 'string') {
       return rawValue
     }
     else {
-      return serializer.read(rawValue)
+      return readValue(rawValue)
     }
   }
 
-  function update(event?: StorageEventLike) {
+  function update(event?: StorageEvent | StorageEventLike) {
     if (event && event.storageArea !== storage)
       return
 
@@ -302,7 +323,7 @@ export function useStorage<T extends (string | number | boolean | object | null)
     pauseWatch()
 
     try {
-      const serializedData = serializer.write(data.value)
+      const serializedData = writeValue(data.value)
       if (event === undefined || event?.newValue !== serializedData) {
         data.value = read(event)
       }

--- a/packages/core/useStorage/index.ts
+++ b/packages/core/useStorage/index.ts
@@ -136,8 +136,7 @@ export function useStorage(key: MaybeRefOrGetter<string>, defaults: MaybeRefOrGe
 export function useStorage(key: MaybeRefOrGetter<string>, defaults: MaybeRefOrGetter<boolean>, storage?: StorageLike, options?: UseStorageOptions<boolean>): RemovableRef<boolean>
 export function useStorage(key: MaybeRefOrGetter<string>, defaults: MaybeRefOrGetter<number>, storage?: StorageLike, options?: UseStorageOptions<number>): RemovableRef<number>
 export function useStorage<T>(key: MaybeRefOrGetter<string>, defaults: MaybeRefOrGetter<T>, storage?: StorageLike, options?: UseStorageOptions<T>): RemovableRef<T>
-export function useStorage<T = unknown>(key: MaybeRefOrGetter<string>, defaults: MaybeRefOrGetter<null>, storage?: StorageLike<T>, options?: UseStorageOptions<T> | UseStorageRawOptions<T>): RemovableRef<T>
-
+export function useStorage<T = unknown>(key: MaybeRefOrGetter<string>, defaults: MaybeRefOrGetter<null>, storage?: StorageLike<T>, options?: UseStorageOptions<T>): RemovableRef<T>
 /**
  * Reactive LocalStorage/SessionStorage.
  *

--- a/packages/core/useStorageAsync/index.browser.test.ts
+++ b/packages/core/useStorageAsync/index.browser.test.ts
@@ -1,11 +1,43 @@
 import type { Awaitable, StorageLikeAsync } from '@vueuse/core'
 import { createEventHook, useStorageAsync } from '@vueuse/core'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, toRaw } from 'vue'
+import { useSetup } from '../../.test'
 
 const KEY = 'custom-key'
 const KEY2 = 'custom-key2'
 const asyncDelay = 10
 const localStorage = globalThis.localStorage
+
+interface RawStorageValue {
+  name: string
+  createdAt: Date
+  nested: {
+    map: Map<string, Set<number>>
+  }
+  self?: RawStorageValue
+}
+
+function createRawStorageValue(name: string): RawStorageValue {
+  const value: RawStorageValue = {
+    name,
+    createdAt: new Date('2024-01-01T00:00:00.000Z'),
+    nested: {
+      map: new Map([
+        ['numbers', new Set([1, 2, 3])],
+      ]),
+    },
+  }
+
+  value.self = value
+
+  return value
+}
+
+async function flushPromises() {
+  await Promise.resolve()
+  await Promise.resolve()
+}
 
 class AsyncStubStorage implements StorageLikeAsync {
   getItem(key: string): Awaitable<string | null> {
@@ -32,6 +64,26 @@ class AsyncStubStorage implements StorageLikeAsync {
         resolve()
       }, asyncDelay)
     })
+  }
+}
+
+class AsyncRawStorage<T = unknown> implements StorageLikeAsync<T> {
+  values = new Map<string, T>()
+
+  constructor(values: [string, T][] = []) {
+    this.values = new Map(values)
+  }
+
+  getItem(key: string): Awaitable<T | null> {
+    return this.values.get(key) ?? null
+  }
+
+  removeItem(key: string): Awaitable<void> {
+    this.values.delete(key)
+  }
+
+  setItem(key: string, value: T): Awaitable<void> {
+    this.values.set(key, value)
   }
 }
 
@@ -65,9 +117,8 @@ describe('useStorageAsync', () => {
     )
 
     expect(storage.value).toBe('')
-    vi.waitFor(async () => {
-      await expect(promise).resolves.toBe('CurrentValue')
-    })
+    await vi.advanceTimersByTimeAsync(asyncDelay)
+    await expect(promise).resolves.toBe('CurrentValue')
   })
 
   it('onReadyByPromise', async () => {
@@ -81,9 +132,67 @@ describe('useStorageAsync', () => {
 
     expect(storage.value).toBe('')
 
-    vi.waitFor(async () => {
-      const result = await storage
-      expect(result.value).toBe('AnotherValue')
+    await vi.advanceTimersByTimeAsync(asyncDelay)
+    let result
+    storage.then((value) => {
+      result = value
     })
+    await flushPromises()
+
+    expect(result).toHaveProperty('value', 'AnotherValue')
+  })
+
+  it('stores values as-is when serializer is false', async () => {
+    const storage = new AsyncRawStorage<RawStorageValue>()
+    const initial = createRawStorageValue('initial')
+    const state = useStorageAsync(KEY, initial, storage, { serializer: false })
+    await flushPromises()
+
+    expect(toRaw(state.value)).toBe(initial)
+    expect(storage.values.get(KEY)).toBe(initial)
+
+    const next = createRawStorageValue('next')
+    state.value = next
+    await nextTick()
+    await flushPromises()
+
+    const storedValue = storage.values.get(KEY)
+    expect(storedValue).toBe(state.value)
+    expect(toRaw(storedValue!)).toBe(next)
+  })
+
+  it('stores vm values as-is when serializer is false', async () => {
+    const storage = new AsyncRawStorage<RawStorageValue>()
+    const initial = createRawStorageValue('initial')
+    const vm = useSetup(() => {
+      const state = useStorageAsync(KEY, initial, storage, { serializer: false })
+
+      return {
+        state,
+      }
+    })
+    await flushPromises()
+
+    expect(toRaw(vm.state)).toBe(initial)
+    expect(storage.values.get(KEY)).toBe(initial)
+
+    const next = createRawStorageValue('next')
+    vm.state = next
+    await nextTick()
+    await flushPromises()
+
+    const storedValue = storage.values.get(KEY)
+    expect(storedValue).toBe(vm.state)
+    expect(toRaw(storedValue!)).toBe(next)
+  })
+
+  it('reads existing values as-is when serializer is false', async () => {
+    const storedValue = createRawStorageValue('stored')
+    const storage = new AsyncRawStorage([[KEY, storedValue]])
+    const state = useStorageAsync(KEY, createRawStorageValue('default'), storage, { serializer: false })
+    await flushPromises()
+
+    expect(toRaw(state.value)).toBe(storedValue)
+    expect(storage.values.get(KEY)).toBe(storedValue)
   })
 })

--- a/packages/core/useStorageAsync/index.ts
+++ b/packages/core/useStorageAsync/index.ts
@@ -12,7 +12,9 @@ import { guessSerializerType } from '../useStorage/guess'
 
 export interface UseStorageAsyncOptions<T> extends Omit<UseStorageOptions<T>, 'serializer'> {
   /**
-   * Custom data serialization
+   * Custom data serialization.
+   *
+   * `false` can be passed to store values as-is without serialization.
    */
   serializer?: SerializerAsync<T>
 
@@ -22,11 +24,19 @@ export interface UseStorageAsyncOptions<T> extends Omit<UseStorageOptions<T>, 's
   onReady?: (value: T) => void
 }
 
+export interface UseStorageAsyncRawOptions<T> extends Omit<UseStorageAsyncOptions<T>, 'serializer'> {
+  /**
+   * Store values as-is without serialization.
+   */
+  serializer: false
+}
+
+export function useStorageAsync<T>(key: string, initialValue: MaybeRefOrGetter<T>, storage: StorageLikeAsync<T>, options: UseStorageAsyncRawOptions<T>): RemovableRef<T> & Promise<RemovableRef<T>>
 export function useStorageAsync(key: string, initialValue: MaybeRefOrGetter<string>, storage?: StorageLikeAsync, options?: UseStorageAsyncOptions<string>): RemovableRef<string> & Promise<RemovableRef<string>>
 export function useStorageAsync(key: string, initialValue: MaybeRefOrGetter<boolean>, storage?: StorageLikeAsync, options?: UseStorageAsyncOptions<boolean>): RemovableRef<boolean> & Promise<RemovableRef<boolean>>
 export function useStorageAsync(key: string, initialValue: MaybeRefOrGetter<number>, storage?: StorageLikeAsync, options?: UseStorageAsyncOptions<number>): RemovableRef<number> & Promise<RemovableRef<number>>
 export function useStorageAsync<T>(key: string, initialValue: MaybeRefOrGetter<T>, storage?: StorageLikeAsync, options?: UseStorageAsyncOptions<T>): RemovableRef<T> & Promise<RemovableRef<T>>
-export function useStorageAsync<T = unknown>(key: string, initialValue: MaybeRefOrGetter<null>, storage?: StorageLikeAsync, options?: UseStorageAsyncOptions<T>): RemovableRef<T> & Promise<RemovableRef<T>>
+export function useStorageAsync<T = unknown>(key: string, initialValue: MaybeRefOrGetter<null>, storage?: StorageLikeAsync<T>, options?: UseStorageAsyncOptions<T> | UseStorageAsyncRawOptions<T>): RemovableRef<T> & Promise<RemovableRef<T>>
 
 /**
  * Reactive Storage with async support.
@@ -40,8 +50,8 @@ export function useStorageAsync<T = unknown>(key: string, initialValue: MaybeRef
 export function useStorageAsync<T extends(string | number | boolean | object | null)>(
   key: string,
   initialValue: MaybeRefOrGetter<T>,
-  storage: StorageLikeAsync | undefined,
-  options: UseStorageAsyncOptions<T> = {},
+  storage: StorageLikeAsync<T> | StorageLikeAsync | undefined,
+  options: UseStorageAsyncOptions<T> | UseStorageAsyncRawOptions<T> = {},
 ): RemovableRef<T> & Promise<RemovableRef<T>> {
   const {
     flush = 'pre',
@@ -63,6 +73,8 @@ export function useStorageAsync<T extends(string | number | boolean | object | n
 
   const data = (shallow ? shallowRef : deepRef)(toValue(initialValue)) as RemovableRef<T>
   const serializer = options.serializer ?? StorageSerializers[type]
+  const readValue = async (raw: any): Promise<T> => serializer === false ? raw : await serializer.read(raw)
+  const writeValue = async (value: T): Promise<any> => serializer === false ? value : await serializer.write(value)
 
   if (!storage) {
     try {
@@ -82,18 +94,21 @@ export function useStorageAsync<T extends(string | number | boolean | object | n
       if (rawValue == null) {
         data.value = rawInit
         if (writeDefaults && rawInit !== null)
-          await storage.setItem(key, await serializer.write(rawInit))
+          await storage.setItem(key, await writeValue(rawInit))
+      }
+      else if (serializer === false) {
+        data.value = rawValue as T
       }
       else if (mergeDefaults) {
-        const value = await serializer.read(rawValue)
+        const value = await readValue(rawValue)
         if (typeof mergeDefaults === 'function')
           data.value = mergeDefaults(value, rawInit)
         else if (type === 'object' && !Array.isArray(value))
-          data.value = { ...(rawInit as any), ...value }
+          data.value = { ...(rawInit as any), ...(value as any) }
         else data.value = value
       }
       else {
-        data.value = await serializer.read(rawValue)
+        data.value = await readValue(rawValue)
       }
     }
     catch (e) {
@@ -119,7 +134,7 @@ export function useStorageAsync<T extends(string | number | boolean | object | n
           if (data.value == null)
             await storage!.removeItem(key)
           else
-            await storage!.setItem(key, await serializer.write(data.value))
+            await storage!.setItem(key, await writeValue(data.value))
         }
         catch (e) {
           onError(e)

--- a/packages/core/useStorageAsync/index.ts
+++ b/packages/core/useStorageAsync/index.ts
@@ -36,7 +36,7 @@ export function useStorageAsync(key: string, initialValue: MaybeRefOrGetter<stri
 export function useStorageAsync(key: string, initialValue: MaybeRefOrGetter<boolean>, storage?: StorageLikeAsync, options?: UseStorageAsyncOptions<boolean>): RemovableRef<boolean> & Promise<RemovableRef<boolean>>
 export function useStorageAsync(key: string, initialValue: MaybeRefOrGetter<number>, storage?: StorageLikeAsync, options?: UseStorageAsyncOptions<number>): RemovableRef<number> & Promise<RemovableRef<number>>
 export function useStorageAsync<T>(key: string, initialValue: MaybeRefOrGetter<T>, storage?: StorageLikeAsync, options?: UseStorageAsyncOptions<T>): RemovableRef<T> & Promise<RemovableRef<T>>
-export function useStorageAsync<T = unknown>(key: string, initialValue: MaybeRefOrGetter<null>, storage?: StorageLikeAsync<T>, options?: UseStorageAsyncOptions<T> | UseStorageAsyncRawOptions<T>): RemovableRef<T> & Promise<RemovableRef<T>>
+export function useStorageAsync<T = unknown>(key: string, initialValue: MaybeRefOrGetter<null>, storage?: StorageLikeAsync<T>, options?: UseStorageAsyncOptions<T>): RemovableRef<T> & Promise<RemovableRef<T>>
 
 /**
  * Reactive Storage with async support.


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Confirm that this PR is based on your own understanding and review of the project, not solely generated or summarized by AI tools.

> **Note**: If this PR is deemed to be primarily generated by AI tools, it may be closed.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Closes https://github.com/vueuse/vueuse/issues/5079

With this, you can simplify code of the following type and ensure type inference works correctly, without needing `as`, `any`, or generics.

<img width="2757" height="971" alt="file-feed4023b162969c2d51741e3eed63bd" src="https://github.com/user-attachments/assets/523c8444-4d90-4a53-b829-5bfe3d8b27a4" />


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

https://github.com/vueuse/vueuse/pull/5097 is too stale and should be closed.
