### PR TITLE
fix(useClipboard): resolve async value provider only once (#5539)

### DIFF
--- a/packages/core/useClipboard/index.test.ts
+++ b/packages/core/useClipboard/index.test.ts
@@ -1,8 +1,53 @@
 import { useClipboard } from '@vueuse/core'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// jsdom does not implement document.execCommand, which the legacy copy path uses.
+function mockExecCommand() {
+  ;(document as unknown as { execCommand: typeof document.execCommand }).execCommand = vi.fn(() => true)
+}
 
 describe('useClipboard', () => {
   it('should be defined', () => {
     expect(useClipboard).toBeDefined()
+  })
+
+  afterEach(() => {
+    delete (document as unknown as { execCommand?: unknown }).execCommand
+  })
+
+  // Regression tests for https://github.com/vueuse/vueuse/issues/5539
+  // The async value provider must be resolved exactly once per copy() call so
+  // that it is never re-invoked when the Clipboard API write fails and the
+  // code falls back to the legacy copy path. (Full reproduction of the original
+  // double-invocation requires a permission-granted browser environment, which
+  // jsdom cannot simulate because the permission state is mount-gated.)
+  it('should resolve an async value provider exactly once and copy the result (#5539)', async () => {
+    mockExecCommand()
+    const { copy, text, copied } = useClipboard({ legacy: true })
+
+    const asyncCopy = vi.fn(() => Promise.resolve('hello'))
+    await copy(asyncCopy)
+
+    expect(asyncCopy).toHaveBeenCalledTimes(1)
+    expect(text.value).toBe('hello')
+    expect(copied.value).toBe(true)
+  })
+
+  it('should propagate a rejection from the async value provider without re-invoking it (#5539)', async () => {
+    mockExecCommand()
+    const { copy } = useClipboard({ legacy: true })
+
+    const failedCopy = vi.fn(() => Promise.reject(new Error('nope')))
+    await expect(copy(failedCopy)).rejects.toThrow('nope')
+    expect(failedCopy).toHaveBeenCalledTimes(1)
+  })
+
+  it('should copy a plain string', async () => {
+    mockExecCommand()
+    const { copy, text, copied } = useClipboard({ legacy: true })
+
+    await copy('hello')
+    expect(text.value).toBe('hello')
+    expect(copied.value).toBe(true)
   })
 })

--- a/packages/core/useClipboard/index.test.ts
+++ b/packages/core/useClipboard/index.test.ts
@@ -1,26 +1,73 @@
+import type { ConfigurableNavigator } from '../_configurable'
 import { useClipboard } from '@vueuse/core'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // jsdom does not implement document.execCommand, which the legacy copy path uses.
 function mockExecCommand() {
   ;(document as unknown as { execCommand: typeof document.execCommand }).execCommand = vi.fn(() => true)
 }
 
+// Minimal ClipboardItem stand-in: jsdom does not provide one, and the Clipboard
+// API path constructs it with a promise resolving to the copied Blob.
+class MockClipboardItem {
+  constructor(public readonly data: Record<string, Promise<Blob> | Blob | string>) {}
+}
+
+interface MockNavigatorOptions {
+  // Reject clipboard.write independently of the value provider (a genuine
+  // Clipboard API failure), instead of awaiting the item data.
+  writeRejects?: boolean
+}
+
+// Builds a navigator with granted clipboard permission and an observable
+// clipboard.write so we can drive the Clipboard API path and its fallback.
+function createClipboardNavigator({ writeRejects = false }: MockNavigatorOptions = {}) {
+  const write = vi.fn(async (items: MockClipboardItem[]) => {
+    if (writeRejects)
+      throw new Error('clipboard blocked')
+    // Awaiting the item data mirrors the real API: a rejected value provider
+    // makes the write reject.
+    await Promise.all(items.flatMap(item => Object.values(item.data)))
+  })
+
+  const navigator = {
+    clipboard: { write, readText: async () => '' },
+    permissions: {
+      query: async () => ({
+        state: 'granted' as PermissionState,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+      }),
+    },
+  }
+
+  return { navigator: navigator as unknown as ConfigurableNavigator['navigator'], write }
+}
+
+// Lets usePermission's async query settle so the Clipboard API path is enabled.
+function flushAsync() {
+  return new Promise(resolve => setTimeout(resolve))
+}
+
 describe('useClipboard', () => {
+  beforeEach(() => {
+    vi.stubGlobal('ClipboardItem', MockClipboardItem)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    delete (document as unknown as { execCommand?: unknown }).execCommand
+  })
+
   it('should be defined', () => {
     expect(useClipboard).toBeDefined()
   })
 
-  afterEach(() => {
-    delete (document as unknown as { execCommand?: unknown }).execCommand
-  })
-
   // Regression tests for https://github.com/vueuse/vueuse/issues/5539
   // The async value provider must be resolved exactly once per copy() call so
-  // that it is never re-invoked when the Clipboard API write fails and the
-  // code falls back to the legacy copy path. (Full reproduction of the original
-  // double-invocation requires a permission-granted browser environment, which
-  // jsdom cannot simulate because the permission state is mount-gated.)
+  // that it is never re-invoked when the code falls back to the legacy copy
+  // path after a Clipboard API failure.
   it('should resolve an async value provider exactly once and copy the result (#5539)', async () => {
     mockExecCommand()
     const { copy, text, copied } = useClipboard({ legacy: true })
@@ -49,5 +96,39 @@ describe('useClipboard', () => {
     await copy('hello')
     expect(text.value).toBe('hello')
     expect(copied.value).toBe(true)
+  })
+
+  // The originally reported path: the Clipboard API is used, the write fails,
+  // and the code falls back to the legacy path. The value provider must be
+  // reused rather than invoked a second time.
+  it('should reuse the resolved value for the legacy fallback when the Clipboard API write fails (#5539)', async () => {
+    mockExecCommand()
+    const { navigator, write } = createClipboardNavigator({ writeRejects: true })
+    const { copy, text, copied } = useClipboard({ navigator })
+    await flushAsync()
+
+    const asyncCopy = vi.fn(() => Promise.resolve('hello'))
+    await copy(asyncCopy)
+
+    expect(write).toHaveBeenCalledTimes(1)
+    expect(asyncCopy).toHaveBeenCalledTimes(1)
+    expect(document.execCommand).toHaveBeenCalledTimes(1)
+    expect(text.value).toBe('hello')
+    expect(copied.value).toBe(true)
+  })
+
+  it('should not fall back to legacy copy when the async value provider rejects on the Clipboard API path (#5539)', async () => {
+    mockExecCommand()
+    const { navigator, write } = createClipboardNavigator()
+    const { copy, copied } = useClipboard({ navigator })
+    await flushAsync()
+
+    const failedCopy = vi.fn(() => Promise.reject(new Error('nope')))
+    await expect(copy(failedCopy)).rejects.toThrow('nope')
+
+    expect(write).toHaveBeenCalledTimes(1)
+    expect(failedCopy).toHaveBeenCalledTimes(1)
+    expect(document.execCommand).not.toHaveBeenCalled()
+    expect(copied.value).toBe(false)
   })
 })

--- a/packages/core/useClipboard/index.ts
+++ b/packages/core/useClipboard/index.ts
@@ -69,8 +69,8 @@ export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<strin
   } = options
 
   const isClipboardApiSupported = useSupported(() => (navigator && 'clipboard' in navigator))
-  const permissionRead = usePermission('clipboard-read')
-  const permissionWrite = usePermission('clipboard-write')
+  const permissionRead = usePermission('clipboard-read', { navigator })
+  const permissionWrite = usePermission('clipboard-write', { navigator })
   const isSupported = computed(() => isClipboardApiSupported.value || legacy)
   const text = shallowRef('')
   const copied = shallowRef(false)
@@ -99,50 +99,53 @@ export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<strin
     const resolvedValue = value ?? toValue(source)
     if (isSupported.value && resolvedValue != null) {
       copyPending.value = true
+      try {
+        // Resolve the value provider exactly once. Keeping its promise lets us
+        // hand it to `ClipboardItem` (which preserves the user gesture on
+        // Safari) and reuse it in the legacy fallback, so a provider is never
+        // invoked twice. See https://github.com/vueuse/vueuse/issues/5539
+        const dataPromise = typeof resolvedValue === 'function'
+          ? resolvedValue()
+          : Promise.resolve(resolvedValue)
 
-      // Resolve the value provider at most once. A function provider that
-      // rejects should surface its error instead of being re-invoked when
-      // falling back to the legacy copy path. See https://github.com/vueuse/vueuse/issues/5539
-      const data = typeof resolvedValue === 'function'
-        ? await resolvedValue()
-        : resolvedValue
+        let useLegacy = !(isClipboardApiSupported.value && isAllowed(permissionWrite.value))
 
-      let useLegacy = !(isClipboardApiSupported.value && isAllowed(permissionWrite.value))
-
-      if (!useLegacy && data != null) {
-        try {
-          const clipboardItem = createClipboardItem(data)
-          await navigator!.clipboard.write([clipboardItem])
+        if (!useLegacy) {
+          try {
+            await navigator!.clipboard.write([createClipboardItem(dataPromise)])
+          }
+          catch {
+            // Fall back only for a genuine Clipboard API failure. When the
+            // value provider rejected, awaiting the shared promise below
+            // rethrows that error instead of running the provider again.
+            useLegacy = true
+          }
         }
-        catch {
-          useLegacy = true
+
+        if (useLegacy) {
+          const data = await dataPromise
+          if (data != null) {
+            text.value = data
+            legacyCopy(data)
+          }
         }
-      }
 
-      if (useLegacy && data != null) {
-        text.value = data
-        legacyCopy(data)
+        copied.value = true
+        timeout.start()
       }
-
-      copied.value = true
-      timeout.start()
-      copyPending.value = false
+      finally {
+        copyPending.value = false
+      }
     }
   }
 
-  function createClipboardItem(value: ClipboardValue): ClipboardItem {
-    if (typeof value === 'string') {
-      text.value = value
-      return new ClipboardItem({ 'text/plain': value })
-    }
-    else {
-      return new ClipboardItem({
-        'text/plain': value().then((resolvedText = '') => {
-          text.value = resolvedText
-          return new Blob([resolvedText], { type: 'text/plain' })
-        }),
-      })
-    }
+  function createClipboardItem(dataPromise: Promise<string | undefined>): ClipboardItem {
+    return new ClipboardItem({
+      'text/plain': dataPromise.then((resolvedText = '') => {
+        text.value = resolvedText
+        return new Blob([resolvedText], { type: 'text/plain' })
+      }),
+    })
   }
 
   function legacyCopy(value: string) {

--- a/packages/core/useClipboard/index.ts
+++ b/packages/core/useClipboard/index.ts
@@ -76,7 +76,6 @@ export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<strin
   const copied = shallowRef(false)
   const copyPending = shallowRef(false)
   const timeout = useTimeoutFn(() => copied.value = false, copiedDuring, { immediate: false })
-  let lastLegacyId = 0
 
   async function updateText() {
     let useLegacy = !(isClipboardApiSupported.value && isAllowed(permissionRead.value))
@@ -100,11 +99,19 @@ export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<strin
     const resolvedValue = value ?? toValue(source)
     if (isSupported.value && resolvedValue != null) {
       copyPending.value = true
+
+      // Resolve the value provider at most once. A function provider that
+      // rejects should surface its error instead of being re-invoked when
+      // falling back to the legacy copy path. See https://github.com/vueuse/vueuse/issues/5539
+      const data = typeof resolvedValue === 'function'
+        ? await resolvedValue()
+        : resolvedValue
+
       let useLegacy = !(isClipboardApiSupported.value && isAllowed(permissionWrite.value))
 
-      if (!useLegacy) {
+      if (!useLegacy && data != null) {
         try {
-          const clipboardItem = createClipboardItem(resolvedValue)
+          const clipboardItem = createClipboardItem(data)
           await navigator!.clipboard.write([clipboardItem])
         }
         catch {
@@ -112,20 +119,9 @@ export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<strin
         }
       }
 
-      if (useLegacy) {
-        if (typeof resolvedValue === 'string') {
-          text.value = resolvedValue
-          legacyCopy(resolvedValue)
-        }
-        else {
-          // For async functions in legacy mode, resolve and copy
-          const currentId = ++lastLegacyId
-          const resolvedText = await resolvedValue()
-          if (resolvedText != null && currentId === lastLegacyId) {
-            text.value = resolvedText
-            legacyCopy(resolvedText)
-          }
-        }
+      if (useLegacy && data != null) {
+        text.value = data
+        legacyCopy(data)
       }
 
       copied.value = true


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Confirm that this PR is based on your own understanding and review of the project, not solely generated or summarized by AI tools.

> **Note**: If this PR is deemed to be primarily generated by AI tools, it may be closed.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Fixes #5539

`useClipboard().copy()` accepts an async callback that returns the text to copy (mainly for Safari’s user-gesture restriction).  
When that callback rejects, the old implementation treated it as a Clipboard API failure and fell back to the legacy path — which called the **same callback again**. If the callback isn’t idempotent (e.g. it makes an API request), it ends up running twice.

This PR resolves the value provider exactly once and keeps the promise around:
- hand it to `ClipboardItem` (so it still happens inside the user gesture)
- the legacy fallback also awaits the same promise instead of re-invoking the provider

If the provider itself rejects, the error is rethrown and we don’t fall back. Only a real Clipboard API write failure (when the provider resolved fine) still triggers the legacy path.


### Additional context

Added regression tests in `packages/core/useClipboard/index.test.ts` covering:
1. Clipboard API write fails → legacy reuses the already-resolved value (provider called only once)
2. provider rejects → error propagates, no legacy retry

They fail on the previous behaviour and pass with this change (`pnpm test:unit --run packages/core/useClipboard/index.test.ts` — 6/6).

The code and tests had some AI help, but the root-cause analysis and the approach were done and double-checked by me. Happy to tweak if reviewers prefer a different direction.