### PR TITLE
fix: reintroduce package normalisation to nuxt package

### DIFF
--- a/meta/packages.ts
+++ b/meta/packages.ts
@@ -34,7 +34,7 @@ export const packages: PackageManifest[] = [
     display: 'Nuxt',
     description: 'VueUse Nuxt Module',
     manualImport: true,
-    excludePkgJson: true,
+    manualEntryPoints: true,
     addon: true,
     iife: false,
     utils: true,

--- a/packages/metadata/types.ts
+++ b/packages/metadata/types.ts
@@ -16,8 +16,7 @@ export interface PackageManifest {
   target?: string
   utils?: boolean
   copy?: string[]
-  // don't change package.json
-  excludePkgJson?: true
+  manualEntryPoints?: true
 }
 
 export interface VueUseFunction {

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -232,10 +232,7 @@ export async function updateCountBadge(indexes: PackageIndexes) {
 export async function updatePackageJSON(indexes: PackageIndexes) {
   const { version } = JSON.parse(await fs.readFile('package.json', { encoding: 'utf8' }))
 
-  for (const { name, description, author, submodules, iife, excludePkgJson } of packages) {
-    if (excludePkgJson) {
-      continue
-    }
+  for (const { name, description, author, submodules, iife, manualEntryPoints } of packages) {
     const packageDir = join(DIR_SRC, name)
     const packageJSONPath = join(packageDir, 'package.json')
     const packageJSON = JSON.parse(await fs.readFile(packageJSONPath, { encoding: 'utf8' }))
@@ -255,32 +252,35 @@ export async function updatePackageJSON(indexes: PackageIndexes) {
       url: 'git+https://github.com/vueuse/vueuse.git',
       directory: `packages/${name}`,
     }
-    packageJSON.main = './dist/index.js'
-    packageJSON.types = './dist/index.d.ts'
-    packageJSON.module = './dist/index.js'
-    if (iife !== false) {
-      packageJSON.unpkg = './dist/index.iife.min.js'
-      packageJSON.jsdelivr = './dist/index.iife.min.js'
-    }
     packageJSON.files = [
       'dist',
     ]
 
-    packageJSON.exports = {
-      '.': './dist/index.js',
-      ...packageJSON.exports,
-      './*': './dist/*',
-    }
+    if (!manualEntryPoints) {
+      packageJSON.main = './dist/index.js'
+      packageJSON.types = './dist/index.d.ts'
+      packageJSON.module = './dist/index.js'
+      if (iife !== false) {
+        packageJSON.unpkg = './dist/index.iife.min.js'
+        packageJSON.jsdelivr = './dist/index.iife.min.js'
+      }
 
-    if (submodules) {
-      indexes.functions
-        .filter(i => i.package === name)
-        .forEach((i) => {
-          packageJSON.exports[`./${i.name}`] = `./dist/${i.name}.js`
-          if (i.component) {
-            packageJSON.exports[`./${i.name}/component`] = `./dist/${i.name}/component.js`
-          }
-        })
+      packageJSON.exports = {
+        '.': './dist/index.js',
+        ...packageJSON.exports,
+        './*': './dist/*',
+      }
+
+      if (submodules) {
+        indexes.functions
+          .filter(i => i.package === name)
+          .forEach((i) => {
+            packageJSON.exports[`./${i.name}`] = `./dist/${i.name}.js`
+            if (i.component) {
+              packageJSON.exports[`./${i.name}/component`] = `./dist/${i.name}/component.js`
+            }
+          })
+      }
     }
 
     await fs.writeFile(packageJSONPath, `${JSON.stringify(packageJSON, null, 2)}\n`)

--- a/test/__snapshots__/tsnapi/@vueuse/metadata/index.snapshot.d.ts
+++ b/test/__snapshots__/tsnapi/@vueuse/metadata/index.snapshot.d.ts
@@ -41,7 +41,7 @@ export interface PackageManifest {
   target?: string;
   utils?: boolean;
   copy?: string[];
-  excludePkgJson?: true;
+  manualEntryPoints?: true;
 }
 export interface VueUseFunction {
   name: string;


### PR DESCRIPTION
In #5503, we introduced an `excludePkgJson` flag to skip normalising the
`package.json` entirely for the `nuxt` package.

This is not granular enough as it now means we have to keep the `nuxt`
package in sync manually with the rest of the monorepo's packages.

To fix this, this change introduces `manualEntryPoints` which means the
normalisation runs but skips setting entry points (the only thing the
`nuxt` package really needed to skip).

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Confirm that this PR is based on your own understanding and review of the project, not solely generated or summarized by AI tools.
