### PR TITLE
fix(toReactive): forward getPrototypeOf to the underlying value

### DIFF
--- a/packages/shared/reactiveComputed/index.test.ts
+++ b/packages/shared/reactiveComputed/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, expectTypeOf, it } from 'vitest'
-import { nextTick, shallowRef, watch, watchEffect } from 'vue'
+import { nextTick, reactive, renderList, shallowRef, toRaw, watch, watchEffect } from 'vue'
 import { reactiveComputed } from './index'
 
 describe('reactiveComputed', () => {
@@ -52,6 +52,20 @@ describe('reactiveComputed', () => {
 
     expect(dummy).toBe(1)
     expect(type).toBe('foo')
+  })
+
+  it('should work with array', () => {
+    const list = reactive([0, 1])
+
+    const state = reactiveComputed(() => list)
+
+    expect(renderList(state, item => item)).toEqual([0, 1])
+    expect(state).toBeInstanceOf(Array)
+    expect(toRaw(state)).toEqual([0, 1])
+
+    list.push(2)
+
+    expect(renderList(state, item => item)).toEqual([0, 1, 2])
   })
 
   it('should allow for previous value access (for vue 3.4+)', () => {

--- a/packages/shared/toReactive/index.test.ts
+++ b/packages/shared/toReactive/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ref as deepRef, isReactive, nextTick, reactive, watchSyncEffect } from 'vue'
+import { ref as deepRef, isReactive, nextTick, reactive, renderList, watchSyncEffect } from 'vue'
 import { toRefs } from '../toRefs'
 import { toReactive } from './index'
 
@@ -82,6 +82,16 @@ describe('toReactive', () => {
 
     expect(dummy).toBe(undefined)
     expect(state).toEqual({ a: 'c' })
+  })
+
+  it('should work with array', () => {
+    const r = deepRef([1, 2, 3])
+    const state = toReactive(r)
+
+    expect([...state]).toEqual([1, 2, 3])
+    expect(Array.from(state)).toEqual([1, 2, 3])
+    expect(renderList(state, item => item)).toEqual([1, 2, 3])
+    expect(state).toBeInstanceOf(Array)
   })
 
   it('toReactive(toRefs())', () => {

--- a/packages/shared/toReactive/index.ts
+++ b/packages/shared/toReactive/index.ts
@@ -40,6 +40,9 @@ export function toReactive<T extends object>(
         configurable: true,
       }
     },
+    getPrototypeOf() {
+      return Object.getPrototypeOf(objectRef.value ?? {})
+    },
   })
 
   return reactive(proxy) as UnwrapNestedRefs<T>


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Confirm that this PR is based on your own understanding and review of the project, not solely generated or summarized by AI tools.

### Description

Iterating an array through `toReactive`/`reactiveComputed` overflows the stack: Vue's array instrumentation calls `toRaw()`, and without a `getPrototypeOf` trap Vue's prototype check never matches, so `toRaw()` hands back the proxy and the iterator recurses into itself. Forwarding `getPrototypeOf` to the current value fixes it.

Note that `Array.isArray()` still returns false, since the proxy target is a plain object — that would need a much more invasive change.

closes #4649

### Additional context

Both added tests fail on `main` with `RangeError: Maximum call stack size exceeded` and pass with this change.
