### PR TITLE
fix(useUserMedia): prevent concurrent getUserMedia stream leaks

### DIFF
--- a/packages/core/useDisplayMedia/index.test.ts
+++ b/packages/core/useDisplayMedia/index.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import { useSetup } from '../../.test'
+import { useDisplayMedia } from './index'
+
+function createMockStream(id: number, live: Set<number>) {
+  const tracks = [{
+    stop: vi.fn(() => {
+      live.delete(id)
+    }),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }]
+  live.add(id)
+  return {
+    id,
+    getTracks: () => tracks,
+    tracks,
+  } as unknown as MediaStream
+}
+
+function createMockMediaDevices(delay = 0) {
+  let n = 0
+  const live = new Set<number>()
+  const getDisplayMedia = vi.fn(() => new Promise<MediaStream>((resolve) => {
+    setTimeout(() => {
+      resolve(createMockStream(++n, live))
+    }, delay)
+  }))
+
+  return {
+    getDisplayMedia,
+    live,
+  }
+}
+
+describe('useDisplayMedia', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('should not leak streams from concurrent starts', async () => {
+    const mediaDevices = createMockMediaDevices(20)
+    const navigator = { mediaDevices } as unknown as Navigator
+
+    const vm = useSetup(() => {
+      const api = useDisplayMedia({ navigator })
+      return { api }
+    })
+
+    const p1 = vm.api.start()
+    const p2 = vm.api.start()
+    await vi.advanceTimersByTimeAsync(20)
+    await Promise.all([p1, p2])
+
+    expect(mediaDevices.getDisplayMedia).toHaveBeenCalledTimes(1)
+    expect(mediaDevices.live.size).toBe(1)
+
+    vm.unmount()
+  })
+
+  it('should discard in-flight stream when stopped before getDisplayMedia resolves', async () => {
+    const mediaDevices = createMockMediaDevices(20)
+    const navigator = { mediaDevices } as unknown as Navigator
+
+    const vm = useSetup(() => {
+      const api = useDisplayMedia({ navigator, enabled: true })
+      return { api }
+    })
+
+    await nextTick()
+    expect(mediaDevices.getDisplayMedia).toHaveBeenCalledTimes(1)
+
+    vm.api.stop()
+    await vi.advanceTimersByTimeAsync(20)
+
+    expect(vm.api.stream.value).toBeUndefined()
+    expect(mediaDevices.live.size).toBe(0)
+
+    vm.unmount()
+  })
+
+  it('should stop orphaned stream tracks when superseded by a later start', async () => {
+    const mediaDevices = createMockMediaDevices(20)
+    const navigator = { mediaDevices } as unknown as Navigator
+
+    const vm = useSetup(() => {
+      const api = useDisplayMedia({ navigator })
+      return { api }
+    })
+
+    const p1 = vm.api.start()
+    await vi.advanceTimersByTimeAsync(10)
+    vm.api.stop()
+    const p2 = vm.api.start()
+    await vi.advanceTimersByTimeAsync(20)
+    await Promise.all([p1, p2])
+
+    expect(mediaDevices.getDisplayMedia).toHaveBeenCalledTimes(2)
+    expect(mediaDevices.live.size).toBe(1)
+    expect(vm.api.stream.value).toBeDefined()
+
+    vm.unmount()
+  })
+})

--- a/packages/core/useDisplayMedia/index.ts
+++ b/packages/core/useDisplayMedia/index.ts
@@ -46,16 +46,37 @@ export function useDisplayMedia(options: UseDisplayMediaOptions = {}): UseDispla
   const constraint: MediaStreamConstraints = { audio, video }
 
   const stream = shallowRef<MediaStream | undefined>()
+  let starting = false
+  let startId = 0
 
   async function _start() {
-    if (!isSupported.value || stream.value)
+    if (!isSupported.value || stream.value || starting)
       return
-    stream.value = await navigator!.mediaDevices.getDisplayMedia(constraint)
-    stream.value?.getTracks().forEach(t => useEventListener(t, 'ended', stop, { passive: true }))
-    return stream.value
+
+    starting = true
+    const id = ++startId
+
+    try {
+      const mediaStream = await navigator!.mediaDevices.getDisplayMedia(constraint)
+
+      if (id !== startId) {
+        mediaStream.getTracks().forEach(t => t.stop())
+        return
+      }
+
+      stream.value = mediaStream
+      stream.value.getTracks().forEach(t => useEventListener(t, 'ended', stop, { passive: true }))
+      return stream.value
+    }
+    finally {
+      if (id === startId)
+        starting = false
+    }
   }
 
   async function _stop() {
+    startId++
+    starting = false
     stream.value?.getTracks().forEach(t => t.stop())
     stream.value = undefined
   }

--- a/packages/core/useUserMedia/index.test.ts
+++ b/packages/core/useUserMedia/index.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import { useSetup } from '../../.test'
+import { useUserMedia } from './index'
+
+function createMockTrack() {
+  return { stop: vi.fn() }
+}
+
+function createMockStream(id: number) {
+  const tracks = [createMockTrack()]
+  return {
+    id,
+    getTracks: () => tracks,
+    tracks,
+  } as unknown as MediaStream
+}
+
+function createMockMediaDevices(delay = 0) {
+  let n = 0
+  const live = new Set<number>()
+  const getUserMedia = vi.fn(() => new Promise<MediaStream>((resolve) => {
+    setTimeout(() => {
+      const stream = createMockStream(++n)
+      live.add(stream.id as number)
+      resolve(stream)
+    }, delay)
+  }))
+
+  return {
+    getUserMedia,
+    live,
+  }
+}
+
+describe('useUserMedia', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('should not leak streams from concurrent starts', async () => {
+    const mediaDevices = createMockMediaDevices(20)
+    const navigator = { mediaDevices } as unknown as Navigator
+
+    const vm = useSetup(() => {
+      const api = useUserMedia({ navigator })
+      return { api }
+    })
+
+    const p1 = vm.api.start()
+    const p2 = vm.api.start()
+    await vi.advanceTimersByTimeAsync(20)
+    await Promise.all([p1, p2])
+
+    expect(mediaDevices.getUserMedia).toHaveBeenCalledTimes(1)
+    expect(mediaDevices.live.size).toBe(1)
+
+    vm.unmount()
+  })
+
+  it('should discard in-flight stream when stopped before getUserMedia resolves', async () => {
+    const mediaDevices = createMockMediaDevices(20)
+    const navigator = { mediaDevices } as unknown as Navigator
+
+    const vm = useSetup(() => {
+      const api = useUserMedia({ navigator, enabled: true })
+      return { api }
+    })
+
+    await nextTick()
+    expect(mediaDevices.getUserMedia).toHaveBeenCalledTimes(1)
+
+    vm.api.stop()
+    await vi.advanceTimersByTimeAsync(20)
+
+    expect(vm.api.stream.value).toBeUndefined()
+    expect(mediaDevices.live.size).toBe(0)
+
+    vm.unmount()
+  })
+
+  it('should stop orphaned stream tracks when superseded by a later start', async () => {
+    const mediaDevices = createMockMediaDevices(20)
+    const navigator = { mediaDevices } as unknown as Navigator
+
+    const vm = useSetup(() => {
+      const api = useUserMedia({ navigator })
+      return { api }
+    })
+
+    const p1 = vm.api.start()
+    await vi.advanceTimersByTimeAsync(10)
+    vm.api.stop()
+    const p2 = vm.api.start()
+    await vi.advanceTimersByTimeAsync(20)
+    await Promise.all([p1, p2])
+
+    expect(mediaDevices.getUserMedia).toHaveBeenCalledTimes(2)
+    expect(mediaDevices.live.size).toBe(1)
+    expect(vm.api.stream.value).toBeDefined()
+
+    vm.unmount()
+  })
+})

--- a/packages/core/useUserMedia/index.test.ts
+++ b/packages/core/useUserMedia/index.test.ts
@@ -3,12 +3,13 @@ import { nextTick } from 'vue'
 import { useSetup } from '../../.test'
 import { useUserMedia } from './index'
 
-function createMockTrack() {
-  return { stop: vi.fn() }
-}
-
-function createMockStream(id: number) {
-  const tracks = [createMockTrack()]
+function createMockStream(id: number, live: Set<number>) {
+  const tracks = [{
+    stop: vi.fn(() => {
+      live.delete(id)
+    }),
+  }]
+  live.add(id)
   return {
     id,
     getTracks: () => tracks,
@@ -21,9 +22,7 @@ function createMockMediaDevices(delay = 0) {
   const live = new Set<number>()
   const getUserMedia = vi.fn(() => new Promise<MediaStream>((resolve) => {
     setTimeout(() => {
-      const stream = createMockStream(++n)
-      live.add(stream.id as number)
-      resolve(stream)
+      resolve(createMockStream(++n, live))
     }, delay)
   }))
 

--- a/packages/core/useUserMedia/index.ts
+++ b/packages/core/useUserMedia/index.ts
@@ -53,6 +53,8 @@ export function useUserMedia(options: UseUserMediaOptions = {}): UseUserMediaRet
   const isSupported = useSupported(() => navigator?.mediaDevices?.getUserMedia)
 
   const stream: Ref<MediaStream | undefined> = shallowRef()
+  let starting = false
+  let startId = 0
 
   function getDeviceOptions(type: 'video' | 'audio') {
     switch (type) {
@@ -70,16 +72,35 @@ export function useUserMedia(options: UseUserMediaOptions = {}): UseUserMediaRet
   }
 
   async function _start() {
-    if (!isSupported.value || stream.value)
+    if (!isSupported.value || stream.value || starting)
       return
-    stream.value = await navigator!.mediaDevices.getUserMedia({
-      video: getDeviceOptions('video'),
-      audio: getDeviceOptions('audio'),
-    })
-    return stream.value
+
+    starting = true
+    const id = ++startId
+
+    try {
+      const mediaStream = await navigator!.mediaDevices.getUserMedia({
+        video: getDeviceOptions('video'),
+        audio: getDeviceOptions('audio'),
+      })
+
+      if (id !== startId) {
+        mediaStream.getTracks().forEach(t => t.stop())
+        return
+      }
+
+      stream.value = mediaStream
+      return stream.value
+    }
+    finally {
+      if (id === startId)
+        starting = false
+    }
   }
 
   function _stop() {
+    startId++
+    starting = false
     stream.value?.getTracks().forEach(t => t.stop())
     stream.value = undefined
   }


### PR DESCRIPTION
## Summary
- Guard in-flight `getUserMedia` calls with a `starting` flag and generation id so overlapping `start()` / `stop()` / `enabled` toggles cannot orphan `MediaStream` tracks
- Apply the same pattern to `useDisplayMedia`
- Add regression tests covering concurrent starts, stop-during-in-flight, and superseded starts

Fixes #5599

## Test plan
- [x] `npx vitest run packages/core/useUserMedia/index.test.ts`

Made with [Cursor](https://cursor.com)