### PR TITLE
Detect useFocusWithin's target's subtree's mutation

### DIFF
--- a/packages/core/useFocusWithin/index.browser.test.ts
+++ b/packages/core/useFocusWithin/index.browser.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useFocusWithin } from './index'
+
+describe('useFocusWithin', () => {
+  let parent: HTMLFormElement
+  let child: HTMLDivElement
+  let grandchild: HTMLInputElement
+  let outsider: HTMLButtonElement
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+
+    parent = document.createElement('form')
+    parent.tabIndex = 0
+    document.body.appendChild(parent)
+
+    child = document.createElement('div')
+    child.tabIndex = 0
+    parent.appendChild(child)
+
+    grandchild = document.createElement('input')
+    grandchild.tabIndex = 0
+    child.appendChild(grandchild)
+
+    // A sibling of `parent`, i.e. not contained within the target.
+    outsider = document.createElement('button')
+    outsider.tabIndex = 0
+    document.body.appendChild(outsider)
+  })
+
+  it('should track focus of descendants', () => {
+    const { focused } = useFocusWithin(parent)
+
+    expect(focused.value).toBeFalsy()
+
+    grandchild.focus()
+    expect(focused.value).toBeTruthy()
+
+    grandchild.blur()
+    expect(focused.value).toBeFalsy()
+  })
+
+  it('should be false when an unrelated element outside the target is focused', () => {
+    const { focused } = useFocusWithin(parent)
+
+    expect(focused.value).toBeFalsy()
+
+    // Focusing an element that is not the target nor a descendant.
+    outsider.focus()
+    expect(focused.value).toBeFalsy()
+
+    grandchild.focus()
+    expect(focused.value).toBeTruthy()
+
+    outsider.focus()
+    expect(focused.value).toBeFalsy()
+  })
+
+  it('should reset the state when the focused descendant is removed', async () => {
+    const { focused } = useFocusWithin(parent)
+
+    grandchild.focus()
+    expect(focused.value).toBeTruthy()
+
+    // Removing the focused element does not reliably fire `focusout`; the
+    // MutationObserver on the subtree is what re-syncs the state here.
+    grandchild.remove()
+
+    await expect.poll(() => focused.value).toBeFalsy()
+  })
+
+  it('should reset the state when a focused deep descendant is removed with its ancestor', async () => {
+    const { focused } = useFocusWithin(parent)
+
+    grandchild.focus()
+    expect(focused.value).toBeTruthy()
+
+    // Remove the intermediate ancestor; the focused `grandchild` goes with it.
+    child.remove()
+
+    await expect.poll(() => focused.value).toBeFalsy()
+  })
+})

--- a/packages/core/useFocusWithin/index.test.ts
+++ b/packages/core/useFocusWithin/index.test.ts
@@ -83,6 +83,19 @@ describe('useFocusWithin', () => {
     expect(focused.value).toBeFalsy()
   })
 
+  it('should reset the state when the focused descendant is removed', async () => {
+    const { focused } = useFocusWithin(parent)
+
+    expect(focused.value).toBeFalsy()
+
+    grandchild?.focus()
+    expect(focused.value).toBeTruthy()
+
+    child.removeChild(grandchild)
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(focused.value).toBeFalsy()
+  })
+
   it('should the state of target always be falsy when document.activeElement invalid', () => {
     const mockWindow = new Proxy(window, {
       get: (target, prop: any) => {

--- a/packages/core/useFocusWithin/index.ts
+++ b/packages/core/useFocusWithin/index.ts
@@ -37,17 +37,17 @@ export function useFocusWithin(target: MaybeElementRef, options: ConfigurableWin
     return { focused }
   }
 
-  const listenerOptions = { passive: true }
-  useEventListener(targetElement, EVENT_FOCUS_IN, () => _focused.value = true, listenerOptions)
-  useEventListener(targetElement, EVENT_FOCUS_OUT, () =>
-    _focused.value = targetElement.value?.matches?.(PSEUDO_CLASS_FOCUS_WITHIN) ?? false, listenerOptions)
-
-  // Removing a focused descendant does not reliably fire `focusout`, so re-check
-  // whether focus is still within the target whenever its subtree changes.
-  useMutationObserver(targetElement, () => {
+  const recheckFocusWithin = () => {
     if (_focused.value)
       _focused.value = targetElement.value?.matches?.(PSEUDO_CLASS_FOCUS_WITHIN) ?? false
-  }, { ...options, childList: true, subtree: true })
+  }
+
+  const listenerOptions = { passive: true }
+  useEventListener(targetElement, EVENT_FOCUS_IN, () => _focused.value = true, listenerOptions)
+  useEventListener(targetElement, EVENT_FOCUS_OUT, recheckFocusWithin, listenerOptions)
+
+  // Removing a focused descendant does not reliably fire `focusout`, so re-check
+  useMutationObserver(targetElement, recheckFocusWithin, { ...options, childList: true, subtree: true })
 
   return { focused }
 }

--- a/packages/core/useFocusWithin/index.ts
+++ b/packages/core/useFocusWithin/index.ts
@@ -6,6 +6,7 @@ import { defaultWindow } from '../_configurable'
 import { unrefElement } from '../unrefElement'
 import { useActiveElement } from '../useActiveElement'
 import { useEventListener } from '../useEventListener'
+import { useMutationObserver } from '../useMutationObserver'
 
 export interface UseFocusWithinReturn {
   /**
@@ -40,6 +41,13 @@ export function useFocusWithin(target: MaybeElementRef, options: ConfigurableWin
   useEventListener(targetElement, EVENT_FOCUS_IN, () => _focused.value = true, listenerOptions)
   useEventListener(targetElement, EVENT_FOCUS_OUT, () =>
     _focused.value = targetElement.value?.matches?.(PSEUDO_CLASS_FOCUS_WITHIN) ?? false, listenerOptions)
+
+  // Removing a focused descendant does not reliably fire `focusout`, so re-check
+  // whether focus is still within the target whenever its subtree changes.
+  useMutationObserver(targetElement, () => {
+    if (_focused.value)
+      _focused.value = targetElement.value?.matches?.(PSEUDO_CLASS_FOCUS_WITHIN) ?? false
+  }, { ...options, childList: true, subtree: true })
 
   return { focused }
 }

--- a/packages/core/useFocusWithin/index.ts
+++ b/packages/core/useFocusWithin/index.ts
@@ -46,7 +46,8 @@ export function useFocusWithin(target: MaybeElementRef, options: ConfigurableWin
   useEventListener(targetElement, EVENT_FOCUS_IN, () => _focused.value = true, listenerOptions)
   useEventListener(targetElement, EVENT_FOCUS_OUT, recheckFocusWithin, listenerOptions)
 
-  // Removing a focused descendant does not reliably fire `focusout`, so re-check
+  // Not all browsers fire a `focusout` event when the focused element is removed from the DOM.
+  // Use a MutationObserver to detect descendant changes
   useMutationObserver(targetElement, recheckFocusWithin, { ...options, childList: true, subtree: true })
 
   return { focused }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Confirm that this PR is based on your own understanding and review of the project, not solely generated or summarized by AI tools.

> **Note**: If this PR is deemed to be primarily generated by AI tools, it may be closed.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
- This PR aims to fix https://github.com/vueuse/vueuse/issues/5560
- Adds a new browser test

Because removing a focused element doesn't emit a focusout event, the focused ref won't update. The fix uses a lightweight useMutationObserver on the target element to detect DOM changes within the target, then re-checks the :focus-within pseudo-class.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
