### PR TITLE
test(useTransition): widen lower bound for WebKit test

### DIFF
--- a/packages/core/useTransition/index.browser.test.ts
+++ b/packages/core/useTransition/index.browser.test.ts
@@ -67,7 +67,7 @@ describe('transition', () => {
 
     await promiseTimeout(25)
 
-    expectBetween(source.value, 0.25, 0.75)
+    expectBetween(source.value, 0.15, 0.75)
 
     await trans
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
- [ ] Confirm that this PR is based on your own understanding and review of the project, not solely generated or summarized by AI tools.

> **Note**: If this PR is deemed to be primarily generated by AI tools, it may be closed.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Fixing the  https://github.com/vueuse/vueuse/actions/runs/29112232289/job/86427074082?pr=5534

Follow-up to [#5305](https://github.com/vueuse/vueuse/pull/5305/changes#diff-4458143fec0381eaa6da1218fb0f074da0e37b06072971d1ec2099efb08930fdL19-R19). It moved tests from jsdom to real browsers. The `transitions between numbers`
test had its lower bound changed from `0.25` to `0.15` to handle `requestAnimationFrame`
timing differences in WebKit, but the `executeTransition` test was left behind. And this causes random CI failures on `browser (webkit)`.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
