### PR TITLE
fix(onLongPress): clear pending long press on pointercancel

### DIFF
--- a/packages/core/onLongPress/index.test.ts
+++ b/packages/core/onLongPress/index.test.ts
@@ -190,6 +190,25 @@ describe('onLongPress', () => {
     expect(onMouseUpCallback.mock.calls[1][0]).toBeGreaterThanOrEqual(500 - 2)
   }
 
+  async function notTriggerCallbackOnPointerCancel(isRef: boolean) {
+    const onLongPressCallback = vi.fn()
+    const onMouseUpCallback = vi.fn()
+    onLongPress(isRef ? element : element.value, onLongPressCallback, { onMouseUp: onMouseUpCallback })
+
+    pointerdownEvent = new PointerEvent('pointerdown', { cancelable: true, bubbles: true })
+    element.value.dispatchEvent(pointerdownEvent)
+
+    await vi.advanceTimersByTimeAsync(250)
+    expect(onLongPressCallback).toHaveBeenCalledTimes(0)
+
+    // the user agent takes the gesture over, e.g. a second pointer starting a pinch
+    element.value.dispatchEvent(new PointerEvent('pointercancel', { bubbles: true }))
+    expect(onMouseUpCallback).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(500)
+    expect(onLongPressCallback).toHaveBeenCalledTimes(0)
+  }
+
   function suites(isRef: boolean) {
     describe('given no options', () => {
       it('should trigger longpress after 500ms', () => triggerCallback(isRef))
@@ -209,6 +228,8 @@ describe('onLongPress', () => {
       it('should trigger longpress if pointer is moved', () => triggerCallbackWithThreshold(isRef))
 
       it('should trigger onMouseUp when pointer is released', () => triggerOnMouseUp(isRef))
+
+      it('should not trigger longpress when the pointer is canceled', () => notTriggerCallbackOnPointerCancel(isRef))
 
       it('should trigger longpress after options.delay ms when options.delay is a function', () => triggerCallbackWithDelay(isRef, () => 2000))
     })

--- a/packages/core/onLongPress/index.ts
+++ b/packages/core/onLongPress/index.ts
@@ -153,7 +153,7 @@ export function onLongPress(
   const cleanup = [
     useEventListener(elementRef, 'pointerdown', onDown, listenerOptions),
     useEventListener(elementRef, 'pointermove', onMove, listenerOptions),
-    useEventListener(elementRef, ['pointerup', 'pointerleave'], onRelease, listenerOptions),
+    useEventListener(elementRef, ['pointerup', 'pointerleave', 'pointercancel'], onRelease, listenerOptions),
   ]
 
   const stop = () => cleanup.forEach(fn => fn())


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Confirm that this PR is based on your own understanding and review of the project, not solely generated or summarized by AI tools.

---

### Description

Follow-up to #5550, split out per @OrbisK's suggestion there. `usePointer` and `useMouse` will follow as separate PRs.

#### Correction to what I said on #5550

In that thread I wrote that on `pointercancel` the pending timer "survives, so the handler can fire for a gesture the browser took over". That was too strong, and I want to correct it before anything else.

Pointer Events Level 3's "suppress a pointer event stream" algorithm fires `pointercancel`, then `pointerout`, then `pointerleave`. `pointerleave` is already bound here, so in the ordinary case the trailing event reaches `onRelease`, `clear()` runs, and the timer is already killed today. Dispatching the full sequence against current `main` in the repo's test environment, the long-press handler fires 0 times without this change.

So this is not a live timer leak in the common path. What is left is narrower, and still real.

#### What is actually reachable

`pointerleave` does not bubble, and under explicit `setPointerCapture` the trailing events can be retargeted away from the listening element; the element may also be unmounted mid-gesture. When the trailing `pointerleave` does not reach the element, nothing clears the timer. Measured against `main`:

| dispatched after `pointerdown` | long-press handler | `onMouseUp` |
|---|---|---|
| `pointercancel` → `pointerout` → `pointerleave` | 0 | 1 |
| `pointercancel` alone | **1** | 0 |
| `pointerup` (control) | 0 | 1 |

The middle row is the bug: the user's handler runs for a gesture the user agent already abandoned. `onMove`'s `distanceThreshold` clears the timer only if the pointer travelled far enough first, so it does not cover a cancel that arrives with little movement — a second pointer starting a pinch, or a system gesture.

It also leaves `onLongPress` as the last pointer-level composable that does not handle `pointercancel`, after #5379 (`usePointerSwipe`) and #5550 (`useDraggable`).

#### What changed

```diff
-    useEventListener(elementRef, ['pointerup', 'pointerleave'], onRelease, listenerOptions),
+    useEventListener(elementRef, ['pointerup', 'pointerleave', 'pointercancel'], onRelease, listenerOptions),
```

`onRelease` needs no changes. `clear()` runs before every early return in it, so the timer is cleared even when `onMouseUp` is not configured or the `self` modifier rejects the target. It cannot double-fire either: `clear()` nulls `posStart`/`startTimestamp`, so a following `pointerup` or `pointerleave` hits the `!_posStart || !_startTimestamp` guard and returns before `onMouseUp`.

#### Why route it through `onRelease` rather than only clearing

I considered registering `pointercancel` to a cancel-only handler that just calls `clear()`, so `onMouseUp` would not fire on a canceled gesture. That looks more conservative but is actually a behaviour change: because the trailing `pointerleave` already reaches `onRelease` today, `onMouseUp` already fires once on a canceled gesture. Clearing on `pointercancel` first would null `posStart`, the trailing `pointerleave` would then early-return, and that existing `onMouseUp` call would silently disappear.

Sharing `onRelease` keeps the call count at exactly one and matches both merged siblings, where the cancel event routes into the same handler that fires the user-facing end callback.

`pointercancel` is not cancelable, so the `modifiers.prevent` branch's `preventDefault()` is a no-op on it.

#### Test

One case added to `packages/core/onLongPress/index.test.ts`, registered in `suites()` so it runs under both the ref and non-ref describes. It fails on `main` and passes with this change.

Locally: `onLongPress` 28/28 including `directive.test.ts`; unit + server projects 872 passed, 0 failed; eslint clean; `vue-tsc --noEmit` clean. (`test/exports.test.ts` and `test/package-json-export.test.ts` fail identically on a clean `main` in my environment — they need built artifacts.)

### Additional context

- The measured numbers above come from the repo's jsdom test environment, not a real browser. The browser behaviour claim about the trailing `pointerleave` is from the spec, not from a device.
- `index.md` and the JSDoc do not enumerate the listened events, so nothing needed updating there.
- Developed with AI assistance; the commit carries a `Co-Authored-By` trailer. The investigation and the reasoning above are mine and I am happy to go into any of it.
