### PR TITLE
fix(usePointer): reset isInside on pointercancel

### DIFF
--- a/packages/core/usePointer/index.test.ts
+++ b/packages/core/usePointer/index.test.ts
@@ -1,0 +1,60 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { h, nextTick, useTemplateRef } from 'vue'
+import { usePointer } from './index'
+
+describe('usePointer', () => {
+  it('sets isInside true on pointerdown and resets it on pointercancel', async () => {
+    const wrapper = mount({
+      setup() {
+        const el = useTemplateRef<HTMLElement>('el')
+        const { isInside } = usePointer({ target: el })
+
+        return () => h('div', {
+          'data-inside': isInside.value,
+          'ref': 'el',
+        })
+      },
+    })
+
+    await nextTick()
+    const element = wrapper.get('div').element
+
+    expect(wrapper.get('div').attributes('data-inside')).toBe('false')
+
+    element.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
+    await nextTick()
+    expect(wrapper.get('div').attributes('data-inside')).toBe('true')
+
+    // the user agent takes the gesture over (e.g. a second pointer starting a
+    // pinch), firing pointercancel without pointerleave reaching the element
+    element.dispatchEvent(new PointerEvent('pointercancel', { bubbles: true }))
+    await nextTick()
+    expect(wrapper.get('div').attributes('data-inside')).toBe('false')
+  })
+
+  it('resets isInside on pointerleave', async () => {
+    const wrapper = mount({
+      setup() {
+        const el = useTemplateRef<HTMLElement>('el')
+        const { isInside } = usePointer({ target: el })
+
+        return () => h('div', {
+          'data-inside': isInside.value,
+          'ref': 'el',
+        })
+      },
+    })
+
+    await nextTick()
+    const element = wrapper.get('div').element
+
+    element.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
+    await nextTick()
+    expect(wrapper.get('div').attributes('data-inside')).toBe('true')
+
+    element.dispatchEvent(new PointerEvent('pointerleave', { bubbles: true }))
+    await nextTick()
+    expect(wrapper.get('div').attributes('data-inside')).toBe('false')
+  })
+})

--- a/packages/core/usePointer/index.ts
+++ b/packages/core/usePointer/index.ts
@@ -90,7 +90,7 @@ export function usePointer(options: UsePointerOptions = {}): UsePointerReturn {
   if (target) {
     const listenerOptions = { passive: true }
     useEventListener(target, ['pointerdown', 'pointermove', 'pointerup'], handler, listenerOptions)
-    useEventListener(target, 'pointerleave', () => isInside.value = false, listenerOptions)
+    useEventListener(target, ['pointerleave', 'pointercancel'], () => isInside.value = false, listenerOptions)
   }
 
   return {


### PR DESCRIPTION
## Description

`usePointer` only reset `isInside` on `pointerleave`. When the browser abandons a gesture it fires `pointercancel` **without** `pointerleave` reaching the element (e.g. when the pointer is under `setPointerCapture` and gets retargeted away), leaving `isInside` stuck at `true`.

## Changes

- Listen for `pointercancel` in addition to `pointerleave` to reset `isInside` (1-line change)
- Added `index.test.ts` for `usePointer` covering both `pointercancel` and `pointerleave` reset behavior

## Context

This is the same class of fixes as:
- #5550 (`useDraggable` pointercancel)
- #5555 (`onLongPress` pointercancel) — its PR description mentioned `usePointer` would follow as a separate PR

Closes #5586