### PR TITLE
fix(useStorageAsync): resolve the returned promise instead of hanging

### DIFF
--- a/packages/core/useStorageAsync/index.browser.test.ts
+++ b/packages/core/useStorageAsync/index.browser.test.ts
@@ -1,6 +1,7 @@
 import type { Awaitable, StorageLikeAsync } from '@vueuse/core'
 import { createEventHook, useStorageAsync } from '@vueuse/core'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { isRef } from 'vue'
 
 const KEY = 'custom-key'
 const KEY2 = 'custom-key2'
@@ -65,7 +66,7 @@ describe('useStorageAsync', () => {
     )
 
     expect(storage.value).toBe('')
-    vi.waitFor(async () => {
+    await vi.waitFor(async () => {
       await expect(promise).resolves.toBe('CurrentValue')
     })
   })
@@ -81,9 +82,43 @@ describe('useStorageAsync', () => {
 
     expect(storage.value).toBe('')
 
-    vi.waitFor(async () => {
+    await vi.waitFor(async () => {
       const result = await storage
       expect(result.value).toBe('AnotherValue')
     })
+  })
+
+  // https://github.com/vueuse/vueuse/issues/5195
+  it('resolves the promise with the storage ref', async () => {
+    localStorage.setItem(KEY2, 'AnotherValue')
+
+    const storage = useStorageAsync(
+      KEY2,
+      '',
+      new AsyncStubStorage(),
+    )
+
+    const settled = Promise.race([
+      Promise.resolve(storage).then(() => 'settled'),
+      new Promise<string>(resolve => setTimeout(resolve, 1000, 'timed out')),
+    ])
+
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(await settled).toBe('settled')
+
+    const result = await storage
+    expect(isRef(result)).toBe(true)
+    expect(result.value).toBe('AnotherValue')
+
+    // stays awaitable once it has already resolved
+    expect(await storage).toBe(result)
+
+    // writes through the returned ref reach the resolved ref and the storage
+    storage.value = 'UpdatedValue'
+    expect(result.value).toBe('UpdatedValue')
+
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(localStorage.getItem(KEY2)).toBe('UpdatedValue')
   })
 })

--- a/packages/core/useStorageAsync/index.ts
+++ b/packages/core/useStorageAsync/index.ts
@@ -101,7 +101,7 @@ export function useStorageAsync<T extends(string | number | boolean | object | n
     }
   }
 
-  const promise = new Promise((resolve) => {
+  const promise = new Promise<RemovableRef<T>>((resolve) => {
     read().then(() => {
       onReady?.(data.value)
       resolve(data)
@@ -133,10 +133,22 @@ export function useStorageAsync<T extends(string | number | boolean | object | n
     )
   }
 
-  Object.assign(data, {
+  // Expose the promise methods on a proxy instead of assigning them to `data`,
+  // so that `promise` settles with a non-thenable ref. Resolving it with a
+  // thenable `data` would make the promise wait for itself and never settle.
+  // https://github.com/vueuse/vueuse/issues/5195
+  const promiseHandlers = {
     then: promise.then.bind(promise),
     catch: promise.catch.bind(promise),
-  })
+    finally: promise.finally.bind(promise),
+  }
 
-  return data as RemovableRef<T> & Promise<RemovableRef<T>>
+  return new Proxy(data, {
+    get(target, prop, receiver) {
+      if (Object.hasOwn(promiseHandlers, prop))
+        return promiseHandlers[prop as keyof typeof promiseHandlers]
+
+      return Reflect.get(target, prop, receiver)
+    },
+  }) as RemovableRef<T> & Promise<RemovableRef<T>>
 }


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Confirm that this PR is based on your own understanding and review of the project, not solely generated or summarized by AI tools.

### Description

`then`/`catch` were assigned onto the returned ref, and the internal promise was resolved with that same ref, so it assimilated itself and stayed pending forever — `await useStorageAsync(...)` never returns. The existing tests missed this because two `vi.waitFor(...)` calls were never awaited.

This follows the direction from the discussion in #5196: the returned value is now a proxy exposing `then`/`catch`/`finally`, and the promise resolves with the untouched `data` ref, so nothing mutates `data` itself. `finally` is new — it was already in the declared type but would have thrown.

closes #5195

### Additional context

`await useStorageAsync(...)` now gives you the plain ref while the call itself returns the proxy — same as how `useFetch` and `useAsyncState` resolve with a separate `shell`. Both are the same reactive source, so writing through either one works.

The two earlier attempts went a different way and were closed: #5196 deleted `then`/`catch` on settle, which breaks `await d; d.then(...)`, and #5470 still mutated `data`.
