### PR TITLE
fix(useEventSource): ignore events from a superseded connection

### DIFF
--- a/packages/core/useEventSource/index.browser.test.ts
+++ b/packages/core/useEventSource/index.browser.test.ts
@@ -77,6 +77,33 @@ describe('useEventSource', () => {
     expect(error.value).toBe(err)
   })
 
+  it('should not set status to OPEN on open event from a superseded event source', () => {
+    const { status, eventSource, open } = useEventSource('https://localhost', [], { immediate: false })
+
+    open()
+    const staleSource = eventSource.value!
+
+    open()
+
+    staleSource.onopen!(new Event('open'))
+
+    expect(status.value).toBe('CONNECTING')
+  })
+
+  it('should not set error status on error event from a superseded event source', () => {
+    const { status, eventSource, error, open } = useEventSource('https://localhost', [], { autoReconnect: false })
+
+    const staleSource = eventSource.value!
+
+    open()
+    eventSource.value!.onopen!(new Event('open'))
+
+    staleSource.onerror!(new Event('error'))
+
+    expect(status.value).toBe('OPEN')
+    expect(error.value).toBe(null)
+  })
+
   it('sets data on message', () => {
     const { data, eventSource, lastEventId } = useEventSource('https://localhost')
 
@@ -129,6 +156,23 @@ describe('useEventSource', () => {
 
     expect(event.value).toBe('custom-event')
     expect(data.value).toBe('bloop')
+  })
+
+  it('should not set data on custom event from a superseded event source', () => {
+    const { data, event, eventSource, open } = useEventSource('https://localhost', [
+      'custom-event',
+    ])
+
+    const staleSource = eventSource.value!
+
+    open()
+
+    staleSource.dispatchEvent(new MessageEvent('custom-event', {
+      data: 'bloop',
+    }))
+
+    expect(event.value).toBe(null)
+    expect(data.value).toBe(null)
   })
 
   it('can manually open()', () => {

--- a/packages/core/useEventSource/index.browser.test.ts
+++ b/packages/core/useEventSource/index.browser.test.ts
@@ -91,6 +91,20 @@ describe('useEventSource', () => {
     expect(lastEventId.value).toBe('303')
   })
 
+  it('should not set data on message from a superseded event source', () => {
+    const { data, eventSource, open } = useEventSource('https://localhost')
+
+    const staleSource = eventSource.value!
+
+    open()
+
+    staleSource.onmessage!(new MessageEvent('message', {
+      data: 'bleep',
+    }))
+
+    expect(data.value).toBe(null)
+  })
+
   it('can set non-string data', () => {
     const { data, eventSource } = useEventSource('https://localhost')
 

--- a/packages/core/useEventSource/index.ts
+++ b/packages/core/useEventSource/index.ts
@@ -163,11 +163,17 @@ export function useEventSource<Events extends string[], Data = any>(
     eventSource.value = es
 
     es.onopen = () => {
+      if (eventSource.value !== es)
+        return
+
       status.value = 'OPEN'
       error.value = null
     }
 
     es.onerror = (e) => {
+      if (eventSource.value !== es)
+        return
+
       status.value = 'CLOSED'
       error.value = e
 
@@ -192,6 +198,9 @@ export function useEventSource<Events extends string[], Data = any>(
     }
 
     es.onmessage = (e: MessageEvent) => {
+      if (eventSource.value !== es)
+        return
+
       event.value = null
       data.value = serializer.read(e.data) ?? null
       lastEventId.value = e.lastEventId
@@ -199,6 +208,9 @@ export function useEventSource<Events extends string[], Data = any>(
 
     for (const event_name of events) {
       useEventListener(es, event_name, (e: Event & { data?: string, lastEventId?: string }) => {
+        if (eventSource.value !== es)
+          return
+
         event.value = event_name
         data.value = serializer.read(e.data) ?? null
         lastEventId.value = e.lastEventId ?? null


### PR DESCRIPTION
`useEventSource`'s `onopen`, `onerror`, `onmessage`, and the per-event listeners never check whether the `EventSource` firing them is still the one `eventSource` points at. A reconnect (URL change or auto-reconnect) creates a new `EventSource` and swaps it in, and anything the old one still delivers before it's fully closed ends up overwriting `status`/`error`/`data` with a value from a connection that's already gone. `useWebSocket` had the same gap on `onmessage` until #5573.

Same guard on all four handlers. `onerror`'s guard also skips its reconnect scheduling for a stale source, since by the time it fires late a fresh connection (or an explicit close) is already in charge of reconnecting.

Fixes #5596
