### PR TITLE
fix(useFetch): ignore stale success response after a newer request starts

### DIFF
--- a/packages/core/useFetch/index.test.ts
+++ b/packages/core/useFetch/index.test.ts
@@ -742,6 +742,42 @@ describe('useFetch', () => {
     expect(error.value).toBeNull()
   })
 
+  it('should not overwrite the data of a newer request when a superseded one resolves', async () => {
+    const secondMessage = { hello: 'again' }
+    const url = shallowRef(jsonUrl)
+    let releaseFirst = () => {}
+    const firstReleased = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+    const afterFetchSpy = vi.fn()
+    const responseSpy = vi.fn()
+
+    const { data, onFetchResponse } = useFetch(url, {
+      refetch: true,
+      async afterFetch(ctx) {
+        afterFetchSpy()
+        if (ctx.data.hello === jsonMessage.hello)
+          await firstReleased
+        return ctx
+      },
+    }).json()
+    onFetchResponse(responseSpy)
+
+    await vi.waitFor(() => {
+      expect(afterFetchSpy).toHaveBeenCalled()
+    })
+    url.value = `${baseUrl}/test?json=${encodeURI(JSON.stringify(secondMessage))}`
+    await vi.waitFor(() => {
+      expect(data.value).toEqual(secondMessage)
+    })
+
+    releaseFirst()
+    await vi.waitFor(() => {
+      expect(responseSpy).toHaveBeenCalledTimes(2)
+    })
+    expect(data.value).toEqual(secondMessage)
+  })
+
   it('should be generated payloadType on execute', async () => {
     const form = deepRef()
     const { execute } = useFetch(baseUrl).post(form)

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -484,14 +484,17 @@ export function useFetch<T>(url: MaybeRefOrGetter<string>, ...args: any[]): UseF
       },
     )
       .then(async (fetchResponse) => {
-        response.value = fetchResponse
-        statusCode.value = fetchResponse.status
+        if (currentExecuteCounter === executeCounter) {
+          response.value = fetchResponse
+          statusCode.value = fetchResponse.status
+        }
 
         responseData = await fetchResponse.clone()[config.type]()
 
         // see: https://www.tjvantoll.com/2015/09/13/fetch-and-errors/
         if (!fetchResponse.ok) {
-          data.value = initialData || null
+          if (currentExecuteCounter === executeCounter)
+            data.value = initialData || null
           throw new Error(fetchResponse.statusText)
         }
 
@@ -503,7 +506,8 @@ export function useFetch<T>(url: MaybeRefOrGetter<string>, ...args: any[]): UseF
             execute,
           }))
         }
-        data.value = responseData
+        if (currentExecuteCounter === executeCounter)
+          data.value = responseData
 
         responseEvent.trigger(fetchResponse)
         return fetchResponse


### PR DESCRIPTION
#5525 guarded the `.catch` handler so a request that has already been superseded can't write its error over the state a newer request produced. The `.then` handler never got the same guard, so a slow request resolving after a newer one has finished still assigns its own `response`, `statusCode` and `data`, quietly replacing fresh data with stale data. The awaits in that handler (body parsing, `afterFetch`) leave a wide enough window for this to happen, so it now runs the same execute-counter check before each assignment.

Fixes #5571