### PR TITLE
fix(useClipboard): fall back to `writeText` when `ClipboardItem` is unavailable

### DIFF
--- a/packages/core/useClipboard/index.test.ts
+++ b/packages/core/useClipboard/index.test.ts
@@ -11,6 +11,7 @@ describe('useClipboard', () => {
     const writeText = vi.fn()
 
     beforeEach(() => {
+      vi.stubGlobal('ClipboardItem', undefined)
       Object.defineProperty(navigator, 'clipboard', {
         configurable: true,
         value: { write, writeText },
@@ -22,6 +23,7 @@ describe('useClipboard', () => {
     })
 
     afterEach(() => {
+      vi.unstubAllGlobals()
       Reflect.deleteProperty(navigator, 'clipboard')
       Reflect.deleteProperty(navigator, 'permissions')
     })

--- a/packages/core/useClipboard/index.test.ts
+++ b/packages/core/useClipboard/index.test.ts
@@ -6,6 +6,47 @@ describe('useClipboard', () => {
     expect(useClipboard).toBeDefined()
   })
 
+  describe('with ClipboardItem support', () => {
+    const write = vi.fn()
+    const writeText = vi.fn()
+
+    class ClipboardItemStub {
+      constructor(public items: Record<string, string | Promise<Blob>>) {}
+    }
+
+    beforeEach(() => {
+      vi.stubGlobal('ClipboardItem', ClipboardItemStub)
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: { write, writeText },
+      })
+      Object.defineProperty(navigator, 'permissions', {
+        configurable: true,
+        value: { query: async () => ({ state: 'granted', addEventListener: () => {}, removeEventListener: () => {} }) },
+      })
+    })
+
+    afterEach(() => {
+      vi.unstubAllGlobals()
+      Reflect.deleteProperty(navigator, 'clipboard')
+      Reflect.deleteProperty(navigator, 'permissions')
+    })
+
+    it('should copy text with write', async () => {
+      const { text, copy, copied } = useClipboard()
+      const writePermission = usePermission('clipboard-write')
+      await vi.waitFor(() => expect(writePermission.value).toBe('granted'))
+
+      await copy('hello')
+
+      expect(writeText).not.toHaveBeenCalled()
+      expect(write).toHaveBeenCalledWith([expect.any(ClipboardItemStub)])
+      expect((write.mock.calls[0][0][0] as ClipboardItemStub).items).toEqual({ 'text/plain': 'hello' })
+      expect(text.value).toBe('hello')
+      expect(copied.value).toBe(true)
+    })
+  })
+
   describe('without ClipboardItem support', () => {
     const write = vi.fn()
     const writeText = vi.fn()

--- a/packages/core/useClipboard/index.test.ts
+++ b/packages/core/useClipboard/index.test.ts
@@ -1,8 +1,55 @@
-import { useClipboard } from '@vueuse/core'
-import { describe, expect, it } from 'vitest'
+import { useClipboard, usePermission } from '@vueuse/core'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 describe('useClipboard', () => {
   it('should be defined', () => {
     expect(useClipboard).toBeDefined()
+  })
+
+  describe('without ClipboardItem support', () => {
+    const write = vi.fn()
+    const writeText = vi.fn()
+
+    beforeEach(() => {
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: { write, writeText },
+      })
+      Object.defineProperty(navigator, 'permissions', {
+        configurable: true,
+        value: { query: async () => ({ state: 'granted', addEventListener: () => {}, removeEventListener: () => {} }) },
+      })
+    })
+
+    afterEach(() => {
+      Reflect.deleteProperty(navigator, 'clipboard')
+      Reflect.deleteProperty(navigator, 'permissions')
+    })
+
+    it('should copy text with writeText', async () => {
+      const { text, copy, copied } = useClipboard()
+      const writePermission = usePermission('clipboard-write')
+      await vi.waitFor(() => expect(writePermission.value).toBe('granted'))
+
+      await copy('hello')
+
+      expect(write).not.toHaveBeenCalled()
+      expect(writeText).toHaveBeenCalledWith('hello')
+      expect(text.value).toBe('hello')
+      expect(copied.value).toBe(true)
+    })
+
+    it('should copy text from async function with writeText', async () => {
+      const { text, copy, copied } = useClipboard()
+      const writePermission = usePermission('clipboard-write')
+      await vi.waitFor(() => expect(writePermission.value).toBe('granted'))
+
+      await copy(async () => 'async text')
+
+      expect(write).not.toHaveBeenCalled()
+      expect(writeText).toHaveBeenCalledWith('async text')
+      expect(text.value).toBe('async text')
+      expect(copied.value).toBe(true)
+    })
   })
 })

--- a/packages/core/useClipboard/index.ts
+++ b/packages/core/useClipboard/index.ts
@@ -69,6 +69,7 @@ export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<strin
   } = options
 
   const isClipboardApiSupported = useSupported(() => (navigator && 'clipboard' in navigator))
+  const isClipboardItemSupported = useSupported(() => typeof ClipboardItem !== 'undefined')
   const permissionRead = usePermission('clipboard-read')
   const permissionWrite = usePermission('clipboard-write')
   const isSupported = computed(() => isClipboardApiSupported.value || legacy)
@@ -104,8 +105,13 @@ export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<strin
 
       if (!useLegacy) {
         try {
-          const clipboardItem = createClipboardItem(resolvedValue)
-          await navigator!.clipboard.write([clipboardItem])
+          if (isClipboardItemSupported.value) {
+            const clipboardItem = createClipboardItem(resolvedValue)
+            await navigator!.clipboard.write([clipboardItem])
+          }
+          else {
+            await navigator!.clipboard.writeText(await resolveText(resolvedValue))
+          }
         }
         catch {
           useLegacy = true
@@ -147,6 +153,12 @@ export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<strin
         }),
       })
     }
+  }
+
+  async function resolveText(value: ClipboardValue) {
+    const resolvedText = typeof value === 'string' ? value : (await value() ?? '')
+    text.value = resolvedText
+    return resolvedText
   }
 
   function legacyCopy(value: string) {


### PR DESCRIPTION
Since #5369 `copy` always builds a `ClipboardItem`, so browsers that have the Clipboard API but not `ClipboardItem` (Firefox before 127, for example) throw and drop all the way down to the `document.execCommand` fallback. They now use `navigator.clipboard.writeText` instead, which they do support.

Fixes #5578