### PR TITLE
test: re-enable firefox browser tests

### DIFF
--- a/packages/core/onClickOutside/index.browser.test.ts
+++ b/packages/core/onClickOutside/index.browser.test.ts
@@ -121,10 +121,14 @@ describe('onClickOutside', () => {
     outerShadow.appendChild(innerHost)
     document.body.appendChild(outerHost)
 
-    // Playwright cannot click an iframe nested 2 levels deep in shadow DOM
+    // Playwright cannot click an iframe nested 2 levels deep in shadow DOM,
+    // and Firefox does not fire window `blur` for programmatic iframe.focus(),
+    // so simulate the focus move: focus() sets the activeElement chain and the
+    // dispatched blur triggers the listener that walks it.
     iframe.focus()
+    window.dispatchEvent(new Event('blur'))
     await vi.waitFor(() => {
-      expect(handler).toHaveBeenCalledOnce()
+      expect(handler).toHaveBeenCalled()
     })
   })
 

--- a/packages/core/onStartTyping/index.browser.test.ts
+++ b/packages/core/onStartTyping/index.browser.test.ts
@@ -3,12 +3,9 @@ import { userEvent } from 'vitest/browser'
 import { onStartTyping } from './index'
 
 describe('onStartTyping', () => {
-  let element: HTMLInputElement
   let callBackFn: any
 
   beforeEach(() => {
-    element = document.createElement('input')
-    element.tabIndex = 1
     callBackFn = vi.fn()
   })
 
@@ -47,19 +44,11 @@ describe('onStartTyping', () => {
   })
 
   it('does not trigger callback with invalid characters', async () => {
-    document.body.appendChild(element)
-    const arrows = range(4, 37)
-    const functionKeys = range(32, 112)
+    const invalidKeys = ['ArrowLeft', 'ArrowUp', 'ArrowRight', 'ArrowDown', ...range(12, 1).map(i => `F${i}`)]
 
     onStartTyping(callBackFn)
 
-    for (let i = 0; i < arrows.length; i++) {
-      await userEvent.fill(element, String.fromCharCode(arrows[i]))
-    }
-
-    for (let i = 0; i < functionKeys.length; i++) {
-      await userEvent.fill(element, String.fromCharCode(functionKeys[i]))
-    }
+    await userEvent.keyboard(invalidKeys.map(key => `{${key}}`).join(''))
 
     expect(callBackFn).toBeCalledTimes(0)
   })

--- a/packages/core/useIntersectionObserver/index.browser.test.ts
+++ b/packages/core/useIntersectionObserver/index.browser.test.ts
@@ -168,7 +168,10 @@ describe('useIntersectionObserver', () => {
           useIntersectionObserver(
             targetNodeRef,
             callbackMock,
-            { threshold: [0, 0.5, 1] },
+            // 0.99 instead of 1: Firefox computes the ratio from subpixel-rounded
+            // rects and reports just below 1 (e.g. 0.9998) for a fully visible
+            // target, so a threshold of exactly 1 never fires there.
+            { threshold: [0, 0.5, 0.99] },
           )
         },
       })
@@ -182,20 +185,24 @@ describe('useIntersectionObserver', () => {
       })
       callbackMock.mockClear()
 
-      // scroll 10px down to "touch" the target
-      window.scrollTo(0, 10)
+      // scroll a couple of px past the boundary so the target just enters the
+      // viewport — browsers like Firefox on HiDPI screens quantize the scroll
+      // position to device pixels, so landing exactly on a boundary (here 10px,
+      // where the target only "touches" the viewport) is not reliable.
+      window.scrollTo(0, 12)
       await vi.waitFor(() => {
         expect(callbackMock).toHaveBeenCalledTimes(1)
-        expect(callbackMock.mock.calls[0][0][0].intersectionRatio).toBe(0)
+        expect(callbackMock.mock.calls[0][0][0].intersectionRatio).toBeLessThan(0.5)
         expect(callbackMock.mock.calls[0][0][0].isIntersecting).toBe(true)
       })
       callbackMock.mockClear()
 
-      // scroll to show 50% of the target
-      window.scrollTo(0, 60)
+      // scroll to show just over 50% of the target
+      window.scrollTo(0, 65)
       await vi.waitFor(() => {
         expect(callbackMock).toHaveBeenCalledTimes(1)
-        expect(callbackMock.mock.calls[0][0][0].intersectionRatio).toBeCloseTo(0.5)
+        expect(callbackMock.mock.calls[0][0][0].intersectionRatio).toBeGreaterThanOrEqual(0.5)
+        expect(callbackMock.mock.calls[0][0][0].intersectionRatio).toBeLessThan(1)
         expect(callbackMock.mock.calls[0][0][0].isIntersecting).toBe(true)
       })
       callbackMock.mockClear()
@@ -204,7 +211,7 @@ describe('useIntersectionObserver', () => {
       window.scrollTo(0, 200)
       await vi.waitFor(() => {
         expect(callbackMock).toHaveBeenCalledTimes(1)
-        expect(callbackMock.mock.calls[0][0][0].intersectionRatio).toBe(1)
+        expect(callbackMock.mock.calls[0][0][0].intersectionRatio).toBeGreaterThanOrEqual(0.99)
         expect(callbackMock.mock.calls[0][0][0].isIntersecting).toBe(true)
       })
     })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -83,7 +83,7 @@ export default defineConfig({
             headless: true,
             instances: [
               { browser: 'chromium' },
-              // { browser: 'firefox' }, // flaky FF test: https://github.com/vitest-dev/vitest/issues/7377
+              { browser: 'firefox' },
               { browser: 'webkit' },
             ],
           },


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it. — the three test changes below fail on firefox without them and pass with them.
- [ ] Confirm that this PR is based on your own understanding and review of the project, not solely generated or summarized by AI tools. — **left unticked deliberately, see the note at the bottom.**

---

### Description

Follow-up to @OrbisK's suggestion in the comments: instead of removing the dead `browser (firefox)` script filters, this now re-enables the firefox instance itself.

**Why it's safe now:** firefox was disabled in #4589 because of flaky `Failed to connect to the browser session` errors (vitest-dev/vitest#7377). That issue was closed as fixed in playwright's firefox build v1480 (microsoft/playwright#34586). This repo pins playwright `1.60.0`, which ships firefox build v1522 — well past the fix. Across several full-suite runs locally, the connection error never appeared.

**What else this needed:** three tests encoded Chromium-specific behavior and fail on firefox regardless of the flakiness fix. Each is made browser-agnostic:

| test | root cause on firefox | fix |
| --- | --- | --- |
| `onClickOutside` › nested shadow DOM iframe | programmatic `iframe.focus()` sets the `activeElement` chain but never fires window `blur`, so the `detectIframe` listener never runs (a real click does fire it — the single-level test passes) | dispatch the `blur` explicitly; the test's purpose is the shadow-root `activeElement` walk, which is unaffected |
| `onStartTyping` › invalid characters | 36 sequential `userEvent.fill` round-trips exceed the 15s timeout — and `fill` never pressed the keys the test is about anyway; it typed characters into a focused editable input, which blocks the callback regardless of key filtering | actually press the invalid keys (`{ArrowLeft}…{F12}`) with no editable element focused |
| `useIntersectionObserver` › threshold | firefox quantizes scroll positions to device pixels (`scrollTo(0, 10)` lands at `scrollY = 9.95`, target never touches the viewport) and reports `intersectionRatio = 0.9998` for a fully visible target, so a threshold of exactly `1` never fires | overshoot each scroll boundary by a few px and assert ratio ranges; use `0.99` as the fully-visible threshold |

**Verification (local, Windows, playwright 1.60.0 / Firefox 150.0.2):**
- `vitest --project="browser (firefox)"`: 3 consecutive full runs, 88 files / 712 tests green each time
- `vitest --project="browser (chromium)"` and `--project="browser (webkit)"`: green on the changed files; full-suite runs only showed pre-existing timing flakes (`useTransition`) that reproduce identically on unmodified `main`

CI runs Ubuntu, so it's worth watching the first few runs of the *other browser tests* step for anything environment-specific.

### Additional context

On the last checkbox: as with the original version of this PR, an AI assistant did the investigation and the changes here, so I'm not ticking the box that asks me to confirm otherwise. Every claim above is reproducible: each of the three tests fails on firefox without its change and passes with it, and the root causes are observable in a debugger (the `blur`-less `iframe.focus()`, the fractional `scrollY`, the `0.9998` ratio). Please close without hesitation if that isn't something you want to take.