### PR TITLE
fix(useEventListener): support custom event names with omitted window target

### DIFF
--- a/packages/core/useEventListener/index.browser.test.ts
+++ b/packages/core/useEventListener/index.browser.test.ts
@@ -1,6 +1,7 @@
 import type { Fn } from '@vueuse/shared'
 import type { MockInstance } from 'vitest'
 import type { Ref } from 'vue'
+import { expectTypeOf } from 'expect-type'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, ref as deepRef, effectScope, nextTick, shallowRef } from 'vue'
 import { useEventListener } from './index'
@@ -406,5 +407,17 @@ describe('useEventListener', () => {
     await nextTick()
 
     expect(listener).toHaveBeenCalledTimes(6)
+  })
+
+  it('should support custom event names with omitted window target (#5567)', () => {
+    useEventListener('my-custom-event', (ev: Event) => {
+      expectTypeOf(ev).toEqualTypeOf<Event>()
+    })
+    useEventListener(window, 'my-custom-event', (ev: Event) => {
+      expectTypeOf(ev).toEqualTypeOf<Event>()
+    })
+    useEventListener('click', (ev) => {
+      expectTypeOf(ev).toEqualTypeOf<MouseEvent>()
+    })
   })
 })

--- a/packages/core/useEventListener/index.browser.test.ts
+++ b/packages/core/useEventListener/index.browser.test.ts
@@ -410,14 +410,20 @@ describe('useEventListener', () => {
   })
 
   it('should support custom event names with omitted window target (#5567)', () => {
-    useEventListener('my-custom-event', (ev: Event) => {
-      expectTypeOf(ev).toEqualTypeOf<Event>()
+    const scope = effectScope()
+
+    scope.run(() => {
+      useEventListener('my-custom-event', (ev: Event) => {
+        expectTypeOf(ev).toEqualTypeOf<Event>()
+      })
+      useEventListener(window, 'my-custom-event', (ev: Event) => {
+        expectTypeOf(ev).toEqualTypeOf<Event>()
+      })
+      useEventListener('click', (ev) => {
+        expectTypeOf(ev).toEqualTypeOf<MouseEvent>()
+      })
     })
-    useEventListener(window, 'my-custom-event', (ev: Event) => {
-      expectTypeOf(ev).toEqualTypeOf<Event>()
-    })
-    useEventListener('click', (ev) => {
-      expectTypeOf(ev).toEqualTypeOf<MouseEvent>()
-    })
+
+    scope.stop()
   })
 })

--- a/packages/core/useEventListener/index.browser.test.ts
+++ b/packages/core/useEventListener/index.browser.test.ts
@@ -1,8 +1,7 @@
 import type { Fn } from '@vueuse/shared'
 import type { MockInstance } from 'vitest'
 import type { Ref } from 'vue'
-import { expectTypeOf } from 'expect-type'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest'
 import { computed, ref as deepRef, effectScope, nextTick, shallowRef } from 'vue'
 import { useEventListener } from './index'
 
@@ -413,10 +412,10 @@ describe('useEventListener', () => {
     const scope = effectScope()
 
     scope.run(() => {
-      useEventListener('my-custom-event', (ev: Event) => {
+      useEventListener('my-custom-event', (ev) => {
         expectTypeOf(ev).toEqualTypeOf<Event>()
       })
-      useEventListener(window, 'my-custom-event', (ev: Event) => {
+      useEventListener(window, 'my-custom-event', (ev) => {
         expectTypeOf(ev).toEqualTypeOf<Event>()
       })
       useEventListener('click', (ev) => {

--- a/packages/core/useEventListener/index.ts
+++ b/packages/core/useEventListener/index.ts
@@ -36,7 +36,20 @@ export function useEventListener<E extends keyof WindowEventMap>(
 /**
  * Register using addEventListener on mounted, and removeEventListener automatically on unmounted.
  *
- * Overload 2: Explicitly Window target
+ * Overload 2: Omitted Window target with custom event names
+ *
+ * @see https://vueuse.org/useEventListener
+ */
+export function useEventListener<Names extends string, EventType = Event>(
+  event: MaybeRefOrGetter<Arrayable<Names>>,
+  listener: MaybeRef<Arrayable<GeneralEventListener<EventType>>>,
+  options?: MaybeRefOrGetter<boolean | AddEventListenerOptions>,
+): Fn
+
+/**
+ * Register using addEventListener on mounted, and removeEventListener automatically on unmounted.
+ *
+ * Overload 3: Explicitly Window target
  *
  * @see https://vueuse.org/useEventListener
  * @param target
@@ -54,7 +67,7 @@ export function useEventListener<E extends keyof WindowEventMap>(
 /**
  * Register using addEventListener on mounted, and removeEventListener automatically on unmounted.
  *
- * Overload 3: Explicitly Document target
+ * Overload 4: Explicitly Document target
  *
  * @see https://vueuse.org/useEventListener
  */
@@ -68,7 +81,7 @@ export function useEventListener<E extends keyof DocumentEventMap>(
 /**
  * Register using addEventListener on mounted, and removeEventListener automatically on unmounted.
  *
- * Overload 4: Explicitly ShadowRoot target
+ * Overload 5: Explicitly ShadowRoot target
  *
  * @see https://vueuse.org/useEventListener
  */
@@ -82,7 +95,7 @@ export function useEventListener<E extends keyof ShadowRootEventMap>(
 /**
  * Register using addEventListener on mounted, and removeEventListener automatically on unmounted.
  *
- * Overload 5: Explicitly HTMLElement target
+ * Overload 6: Explicitly HTMLElement target
  *
  * @see https://vueuse.org/useEventListener
  */
@@ -96,7 +109,7 @@ export function useEventListener<E extends keyof HTMLElementEventMap>(
 /**
  * Register using addEventListener on mounted, and removeEventListener automatically on unmounted.
  *
- * Overload 6: Custom event target with event type infer
+ * Overload 7: Custom event target with event type infer
  *
  * @see https://vueuse.org/useEventListener
  */
@@ -110,7 +123,7 @@ export function useEventListener<Names extends string, EventType = Event>(
 /**
  * Register using addEventListener on mounted, and removeEventListener automatically on unmounted.
  *
- * Overload 7: Custom event target fallback
+ * Overload 8: Custom event target fallback
  *
  * @see https://vueuse.org/useEventListener
  */


### PR DESCRIPTION
close #5567

## Problem

With an omitted target, only window event-map keys type-check:

```ts
useEventListener(window, 'foo', () => {}) // OK (overload 7)
useEventListener('foo', () => {})         // TS2345: '"foo"' is not assignable to
                                          // 'MaybeRefOrGetter<Arrayable<keyof WindowEventMap>>'
```

The overload list has no omitted-target signature for custom event names, so
the call falls through to the only omitted-target overload (constrained to
`keyof WindowEventMap`) and fails.

## Solution

Add an omitted-target overload for arbitrary `Names extends string` right
after the existing window-event-map overload. Known event names still match
the first overload (keeping `MouseEvent` precision on `'click'`); custom
names fall through to the new one:

```ts
export function useEventListener<Names extends string, EventType = Event>(
  event: MaybeRefOrGetter<Arrayable<Names>>,
  listener: MaybeRef<Arrayable<GeneralEventListener<EventType>>>,
  options?: MaybeRefOrGetter<boolean | AddEventListenerOptions>,
): Fn
```

The runtime already handles this shape (strings in `args[0]` resolve to
`defaultWindow`), so this is a types-only change. Overload doc comments are
renumbered to follow the inserted overload.

## Tests

Added a type test covering: omitted target + custom event, explicit window +
custom event, and omitted target + `'click'` keeping `MouseEvent` precision.