### PR TITLE
feat(computedDebounced): new function

### DIFF
--- a/packages/shared/computedDebounced/demo.vue
+++ b/packages/shared/computedDebounced/demo.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { computedDebounced } from '@vueuse/core'
+import { ref } from 'vue'
+
+const input = ref('')
+const delay = ref(500)
+
+const stats = computedDebounced(() => {
+  const text = input.value.trim()
+  return {
+    words: text ? text.split(/\s+/).length : 0,
+    chars: text.length,
+  }
+}, delay)
+</script>
+
+<template>
+  <div>
+    <div class="demo-input">
+      <input v-model="input" type="text" placeholder="Type something..." />
+    </div>
+    <div class="demo-stats">
+      <span>words: {{ stats.words }}</span>
+      <span>chars: {{ stats.chars }}</span>
+      <span class="demo-delay">updates {{ delay }}ms after you stop typing</span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.demo-input input {
+  width: 100%;
+  padding: 0.5rem;
+  font-size: 1rem;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 0.375rem;
+  background: transparent;
+  color: var(--vp-c-text-1);
+}
+
+.demo-stats {
+  display: flex;
+  gap: 1rem;
+  margin-top: 0.5rem;
+  font-size: 0.875rem;
+  color: var(--vp-c-text-2);
+}
+
+.demo-delay {
+  margin-left: auto;
+}
+</style>

--- a/packages/shared/computedDebounced/index.md
+++ b/packages/shared/computedDebounced/index.md
@@ -45,7 +45,7 @@ The third argument accepts both debounce options and watch options:
 computedDebounced(() => value, 1000, { maxWait: 5000, flush: 'post' })
 ```
 
-- `maxWait` — the maximum time allowed to be delayed before the getter is invoked, in milliseconds.
+- `maxWait` — the maximum time the debounced update is allowed to be delayed, in milliseconds. The getter itself may still run earlier as its reactive dependencies change.
 - `flush` — the flush timing of the underlying watch, see [Vue watch options](https://vuejs.org/api/reactivity-core#watch).
 
 ## Type Declarations

--- a/packages/shared/computedDebounced/index.md
+++ b/packages/shared/computedDebounced/index.md
@@ -1,0 +1,61 @@
+---
+category: Reactivity
+---
+
+# computedDebounced
+
+Debounce updates of a computed value.
+
+A computed that depends on other reactive state, but only updates after that other state has stopped changing for a certain time.
+
+## Usage
+
+```ts
+import { computedDebounced } from '@vueuse/core'
+
+const inputText = ref('')
+const preview = computedDebounced(
+  () => generatePreview(inputText.value),
+  1000,
+)
+
+watchEffect(() => {
+  // Only runs after the input has been idle for 1000ms.
+  renderPreview(preview.value)
+})
+```
+
+## Description
+
+`computedDebounced` is like `refDebounced` for computed getters: the initial value is computed eagerly, and subsequent updates only happen after the reactive dependencies have stopped changing for the debounce delay.
+
+Compared to the `watchDebounced` workaround, it stays declarative and works naturally inside other computeds and templates.
+
+| | Behavior |
+|---|---|
+| Initial value | Computed synchronously, no delay |
+| Subsequent updates | Debounced (trailing edge) |
+| Rapid changes | Merged into a single update |
+
+## Options
+
+The third argument accepts both debounce options and watch options:
+
+```ts
+computedDebounced(() => value, 1000, { maxWait: 5000, flush: 'post' })
+```
+
+- `maxWait` — the maximum time allowed to be delayed before the getter is invoked, in milliseconds.
+- `flush` — the flush timing of the underlying watch, see [Vue watch options](https://vuejs.org/api/reactivity-core#watch).
+
+## Type Declarations
+
+```ts
+export type ComputedDebouncedOptions = DebounceFilterOptions & WatchOptionsBase
+
+export declare function computedDebounced<T>(
+  getter: () => T,
+  ms?: MaybeRefOrGetter<number>,
+  options?: ComputedDebouncedOptions,
+): Readonly<Ref<T>>
+```

--- a/packages/shared/computedDebounced/index.test.ts
+++ b/packages/shared/computedDebounced/index.test.ts
@@ -1,6 +1,5 @@
-import { expectTypeOf } from 'expect-type'
 import type { Ref } from 'vue'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest'
 import { ref } from 'vue'
 import { computedDebounced } from './index'
 

--- a/packages/shared/computedDebounced/index.test.ts
+++ b/packages/shared/computedDebounced/index.test.ts
@@ -1,10 +1,18 @@
 import { expectTypeOf } from 'expect-type'
 import type { Ref } from 'vue'
-import { computedDebounced } from './index'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
+import { computedDebounced } from './index'
 
 describe('computedDebounced', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('should be defined', () => {
     expect(computedDebounced).toBeDefined()
   })
@@ -17,7 +25,6 @@ describe('computedDebounced', () => {
   })
 
   it('updates after the debounce delay', async () => {
-    vi.useFakeTimers()
     const source = ref(1)
     const value = computedDebounced(() => source.value * 2, 100)
 
@@ -29,12 +36,9 @@ describe('computedDebounced', () => {
 
     await vi.advanceTimersByTimeAsync(1)
     expect(value.value).toBe(4)
-
-    vi.useRealTimers()
   })
 
   it('merges rapid changes into a single update', async () => {
-    vi.useFakeTimers()
     const source = ref(1)
     const getter = vi.fn(() => source.value * 2)
     const value = computedDebounced(getter, 100)
@@ -49,12 +53,9 @@ describe('computedDebounced', () => {
 
     expect(value.value).toBe(8)
     expect(getter).toHaveBeenCalledTimes(2) // initial + one debounced update
-
-    vi.useRealTimers()
   })
 
   it('reacts to multiple reactive dependencies', async () => {
-    vi.useFakeTimers()
     const a = ref(1)
     const b = ref(10)
     const value = computedDebounced(() => a.value + b.value, 100)
@@ -66,12 +67,9 @@ describe('computedDebounced', () => {
     b.value = 20
     await vi.advanceTimersByTimeAsync(100)
     expect(value.value).toBe(22)
-
-    vi.useRealTimers()
   })
 
   it('does not trigger when the computed value is unchanged', async () => {
-    vi.useFakeTimers()
     const source = ref('a')
     let getterCalls = 0
     const value = computedDebounced(() => {
@@ -88,12 +86,9 @@ describe('computedDebounced', () => {
     expect(value.value).toBe('a')
     // the computed cache means the getter re-runs, but the ref is not updated
     expect(getterCalls).toBe(2)
-
-    vi.useRealTimers()
   })
 
   it('supports maxWait', async () => {
-    vi.useFakeTimers()
     const source = ref(1)
     const value = computedDebounced(() => source.value * 2, 1000, { maxWait: 150 })
 
@@ -106,12 +101,9 @@ describe('computedDebounced', () => {
 
     // maxWait forced the debounced update through at least once by now
     expect(value.value).toBeGreaterThan(2)
-
-    vi.useRealTimers()
   })
 
   it('supports a reactive delay', async () => {
-    vi.useFakeTimers()
     const source = ref(1)
     const delay = ref(100)
     const value = computedDebounced(() => source.value * 2, delay)
@@ -126,8 +118,6 @@ describe('computedDebounced', () => {
     expect(value.value).toBe(4) // not yet
     await vi.advanceTimersByTimeAsync(400)
     expect(value.value).toBe(6)
-
-    vi.useRealTimers()
   })
 
   it('returns a readonly ref', () => {

--- a/packages/shared/computedDebounced/index.test.ts
+++ b/packages/shared/computedDebounced/index.test.ts
@@ -1,0 +1,142 @@
+import { expectTypeOf } from 'expect-type'
+import type { Ref } from 'vue'
+import { computedDebounced } from './index'
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+describe('computedDebounced', () => {
+  it('should be defined', () => {
+    expect(computedDebounced).toBeDefined()
+  })
+
+  it('computes the initial value eagerly', () => {
+    const source = ref('hello')
+    const value = computedDebounced(() => source.value.toUpperCase(), 100)
+
+    expect(value.value).toBe('HELLO')
+  })
+
+  it('updates after the debounce delay', async () => {
+    vi.useFakeTimers()
+    const source = ref(1)
+    const value = computedDebounced(() => source.value * 2, 100)
+
+    source.value = 2
+    expect(value.value).toBe(2) // still the old value
+
+    await vi.advanceTimersByTimeAsync(99)
+    expect(value.value).toBe(2)
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(value.value).toBe(4)
+
+    vi.useRealTimers()
+  })
+
+  it('merges rapid changes into a single update', async () => {
+    vi.useFakeTimers()
+    const source = ref(1)
+    const getter = vi.fn(() => source.value * 2)
+    const value = computedDebounced(getter, 100)
+
+    expect(getter).toHaveBeenCalledTimes(1) // eager initial computation
+
+    source.value = 2
+    source.value = 3
+    source.value = 4
+
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(value.value).toBe(8)
+    expect(getter).toHaveBeenCalledTimes(2) // initial + one debounced update
+
+    vi.useRealTimers()
+  })
+
+  it('reacts to multiple reactive dependencies', async () => {
+    vi.useFakeTimers()
+    const a = ref(1)
+    const b = ref(10)
+    const value = computedDebounced(() => a.value + b.value, 100)
+
+    a.value = 2
+    await vi.advanceTimersByTimeAsync(100)
+    expect(value.value).toBe(12)
+
+    b.value = 20
+    await vi.advanceTimersByTimeAsync(100)
+    expect(value.value).toBe(22)
+
+    vi.useRealTimers()
+  })
+
+  it('does not trigger when the computed value is unchanged', async () => {
+    vi.useFakeTimers()
+    const source = ref('a')
+    let getterCalls = 0
+    const value = computedDebounced(() => {
+      getterCalls++
+      return source.value.trim()
+    }, 100)
+
+    expect(getterCalls).toBe(1)
+
+    // changing the dependency to a value that trims to the same string
+    source.value = ' a '
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(value.value).toBe('a')
+    // the computed cache means the getter re-runs, but the ref is not updated
+    expect(getterCalls).toBe(2)
+
+    vi.useRealTimers()
+  })
+
+  it('supports maxWait', async () => {
+    vi.useFakeTimers()
+    const source = ref(1)
+    const value = computedDebounced(() => source.value * 2, 1000, { maxWait: 150 })
+
+    source.value = 2
+    // keep the source changing so the debounce never settles
+    for (let i = 0; i < 10; i++) {
+      await vi.advanceTimersByTimeAsync(80)
+      source.value++
+    }
+
+    // maxWait fired the getter at least once by now
+    expect(value.value).toBeGreaterThan(2)
+
+    vi.useRealTimers()
+  })
+
+  it('supports a reactive delay', async () => {
+    vi.useFakeTimers()
+    const source = ref(1)
+    const delay = ref(100)
+    const value = computedDebounced(() => source.value * 2, delay)
+
+    source.value = 2
+    await vi.advanceTimersByTimeAsync(100)
+    expect(value.value).toBe(4)
+
+    delay.value = 500
+    source.value = 3
+    await vi.advanceTimersByTimeAsync(100)
+    expect(value.value).toBe(4) // not yet
+    await vi.advanceTimersByTimeAsync(400)
+    expect(value.value).toBe(6)
+
+    vi.useRealTimers()
+  })
+
+  it('returns a readonly ref', () => {
+    const source = ref(1)
+    const value = computedDebounced(() => source.value, 100)
+
+    // @ts-expect-error - readonly
+    value.value = 999
+
+    expectTypeOf(value).toExtend<Readonly<Ref<number>>>()
+  })
+})

--- a/packages/shared/computedDebounced/index.test.ts
+++ b/packages/shared/computedDebounced/index.test.ts
@@ -104,7 +104,7 @@ describe('computedDebounced', () => {
       source.value++
     }
 
-    // maxWait fired the getter at least once by now
+    // maxWait forced the debounced update through at least once by now
     expect(value.value).toBeGreaterThan(2)
 
     vi.useRealTimers()

--- a/packages/shared/computedDebounced/index.ts
+++ b/packages/shared/computedDebounced/index.ts
@@ -1,0 +1,39 @@
+import type { MaybeRefOrGetter, Ref, WatchOptionsBase } from 'vue'
+import type { DebounceFilterOptions } from '../utils'
+import { computed, ref as deepRef, shallowReadonly, watch } from 'vue'
+import { useDebounceFn } from '../useDebounceFn'
+
+export type ComputedDebouncedOptions = DebounceFilterOptions & WatchOptionsBase
+
+export type ComputedDebouncedReturn<T = any> = Readonly<Ref<T>>
+
+/**
+ * Debounce updates of a computed value.
+ *
+ * A computed that depends on other reactive state, but only updates after
+ * that other state has stopped changing for a certain time.
+ *
+ * @see https://vueuse.org/shared/computedDebounced/
+ * @param getter the getter function
+ * @param ms debounce delay in milliseconds
+ * @param options debounce and watch options
+ * @return a readonly ref that updates with debounce
+ */
+export function computedDebounced<T>(
+  getter: () => T,
+  ms: MaybeRefOrGetter<number> = 200,
+  options: ComputedDebouncedOptions = {},
+): ComputedDebouncedReturn<T> {
+  const tracked = computed(getter)
+
+  // Activate dependency tracking and read the eager initial value.
+  const value = deepRef(tracked.value) as Ref<T>
+
+  const updater = useDebounceFn(() => {
+    value.value = tracked.value
+  }, ms, options)
+
+  watch(tracked, () => updater(), options)
+
+  return shallowReadonly(value)
+}

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -1,4 +1,5 @@
 export * from './computedEager'
+export * from './computedDebounced'
 export * from './computedWithControl'
 export * from './createDisposableDirective'
 export * from './createEventHook'


### PR DESCRIPTION
close #2043

## What

Adds `computedDebounced` — a computed that only updates after its reactive dependencies have stopped changing for a given time. The issue has been open since 2022-08 with 24 👍.

```ts
const preview = computedDebounced(() => generatePreview(props.inputText), 1000)
```

## Implementation

Built on a lazy `computed` + `useDebounceFn`, so it keeps real computed semantics:

```ts
export function computedDebounced<T>(
  getter: () => T,
  ms: MaybeRefOrGetter<number> = 200,
  options: ComputedDebouncedOptions = {},
): Readonly<Ref<T>> {
  const tracked = computed(getter)
  const value = deepRef(tracked.value) as Ref<T>   // eager initial value
  const updater = useDebounceFn(() => {
    value.value = tracked.value
  }, ms, options)
  watch(tracked, () => updater(), options)
  return shallowReadonly(value)
}
```

Key semantics:

- **Eager initial value** — computed synchronously on creation, no delay (same as `computed`/matches `refDebounced`).
- **Trailing-edge debounce** — rapid changes merge into one update after the delay.
- **Value-change gating** — the inner `computed` cache means a re-run that yields the same value (Vue 3.4+) does not push through the debounce.
- **Options** are `DebounceFilterOptions & WatchOptionsBase`, so `maxWait`, `rejectOnCancel`, and `flush` are all available.

The `watch` targets the cached `computed` rather than the raw getter, so the getter is not invoked an extra time for dependency collection (a plain `watch(getter)` runs the getter once more than `computed` semantics allow).

## Tests

Seven unit tests cover: eager initial value, delayed update, rapid-change merging (asserting the getter runs exactly twice), multiple dependencies, unchanged-value gating, `maxWait`, and a reactive delay.