### PR TITLE
fix(skills): correct broken relative links in generated function references

### DIFF
--- a/packages/skills/build.ts
+++ b/packages/skills/build.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import * as metadata from '@vueuse/metadata'
 import { getTypeDefinition } from '../../scripts/utils'
+import { rewriteFunctionLinks } from './rewrite-function-links'
 
 type FunctionInvocation = 'AUTO' | 'EXTERNAL' | 'EXPLICIT_ONLY'
 
@@ -119,14 +120,6 @@ function toTitleCase(str: string): string {
   if (first < 'a' || first > 'z')
     return str
   return first.toUpperCase() + str.slice(1)
-}
-
-// Function docs link to each other via `../{name}/index.md`, but the generated
-// references are flattened into a single directory as `{name}.md`, so rewrite
-// those links to point at the reference file. `prefix` is the path to the
-// reference directory relative to the file the link lives in.
-function rewriteFunctionLinks(md: string, prefix: string) {
-  return md.replace(/\]\(\.\.\/([^/)]+)\/index\.md(#[^)]*)?\)/g, `](${prefix}$1.md$2)`)
 }
 
 async function genFunctionReference(pkg: string, name: string, mdPath: string) {

--- a/packages/skills/build.ts
+++ b/packages/skills/build.ts
@@ -60,7 +60,7 @@ async function prepareFunctionReferences(outDir: string, referenceDir = SKILL_RE
 
     const functions = metadata.functions.filter(i => i.category === category && !i.internal)
     for (const fn of functions) {
-      const description = toTitleCase(fn.description?.replace(/\|/g, '\\|') ?? '')
+      const description = rewriteFunctionLinks(toTitleCase(fn.description?.replace(/\|/g, '\\|') ?? ''), `${referenceDir.replace(/^\.\//, '')}/`)
 
       if (fn.external) {
         refs.push({ name: fn.name, description, reference: fn.external })
@@ -121,8 +121,16 @@ function toTitleCase(str: string): string {
   return first.toUpperCase() + str.slice(1)
 }
 
+// Function docs link to each other via `../{name}/index.md`, but the generated
+// references are flattened into a single directory as `{name}.md`, so rewrite
+// those links to point at the reference file. `prefix` is the path to the
+// reference directory relative to the file the link lives in.
+function rewriteFunctionLinks(md: string, prefix: string) {
+  return md.replace(/\]\(\.\.\/([^/)]+)\/index\.md(#[^)]*)?\)/g, `](${prefix}$1.md$2)`)
+}
+
 async function genFunctionReference(pkg: string, name: string, mdPath: string) {
-  const md = readFileSync(mdPath, 'utf-8')
+  const md = rewriteFunctionLinks(readFileSync(mdPath, 'utf-8'), './')
   const types = await getTypeDefinition(pkg, name)
   if (types) {
     return `${md}

--- a/packages/skills/rewrite-function-links.test.ts
+++ b/packages/skills/rewrite-function-links.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { rewriteFunctionLinks } from './rewrite-function-links'
+
+describe('rewriteFunctionLinks', () => {
+  it('rewrites a plain function link', () => {
+    expect(rewriteFunctionLinks('[useMouse](../useMouse/index.md)', './')).toBe('[useMouse](./useMouse.md)')
+  })
+
+  it('preserves an anchor on the link', () => {
+    expect(rewriteFunctionLinks('[useMouse](../useMouse/index.md#options)', 'references/')).toBe('[useMouse](references/useMouse.md#options)')
+  })
+
+  it('leaves unrelated links untouched', () => {
+    expect(rewriteFunctionLinks('[Vue](https://vuejs.org)', './')).toBe('[Vue](https://vuejs.org)')
+  })
+})

--- a/packages/skills/rewrite-function-links.ts
+++ b/packages/skills/rewrite-function-links.ts
@@ -1,0 +1,4 @@
+// Rewrites `../{name}/index.md` links to point at the flattened `{name}.md` reference file.
+export function rewriteFunctionLinks(md: string, prefix: string) {
+  return md.replace(/\]\(\.\.\/([^/)]+)\/index\.md(#[^)]*)?\)/g, `](${prefix}$1.md$2)`)
+}

--- a/skills/vueuse-functions/SKILL.md
+++ b/skills/vueuse-functions/SKILL.md
@@ -109,7 +109,7 @@ IMPORTANT: Each function entry includes a short `Description` and a detailed `Re
 | [`useScreenSafeArea`](references/useScreenSafeArea.md) | Reactive `env(safe-area-inset-*)` | AUTO |
 | [`useScriptTag`](references/useScriptTag.md) | Creates a script tag | AUTO |
 | [`useShare`](references/useShare.md) | Reactive [Web Share API](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/share) | AUTO |
-| [`useSSRWidth`](references/useSSRWidth.md) | Used to set a global viewport width which will be used when rendering SSR components that rely on the viewport width like [`useMediaQuery`](../useMediaQuery/index.md) or [`useBreakpoints`](../useBreakpoints/index.md) | AUTO |
+| [`useSSRWidth`](references/useSSRWidth.md) | Used to set a global viewport width which will be used when rendering SSR components that rely on the viewport width like [`useMediaQuery`](references/useMediaQuery.md) or [`useBreakpoints`](references/useBreakpoints.md) | AUTO |
 | [`useStyleTag`](references/useStyleTag.md) | Inject reactive `style` element in head | AUTO |
 | [`useTextareaAutosize`](references/useTextareaAutosize.md) | Automatically update the height of a textarea depending on the content | AUTO |
 | [`useTextDirection`](references/useTextDirection.md) | Reactive [dir](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir) of the element's text | AUTO |

--- a/skills/vueuse-functions/references/useBreakpoints.md
+++ b/skills/vueuse-functions/references/useBreakpoints.md
@@ -100,7 +100,7 @@ const breakpoints = useBreakpoints(breakpointsTailwind, {
 })
 ```
 
-Alternatively you can set this up globally for your app using [`provideSSRWidth`](../useSSRWidth/index.md)
+Alternatively you can set this up globally for your app using [`provideSSRWidth`](./useSSRWidth.md)
 
 ## Presets
 

--- a/skills/vueuse-functions/references/useMediaQuery.md
+++ b/skills/vueuse-functions/references/useMediaQuery.md
@@ -32,7 +32,7 @@ onMounted(() => {
 })
 ```
 
-Alternatively you can set this up globally for your app using [`provideSSRWidth`](../useSSRWidth/index.md)
+Alternatively you can set this up globally for your app using [`provideSSRWidth`](./useSSRWidth.md)
 
 ## Type Declarations
 

--- a/skills/vueuse-functions/references/useSSRWidth.md
+++ b/skills/vueuse-functions/references/useSSRWidth.md
@@ -4,7 +4,7 @@ category: Browser
 
 # useSSRWidth
 
-Used to set a global viewport width which will be used when rendering SSR components that rely on the viewport width like [`useMediaQuery`](../useMediaQuery/index.md) or [`useBreakpoints`](../useBreakpoints/index.md)
+Used to set a global viewport width which will be used when rendering SSR components that rely on the viewport width like [`useMediaQuery`](./useMediaQuery.md) or [`useBreakpoints`](./useBreakpoints.md)
 
 ## Usage
 


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Confirm that this PR is based on your own understanding and review of the project, not solely generated or summarized by AI tools.

### Description

Fixes #5547

The generated function references in `skills/vueuse-functions/references/` carry cross-links copied from the source docs, written as `../{name}/index.md`. Those paths only work in the original `packages/{pkg}/{name}/index.md` layout. Once the build flattens every doc into a single `references/` directory as `{name}.md`, the links point nowhere. The same broken links show up in the function table descriptions in `SKILL.md`.

This rewrites `../{name}/index.md` links during generation so they point at the flattened target: `./{name}.md` inside reference files, and `references/{name}.md` in `SKILL.md`. The affected files have been regenerated.

### Additional context

Reproduced by running the skills build and inspecting the generated `useMediaQuery.md`, `useBreakpoints.md`, and `useSSRWidth.md`.
