### PR TITLE
fix(useNetwork): don't subscribe to connection change when it's not an EventTarget

### DIFF
--- a/packages/core/useNetwork/index.test.ts
+++ b/packages/core/useNetwork/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
+import { effectScope } from 'vue'
 import { useNetwork } from '.'
 
 function createMockWindow(connection?: unknown) {
@@ -52,12 +53,39 @@ describe('useNetwork', () => {
       effectiveType: '3g',
     })
 
-    expect(() => useNetwork({ window: mockWindow as any })).not.toThrow()
-
     const { isOnline, downlink, effectiveType } = useNetwork({ window: mockWindow as any })
 
     expect(isOnline.value).toBe(true)
     expect(downlink.value).toBe(5)
     expect(effectiveType.value).toBe('3g')
+  })
+
+  it('should unsubscribe from connection changes on scope dispose', () => {
+    const connection = {
+      downlink: 10,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }
+    const mockWindow = createMockWindow(connection)
+    const scope = effectScope()
+
+    scope.run(() => useNetwork({ window: mockWindow as any }))
+    scope.stop()
+
+    expect(connection.removeEventListener).toHaveBeenCalledWith('change', expect.any(Function), expect.objectContaining({ passive: true }))
+  })
+
+  it('should not subscribe when connection cannot remove listeners', () => {
+    const connection = {
+      downlink: 5,
+      addEventListener: vi.fn(),
+    }
+    const mockWindow = createMockWindow(connection)
+    const scope = effectScope()
+
+    scope.run(() => useNetwork({ window: mockWindow as any }))
+
+    expect(connection.addEventListener).not.toHaveBeenCalled()
+    expect(() => scope.stop()).not.toThrow()
   })
 })

--- a/packages/core/useNetwork/index.test.ts
+++ b/packages/core/useNetwork/index.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest'
+import { useNetwork } from '.'
+
+function createMockWindow(connection?: unknown) {
+  return {
+    navigator: {
+      onLine: true,
+      ...(connection ? { connection } : {}),
+    },
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }
+}
+
+describe('useNetwork', () => {
+  it('should be defined', () => {
+    expect(useNetwork).toBeDefined()
+  })
+
+  it('should read connection information', () => {
+    const mockWindow = createMockWindow({
+      downlink: 10,
+      effectiveType: '4g',
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })
+
+    const { isSupported, isOnline, downlink, effectiveType } = useNetwork({ window: mockWindow as any })
+
+    expect(isSupported.value).toBe(true)
+    expect(isOnline.value).toBe(true)
+    expect(downlink.value).toBe(10)
+    expect(effectiveType.value).toBe('4g')
+  })
+
+  it('should subscribe to connection changes when connection is an EventTarget', () => {
+    const connection = {
+      downlink: 10,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }
+    const mockWindow = createMockWindow(connection)
+
+    useNetwork({ window: mockWindow as any })
+
+    expect(connection.addEventListener).toHaveBeenCalledWith('change', expect.any(Function), expect.objectContaining({ passive: true }))
+  })
+
+  it('should not throw when navigator.connection is not an EventTarget', () => {
+    const mockWindow = createMockWindow({
+      downlink: 5,
+      effectiveType: '3g',
+    })
+
+    expect(() => useNetwork({ window: mockWindow as any })).not.toThrow()
+
+    const { isOnline, downlink, effectiveType } = useNetwork({ window: mockWindow as any })
+
+    expect(isOnline.value).toBe(true)
+    expect(downlink.value).toBe(5)
+    expect(effectiveType.value).toBe('3g')
+  })
+})

--- a/packages/core/useNetwork/index.ts
+++ b/packages/core/useNetwork/index.ts
@@ -113,7 +113,10 @@ export function useNetwork(options: UseNetworkOptions = {}): UseNetworkReturn {
     }, listenerOptions)
   }
 
-  if (connection)
+  // Some environments (in-app WebViews, partial NetworkInformation
+  // implementations) expose `navigator.connection` as a plain object
+  // that does not inherit from EventTarget
+  if (connection && typeof connection.addEventListener === 'function')
     useEventListener(connection, 'change', updateNetworkInformation, listenerOptions)
 
   updateNetworkInformation()

--- a/packages/core/useNetwork/index.ts
+++ b/packages/core/useNetwork/index.ts
@@ -115,9 +115,14 @@ export function useNetwork(options: UseNetworkOptions = {}): UseNetworkReturn {
 
   // Some environments (in-app WebViews, partial NetworkInformation
   // implementations) expose `navigator.connection` as a plain object
-  // that does not inherit from EventTarget
-  if (connection && typeof connection.addEventListener === 'function')
+  // that does not implement the whole EventTarget interface
+  if (
+    connection
+    && typeof connection.addEventListener === 'function'
+    && typeof connection.removeEventListener === 'function'
+  ) {
     useEventListener(connection, 'change', updateNetworkInformation, listenerOptions)
+  }
 
   updateNetworkInformation()
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Confirm that this PR is based on your own understanding and review of the project, not solely generated or summarized by AI tools.

### Description

`useNetwork()` (and therefore `useOnline()`) throws `TypeError: xxx.addEventListener is not a function` in environments where `navigator.connection` exists but is a plain object that does not inherit from `EventTarget`.

The `isSupported` check only tests `'connection' in navigator`, after which the composable unconditionally subscribes via `useEventListener(connection, 'change', ...)`, whose internal `register` calls `connection.addEventListener(...)` directly — and crashes.

Per spec `NetworkInformation` extends `EventTarget`, but some real-world environments ship partial implementations. We hit this in production on myshows.me: ~30 users/week crashing inside `useOnline()`, mostly Android in-app WebViews reporting as Chrome Mobile 148–151 and Huawei Browser 17 (stack: `useOnline → useNetwork → useEventListener/register`).

The fix subscribes to the `change` event only when `connection.addEventListener` is actually a function. Connection values (`downlink`, `effectiveType`, …) are still read once in `updateNetworkInformation()` — they just won't live-update in such environments, which degrades gracefully instead of breaking the whole composable.

`useNetwork` had no tests, so this PR adds `packages/core/useNetwork/index.test.ts`. The regression test fails on `main` with `TypeError: el.addEventListener is not a function` and passes with this fix.

### Additional context

Merged precedents for the same class of defensive guard against non-conformant browser objects: #1441 (`getModifierState` is not a function), #4056 (`el.getBoundingClientRect` is not a function).
