### PR TITLE
fix(useCloned): make custom clone function type-safe

### DIFF
--- a/packages/core/useCloned/index.browser.test.ts
+++ b/packages/core/useCloned/index.browser.test.ts
@@ -1,5 +1,5 @@
 import { useCloned } from '@vueuse/core'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, expectTypeOf, it } from 'vitest'
 import { ref as deepRef, nextTick } from 'vue'
 
 describe('useCloned', () => {
@@ -68,6 +68,17 @@ describe('useCloned', () => {
 
     expect(cloned.value.test).toBe('partial')
     expect(cloned.value.proxyTest).toBe(true)
+  })
+
+  it('infers source type in custom clone function', () => {
+    const data = deepRef({ test: 'test' })
+
+    useCloned(data, {
+      clone: (source) => {
+        expectTypeOf(source).toEqualTypeOf<{ test: string }>()
+        return source
+      },
+    })
   })
 
   it('works with watch options', async () => {

--- a/packages/core/useCloned/index.ts
+++ b/packages/core/useCloned/index.ts
@@ -40,7 +40,7 @@ export function cloneFnJSON<T>(source: T): T {
 
 export function useCloned<T>(
   source: MaybeRefOrGetter<T>,
-  options: UseClonedOptions = {},
+  options: UseClonedOptions<T> = {},
 ): UseClonedReturn<T> {
   const cloned = deepRef({} as T) as Ref<T>
   const isModified = shallowRef<boolean>(false)

--- a/test/__snapshots__/tsnapi/@vueuse/core/index.snapshot.d.ts
+++ b/test/__snapshots__/tsnapi/@vueuse/core/index.snapshot.d.ts
@@ -1797,7 +1797,7 @@ export declare function useClipboard(_?: UseClipboardOptions<undefined>): UseCli
 export declare function useClipboard(_: UseClipboardOptions<MaybeRefOrGetter<string>>): UseClipboardReturn<true>;
 export declare function useClipboardItems(_?: UseClipboardItemsOptions<undefined>): UseClipboardItemsReturn<false>;
 export declare function useClipboardItems(_: UseClipboardItemsOptions<MaybeRefOrGetter<ClipboardItems>>): UseClipboardItemsReturn<true>;
-export declare function useCloned<T>(_: MaybeRefOrGetter<T>, _?: UseClonedOptions): UseClonedReturn<T>;
+export declare function useCloned<T>(_: MaybeRefOrGetter<T>, _?: UseClonedOptions<T>): UseClonedReturn<T>;
 export declare function useColorMode<T extends string = BasicColorMode>(_?: UseColorModeOptions<T>): UseColorModeReturn<T>;
 export declare function useConfirmDialog<RevealData = any, ConfirmData = any, CancelData = any>(_?: ShallowRef<boolean>): UseConfirmDialogReturn<RevealData, ConfirmData, CancelData>;
 export declare function useCountdown(_: MaybeRefOrGetter<number>, _?: UseCountdownOptions): UseCountdownReturn;


### PR DESCRIPTION
`useCloned<T>` threads its generic through the source and return types, but the `options` argument was typed as the non-generic `UseClonedOptions`, so `T` fell back to `any`. That dropped the type of `source` inside a custom `clone` function, leaving callers with no inference or checking on their own callback. Passing `<T>` into the options restores it.

Fixes #5558