### PR TITLE
fix(docs): delay twoslash tooltip display

### DIFF
--- a/packages/.vitepress/theme/index.ts
+++ b/packages/.vitepress/theme/index.ts
@@ -17,7 +17,13 @@ export default {
   enhanceApp(ctx) {
     if (typeof window !== 'undefined')
       handleRedirects(ctx.router)
-    ctx.app.use(TwoSlashFloatingVue)
+    ctx.app.use(TwoSlashFloatingVue, {
+      themes: {
+        twoslash: {
+          delay: { show: 200, hide: 0 },
+        },
+      },
+    })
 
     // Redirect function shorthands
     // For example `/useDark` to `/core/useDark`


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Confirm that this PR is based on your own understanding and review of the project, not solely generated or summarized by AI tools.

> **Note**: If this PR is deemed to be primarily generated by AI tools, it may be closed.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Fixes #4983

Delays Twoslash hover tooltips by 200 ms while keeping the hide delay at 0. This gives text-selection drags time to begin before a tooltip appears and intercepts the drag path.

The issue was reproduced on the live `useMediaControls` documentation with Playwright. Hovering a Twoslash token displayed its popup effectively immediately, and dragging a selection through the popup selected unrelated page and tooltip content.

### Additional context

Full workspace installation could not complete in Google Cloud Shell because of memory limits. Verification therefore consisted of:

- Live Playwright reproduction
- Targeted TypeScript verification of the Twoslash plugin options
- `git diff --check`
- Codex review, which found no blocking issues, warnings, or recommended changes

No automated test was added because the change is limited to VitePress plugin initialization and the repository does not have a focused documentation E2E test seam for this behavior.
