### PR TITLE
docs(useIntersectionObserver): document controls and automatic cleanup

### DIFF
--- a/packages/core/useIntersectionObserver/index.md
+++ b/packages/core/useIntersectionObserver/index.md
@@ -31,6 +31,34 @@ const { stop } = useIntersectionObserver(
 </template>
 ```
 
+### Controls and cleanup
+
+`useIntersectionObserver` returns controls for the underlying observer:
+
+| State         | Type                   | Description                                                                           |
+| ------------- | ---------------------- | ------------------------------------------------------------------------------------- |
+| `isSupported` | `ComputedRef<boolean>` | Whether the `IntersectionObserver` API is available.                                  |
+| `isActive`    | `ShallowRef<boolean>`  | Whether the observer is currently running. Turns `false` after `pause()` or `stop()`. |
+| `pause`       | `() => void`           | Pause observing and set `isActive` to `false`.                                        |
+| `resume`      | `() => void`           | Resume observing.                                                                     |
+| `stop`        | `() => void`           | Stop observing permanently.                                                           |
+
+The observer is disconnected automatically via [`tryOnScopeDispose`](https://vueuse.org/shared/tryOnScopeDispose/) when the component or effect scope that created it is disposed, so in most cases you don't need to call `stop` yourself. Call `stop()` to disconnect the observer earlier, for example once the element has become visible:
+
+```ts
+import { useIntersectionObserver } from '@vueuse/core'
+// ---cut---
+const { stop } = useIntersectionObserver(
+  target,
+  ([entry]) => {
+    if (entry?.isIntersecting) {
+      // react to the element becoming visible once, then stop observing
+      stop()
+    }
+  },
+)
+```
+
 ## Directive Usage
 
 ```vue


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Confirm that this PR is based on your own understanding and review of the project, not solely generated or summarized by AI tools.

> **Note**: If this PR is deemed to be primarily generated by AI tools, it may be closed.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Documents the return values of `useIntersectionObserver` on its docs page, which currently don't mention them at all. This adds a "Controls and cleanup" section with:

- a table of the returned controls (`isSupported`, `isActive`, `pause`, `resume`, `stop`)
- a note that the observer is disconnected automatically via `tryOnScopeDispose` when the owning component/effect scope is disposed (this is what the issue asks to clarify — the behavior exists in `index.ts` but was undocumented)
- a short example of calling `stop()` manually to disconnect early

Follows the format of the recently merged `useElementVisibility` controls docs (#5515). 

fixes #3824

### Additional context

Docs-only change, no code touched — the auto-cleanup behavior being documented is already implemented (`tryOnScopeDispose(stop)` in `useIntersectionObserver/index.ts`) and covered by the existing browser tests, so no new tests are included. The only previous attempt at this issue was a bot-generated PR (#5362) that was closed.