### PR TITLE
docs(useTextareaAutosize): restore demo textarea autosizing

### DIFF
--- a/packages/core/useTextareaAutosize/demo.vue
+++ b/packages/core/useTextareaAutosize/demo.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { useTextareaAutosize } from '@vueuse/core'
+import { useTemplateRef } from 'vue'
 
-const { input } = useTextareaAutosize()
+const textarea = useTemplateRef<HTMLTextAreaElement>('textarea')
+const { input } = useTextareaAutosize({ element: textarea })
 </script>
 
 <template>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Confirm that this PR is based on your own understanding and review of the project, not solely generated or summarized by AI tools.

> **Note**: If this PR is deemed to be primarily generated by AI tools, it may be closed.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

The demo on the docs site stopped autosizing (#5380)

Root cause: #5247 removed `textarea` from the destructured return to
satisfy the linter, but the template's `ref="textarea"` relied on that
variable, so the composable never received the element and
`triggerResize()` bailed early.

This restores the binding explicitly via `useTemplateRef` and the
`element` option, which keeps the linter happy.

fixes #5380

### Additional context

No tests added, because the change only affects the docs demo (demo.vue), which isn't covered by unit tests. Verified manually: the textarea grows again in the local docs.