### PR TITLE
fix(onLongPress): clear the pending timer on pointercancel

### DIFF
--- a/packages/core/onLongPress/index.test.ts
+++ b/packages/core/onLongPress/index.test.ts
@@ -190,6 +190,25 @@ describe('onLongPress', () => {
     expect(onMouseUpCallback.mock.calls[1][0]).toBeGreaterThanOrEqual(500 - 2)
   }
 
+  async function cancelLongPressOnPointerCancel(isRef: boolean) {
+    const onLongPressCallback = vi.fn()
+    onLongPress(isRef ? element : element.value, onLongPressCallback, { delay: 1000 })
+
+    element.value.dispatchEvent(pointerdownEvent)
+
+    // wait for 500ms after pointer down
+    await vi.advanceTimersByTimeAsync(500)
+    expect(onLongPressCallback).toHaveBeenCalledTimes(0)
+
+    // pointercancel to cancel callback
+    const pointerCancelEvent = new PointerEvent('pointercancel', { cancelable: true, bubbles: true })
+    element.value.dispatchEvent(pointerCancelEvent)
+
+    // wait for the remaining delay after pointercancel
+    await vi.advanceTimersByTimeAsync(500)
+    expect(onLongPressCallback).toHaveBeenCalledTimes(0)
+  }
+
   function suites(isRef: boolean) {
     describe('given no options', () => {
       it('should trigger longpress after 500ms', () => triggerCallback(isRef))
@@ -209,6 +228,8 @@ describe('onLongPress', () => {
       it('should trigger longpress if pointer is moved', () => triggerCallbackWithThreshold(isRef))
 
       it('should trigger onMouseUp when pointer is released', () => triggerOnMouseUp(isRef))
+
+      it('should not trigger longpress when pointer is cancelled', () => cancelLongPressOnPointerCancel(isRef))
 
       it('should trigger longpress after options.delay ms when options.delay is a function', () => triggerCallbackWithDelay(isRef, () => 2000))
     })

--- a/packages/core/onLongPress/index.ts
+++ b/packages/core/onLongPress/index.ts
@@ -153,7 +153,7 @@ export function onLongPress(
   const cleanup = [
     useEventListener(elementRef, 'pointerdown', onDown, listenerOptions),
     useEventListener(elementRef, 'pointermove', onMove, listenerOptions),
-    useEventListener(elementRef, ['pointerup', 'pointerleave'], onRelease, listenerOptions),
+    useEventListener(elementRef, ['pointerup', 'pointerleave', 'pointercancel'], onRelease, listenerOptions),
   ]
 
   const stop = () => cleanup.forEach(fn => fn())


### PR DESCRIPTION
## What

`onLongPress` only listened for `pointerup` and `pointerleave` to release a pending long press. It missed `pointercancel`, which fires when the browser cancels a pointer interaction (an OS gesture interrupting a touch-and-hold, pointer capture being stolen, and so on). A cancelled touch then never reached the release handler, the `setTimeout` scheduled in `onDown` kept running, and the long press handler still fired after the delay even though the interaction was already cancelled.

This adds `pointercancel` to the release events so the pending timer is cleared the same way it is on a normal release.

## Why

`useDraggable` was fixed for the same class of bug in #5550 and already listens for `['pointerup', 'pointercancel']`, and `usePointerSwipe` does too. `onLongPress` is the sibling that was missed, so this just brings it in line with the others.

## Test

Added a test that dispatches a `pointercancel` after a pointer down and asserts the long press callback does not fire once the delay elapses. It covers both the ref and non-ref forms of the call.

Verified locally with `vitest --project unit packages/core/onLongPress/`, all tests pass.