### PR TITLE
fix(useAxios): ignore the result of a superseded request

### DIFF
--- a/packages/integrations/useAxios/index.test.ts
+++ b/packages/integrations/useAxios/index.test.ts
@@ -3,6 +3,7 @@ import type { UseAxiosOptions, UseAxiosOptionsBase, UseAxiosOptionsWithInitialDa
 import axios from 'axios'
 import { describe, expect, expectTypeOf, it, vi } from 'vitest'
 import { nextTick } from 'vue'
+import { baseUrl } from '../../.test/mockServer'
 import { useAxios } from './index'
 
 describe('useAxios', () => {
@@ -345,6 +346,32 @@ describe('useAxios', () => {
   it('should use initialData', async () => {
     const { data } = useAxios(url, config, { ...options, initialData: { value: 1 } })
     expect(data.value).toEqual({ value: 1 })
+  })
+
+  it('should ignore a superseded request that resolves later', async () => {
+    const onSuccess = vi.fn()
+    const onFinish = vi.fn()
+    const { data, execute } = useAxios(url, config, { ...options, abortPrevious: false, onSuccess, onFinish })
+
+    execute(`${baseUrl}?text=stale&delay=50`)
+    await execute(`${baseUrl}?text=fresh`)
+    await vi.waitFor(() => expect(onFinish).toBeCalledTimes(2))
+
+    expect(data.value).toBe('fresh')
+    expect(onSuccess).toBeCalledTimes(1)
+    expect(onSuccess).toHaveBeenCalledWith('fresh')
+  })
+
+  it('should ignore a superseded request that rejects later', async () => {
+    const onFinish = vi.fn()
+    const { data, error, execute } = useAxios(url, config, { ...options, abortPrevious: false, onFinish })
+
+    execute(`${baseUrl}?status=500&delay=50`)
+    await execute(`${baseUrl}?text=fresh`)
+    await vi.waitFor(() => expect(onFinish).toBeCalledTimes(2))
+
+    expect(data.value).toBe('fresh')
+    expect(error.value).toBeUndefined()
   })
 
   it('should not crash when options is undefined', async () => {

--- a/packages/integrations/useAxios/index.ts
+++ b/packages/integrations/useAxios/index.ts
@@ -247,7 +247,7 @@ export function useAxios<T = any, R = AxiosResponse<T>, D = any>(...args: any[])
 
     instance(_url, { ...defaultConfig, ...typeof executeUrl === 'object' ? executeUrl : config, signal: abortController.signal })
       .then((r: any) => {
-        if (isAborted.value)
+        if (isAborted.value || currentExecuteCounter !== executeCounter)
           return
         response.value = r
         const result = r?.data
@@ -255,7 +255,8 @@ export function useAxios<T = any, R = AxiosResponse<T>, D = any>(...args: any[])
         onSuccess(result)
       })
       .catch((e: any) => {
-        error.value = e
+        if (currentExecuteCounter === executeCounter)
+          error.value = e
         onError(e)
       })
       .finally(() => {


### PR DESCRIPTION
`execute()` only guarded its `.then` with `isAborted`, and any newer `execute()` call resets that ref to `false`, so a superseded request could still write its response into `data`/`response` and call `onSuccess` after the newer request had already settled. The `.catch` branch had no staleness check at all, so a late rejection overwrote `error` too.

Both branches now compare `currentExecuteCounter` against `executeCounter`, the guard the `.finally` right below already uses. `onError` still fires for a superseded request, since the abort behaviour covered by the existing tests depends on it.

Fixes #5575