### PR TITLE
fix(useFetch): reset response before each request to avoid a stale onFetchError response

### DIFF
--- a/packages/core/useFetch/index.test.ts
+++ b/packages/core/useFetch/index.test.ts
@@ -605,6 +605,24 @@ describe('useFetch', () => {
     })
   })
 
+  it('should not pass a stale response to onFetchError when a later fetch rejects', async () => {
+    let errorResponse: Response | null | undefined
+    const { execute } = useFetch(`${baseUrl}?text=hello`, {
+      immediate: false,
+      onFetchError(ctx) {
+        errorResponse = ctx.response
+        return ctx
+      },
+    })
+
+    await execute()
+
+    fetchSpy.mockRejectedValueOnce(new Error('Network request failed'))
+    await execute()
+
+    expect(errorResponse).toBeNull()
+  })
+
   it('should emit onFetchResponse event', async () => {
     const { onFetchResponse, onFetchError, onFetchFinally } = useFetch(baseUrl)
 

--- a/packages/core/useFetch/index.test.ts
+++ b/packages/core/useFetch/index.test.ts
@@ -623,6 +623,20 @@ describe('useFetch', () => {
     expect(errorResponse).toBeNull()
   })
 
+  it('should keep the previous response.value until the next request settles', async () => {
+    const { execute, response } = useFetch(`${baseUrl}?text=hello`, { immediate: false })
+
+    await execute()
+    const firstResponse = response.value
+    expect(firstResponse).not.toBeNull()
+
+    const executePromise = execute()
+    expect(response.value).toBe(firstResponse)
+
+    await executePromise
+    expect(response.value).not.toBe(firstResponse)
+  })
+
   it('should emit onFetchResponse event', async () => {
     const { onFetchResponse, onFetchError, onFetchFinally } = useFetch(baseUrl)
 

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -422,6 +422,7 @@ export function useFetch<T>(url: MaybeRefOrGetter<string>, ...args: any[]): UseF
     loading(true)
     error.value = null
     statusCode.value = null
+    response.value = null
     aborted.value = false
 
     executeCounter += 1

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -422,7 +422,6 @@ export function useFetch<T>(url: MaybeRefOrGetter<string>, ...args: any[]): UseF
     loading(true)
     error.value = null
     statusCode.value = null
-    response.value = null
     aborted.value = false
 
     executeCounter += 1
@@ -469,6 +468,7 @@ export function useFetch<T>(url: MaybeRefOrGetter<string>, ...args: any[]): UseF
     }
 
     let responseData: any = null
+    let currentResponse: Response | null = null
 
     if (timer)
       timer.start()
@@ -485,6 +485,7 @@ export function useFetch<T>(url: MaybeRefOrGetter<string>, ...args: any[]): UseF
       },
     )
       .then(async (fetchResponse) => {
+        currentResponse = fetchResponse
         if (currentExecuteCounter === executeCounter) {
           response.value = fetchResponse
           statusCode.value = fetchResponse.status
@@ -520,7 +521,7 @@ export function useFetch<T>(url: MaybeRefOrGetter<string>, ...args: any[]): UseF
           ({ error: errorData, data: responseData } = await options.onFetchError({
             data: responseData,
             error: fetchError,
-            response: response.value,
+            response: currentResponse,
             context,
             execute,
           }))


### PR DESCRIPTION
When a request fails at the network level, `onFetchError` got the response from the previous successful request instead of nothing. `execute()` already clears `error`, `statusCode`, and `aborted` before each run but left `response` alone, so the stale one carried over. Now it clears `response` too.

Fixes #5536
