### PR TITLE
fix(injectLocal): use function declaration for Rollup @__NO_SIDE_EFFECTS__ annotation

### DIFF
--- a/packages/shared/injectLocal/index.ts
+++ b/packages/shared/injectLocal/index.ts
@@ -14,7 +14,7 @@ import { localProvidedStateMap } from '../provideLocal/map'
  * @__NO_SIDE_EFFECTS__
  */
 // @ts-expect-error overloads are not compatible
-export const injectLocal: typeof inject = <T>(...args) => {
+export function injectLocal<T>(...args: Parameters<typeof inject>): ReturnType<typeof inject> {
   const key = args[0] as InjectionKey<T> | string | number
   const instance = getCurrentInstance()?.proxy
   const owner = instance ?? getCurrentScope()

--- a/packages/shared/injectLocal/index.ts
+++ b/packages/shared/injectLocal/index.ts
@@ -13,8 +13,10 @@ import { localProvidedStateMap } from '../provideLocal/map'
  *
  * @__NO_SIDE_EFFECTS__
  */
-// @ts-expect-error overloads are not compatible
-export function injectLocal<T>(...args: Parameters<typeof inject>): ReturnType<typeof inject> {
+export function injectLocal<T>(key: InjectionKey<T> | string): T | undefined
+export function injectLocal<T>(key: InjectionKey<T> | string, defaultValue: T, treatDefaultAsFactory?: false): T
+export function injectLocal<T>(key: InjectionKey<T> | string, defaultValue: T | (() => T), treatDefaultAsFactory: true): T
+export function injectLocal<T>(...args: any[]): T | undefined {
   const key = args[0] as InjectionKey<T> | string | number
   const instance = getCurrentInstance()?.proxy
   const owner = instance ?? getCurrentScope()
@@ -23,7 +25,7 @@ export function injectLocal<T>(...args: Parameters<typeof inject>): ReturnType<t
     throw new Error('injectLocal must be called in setup')
 
   if (owner && localProvidedStateMap.has(owner) && key in localProvidedStateMap.get(owner)!)
-    return localProvidedStateMap.get(owner)![key]
+    return localProvidedStateMap.get(owner)![key] as T
 
   // @ts-expect-error overloads are not compatible
   return inject(...args)

--- a/packages/shared/injectLocal/index.ts
+++ b/packages/shared/injectLocal/index.ts
@@ -16,6 +16,7 @@ import { localProvidedStateMap } from '../provideLocal/map'
 export function injectLocal<T>(key: InjectionKey<T> | string): T | undefined
 export function injectLocal<T>(key: InjectionKey<T> | string, defaultValue: T, treatDefaultAsFactory?: false): T
 export function injectLocal<T>(key: InjectionKey<T> | string, defaultValue: T | (() => T), treatDefaultAsFactory: true): T
+/* @__NO_SIDE_EFFECTS__ */
 export function injectLocal<T>(...args: any[]): T | undefined {
   const key = args[0] as InjectionKey<T> | string | number
   const instance = getCurrentInstance()?.proxy

--- a/test/__snapshots__/tsnapi/@vueuse/shared/index.snapshot.d.ts
+++ b/test/__snapshots__/tsnapi/@vueuse/shared/index.snapshot.d.ts
@@ -331,6 +331,9 @@ export declare function identity<T>(_: T): T;
 export declare function increaseWithUnit(_: number, _: number): number;
 export declare function increaseWithUnit(_: string, _: number): string;
 export declare function increaseWithUnit(_: string | number, _: number): string | number;
+export declare function injectLocal<T>(_: InjectionKey<T> | string): T | undefined;
+export declare function injectLocal<T>(_: InjectionKey<T> | string, _: T, _?: false): T;
+export declare function injectLocal<T>(_: InjectionKey<T> | string, _: T | (() => T), _: true): T;
 export declare function invoke<T>(_: () => T): T;
 export declare function isDefined<T>(_: ComputedRef<T>): v is ComputedRef<Exclude<T, null | undefined>>;
 export declare function isDefined<T>(_: Ref<T>): v is Ref<Exclude<T, null | undefined>>;
@@ -493,7 +496,6 @@ export declare const hasOwn: <T extends object, K extends keyof T>(val: T, key: 
 export declare const hyphenate: (str: string) => string;
 /** @deprecated */
 export declare const ignorableWatch: typeof watchIgnorable;
-export declare const injectLocal: typeof inject;
 export declare const isClient: boolean;
 export declare const isDef: <T = any>(val?: T) => val is T;
 export declare const isIOS: boolean;

--- a/test/__snapshots__/tsnapi/@vueuse/shared/index.snapshot.js
+++ b/test/__snapshots__/tsnapi/@vueuse/shared/index.snapshot.js
@@ -21,6 +21,7 @@ export function get(_, _) {}
 export function getLifeCycleTarget(_) {}
 export function identity(_) {}
 export function increaseWithUnit(_, _) {}
+export function injectLocal(..._) {}
 export function invoke(_) {}
 export function isDefined(_) {}
 export function makeDestructurable(_, _) {}
@@ -119,7 +120,6 @@ export var hasOwn /* const */
 export var hyphenate /* const */
 /** @deprecated */
 export var ignorableWatch /* const */
-export var injectLocal /* const */
 export var isClient /* const */
 export var isDef /* const */
 export var isIOS /* const */


### PR DESCRIPTION
Fixes #5535

## Summary

- Change `injectLocal` from a `const` arrow export to a `function` declaration so Rollup/Rolldown can interpret the JSDoc `@__NO_SIDE_EFFECTS__` tag during bundling
- Matches the pattern used by other annotated exports in `@vueuse/shared` (e.g. `useArrayFind`, `useToggle`)

## Problem

When building a Nuxt 4 app for production, Nitro/Rollup emits a warning like:

```
A comment
"/**
* ...
* @__NO_SIDE_EFFECTS__
*/"
in ".nuxt/dist/server/server.mjs" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.
```

`injectLocal` is currently exported as:

```ts
/** @__NO_SIDE_EFFECTS__ */
export const injectLocal: typeof inject = <T>(...args) => { ... }
```

Rollup only understands `#__NO_SIDE_EFFECTS__` / `@__NO_SIDE_EFFECTS__` on **function declarations**, not on `const` bindings. `provideLocal` is a plain `function` without this JSDoc tag and does not trigger the warning.

## Reproduction

Minimal repro (Nuxt 4.5.2 + @vueuse/nuxt 14.4.0, `useBreakpoints()` in `app.vue`):

- **GitHub:** https://github.com/s00d/nuxt-vueuse-injectlocal-warning-repro
- **StackBlitz:** https://stackblitz.com/github/s00d/nuxt-vueuse-injectlocal-warning-repro

```bash
pnpm install && pnpm build
```

The warning appears during the **Nitro server bundle** step (after Vite SSR), not during client build or `nuxt dev`.

Applying a local patch that changes `const injectLocal` → `function injectLocal` in `@vueuse/shared` removes the warning (see `patches/@vueuse__shared@14.4.0.patch` in the repro repo).

## Test plan

- [x] `pnpm test:unit packages/shared/injectLocal/index.test.ts`

Made with [Cursor](https://cursor.com)