### PR TITLE
fix(watchIgnorable): do not attach debug hooks to the internal counting watch

### DIFF
--- a/packages/shared/watchIgnorable/index.test.ts
+++ b/packages/shared/watchIgnorable/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { nextTick, shallowRef } from 'vue'
+import { ref as deepRef, nextTick, shallowRef, watch } from 'vue'
 import { ignorableWatch, watchIgnorable } from './index'
 
 describe('watchIgnorable', () => {
@@ -85,6 +85,52 @@ describe('watchIgnorable', () => {
     ignorePrevAsyncUpdates()
 
     expect(target.value).toBe(5)
+  })
+
+  it('does not report the internal counting watch to the debug hooks', async () => {
+    // `watchIgnorable` runs an extra sync watch to count updates to the source.
+    // That watch is an implementation detail, so the debug hooks should observe
+    // exactly what a plain `watch` on the same source would observe.
+    const plainSource = shallowRef(0)
+    const plainOnTrack = vi.fn()
+    const plainOnTrigger = vi.fn()
+    watch(plainSource, () => {}, { onTrack: plainOnTrack, onTrigger: plainOnTrigger })
+
+    const source = shallowRef(0)
+    const onTrack = vi.fn()
+    const onTrigger = vi.fn()
+    watchIgnorable(source, () => {}, { onTrack, onTrigger })
+
+    plainSource.value = 1
+    source.value = 1
+    await nextTick()
+
+    // guards against a "fix" that simply drops the hooks altogether
+    expect(plainOnTrigger).toHaveBeenCalledTimes(1)
+    expect(plainOnTrack).toHaveBeenCalled()
+
+    expect(onTrigger).toHaveBeenCalledTimes(plainOnTrigger.mock.calls.length)
+    expect(onTrack).toHaveBeenCalledTimes(plainOnTrack.mock.calls.length)
+  })
+
+  it('ignore deep updates', async () => {
+    // the counting watch still needs `deep`, otherwise nested mutations are
+    // never counted and `ignoreUpdates` stops ignoring anything
+    const source = deepRef({ foo: 0 })
+    const callback = vi.fn()
+    const { ignoreUpdates } = watchIgnorable(source, callback, { deep: true })
+
+    ignoreUpdates(() => {
+      source.value.foo = 1
+    })
+
+    await nextTick()
+    expect(callback).toHaveBeenCalledTimes(0)
+
+    source.value.foo = 2
+
+    await nextTick()
+    expect(callback).toHaveBeenCalledTimes(1)
   })
 
   it('stop watch', async () => {

--- a/packages/shared/watchIgnorable/index.ts
+++ b/packages/shared/watchIgnorable/index.ts
@@ -105,6 +105,11 @@ export function watchIgnorable<Immediate extends Readonly<boolean> = false>(
       ignoreCounter = syncCounter
     }
 
+    // The counting watch below is an implementation detail, so the user's debug
+    // hooks must not be attached to it. Otherwise every change to the source is
+    // reported twice: once by the counting watch and once by the actual watch.
+    const { onTrack, onTrigger, ...countingWatchOptions } = watchOptions
+
     // Sync watch to count modifications to the source
     disposables.push(
       watch(
@@ -112,7 +117,7 @@ export function watchIgnorable<Immediate extends Readonly<boolean> = false>(
         () => {
           syncCounter++
         },
-        { ...watchOptions, flush: 'sync' },
+        { ...countingWatchOptions, flush: 'sync' },
       ),
     )
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Confirm that this PR is based on your own understanding and review of the project, not solely generated or summarized by AI tools.

---

### Description

Relates to #4045.

With the default `flush: 'pre'` (and with `'post'`), `watchIgnorable` creates two watches: the user-facing one, and an internal `flush: 'sync'` one that only increments `syncCounter` so `ignoreUpdates` / `ignorePrevAsyncUpdates` know how many updates to swallow. At `packages/shared/watchIgnorable/index.ts:115` the entire option bag was spread into that internal watch, `onTrack` and `onTrigger` included.

The result is that the user's debug hooks are attached to a watch the user never asked for. Measured on `main`, for a single change to a `shallowRef` source:

| | `watch` | `watchIgnorable` before | `watchIgnorable` after |
| --- | --- | --- | --- |
| `onTrigger` | 1 | 2 | 1 |
| `onTrack` | 2 | 4 | 2 |

This PR keeps the debug hooks on the user-facing watch only, so `watchIgnorable` now reports exactly what a plain `watch` on the same source reports. `flush: 'sync'` was never affected, since that branch creates a single watch.

The other options are still forwarded to the counting watch, because `deep` is load-bearing: without it, nested mutations are never counted and `ignoreUpdates` silently stops ignoring anything on a deep source. I added a test for that case too, since it is easy to "simplify" this line into a regression.

### Additional context

Two things I would rather flag than quietly decide.

**This does not cover the whole of #4045.** The issue has two halves. The "several times" half is what this PR fixes. The other half — `onTrigger` firing at all for an update that was ignored — is still there: it now fires once instead of twice, but it does fire.

I stopped short of that deliberately, and I am happy to be overruled:

- It would make `watchIgnorable` inconsistent with the rest of the filter family. `watchPausable` while paused, and `watchDebounced` / `watchThrottled` while filtering, all still report the trigger and then suppress the callback. Ignoring an update is the same shape of thing.
- It could only ever be half an API. `ignorePrevAsyncUpdates()` is retroactive — by the time it is called, the trigger has already happened and `onTrigger` has already run. So `ignoreUpdates` would suppress the hook while `ignorePrevAsyncUpdates` could not, which seems worse than a consistent rule.
- `onTrigger` is a reactivity-debugging hook. The effect genuinely does re-run on an ignored update; it is `watchIgnorable`'s callback wrapper that returns early. Hiding that hides the thing the hook exists to show.

If you would prefer the behaviour in your sketch from the issue, the `flush: 'sync'` branch already has the `ignore` flag it needs, and the async branch would need an equivalent flag set around `updater()`. Say the word and I will add it here or in a follow-up.

**Unrelated, found while measuring, not touched here:** `once: true` and `ignoreUpdates` do not work together. The first ignored update satisfies Vue's `once`, so the watcher stops before it ever delivers a callback. That is arguably just what `once` means, so I left it alone — happy to open a separate issue if you think it is worth tracking.
