### PR TITLE
fix(integrations): align drauu peer range with the version actually used

### DIFF
--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -60,7 +60,7 @@
     "async-validator": "^4",
     "axios": "^1",
     "change-case": "^5",
-    "drauu": "^0.4",
+    "drauu": "^1",
     "focus-trap": "^7 || ^8",
     "fuse.js": "^7",
     "idb-keyval": "^6",

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -60,7 +60,7 @@
     "async-validator": "^4",
     "axios": "^1",
     "change-case": "^5",
-    "drauu": "^1",
+    "drauu": "^1 || ^0.4",
     "focus-trap": "^7 || ^8",
     "fuse.js": "^7",
     "idb-keyval": "^6",


### PR DESCRIPTION
Fixes #5594.

## Problem

`@vueuse/integrations` declares `drauu` as a peer dependency at `^0.4`, but the package is developed and tested against v1:

- `pnpm-workspace.yaml` catalog (`integrations`) pins `drauu: ^1.0.0`
- `pnpm-lock.yaml` resolves `drauu@1.0.0`
- `packages/integrations/package.json` `peerDependencies` still says `^0.4`

So a consumer installing the version this package is actually built against gets an unmet-peer warning, while the range nominally endorses a major version that is no longer used in CI.

## Solution

Bump the `drauu` peer range to `^1` so it matches the catalog and lockfile.

`useDrauu` only uses `createDrauu` plus the `Brush` / `Drauu` / `DrawingMode` / `Options` types, all of which are the v1 surface it is already compiled and tested against — so this only corrects the declared range, with no source change needed.

## Note

I checked the other `integrations` peer ranges against the catalog for the same drift and `drauu` is the only mismatch, so this is intentionally a one-line change.
