### PR TITLE
refactor(useEventListener): remove @ts-expect-error by casting the options

### DIFF
--- a/packages/core/useEventListener/index.ts
+++ b/packages/core/useEventListener/index.ts
@@ -142,8 +142,7 @@ export function useEventListener(...args: Parameters<typeof useEventListener>) {
       firstParamTargets.value?.map(e => unrefElement(e as never)) ?? [defaultWindow].filter(e => e != null),
       toArray(toValue(firstParamTargets.value ? args[1] : args[0]) as string[]),
       toArray(unref(firstParamTargets.value ? args[2] : args[1]) as Function[]),
-      // @ts-expect-error - TypeScript gets the correct types, but somehow still complains
-      toValue(firstParamTargets.value ? args[3] : args[2]) as boolean | AddEventListenerOptions | undefined,
+      toValue((firstParamTargets.value ? args[3] : args[2]) as MaybeRefOrGetter<boolean | AddEventListenerOptions> | undefined),
     ] as const,
     ([raw_targets, raw_events, raw_listeners, raw_options], _, onCleanup) => {
       if (!raw_targets?.length || !raw_events?.length || !raw_listeners?.length)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Confirm that this PR is based on your own understanding and review of the project, not solely generated or summarized by AI tools.

> **Note**: If this PR is deemed to be primarily generated by AI tools, it may be closed.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Removes the `@ts-expect-error` on the `options` line of `useEventListener`'s implementation by moving the type assertion from `toValue`'s return value to its argument.

The origin error
```
Argument of type 'boolean | AddEventListenerOptions | Ref<boolean | AddEventListenerOptions, boolean | AddEventListenerOptions> | ... 4 more ... | undefined' is not assignable to parameter of type 'MaybeRefOrGetter<boolean | AddEventListenerOptions | GeneralEventListener<unknown>[] | undefined>'.
  Type 'GeneralEventListener<unknown>' is not assignable to type 'MaybeRefOrGetter<boolean | AddEventListenerOptions | GeneralEventListener<unknown>[] | undefined>'.
    Type 'GeneralEventListener<unknown>' is not assignable to type '() => boolean | AddEventListenerOptions | GeneralEventListener<unknown>[] | undefined'.
      Target signature provides too few arguments. Expected 1 or more, but got 0.
```
happens while checking `toValue`'s argument, so an assertion on the result can never reach it.

So the fix assertion is applied to the argument: `MaybeRefOrGetter<boolean | AddEventListenerOptions> | undefined`. `toValue` then returns `boolean | AddEventListenerOptions | undefined` on its own, so the assertion on the result is no longer needed either.

### Additional context

- Type-level change only.
- passed typecheck.