### PR TITLE
fix(useWebSocket): ignore messages from a superseded socket

### DIFF
--- a/packages/core/useWebSocket/index.test.ts
+++ b/packages/core/useWebSocket/index.test.ts
@@ -234,6 +234,29 @@ describe('useWebSocket', () => {
     expect(vm.ref.data.value).toBe('bleep bloop')
   })
 
+  it('should not set data on message from a superseded socket', async () => {
+    const url = shallowRef('ws://localhost')
+    vm = useSetup(() => {
+      const ref = useWebSocket(url)
+
+      return {
+        ref,
+      }
+    })
+
+    const ws = vm.ref.ws.value
+    ws?.onopen?.(new Event('open'))
+
+    url.value = 'ws://127.0.0.1'
+    await nextTick()
+
+    ws?.onmessage?.(new MessageEvent('message', {
+      data: 'bleep bloop',
+    }))
+
+    expect(vm.ref.data.value).toBe(null)
+  })
+
   it('should call onMessage on message', () => {
     const onMessage = vi.fn()
 

--- a/packages/core/useWebSocket/index.ts
+++ b/packages/core/useWebSocket/index.ts
@@ -300,6 +300,9 @@ export function useWebSocket<Data = any>(
     }
 
     ws.onmessage = (e: MessageEvent) => {
+      if (wsRef.value !== ws)
+        return
+
       if (options.heartbeat) {
         resetHeartbeat()
         const {


### PR DESCRIPTION
`onopen` and `onclose` both check whether the socket firing them is still the one `wsRef` points at, but `onmessage` doesn't. A reconnect closes the old socket and swaps in a new one, and any message the old socket still delivers before its close handshake finishes ends up writing to `data`, so consumers see a value from a connection that's already gone.

Same guard on `onmessage`.

Fixes #5572