### PR TITLE
fix(useRouteParams,useRouteQuery): stop transform value type from narrowing to the default value type

### DIFF
--- a/packages/router/useRouteParams/index.test.ts
+++ b/packages/router/useRouteParams/index.test.ts
@@ -1,5 +1,5 @@
 import type { Ref } from 'vue'
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, expectTypeOf, it, vi } from 'vitest'
 import { computed, ref as deepRef, effectScope, nextTick, reactive, shallowRef, watch } from 'vue'
 import { useRouteParams } from './index'
 
@@ -38,6 +38,22 @@ describe('useRouteParams', () => {
     const id = useRouteParams('id', '1', { transform: Number, route, router })
 
     expect(id.value).toBe(1)
+  })
+
+  it('should not narrow the transform value type to the default value type', () => {
+    const route = getRoute()
+    const router = {} as any
+
+    const id = useRouteParams('id', null, {
+      transform: (value) => {
+        expectTypeOf(value).not.toEqualTypeOf<null>()
+        return value == null ? null : Number(value)
+      },
+      route,
+      router,
+    })
+
+    expectTypeOf(id.value).toEqualTypeOf<number | null>()
   })
 
   it('should handle transform get/set', async () => {

--- a/packages/router/useRouteParams/index.ts
+++ b/packages/router/useRouteParams/index.ts
@@ -16,7 +16,7 @@ export function useRouteParams<
   K = T,
 >(
   name: string,
-  defaultValue?: MaybeRefOrGetter<T>,
+  defaultValue?: MaybeRefOrGetter<NoInfer<T>>,
   options?: ReactiveRouteOptionsWithTransform<T, K>,
 ): Ref<K>
 

--- a/packages/router/useRouteQuery/index.test.ts
+++ b/packages/router/useRouteQuery/index.test.ts
@@ -1,5 +1,5 @@
 import type { Ref } from 'vue'
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, expectTypeOf, it, vi } from 'vitest'
 import { computed, ref as deepRef, effectScope, nextTick, reactive, shallowRef, toValue, watch } from 'vue'
 import { useRouteQuery } from './index'
 
@@ -36,6 +36,22 @@ describe('useRouteQuery', () => {
     expect(page.value).toBe(1)
     expect(perPage.value).toBe(15)
     expect(tags.value).toEqual(['vite'])
+  })
+
+  it('should not narrow the transform value type to the default value type', () => {
+    const route = getRoute()
+    const router = {} as any
+
+    const page = useRouteQuery('page', null, {
+      transform: (value) => {
+        expectTypeOf(value).not.toEqualTypeOf<null>()
+        return value == null ? null : Number(value)
+      },
+      route,
+      router,
+    })
+
+    expectTypeOf(page.value).toEqualTypeOf<number | null>()
   })
 
   it('should handle transform get/set', async () => {

--- a/packages/router/useRouteQuery/index.ts
+++ b/packages/router/useRouteQuery/index.ts
@@ -16,7 +16,7 @@ export function useRouteQuery<
   K = T,
 >(
   name: string,
-  defaultValue?: MaybeRefOrGetter<T>,
+  defaultValue?: MaybeRefOrGetter<NoInfer<T>>,
   options?: ReactiveRouteOptionsWithTransform<T, K>,
 ): Ref<K>
 

--- a/test/__snapshots__/tsnapi/@vueuse/router/index.snapshot.d.ts
+++ b/test/__snapshots__/tsnapi/@vueuse/router/index.snapshot.d.ts
@@ -4,7 +4,7 @@
 // #region Functions
 export declare function useRouteHash(_?: MaybeRefOrGetter<RouteHashValueRaw>, { mode, route, router }?: ReactiveRouteOptions): import("vue").Ref<RouteHashValueRaw, RouteHashValueRaw>;
 export declare function useRouteParams(_: string): Ref<null | string | string[]>;
-export declare function useRouteParams<T extends RouteParamValueRaw = RouteParamValueRaw, K = T>(_: string, _?: MaybeRefOrGetter<T>, _?: ReactiveRouteOptionsWithTransform<T, K>): Ref<K>;
+export declare function useRouteParams<T extends RouteParamValueRaw = RouteParamValueRaw, K = T>(_: string, _?: MaybeRefOrGetter<NoInfer<T>>, _?: ReactiveRouteOptionsWithTransform<T, K>): Ref<K>;
 export declare function useRouteQuery(_: string): Ref<undefined | null | string | string[]>;
-export declare function useRouteQuery<T extends RouteQueryValueRaw = RouteQueryValueRaw, K = T>(_: string, _?: MaybeRefOrGetter<T>, _?: ReactiveRouteOptionsWithTransform<T, K>): Ref<K>;
+export declare function useRouteQuery<T extends RouteQueryValueRaw = RouteQueryValueRaw, K = T>(_: string, _?: MaybeRefOrGetter<NoInfer<T>>, _?: ReactiveRouteOptionsWithTransform<T, K>): Ref<K>;
 // #endregion


### PR DESCRIPTION
useRouteParams and useRouteQuery infer the transform callback's parameter type from the literal type of defaultValue instead of the full raw param/query union, so passing null as the default (a common pattern) makes TypeScript treat the raw value as always null inside transform. Wrapping defaultValue's generic argument in NoInfer keeps T tied to the actual param type while the transform's return type still drives K as before.

Fixes #5588