### PR TITLE
fix(useEventBus): use `tryOnScopeDispose` to avoid operating Vue internal API

### DIFF
--- a/packages/core/useEventBus/index.ts
+++ b/packages/core/useEventBus/index.ts
@@ -1,5 +1,5 @@
 import type { Fn } from '@vueuse/shared'
-import { getCurrentScope } from 'vue'
+import { tryOnScopeDispose } from '@vueuse/shared'
 import { events } from './internal'
 
 export type EventBusListener<T = unknown, P = any> = (event: T, payload?: P) => void
@@ -41,7 +41,6 @@ export interface UseEventBusReturn<T, P> {
 
 /* @__NO_SIDE_EFFECTS__ */
 export function useEventBus<T = unknown, P = any>(key: EventBusIdentifier<T>): UseEventBusReturn<T, P> {
-  const scope = getCurrentScope()
   function on(listener: EventBusListener<T, P>) {
     const listeners = (events.get(key) || new Set())
     listeners.add(listener)
@@ -49,8 +48,7 @@ export function useEventBus<T = unknown, P = any>(key: EventBusIdentifier<T>): U
 
     const _off = () => off(listener)
     // auto unsubscribe when scope get disposed
-    // @ts-expect-error vue3 and vue2 mis-align
-    scope?.cleanups?.push(_off)
+    tryOnScopeDispose(_off)
     return _off
   }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Confirm that this PR is based on your own understanding and review of the project, not solely generated or summarized by AI tools.

> **Note**: If this PR is deemed to be primarily generated by AI tools, it may be closed.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

After Vue 3.6, Vue imports a `cleanupsLength` for performnace. So directly pushing items into `cleanups` array no longer works.

This PR changes it with `tryOnScopeDispose` function.

### Additional context

This PR follows Vue core team member and maintainer Edison's guidance in https://github.com/vuejs/core/pull/13606.

Related to a failing test in #5546
