### PR TITLE
fix(useDraggable): end drag on pointercancel

### DIFF
--- a/packages/core/useDraggable/index.test.ts
+++ b/packages/core/useDraggable/index.test.ts
@@ -70,6 +70,42 @@ describe('useDraggable', () => {
     expect(wrapper.get('div').element.dataset.isDragging).toBe('false')
   })
 
+  it('ends the drag when the pointer is canceled', async () => {
+    const onEnd = vi.fn()
+
+    const wrapper = mount({
+      setup() {
+        const el = useTemplateRef<HTMLElement>('el')
+
+        const { isDragging, style } = useDraggable(el, { onEnd })
+
+        return () => h('div', {
+          'data-is-dragging': isDragging.value,
+          'ref': 'el',
+          'style': style.value,
+        })
+      },
+    })
+
+    await nextTick()
+    wrapper.get('div').element.dispatchEvent(new PointerEvent('pointerdown', {
+      clientX: 0,
+      clientY: 0,
+    }))
+    await nextTick()
+    window.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: 10,
+      clientY: 20,
+    }))
+    await nextTick()
+    expect(wrapper.get('div').element.dataset.isDragging).toBe('true')
+
+    window.dispatchEvent(new PointerEvent('pointercancel'))
+    await nextTick()
+    expect(onEnd).toHaveBeenCalledOnce()
+    expect(wrapper.get('div').element.dataset.isDragging).toBe('false')
+  })
+
   it('component', async () => {
     const onStart = vi.fn()
     const onMove = vi.fn()

--- a/packages/core/useDraggable/index.ts
+++ b/packages/core/useDraggable/index.ts
@@ -415,7 +415,7 @@ export function useDraggable(
     })
     useEventListener(draggingHandle, 'pointerdown', start, config)
     useEventListener(draggingElement, 'pointermove', move, config)
-    useEventListener(draggingElement, 'pointerup', end, config)
+    useEventListener(draggingElement, ['pointerup', 'pointercancel'], end, config)
   }
 
   return {


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Confirm that this PR is based on your own understanding and review of the project, not solely generated or summarized by AI tools.

---

### Description

Fixes #5162.

#### What is broken

`useDraggable` attaches `pointerdown` to the handle and `pointermove` / `pointerup` to `draggingElement`. It never listens for `pointercancel`.

When the user agent takes over an in-progress touch gesture — most commonly when it decides a touch drag is really a page scroll or pan — it fires `pointercancel` for that pointer and then emits no further events for it. Since nothing handles that event, `pressedDelta` is never cleared, so:

- `onEnd` never fires
- `isDragging` stays `true`
- the element keeps following the pointer until the next `pointerdown`

That is the "drag going on until clicking/touching once more" reported in #5162.

Per [Pointer Events Level 3](https://www.w3.org/TR/pointerevents3/), the UA must fire `pointercancel` when "the pointer is subsequently used by the user agent to manipulate the page viewport", so this is the specified signal for this situation rather than a browser quirk.

#### On the fix proposed in the issue

#5162 suggests removing the element argument from the `pointerup` listener. That is already the case and is not the cause: `draggingElement` defaults to `window`, so a `pointerup` released outside the dragged element already ends the drag correctly. I checked this first with a throwaway test that releases the pointer at coordinates far outside the element — `onEnd` fires as expected on current `main`. The only missing piece is `pointercancel`.

#### What changed

```diff
-    useEventListener(draggingElement, 'pointerup', end, config)
+    useEventListener(draggingElement, ['pointerup', 'pointercancel'], end, config)
```

This mirrors #5379, which fixed the same defect in `usePointerSwipe` with the identical change.

`end` itself needs no changes:

- it already returns early when `pressedDelta` is unset, so it stays idempotent if both a cancel and an up arrive for one gesture
- `pointercancel` is not cancelable, so the existing `handleEvent` call is a no-op on it
- routing this path through `end` means `stopAutoScroll()` now also runs for a canceled drag, which previously left the auto-scroll interval running

#### Why this approach

The two comments on #5162 suggest a non-passive `touchmove` `preventDefault` in user code. That does work, because it stops the browser from claiming the gesture so `pointercancel` never fires — but it asks every consumer to suppress native scrolling globally for the duration of a drag, and it avoids a specified event rather than handling it.

I also considered a `blur` listener on the window to catch drags interrupted by focus loss. That would change behaviour for all mouse users and is not what #5162 describes, so it is out of scope here.

#### Test

One case added to `packages/core/useDraggable/index.test.ts`, directly beneath the existing `basic functionality` case whose shape it mirrors: `pointerdown` on the element, `pointermove` on `window`, assert dragging, then `pointercancel` and assert `onEnd` fired once and `isDragging` is `false`.

It fails on `main` (`onEnd` called 0 times) and passes with this change. Locally: unit + server projects pass (129 files, 877 tests), `eslint` clean, `vue-tsc --noEmit` clean.

### Additional context

- Orthogonal to the other open PRs touching these files (#5496, #4758): this is one line in the listener registration plus one test. Happy to rebase if either lands first.
- Unrelated to #5325 / `setPointerCapture` — pointer capture does not suppress `pointercancel`, so `end` still needs to hear it.
- The `draggingElement` JSDoc, and the matching comment in `index.md`, both enumerate "pointermove and pointerup" and are now strictly incomplete. I left them out to keep the diff minimal — happy to update both here or in a follow-up, whichever you prefer.
- Developed with AI assistance; the commit carries a `Co-Authored-By` trailer. The diagnosis and the reasoning above are mine and I am happy to go into any of it.
