### PR TITLE
fix(useFetch): expose error response body via onFetchError

### DIFF
--- a/packages/core/useFetch/index.md
+++ b/packages/core/useFetch/index.md
@@ -314,6 +314,8 @@ const { isFetching, error, data } = useMyFetch('users')
 
 The `onFetchResponse` and `onFetchError` will fire on fetch request responses and errors respectively.
 
+When the response arrives with a non-ok status, the error also exposes the parsed body of the response as `data` and the raw [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) as `response`. Both are `undefined` when the request failed without receiving a response (e.g. a network error or an aborted request).
+
 ```ts
 import { useFetch } from '@vueuse/core'
 // ---cut---
@@ -325,5 +327,7 @@ onFetchResponse((response) => {
 
 onFetchError((error) => {
   console.error(error.message)
+  console.error(error.data) // Parsed body of the error response, e.g. { message: 'Invalid request' }
+  console.error(error.response?.status) // e.g. 400
 })
 ```

--- a/packages/core/useFetch/index.test.ts
+++ b/packages/core/useFetch/index.test.ts
@@ -1,4 +1,4 @@
-import type { AfterFetchContext, OnFetchErrorContext } from './index'
+import type { AfterFetchContext, OnFetchErrorContext, UseFetchError } from './index'
 import { until } from '@vueuse/shared'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref as deepRef, nextTick, shallowRef } from 'vue'
@@ -851,6 +851,25 @@ describe('useFetch', () => {
     await vi.waitFor(() => {
       expect(aborted.value).toBe(true)
       expect(error).toBe(reason)
+    })
+  })
+
+  it('should expose the response body via the onFetchError event hook', async () => {
+    const errorBody = { title: 'Invalid request' }
+    let capturedError: UseFetchError
+
+    const { onFetchError } = useFetch(`${baseUrl}?status=400&json=${encodeURIComponent(JSON.stringify(errorBody))}`).json()
+
+    onFetchError((error) => {
+      capturedError = error
+    })
+
+    await vi.waitFor(() => {
+      expect(capturedError).toBeInstanceOf(Error)
+      expect(capturedError.message).toBe('Bad Request')
+      expect(capturedError.data).toEqual(errorBody)
+      expect(capturedError.response).toBeInstanceOf(Response)
+      expect(capturedError.response?.status).toBe(400)
     })
   })
 })

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -64,7 +64,7 @@ export interface UseFetchReturn<T> {
   /**
    * Fires after a fetch request error
    */
-  onFetchError: EventHookOn
+  onFetchError: EventHookOn<UseFetchError>
 
   /**
    * Fires after a fetch has completed
@@ -219,6 +219,25 @@ export interface CreateFetchOptions {
    * Options for the fetch request
    */
   fetchOptions?: RequestInit
+}
+
+/**
+ * Thrown when a response arrives with a non-ok status.
+ * Delivered to onFetchError subscribers and becomes a rejection of execute(true).
+ */
+export interface UseFetchError<T = any> extends Error {
+  /**
+   * The parsed body of an error response;
+   * undefined - when the request failed before receiving a response (network error, abort);
+   * null - there was a response, but the body parsed to null.
+   */
+  data?: T | null
+
+  /**
+   * Raw Response of an error response;
+   * undefined - when the request failed before receiving a response (network error, abort).
+   */
+  response?: Response
 }
 
 /**
@@ -492,7 +511,10 @@ export function useFetch<T>(url: MaybeRefOrGetter<string>, ...args: any[]): UseF
         // see: https://www.tjvantoll.com/2015/09/13/fetch-and-errors/
         if (!fetchResponse.ok) {
           data.value = initialData || null
-          throw new Error(fetchResponse.statusText)
+          const err: UseFetchError = new Error(fetchResponse.statusText)
+          err.data = responseData
+          err.response = fetchResponse
+          throw err
         }
 
         if (options.afterFetch) {

--- a/test/__snapshots__/tsnapi/@vueuse/core/index.snapshot.d.ts
+++ b/test/__snapshots__/tsnapi/@vueuse/core/index.snapshot.d.ts
@@ -657,6 +657,10 @@ export interface UseFaviconOptions extends ConfigurableDocument {
   baseUrl?: string;
   rel?: string;
 }
+export interface UseFetchError<T = any> extends Error {
+  data?: T | null;
+  response?: Response;
+}
 export interface UseFetchOptions {
   fetch?: typeof window.fetch;
   immediate?: boolean;
@@ -680,7 +684,7 @@ export interface UseFetchReturn<T> {
   abort: (_?: any) => void;
   execute: (_?: boolean) => Promise<any>;
   onFetchResponse: EventHookOn<Response>;
-  onFetchError: EventHookOn;
+  onFetchError: EventHookOn<UseFetchError>;
   onFetchFinally: EventHookOn;
   get: () => UseFetchReturn<T> & PromiseLike<UseFetchReturn<T>>;
   post: (_?: MaybeRefOrGetter<unknown>, _?: string) => UseFetchReturn<T> & PromiseLike<UseFetchReturn<T>>;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Confirm that this PR is based on your own understanding and review of the project, not solely generated or summarized by AI tools.

> **Note**: If this PR is deemed to be primarily generated by AI tools, it may be closed.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
The `onFetchError` event hook only receives a bare `Error` with the status text as its message, so the body of an error response (e.g. `application/problem+json`) is not accessible to subscribers - even though it is already parsed internally.

With this change, the error thrown for non-ok responses carries the parsed body as `error.data` and the raw `Response` as `error.response`. Both fields are optional, since errors without a response (network failures, aborts) also reach the hook. The new exported `UseFetchError` interface types the event hook, so the fields are discoverable from completions.

fixes #5405

- The added test fails without the fix (`error.data` was `undefined`) and passes with it.
- Existing behavior is untouched: the error is still an `Error` with the same message; `error.value`, `updateDataOnError` and the `onFetchError` option work as before (54/54 tests pass).
- Docs: extended the Events section with the new fields.


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
Out of scope, kept for a possible follow-up: when the error body can't be parsed by the configured parser (e.g. `.json()` on a plain-text body), the parse error still masks the response body.

