### PR TITLE
fix: use mutable ref as source in history demos

### DIFF
--- a/packages/core/useDebouncedRefHistory/demo.vue
+++ b/packages/core/useDebouncedRefHistory/demo.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { formatDate, useCounter, useDebouncedRefHistory } from '@vueuse/core'
+import { formatDate, useDebouncedRefHistory } from '@vueuse/core'
 import { shallowRef } from 'vue'
 
 function format(ts: number) {
@@ -7,7 +7,10 @@ function format(ts: number) {
 }
 const delay = shallowRef(1000)
 
-const { count, inc, dec } = useCounter()
+const count = shallowRef(0)
+const inc = () => count.value++
+const dec = () => count.value--
+
 const { history, undo, redo, canUndo, canRedo } = useDebouncedRefHistory(
   count,
   { capacity: 10, debounce: delay },

--- a/packages/core/useManualRefHistory/demo.vue
+++ b/packages/core/useManualRefHistory/demo.vue
@@ -1,21 +1,16 @@
 <script setup lang="ts">
-import { formatDate, useManualRefHistory } from '@vueuse/core'
-import { shallowRef } from 'vue'
+import { formatDate, useManualRefHistory, useCounter } from '@vueuse/core'
 
 function format(ts: number) {
   return formatDate(new Date(ts), 'YYYY-MM-DD HH:mm:ss')
 }
-const count = shallowRef(0)
 
-function inc() {
-  count.value++
-}
+const { inc, dec, count, set } = useCounter()
 
-function dec() {
-  count.value--
-}
-
-const { canUndo, canRedo, history, commit, undo, redo } = useManualRefHistory(count, { capacity: 10 })
+const { canUndo, canRedo, history, commit, undo, redo } = useManualRefHistory(
+  count,
+  { capacity: 10, setSource: (_source, value: number) => set(value) },
+)
 </script>
 
 <template>

--- a/packages/core/useManualRefHistory/demo.vue
+++ b/packages/core/useManualRefHistory/demo.vue
@@ -1,11 +1,20 @@
 <script setup lang="ts">
-import { formatDate, useCounter, useManualRefHistory } from '@vueuse/core'
+import { formatDate, useManualRefHistory } from '@vueuse/core'
+import { shallowRef } from 'vue'
 
 function format(ts: number) {
   return formatDate(new Date(ts), 'YYYY-MM-DD HH:mm:ss')
 }
+const count = shallowRef(0)
 
-const { inc, dec, count } = useCounter()
+function inc() {
+  count.value++
+}
+
+function dec() {
+  count.value--
+}
+
 const { canUndo, canRedo, history, commit, undo, redo } = useManualRefHistory(count, { capacity: 10 })
 </script>
 

--- a/packages/core/useThrottledRefHistory/demo.vue
+++ b/packages/core/useThrottledRefHistory/demo.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { formatDate, useCounter, useThrottledRefHistory } from '@vueuse/core'
+import { formatDate, useThrottledRefHistory } from '@vueuse/core'
 import { shallowRef } from 'vue'
 
 function format(ts: number) {
@@ -7,7 +7,10 @@ function format(ts: number) {
 }
 const delay = shallowRef(1000)
 
-const { count, inc, dec } = useCounter()
+const count = shallowRef(0)
+const inc = () => count.value++
+const dec = () => count.value--
+
 const { history, undo, redo, canUndo, canRedo } = useThrottledRefHistory(
   count,
   {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
- [ ] Confirm that this PR is based on your own understanding and review of the project, not solely generated or summarized by AI tools.

> **Note**: If this PR is deemed to be primarily generated by AI tools, it may be closed.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Fix the demo of `useDebouncedRefHistory`, `useThrottledRefHistory`, and `useManualRefHistory`, where the `undo` action did not update the displayed count.

The root cause is that these demos used the readonly `count` returned by `useCounter` as the source of the ref history. Since the source is readonly, writing back the value during `undo`/`redo` has no effect.

Changes:
- `useDebouncedRefHistory` demo: use a mutable ref as the source.
- `useThrottledRefHistory` demo: use a mutable ref as the source.
- `useManualRefHistory` demo: use `useCounter`'s `set` method via the `setSource` option.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
