### PR TITLE
fix(usePrecision): apply float-error correction to negative values

### DIFF
--- a/packages/math/usePrecision/index.test.ts
+++ b/packages/math/usePrecision/index.test.ts
@@ -34,4 +34,16 @@ describe('usePrecision', () => {
     base.value = -2.3
     expect(result.value).toMatchInlineSnapshot('-2.3')
   })
+
+  it('should apply float-error correction to negative values', () => {
+    const base = deepRef(-1.1)
+    const floored = usePrecision(base, 2, { math: 'floor' })
+    expect(floored.value).toBe(-1.1)
+
+    base.value = -2.2
+    expect(floored.value).toBe(-2.2)
+
+    const ceiled = usePrecision(deepRef(-2.3), 2, { math: 'ceil' })
+    expect(ceiled.value).toBe(-2.3)
+  })
 })

--- a/packages/math/usePrecision/index.ts
+++ b/packages/math/usePrecision/index.ts
@@ -11,7 +11,7 @@ import { computed, toValue } from 'vue'
 function accurateMultiply(value: number, power: number): number {
   const valueStr = value.toString()
 
-  if (value > 0 && valueStr.includes('.')) {
+  if (value !== 0 && valueStr.includes('.')) {
     const decimalPlaces = valueStr.split('.')[1].length
     const multiplier = 10 ** decimalPlaces
 


### PR DESCRIPTION
### Description

`usePrecision` returns an incorrect value for some negative inputs. `accurateMultiply` only applies its floating-point-error correction when `value > 0`, so negative non-integers fall through to the naive `value * power` path and hit the same float errors the correction was written to avoid:

```ts
usePrecision(-1.1, 2, { math: 'floor' }) // -1.11  (should be -1.1)
usePrecision(1.1, 2, { math: 'floor' })  //  1.1   (correct, mirror case)
```

Since `-1.1` already has fewer than 2 decimal places, its value at precision 2 should be unchanged — exactly like the positive mirror.

### Fix

Change the guard from `value > 0` to `value !== 0` so the correction also runs for negatives. (For `value === 0`, `"0"` has no `.`, so that branch was never taken anyway — behaviour is unchanged there.)

### Test

Added a case asserting `-1.1` / `-2.2` (floor) and `-2.3` (ceil) stay unchanged at precision 2. It fails on `main` and passes with this change; the existing tests are unaffected.