### PR TITLE
fix(useVirtualList): recompute range when item size changes

### DIFF
--- a/packages/core/useVirtualList/index.test.ts
+++ b/packages/core/useVirtualList/index.test.ts
@@ -120,6 +120,31 @@ describe('useVirtualList, vertical', () => {
     scrollTo(3, { block: 'nearest' })
     expect(list.value.map(i => i.data)).toEqual(['b', 'c', 'd', 'e'])
   })
+
+  it('recomputes the visible range when a reactive item height changes without scrolling', async () => {
+    const itemHeight = deepRef(50)
+    const {
+      list,
+      containerProps: { ref: containerRef },
+      scrollTo,
+    } = useVirtualList(deepRef(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']), { itemHeight: () => itemHeight.value, overscan: 1 })
+    const div = createDiv({ clientHeight: 100 })
+
+    containerRef.value = div
+    scrollTo(0)
+    // Let the element-size observer settle so the item-height change below is
+    // the only thing that can trigger a recalculation.
+    await nextTick()
+    await nextTick()
+    expect(list.value.map(i => i.data)).toEqual(['a', 'b', 'c', 'd'])
+
+    // Shrinking the items makes more of them fit; the range must update even
+    // though neither the source nor the container size changed and no scroll
+    // event occurred.
+    itemHeight.value = 25
+    await nextTick()
+    expect(list.value.map(i => i.data)).toEqual(['a', 'b', 'c', 'd', 'e', 'f'])
+  })
 })
 
 describe('useVirtualList, horizontal', () => {

--- a/packages/core/useVirtualList/index.ts
+++ b/packages/core/useVirtualList/index.ts
@@ -212,8 +212,8 @@ function createGetDistance<T>(itemSize: UseVirtualListItemSize, source: UseVirtu
   }
 }
 
-function useWatchForSizes<T>(size: UseVirtualElementSizes, listRef: Ref<readonly T[]>, containerRef: Ref<HTMLElement | null>, calculateRange: () => void) {
-  watch([size.width, size.height, listRef, containerRef], () => {
+function useWatchForSizes<T>(size: UseVirtualElementSizes, listRef: Ref<readonly T[]>, totalSize: ComputedRef<number>, containerRef: Ref<HTMLElement | null>, calculateRange: () => void) {
+  watch([size.width, size.height, listRef, totalSize, containerRef], () => {
     calculateRange()
   })
 }
@@ -299,7 +299,7 @@ function useHorizontalVirtualList<T>(options: UseHorizontalVirtualListOptions, l
 
   const totalWidth = createComputedTotalSize(itemWidth, source)
 
-  useWatchForSizes(size, source, containerRef, calculateRange)
+  useWatchForSizes(size, source, totalWidth, containerRef, calculateRange)
 
   const scrollTo = createScrollTo('horizontal', calculateRange, getDistanceLeft, containerRef, itemWidth)
 
@@ -345,7 +345,7 @@ function useVerticalVirtualList<T>(options: UseVerticalVirtualListOptions, list:
 
   const totalHeight = createComputedTotalSize(itemHeight, source)
 
-  useWatchForSizes(size, source, containerRef, calculateRange)
+  useWatchForSizes(size, source, totalHeight, containerRef, calculateRange)
 
   const scrollTo = createScrollTo('vertical', calculateRange, getDistanceTop, containerRef, itemHeight)
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Confirm that this PR is based on your own understanding and review of the project, not solely generated or summarized by AI tools.

> **Note**: If this PR is deemed to be primarily generated by AI tools, it may be closed.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

For `useVirtualList`, `itemHeight/itemWidth` is provided either as a plain value or getter, therefore it's not reactive and wouldn't trigger any virtual list update if changed.
With having a UI option to change itemSize (e.g. compact mode), it might introduce visual bugs (see report at https://github.com/nextcloud/spreed/issues/16586)
On the other hand, `totalHeight/totalWidth` is a computed, that checks that, and that can be watched for changes


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
Please pay attention that this diff (code change and regression tests) is AI-assisted (by: ClaudeCode:claude-opus-4-8). AI was also used to debug the downstream issue mentioned, with implemented workaround (watch for reactive `itemHeight` to trigger `containerProps.onScroll()`). Still would be nice to have it handled by upstream.
If this need additional adjustments or explanation from my side, I'll be happy to assist
