### PR TITLE
feat(useMediaControls): add support for configuring Media Session API

### DIFF
--- a/packages/core/useMediaControls/demo.vue
+++ b/packages/core/useMediaControls/demo.vue
@@ -69,7 +69,6 @@ const {
   togglePictureInPicture,
   enableTrack,
   disableTrack,
-
 } = controls
 const text = stringify(reactive(controls))
 const endBuffer = computed(() => buffered.value.length > 0 ? buffered.value[buffered.value.length - 1][1] : 0)

--- a/packages/core/useMediaControls/demo.vue
+++ b/packages/core/useMediaControls/demo.vue
@@ -23,6 +23,14 @@ const video = useTemplateRef('video')
 const loop = shallowRef(false)
 const poster = 'https://cdn.bitmovin.com/content/assets/sintel/poster.png'
 
+const metadata = reactive<MediaMetadataInit>({
+  title: 'Sintel',
+  artist: 'Blender Foundation',
+  album: 'Sintel',
+  artwork: [
+    { src: 'https://dummyimage.com/512x512/000/fff.jpg', sizes: '512x512', type: 'image/jpeg' },
+  ],
+})
 const controls = useMediaControls(video, {
   src: {
     src: 'https://upload.wikimedia.org/wikipedia/commons/f/f1/Sintel_movie_4K.webm',
@@ -43,6 +51,7 @@ const controls = useMediaControls(video, {
       srcLang: 'fr',
     },
   ],
+  metadata,
 })
 
 const {
@@ -60,6 +69,7 @@ const {
   togglePictureInPicture,
   enableTrack,
   disableTrack,
+
 } = controls
 const text = stringify(reactive(controls))
 const endBuffer = computed(() => buffered.value.length > 0 ? buffered.value[buffered.value.length - 1][1] : 0)
@@ -190,5 +200,8 @@ function formatDuration(seconds: number) {
       </Menu>
     </div>
   </div>
+  <p>Controls:</p>
   <pre class="code-block" lang="yaml">{{ text }}</pre>
+  <p>Metadata of Media Session API:</p>
+  <pre class="code-block" lang="yaml">{{ stringify(metadata) }}</pre>
 </template>

--- a/packages/core/useMediaControls/demo.vue
+++ b/packages/core/useMediaControls/demo.vue
@@ -28,7 +28,7 @@ const metadata = reactive<MediaMetadataInit>({
   artist: 'Blender Foundation',
   album: 'Sintel',
   artwork: [
-    { src: 'https://dummyimage.com/512x512/000/fff.jpg', sizes: '512x512', type: 'image/jpeg' },
+    { src: 'https://studio.blender.org/files/public/thumbnail/47/a9/47a954682dbd4f064da7e78ad6c2d32f044a3e85_m.webp', sizes: '640x360', type: 'image/webp' },
   ],
 })
 const controls = useMediaControls(video, {

--- a/packages/core/useMediaControls/index.md
+++ b/packages/core/useMediaControls/index.md
@@ -74,3 +74,40 @@ const {
   </button>
 </template>
 ```
+
+### Configure Media Session API
+
+You can provide [`metadata`](https://developer.mozilla.org/en-US/docs/Web/API/MediaMetadata) inside options to setup the [Media Session API](https://developer.mozilla.org/en-US/docs/Web/API/Media_Session_API).
+
+```vue
+<script setup lang="ts">
+import { useMediaControls } from '@vueuse/core'
+import { onMounted, useTemplateRef } from 'vue'
+
+const video = useTemplateRef('video')
+const metadata = reactive<MediaMetadataInit>({
+  title: 'Sintel',
+  artist: 'Blender Foundation',
+  album: 'Sintel',
+  artwork: [
+    {
+      src: 'https://dummyimage.com/512x512/000/fff.jpg',
+      sizes: '512x512',
+      type: 'image/jpeg'
+    },
+  ],
+})
+const { playing, currentTime, duration, volume } = useMediaControls(video, {
+  src: 'video.mp4',
+  metadata,
+})
+</script>
+
+<template>
+  <video ref="video" />
+  <button @click="playing = !playing">
+    Play / Pause
+  </button>
+  <span>{{ currentTime }} / {{ duration }}</span>
+</template>
+```

--- a/packages/core/useMediaControls/index.ts
+++ b/packages/core/useMediaControls/index.ts
@@ -1,7 +1,7 @@
 import type { EventHookOn, Fn } from '@vueuse/shared'
 import type { MaybeRef, MaybeRefOrGetter, ShallowRef } from 'vue'
 import type { ConfigurableDocument } from '../_configurable'
-import { createEventHook, isObject, toRef, tryOnBeforeUnmount, tryOnMounted, tryOnScopeDispose, watchIgnorable } from '@vueuse/shared'
+import { createEventHook, isObject, toRef, tryOnMounted, tryOnScopeDispose, watchIgnorable } from '@vueuse/shared'
 import { shallowRef, toValue, watch, watchEffect } from 'vue'
 import { defaultDocument } from '../_configurable'
 import { useEventListener } from '../useEventListener'
@@ -588,7 +588,7 @@ export function useMediaControls(target: MaybeRef<HTMLMediaElement | null | unde
       navigator.mediaSession.metadata = new MediaMetadata({ ...metadata })
     })
   })
-  tryOnBeforeUnmount(clearMediaSession)
+  tryOnScopeDispose(clearMediaSession)
 
   // Remove text track listeners
   tryOnScopeDispose(() => listeners.forEach(listener => listener()))

--- a/packages/core/useMediaControls/index.ts
+++ b/packages/core/useMediaControls/index.ts
@@ -1,14 +1,14 @@
 import type { EventHookOn, Fn } from '@vueuse/shared'
 import type { MaybeRef, MaybeRefOrGetter, ShallowRef } from 'vue'
 import type { ConfigurableDocument } from '../_configurable'
-import { createEventHook, isObject, toRef, tryOnScopeDispose, watchIgnorable } from '@vueuse/shared'
+import { createEventHook, isObject, toRef, tryOnBeforeUnmount, tryOnMounted, tryOnScopeDispose, watchIgnorable } from '@vueuse/shared'
 import { shallowRef, toValue, watch, watchEffect } from 'vue'
 import { defaultDocument } from '../_configurable'
 import { useEventListener } from '../useEventListener'
 
 /**
  * Many of the jsdoc definitions here are modified version of the
- * documentation from MDN(https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement)
+ * documentation from MDN (https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement) and
  */
 
 export interface UseMediaSource {
@@ -70,6 +70,14 @@ interface UseMediaControlsOptions extends ConfigurableDocument {
    * A list of text tracks for the media
    */
   tracks?: MaybeRefOrGetter<UseMediaTextTrackSource[]>
+
+  /**
+   * The MediaMetadata interface of the Media Session API allows a web page
+   * to provide rich media metadata for display in a platform UI.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/MediaMetadata/
+   */
+  metadata?: MaybeRefOrGetter<MediaMetadataInit>
 }
 
 export interface UseMediaTextTrack {
@@ -169,6 +177,19 @@ function timeRangeToArray(timeRanges: TimeRanges) {
 function tracksToArray(tracks: TextTrackList): UseMediaTextTrack[] {
   return Array.from(tracks)
     .map(({ label, kind, language, mode, activeCues, cues, inBandMetadataTrackDispatchType }, id) => ({ id, label, kind, language, mode, activeCues, cues, inBandMetadataTrackDispatchType }))
+}
+
+function clearMediaSession() {
+  if (!('mediaSession' in navigator))
+    return
+
+  navigator.mediaSession.metadata = null
+  navigator.mediaSession.playbackState = 'none'
+  navigator.mediaSession.setPositionState({
+    duration: 0,
+    playbackRate: 1,
+    position: 0,
+  })
 }
 
 const defaultOptions: UseMediaControlsOptions = {
@@ -543,6 +564,30 @@ export function useMediaControls(target: MaybeRef<HTMLMediaElement | null | unde
     listeners[1] = useEventListener(el.textTracks, 'removetrack', () => tracks.value = tracksToArray(el.textTracks), listenerOptions)
     listeners[2] = useEventListener(el.textTracks, 'change', () => tracks.value = tracksToArray(el.textTracks), listenerOptions)
   })
+
+  // Configure Media Session API
+  tryOnMounted(() => {
+    if (!('mediaSession' in navigator))
+      return
+
+    navigator.mediaSession.setActionHandler('play', () => ignorePlayingUpdates(() => playing.value = true))
+    navigator.mediaSession.setActionHandler('pause', () => ignorePlayingUpdates(() => playing.value = false))
+
+    navigator.mediaSession.setActionHandler('seekbackward', () => currentTime.value -= 10)
+    navigator.mediaSession.setActionHandler('seekforward', () => currentTime.value += 10)
+    navigator.mediaSession.setActionHandler('seekto', e => currentTime.value += e.seekTime!)
+
+    watchEffect(() => {
+      const metadata = toValue(options.metadata)
+      if (!metadata) {
+        navigator.mediaSession.metadata = null
+        return
+      }
+
+      navigator.mediaSession.metadata = new MediaMetadata({ ...metadata })
+    })
+  })
+  tryOnBeforeUnmount(clearMediaSession)
 
   // Remove text track listeners
   tryOnScopeDispose(() => listeners.forEach(listener => listener()))

--- a/packages/core/useMediaControls/index.ts
+++ b/packages/core/useMediaControls/index.ts
@@ -8,7 +8,8 @@ import { useEventListener } from '../useEventListener'
 
 /**
  * Many of the jsdoc definitions here are modified version of the
- * documentation from MDN (https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement) and
+ * documentation from MDN (https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement)
+ * and (https://developer.mozilla.org/en-US/docs/Web/API/Media_Session_API)
  */
 
 export interface UseMediaSource {

--- a/packages/core/useMediaControls/index.ts
+++ b/packages/core/useMediaControls/index.ts
@@ -232,6 +232,18 @@ export function useMediaControls(target: MaybeRef<HTMLMediaElement | null | unde
   const sourceErrorEvent = createEventHook<Event>()
   const playbackErrorEvent = createEventHook<Event>()
 
+  // For updateing the position state of media session
+  function updatePositionState() {
+    if (!('mediaSession' in navigator))
+      return
+
+    navigator.mediaSession.setPositionState({
+      duration: duration.value,
+      playbackRate: rate.value,
+      position: currentTime.value,
+    })
+  }
+
   /**
    * Disables the specified track. If no track is specified then
    * all tracks will be disabled
@@ -445,7 +457,10 @@ export function useMediaControls(target: MaybeRef<HTMLMediaElement | null | unde
   useEventListener(
     target,
     'durationchange',
-    () => duration.value = (toValue(target))!.duration,
+    () => {
+      duration.value = (toValue(target))!.duration
+      updatePositionState()
+    },
     listenerOptions,
   )
   useEventListener(
@@ -463,7 +478,10 @@ export function useMediaControls(target: MaybeRef<HTMLMediaElement | null | unde
   useEventListener(
     target,
     'seeked',
-    () => seeking.value = false,
+    () => {
+      seeking.value = false
+      updatePositionState()
+    },
     listenerOptions,
   )
   useEventListener(
@@ -478,7 +496,10 @@ export function useMediaControls(target: MaybeRef<HTMLMediaElement | null | unde
   useEventListener(
     target,
     'loadeddata',
-    () => waiting.value = false,
+    () => {
+      waiting.value = false
+      updatePositionState()
+    },
     listenerOptions,
   )
   useEventListener(
@@ -488,13 +509,17 @@ export function useMediaControls(target: MaybeRef<HTMLMediaElement | null | unde
       waiting.value = false
       ended.value = false
       ignorePlayingUpdates(() => playing.value = true)
+      updatePositionState()
     },
     listenerOptions,
   )
   useEventListener(
     target,
     'ratechange',
-    () => rate.value = (toValue(target))!.playbackRate,
+    () => {
+      rate.value = (toValue(target))!.playbackRate
+      updatePositionState()
+    },
     listenerOptions,
   )
   useEventListener(
@@ -506,19 +531,28 @@ export function useMediaControls(target: MaybeRef<HTMLMediaElement | null | unde
   useEventListener(
     target,
     'ended',
-    () => ended.value = true,
+    () => {
+      ended.value = true
+      navigator.mediaSession.playbackState = 'none'
+    },
     listenerOptions,
   )
   useEventListener(
     target,
     'pause',
-    () => ignorePlayingUpdates(() => playing.value = false),
+    () => ignorePlayingUpdates(() => {
+      playing.value = false
+      navigator.mediaSession.playbackState = 'paused'
+    }),
     listenerOptions,
   )
   useEventListener(
     target,
     'play',
-    () => ignorePlayingUpdates(() => playing.value = true),
+    () => ignorePlayingUpdates(() => {
+      playing.value = true
+      navigator.mediaSession.playbackState = 'playing'
+    }),
     listenerOptions,
   )
   useEventListener(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Confirm that this PR is based on your own understanding and review of the project, not solely generated or summarized by AI tools.

> **Note**: If this PR is deemed to be primarily generated by AI tools, it may be closed.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

Add the 3rd option to `useMediaControls`, so that users can provide reactive `metadata` (i.e. `title`, `artists`, `album`, `artworks`) to setup the Media Session API at the same time. Currently only 5 handlers are setup: `play`, `pause`, `seekbackward`, `seekforward`, `seekto`

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
