### PR TITLE
fix(useMouse): reset on touchcancel when resetOnTouchEnds is set

### DIFF
--- a/packages/core/useMouse/index.test.ts
+++ b/packages/core/useMouse/index.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { useMouse } from './index'
+
+describe('useMouse', () => {
+  const target = document.createElement('div')
+  document.body.appendChild(target)
+
+  const touchEventInit = (x: number, y: number): TouchEventInit => ({
+    touches: [{
+      clientX: x,
+      clientY: y,
+      force: 0,
+      identifier: 0,
+      pageX: x,
+      pageY: y,
+      radiusX: 0,
+      radiusY: 0,
+      rotationAngle: 0,
+      screenX: x,
+      screenY: y,
+      target,
+    }],
+  })
+
+  it('updates position from touch', () => {
+    const { x, y, sourceType } = useMouse({ target })
+
+    target.dispatchEvent(new TouchEvent('touchstart', touchEventInit(10, 20)))
+
+    expect([x.value, y.value, sourceType.value]).toEqual([10, 20, 'touch'])
+  })
+
+  it('resets on touchend when resetOnTouchEnds is set', () => {
+    const { x, y } = useMouse({ target, resetOnTouchEnds: true, initialValue: { x: 1, y: 2 } })
+
+    target.dispatchEvent(new TouchEvent('touchstart', touchEventInit(10, 20)))
+    expect([x.value, y.value]).toEqual([10, 20])
+
+    target.dispatchEvent(new TouchEvent('touchend'))
+    expect([x.value, y.value]).toEqual([1, 2])
+  })
+
+  it('resets on touchcancel when resetOnTouchEnds is set', () => {
+    const { x, y } = useMouse({ target, resetOnTouchEnds: true, initialValue: { x: 1, y: 2 } })
+
+    target.dispatchEvent(new TouchEvent('touchstart', touchEventInit(10, 20)))
+    expect([x.value, y.value]).toEqual([10, 20])
+
+    // the browser takes the gesture over (scroll, system dialog): touchcancel
+    // fires and touchend never does
+    target.dispatchEvent(new TouchEvent('touchcancel'))
+    expect([x.value, y.value]).toEqual([1, 2])
+  })
+
+  it('keeps the last position when resetOnTouchEnds is not set', () => {
+    const { x, y } = useMouse({ target })
+
+    target.dispatchEvent(new TouchEvent('touchstart', touchEventInit(10, 20)))
+    target.dispatchEvent(new TouchEvent('touchend'))
+    target.dispatchEvent(new TouchEvent('touchcancel'))
+
+    expect([x.value, y.value]).toEqual([10, 20])
+  })
+})

--- a/packages/core/useMouse/index.ts
+++ b/packages/core/useMouse/index.ts
@@ -40,7 +40,7 @@ export interface UseMouseOptions extends ConfigurableWindow, ConfigurableEventFi
   scroll?: boolean
 
   /**
-   * Reset to initial value when `touchend` event fired
+   * Reset to initial value when `touchend` or `touchcancel` event fired
    *
    * @default false
    */
@@ -157,7 +157,7 @@ export function useMouse(options: UseMouseOptions = {}): UseMouseReturn {
     if (touch && type !== 'movement') {
       useEventListener(target, ['touchstart', 'touchmove'], touchHandlerWrapper, listenerOptions)
       if (resetOnTouchEnds)
-        useEventListener(target, 'touchend', reset, listenerOptions)
+        useEventListener(target, ['touchend', 'touchcancel'], reset, listenerOptions)
     }
     if (scroll && type === 'page')
       useEventListener(window, 'scroll', scrollHandlerWrapper, listenerOptions)


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [ ] Confirm that this PR is based on your own understanding and review of the project, not solely generated or summarized by AI tools.

---

### Description

`useMouse` only listens for `touchend` when `resetOnTouchEnds` is set. When the user agent takes a
gesture over — a scroll takeover, a system dialog, a second finger starting a pinch — it fires
`touchcancel` and `touchend` never arrives, so the position is left at the last touch coordinates
instead of resetting.

This adds `touchcancel` alongside `touchend`. The sibling composables already treat the two the same
way: `useMousePressed` registers both, `useSwipe` uses `['touchend', 'touchcancel']`, and `usePointer`
got the pointer-event equivalent in #5587.

This is the `useMouse` half of the follow-up from the #5550 discussion — #5555 mentioned it would come
as a separate PR.

### Additional context

`packages/core/useMouse/` had no unit test file, so this adds one covering the touch path: position
updates from touch, reset on `touchend`, reset on `touchcancel`, and no reset when `resetOnTouchEnds`
is not set. Only the `touchcancel` case fails without the change.

One thing I left alone deliberately: `reset()` restores `x`/`y` but not `sourceType`.
`useMousePressed` does clear its equivalent on release, so there may be an inconsistency there, but
it's pre-existing and outside what this fixes — happy to follow up separately if you'd like it
changed.
