### PR TITLE
fix(useTimeoutPoll): await the immediate callback before scheduling the next poll

### DIFF
--- a/packages/core/useTimeoutPoll/index.browser.test.ts
+++ b/packages/core/useTimeoutPoll/index.browser.test.ts
@@ -35,7 +35,20 @@ describe('useTimeoutPoll', () => {
 
     expect(callback).toHaveBeenCalledTimes(1)
 
-    vi.advanceTimersByTime(100)
+    await vi.advanceTimersByTimeAsync(50)
+    expect(callback).toHaveBeenCalledTimes(2)
+  })
+
+  it('immediateCallback waits for the callback to finish', async () => {
+    const callback = vi.fn(() => new Promise<void>(resolve => setTimeout(resolve, 50)))
+    useTimeoutPoll(callback, 50, { immediateCallback: true })
+
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(50)
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(50)
     expect(callback).toHaveBeenCalledTimes(2)
   })
 

--- a/packages/core/useTimeoutPoll/index.browser.test.ts
+++ b/packages/core/useTimeoutPoll/index.browser.test.ts
@@ -52,6 +52,41 @@ describe('useTimeoutPoll', () => {
     expect(callback).toHaveBeenCalledTimes(2)
   })
 
+  it('keeps polling when the callback rejects', async () => {
+    const ignoreRejection = (e: PromiseRejectionEvent) => e.preventDefault()
+    window.addEventListener('unhandledrejection', ignoreRejection)
+
+    try {
+      const callback = vi.fn(() => Promise.reject(new Error('failed')))
+      useTimeoutPoll(callback, 50, { immediateCallback: true })
+
+      expect(callback).toHaveBeenCalledTimes(1)
+
+      await vi.advanceTimersByTimeAsync(50)
+      expect(callback).toHaveBeenCalledTimes(2)
+
+      await vi.advanceTimersByTimeAsync(50)
+      expect(callback).toHaveBeenCalledTimes(3)
+    }
+    finally {
+      window.removeEventListener('unhandledrejection', ignoreRejection)
+    }
+  })
+
+  it('does not schedule another round when paused during the callback', async () => {
+    const callback = vi.fn(() => new Promise<void>(resolve => setTimeout(resolve, 50)))
+    const { pause } = useTimeoutPoll(callback, 50, { immediateCallback: true })
+
+    expect(callback).toHaveBeenCalledTimes(1)
+    pause()
+
+    await vi.advanceTimersByTimeAsync(50)
+    expect(vi.getTimerCount()).toBe(0)
+
+    await vi.advanceTimersByTimeAsync(50)
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+
   it('pause/resume in scope', async () => {
     const callback = vi.fn()
     const interval = shallowRef(0)

--- a/packages/core/useTimeoutPoll/index.ts
+++ b/packages/core/useTimeoutPoll/index.ts
@@ -29,7 +29,7 @@ export function useTimeoutPoll(
     immediateCallback = false,
   } = options
 
-  const { start } = useTimeoutFn(loop, interval, { immediate })
+  const { start } = useTimeoutFn(loop, interval, { immediate: false })
 
   const isActive = shallowRef(false)
 
@@ -45,8 +45,9 @@ export function useTimeoutPoll(
     if (!isActive.value) {
       isActive.value = true
       if (immediateCallback)
-        fn()
-      start()
+        loop()
+      else
+        start()
     }
   }
 

--- a/packages/core/useTimeoutPoll/index.ts
+++ b/packages/core/useTimeoutPoll/index.ts
@@ -37,8 +37,13 @@ export function useTimeoutPoll(
     if (!isActive.value)
       return
 
-    await fn()
-    start()
+    try {
+      await fn()
+    }
+    finally {
+      if (isActive.value)
+        start()
+    }
   }
 
   function resume() {


### PR DESCRIPTION
`useTimeoutPoll` is documented to trigger the callback only after the last task is done, but the `immediateCallback` path calls `fn()` without awaiting it, so an async callback can still be running when the first regular tick fires. On top of that, `useTimeoutFn` was told to start immediately as well, so its timer ran on its own schedule next to the one `resume()` starts.

Now `resume()` goes through `loop()`, which awaits the callback before scheduling the next poll, and the timeout only starts from there.

Fixes #5582