### PR TITLE
chore: release v14.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vueuse/monorepo",
   "type": "module",
-  "version": "14.3.0",
+  "version": "14.4.0",
   "private": true,
   "packageManager": "pnpm@11.17.0",
   "description": "Collection of essential Vue Composition Utilities",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vueuse/components",
   "type": "module",
-  "version": "14.3.0",
+  "version": "14.4.0",
   "description": "Renderless components for VueUse",
   "author": "Jacob Clevenger<https://github.com/wheatjs>",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vueuse/core",
   "type": "module",
-  "version": "14.3.0",
+  "version": "14.4.0",
   "description": "Collection of essential Vue Composition Utilities",
   "author": "Anthony Fu <https://github.com/antfu>",
   "license": "MIT",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vueuse/electron",
   "type": "module",
-  "version": "14.3.0",
+  "version": "14.4.0",
   "description": "Electron renderer process modules for VueUse",
   "author": "Archer Gu<https://github.com/ArcherGu>",
   "license": "MIT",

--- a/packages/firebase/package.json
+++ b/packages/firebase/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vueuse/firebase",
   "type": "module",
-  "version": "14.3.0",
+  "version": "14.4.0",
   "description": "Enables realtime bindings for Firebase",
   "author": "Anthony Fu <https://github.com/antfu>",
   "license": "MIT",

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vueuse/integrations",
   "type": "module",
-  "version": "14.3.0",
+  "version": "14.4.0",
   "description": "Integration wrappers for utility libraries",
   "author": "Anthony Fu <https://github.com/antfu>",
   "license": "MIT",

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vueuse/math",
   "type": "module",
-  "version": "14.3.0",
+  "version": "14.4.0",
   "description": "Math functions for VueUse",
   "author": "Anthony Fu <https://github.com/antfu>",
   "license": "MIT",

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vueuse/metadata",
   "type": "module",
-  "version": "14.3.0",
+  "version": "14.4.0",
   "description": "Metadata for VueUse functions",
   "author": "Anthony Fu <https://github.com/antfu>",
   "license": "MIT",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vueuse/nuxt",
   "type": "module",
-  "version": "14.3.0",
+  "version": "14.4.0",
   "description": "VueUse Nuxt Module",
   "author": "Anthony Fu <https://github.com/antfu>",
   "license": "MIT",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vueuse/router",
   "type": "module",
-  "version": "14.3.0",
+  "version": "14.4.0",
   "description": "Utilities for vue-router",
   "author": "Anthony Fu <https://github.com/antfu>",
   "license": "MIT",

--- a/packages/rxjs/package.json
+++ b/packages/rxjs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vueuse/rxjs",
   "type": "module",
-  "version": "14.3.0",
+  "version": "14.4.0",
   "description": "Enables RxJS reactive functions in Vue",
   "author": "Anthony Fu <https://github.com/antfu>",
   "license": "MIT",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vueuse/shared",
   "type": "module",
-  "version": "14.3.0",
+  "version": "14.4.0",
   "author": "Anthony Fu <https://github.com/antfu>",
   "license": "MIT",
   "funding": "https://github.com/sponsors/antfu",

--- a/skills/vueuse-functions/references/computedWithControl.md
+++ b/skills/vueuse-functions/references/computedWithControl.md
@@ -81,8 +81,7 @@ export interface ComputedRefWithControl<T>
 export interface WritableComputedRefWithControl<T>
   extends WritableComputedRef<T>, ComputedWithControlRefExtra {}
 export type ComputedWithControlRef<T = any> =
-  | ComputedRefWithControl<T>
-  | WritableComputedRefWithControl<T>
+  ComputedRefWithControl<T> | WritableComputedRefWithControl<T>
 export declare function computedWithControl<T>(
   source: WatchSource | MultiWatchSources,
   fn: ComputedGetter<T>,

--- a/skills/vueuse-functions/references/createDisposableDirective.md
+++ b/skills/vueuse-functions/references/createDisposableDirective.md
@@ -30,8 +30,7 @@ export const VDirective = createDisposableDirective({
 
 ```ts
 type originDirective<H, V, A> =
-  | FunctionDirective<H, V, string, A>
-  | ObjectDirective<H, V, string, A>
+  FunctionDirective<H, V, string, A> | ObjectDirective<H, V, string, A>
 /**
  * Utility for authoring disposable directives. Reactive effects created within `mounted` directive hook will be tracked and automatically disposed when directive is unmounted.
  *

--- a/skills/vueuse-functions/references/unrefElement.md
+++ b/skills/vueuse-functions/references/unrefElement.md
@@ -36,11 +36,13 @@ export type MaybeElementRef<T extends MaybeElement = MaybeElement> = MaybeRef<T>
 export type MaybeComputedElementRef<T extends MaybeElement = MaybeElement> =
   MaybeRefOrGetter<T>
 export type MaybeElement =
-  | HTMLElement
-  | SVGElement
-  | VueInstance
-  | undefined
-  | null
+  HTMLElement | SVGElement | VueInstance | undefined | null
+export type MaybeComputedElementRefOrArray<
+  T extends MaybeElement = MaybeElement,
+> =
+  | MaybeComputedElementRef<T>
+  | MaybeComputedElementRef<T>[]
+  | MaybeRefOrGetter<T[] | null>
 export type UnRefElementReturn<T extends MaybeElement = MaybeElement> =
   T extends VueInstance ? Exclude<MaybeElement, VueInstance> : T | undefined
 /**

--- a/skills/vueuse-functions/references/useAsyncState.md
+++ b/skills/vueuse-functions/references/useAsyncState.md
@@ -22,14 +22,14 @@ const { state, isReady, isLoading, error } = useAsyncState(
 
 ### Return Values
 
-| Property           | Description                                         |
-| ------------------ | --------------------------------------------------- |
-| `state`            | The result of the async function                    |
-| `isReady`          | `true` when the promise has resolved at least once  |
-| `isLoading`        | `true` while the promise is pending                 |
-| `error`            | The error if the promise was rejected               |
-| `execute`          | Re-execute the async function with optional delay   |
-| `executeImmediate` | Re-execute immediately (shorthand for `execute(0)`) |
+| Property           | Description                                                                                                                    |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| `state`            | The result of the async function                                                                                               |
+| `isReady`          | `true` when the latest execution has resolved successfully. Reset to `false` on each execution and stays `false` if it rejects |
+| `isLoading`        | `true` while the promise is pending                                                                                            |
+| `error`            | The error if the promise was rejected                                                                                          |
+| `execute`          | Re-execute the async function with optional delay                                                                              |
+| `executeImmediate` | Re-execute immediately (shorthand for `execute(0)`)                                                                            |
 
 ### Awaiting the Result
 

--- a/skills/vueuse-functions/references/useAxios.md
+++ b/skills/vueuse-functions/references/useAxios.md
@@ -245,8 +245,7 @@ export interface UseAxiosOptionsWithInitialData<
   initialData: T
 }
 export type UseAxiosOptions<T = any> =
-  | UseAxiosOptionsBase<T>
-  | UseAxiosOptionsWithInitialData<T>
+  UseAxiosOptionsBase<T> | UseAxiosOptionsWithInitialData<T>
 export declare function useAxios<
   T = any,
   R = AxiosResponse<T>,

--- a/skills/vueuse-functions/references/useDropZone.md
+++ b/skills/vueuse-functions/references/useDropZone.md
@@ -56,8 +56,7 @@ export interface UseDropZoneOptions {
    * Also can be a function to check the data types.
    */
   dataTypes?:
-    | MaybeRef<readonly string[]>
-    | ((types: readonly string[]) => boolean)
+    MaybeRef<readonly string[]> | ((types: readonly string[]) => boolean)
   /**
    * Similar to dataTypes, but exposes the DataTransferItemList for custom validation.
    * If provided, this function takes precedence over dataTypes.

--- a/skills/vueuse-functions/references/useElementVisibility.md
+++ b/skills/vueuse-functions/references/useElementVisibility.md
@@ -54,6 +54,38 @@ const targetIsVisible = useElementVisibility(target, {
 })
 ```
 
+### controls
+
+By default `useElementVisibility` returns a `ShallowRef<boolean>`. Set `controls: true` to receive the visibility ref together with the controls of the underlying `useIntersectionObserver`:
+
+```ts
+import { useElementVisibility } from '@vueuse/core'
+// ---cut---
+const { isVisible, isActive, pause, resume, stop, isSupported } = useElementVisibility(target, {
+  controls: true,
+})
+```
+
+| State         | Type                   | Description                                                                                                                  |
+| ------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `isVisible`   | `ShallowRef<boolean>`  | Whether the target is currently visible in the viewport.                                                                     |
+| `isActive`    | `ShallowRef<boolean>`  | Whether the observer is currently running. Turns `false` once the observer is stopped, for example after `once: true` fires. |
+| `isSupported` | `ComputedRef<boolean>` | Whether the `IntersectionObserver` API is available.                                                                         |
+| `pause`       | `() => void`           | Pause observing and set `isActive` to `false`.                                                                               |
+| `resume`      | `() => void`           | Resume observing.                                                                                                            |
+| `stop`        | `() => void`           | Stop observing permanently.                                                                                                  |
+
+With `once: true`, read `isActive` to tell whether tracking has already stopped after the element first became visible:
+
+```ts
+import { useElementVisibility } from '@vueuse/core'
+// ---cut---
+const { isVisible, isActive } = useElementVisibility(target, {
+  controls: true,
+  once: true,
+})
+```
+
 ## Component Usage
 
 ```vue

--- a/skills/vueuse-functions/references/useFavicon.md
+++ b/skills/vueuse-functions/references/useFavicon.md
@@ -49,8 +49,7 @@ export interface UseFaviconOptions extends ConfigurableDocument {
   rel?: string
 }
 export type UseFaviconReturn =
-  | ComputedRef<string | null | undefined>
-  | Ref<string | null | undefined>
+  ComputedRef<string | null | undefined> | Ref<string | null | undefined>
 /**
  * Reactive favicon.
  *

--- a/skills/vueuse-functions/references/useFocusTrap.md
+++ b/skills/vueuse-functions/references/useFocusTrap.md
@@ -65,7 +65,7 @@ const { hasFocus, activate, deactivate } = useFocusTrap([targetOne, targetTwo])
       <input type="text">
     </div>
     ...
-    <div ref="targetTow">
+    <div ref="targetTwo">
       <p>Another target here</p>
       <input type="text">
       <button @click="deactivate()">

--- a/skills/vueuse-functions/references/useInfiniteScroll.md
+++ b/skills/vueuse-functions/references/useInfiniteScroll.md
@@ -105,12 +105,7 @@ function canLoadMore() {
 
 ```ts
 type InfiniteScrollElement =
-  | HTMLElement
-  | SVGElement
-  | Window
-  | Document
-  | null
-  | undefined
+  HTMLElement | SVGElement | Window | Document | null | undefined
 export interface UseInfiniteScrollOptions<
   T extends InfiniteScrollElement = InfiniteScrollElement,
 > extends UseScrollOptions {

--- a/skills/vueuse-functions/references/useIntersectionObserver.md
+++ b/skills/vueuse-functions/references/useIntersectionObserver.md
@@ -107,10 +107,7 @@ export interface UseIntersectionObserverReturn extends Supportable, Pausable {
  * @param options
  */
 export declare function useIntersectionObserver(
-  target:
-    | MaybeComputedElementRef
-    | MaybeRefOrGetter<MaybeElement[]>
-    | MaybeComputedElementRef[],
+  target: MaybeComputedElementRefOrArray,
   callback: IntersectionObserverCallback,
   options?: UseIntersectionObserverOptions,
 ): UseIntersectionObserverReturn

--- a/skills/vueuse-functions/references/useInterval.md
+++ b/skills/vueuse-functions/references/useInterval.md
@@ -92,8 +92,7 @@ export interface UseIntervalControls {
   reset: () => void
 }
 export type UseIntervalReturn =
-  | Readonly<ShallowRef<number>>
-  | Readonly<UseIntervalControls & Pausable>
+  Readonly<ShallowRef<number>> | Readonly<UseIntervalControls & Pausable>
 /**
  * Reactive counter increases on every interval
  *

--- a/skills/vueuse-functions/references/useLastChanged.md
+++ b/skills/vueuse-functions/references/useLastChanged.md
@@ -45,8 +45,7 @@ export interface UseLastChangedOptions<
   initialValue?: InitialValue
 }
 export type UseLastChangedReturn =
-  | Readonly<ShallowRef<number | null>>
-  | Readonly<ShallowRef<number>>
+  Readonly<ShallowRef<number | null>> | Readonly<ShallowRef<number>>
 /**
  * Records the timestamp of the last change
  *

--- a/skills/vueuse-functions/references/useMath.md
+++ b/skills/vueuse-functions/references/useMath.md
@@ -26,9 +26,9 @@ console.log(root.value) // 2
 
 ```ts
 export type UseMathKeys = keyof {
-  [K in keyof Math as Math[K] extends (...args: any) => any
-    ? K
-    : never]: unknown
+  [
+    K in keyof Math as Math[K] extends (...args: any) => any ? K : never
+  ]: unknown
 }
 export type UseMathReturn<K extends keyof Math> = ReturnType<
   Reactified<Math[K], true>

--- a/skills/vueuse-functions/references/useMutationObserver.md
+++ b/skills/vueuse-functions/references/useMutationObserver.md
@@ -50,10 +50,7 @@ export interface UseMutationObserverReturn extends Supportable {
  * @param options
  */
 export declare function useMutationObserver(
-  target:
-    | MaybeComputedElementRef
-    | MaybeComputedElementRef[]
-    | MaybeRefOrGetter<MaybeElement[]>,
+  target: MaybeComputedElementRefOrArray,
   callback: MutationCallback,
   options?: UseMutationObserverOptions,
 ): UseMutationObserverReturn

--- a/skills/vueuse-functions/references/usePermission.md
+++ b/skills/vueuse-functions/references/usePermission.md
@@ -65,14 +65,12 @@ export interface UsePermissionReturnWithControls extends Supportable {
  */
 export declare function usePermission(
   permissionDesc:
-    | GeneralPermissionDescriptor
-    | GeneralPermissionDescriptor["name"],
+    GeneralPermissionDescriptor | GeneralPermissionDescriptor["name"],
   options?: UsePermissionOptions<false>,
 ): UsePermissionReturn
 export declare function usePermission(
   permissionDesc:
-    | GeneralPermissionDescriptor
-    | GeneralPermissionDescriptor["name"],
+    GeneralPermissionDescriptor | GeneralPermissionDescriptor["name"],
   options: UsePermissionOptions<true>,
 ): UsePermissionReturnWithControls
 ```

--- a/skills/vueuse-functions/references/useResizeObserver.md
+++ b/skills/vueuse-functions/references/useResizeObserver.md
@@ -98,10 +98,7 @@ export interface UseResizeObserverReturn extends Supportable {
  * @param options
  */
 export declare function useResizeObserver(
-  target:
-    | MaybeComputedElementRef
-    | MaybeComputedElementRef[]
-    | MaybeRefOrGetter<MaybeElement[]>,
+  target: MaybeComputedElementRefOrArray,
   callback: globalThis.ResizeObserverCallback,
   options?: UseResizeObserverOptions,
 ): UseResizeObserverReturn

--- a/skills/vueuse-functions/references/useTimeAgo.md
+++ b/skills/vueuse-functions/references/useTimeAgo.md
@@ -1,5 +1,6 @@
 ---
 category: Time
+utils: formatTimeAgo
 ---
 
 # useTimeAgo
@@ -42,13 +43,7 @@ export type UseTimeAgoFormatter<T = number> = (
   isPast: boolean,
 ) => string
 export type UseTimeAgoUnitNamesDefault =
-  | "second"
-  | "minute"
-  | "hour"
-  | "day"
-  | "week"
-  | "month"
-  | "year"
+  "second" | "minute" | "hour" | "day" | "week" | "month" | "year"
 export interface UseTimeAgoMessagesBuiltIn {
   justNow: string
   past: string | UseTimeAgoFormatter<string>

--- a/skills/vueuse-functions/references/useTimeAgoIntl.md
+++ b/skills/vueuse-functions/references/useTimeAgoIntl.md
@@ -1,5 +1,6 @@
 ---
 category: Time
+utils: formatTimeAgoIntl
 ---
 
 # useTimeAgoIntl

--- a/skills/vueuse-functions/references/useTitle.md
+++ b/skills/vueuse-functions/references/useTitle.md
@@ -94,8 +94,7 @@ export type UseTitleOptionsBase = {
 )
 export type UseTitleOptions = ConfigurableDocument & UseTitleOptionsBase
 export type UseTitleReturn =
-  | ComputedRef<string | null | undefined>
-  | Ref<string | null | undefined>
+  ComputedRef<string | null | undefined> | Ref<string | null | undefined>
 /**
  * Reactive document title.
  *

--- a/skills/vueuse-functions/references/useVibrate.md
+++ b/skills/vueuse-functions/references/useVibrate.md
@@ -63,7 +63,7 @@ export interface UseVibrateOptions
    * @default 0
    *
    */
-  interval: number
+  interval?: number
 }
 export interface UseVibrateReturn extends Supportable {
   pattern: MaybeRefOrGetter<Arrayable<number>>

--- a/skills/vueuse-functions/references/useVirtualList.md
+++ b/skills/vueuse-functions/references/useVirtualList.md
@@ -143,8 +143,7 @@ export interface UseVirtualListOptionsBase {
   overscan?: number
 }
 export type UseVirtualListOptions =
-  | UseHorizontalVirtualListOptions
-  | UseVerticalVirtualListOptions
+  UseHorizontalVirtualListOptions | UseVerticalVirtualListOptions
 export interface UseVirtualListItem<T> {
   data: T
   index: number

--- a/skills/vueuse-functions/references/useWebWorkerFn.md
+++ b/skills/vueuse-functions/references/useWebWorkerFn.md
@@ -62,11 +62,7 @@ This function is a Vue port of https://github.com/alewin/useWorker by Alessio Ko
 
 ```ts
 export type WebWorkerStatus =
-  | "PENDING"
-  | "SUCCESS"
-  | "RUNNING"
-  | "ERROR"
-  | "TIMEOUT_EXPIRED"
+  "PENDING" | "SUCCESS" | "RUNNING" | "ERROR" | "TIMEOUT_EXPIRED"
 export interface UseWebWorkerOptions extends ConfigurableWindow {
   /**
    * Number of milliseconds before killing the worker


### PR DESCRIPTION
Release `v14.4.0` (`14.3.0` → `14.4.0`).

### Commits

- chore: bump ci test to node v22 (c7bbc2a9)
- chore: update playgrounds deps (3039663e)
- chore: update pnpm v11, update deps, snapshots (90349ff2)
- fix(useDraggable): end drag on pointercancel (6aa9d6d3)
- fix(useElementSize): prefill size based on box option (5fe49456)
- chore: include .vitepress/theme in tsconfig and add vite/client types (88dd7b2f)
- fix(useVirtualList): recompute range when item size changes (0f6d55d0)
- feat(nuxt): generate nuxt module builder output layout (40a1f414)
- docs: fix typo in add-ons (e6c1d8ed)
- test(useTransition): widen lower bound for WebKit test (8f266733)
- fix(skills): correct broken relative links in generated function references (910db622)
- ci: try new pr based release workflow (bcc06e4f)
- chore: update skills before release (a7d9aba0)
- chore: use allowBuilds (575e44bb)
- fix(useEventBus): use `tryOnScopeDispose` to avoid operating Vue internal API (2cad765b)
- fix(useGamepad): keep updating remaining gamepads after one disconnects (653283c0)
- docs(useTextareaAutosize): restore demo textarea autosizing (d39699c2)
- fix(useFetch): ignore stale abort error after refetch succeeds (8442658d)
- fix: accept array template ref bound to v-for as observer target (bccb159d)
- chore: move to manual releases (ddcbea93)
- chore: bind publishing to production env (0665ab0f)
- feat(useElementOverflow): new function (d49f56df)
- docs(useElementVisibility): document controls return values (579656ef)
- fix(tests): deduplicate ci test runs (5b2721ff)
- fix(useWebSocket): sync status to 'CLOSED' after explicit close() (351bf84e)
- fix(useFuse): trigger fuse ref after setCollection (3e10ce87)
- chore: tweak action security settings (382d7e55)
- chore: pin actions to sha (8faea180)
- test(core): migrate to browser tests (0116e9a5)
- fix(nuxt): register formatTimeAgo variants for auto-import (8a908d7e)
- docs(useAsyncState): correct `isReady` description to match actual behavior (eda20ae9)
- docs: fix typo 'targetTow' to 'targetTwo' in useFocusTrap example (de83a043)
- fix(useBrowserLocation): Skip write-back watching on 'load' state (fbdd2867)
- feat: update skills (f475894f)
- fix(useVibrate): make interval option optional (305eef67)
- feat(useDebounceFn): add flush and isPending to filter system (4aa1803a)
- fix(useStyleTag): avoid error when multiple components share the same id (6d913829)
- chore: add AI-generated PR handling to template (1218457e)
- feat(nuxt): disable `useColorMode` auto import if `@nuxtjs/color-mode` is detected (60687100)
- chore: update deps (62045ded)
- feat(useVirtualList): Add options `behavior`, `block` and `inline` to exposed scrollTo method (0187570d)
- chore: bump playwright (e0b0f863)
- fix(usePointerSwipe): handle pointercancel event to reset state and trigger onSwipeEnd (4c08a856)
- docs: change nuxt3 to 4 from get-start demos (39ecd5b5)
- fix(docs): fix typo 'feedbacks' to 'feedback' in work-with-ai.md (a4253752)
- feat(useSpeechRecognition): expose confidence of latest result (17dc97f7)
- feat(onStartTyping): add more configurable options for `onStartTyping` (1f2b7503)
- fix: drop unnecessary `PURE` annotation to avoid Rollup warning (169331dc)
- docs(useTextareaAutosize): add note for native css option (4be9ac52)
- test: update snapshots (4f02a06a)