### PR TITLE
docs(usePerformanceObserver): fix typo `entrys` to `entries`

### DIFF
--- a/packages/core/usePerformanceObserver/demo.vue
+++ b/packages/core/usePerformanceObserver/demo.vue
@@ -2,11 +2,11 @@
 import { usePerformanceObserver } from '@vueuse/core'
 import { shallowRef } from 'vue'
 
-const entrys = shallowRef<PerformanceEntry[]>([])
+const entries = shallowRef<PerformanceEntry[]>([])
 usePerformanceObserver({
   entryTypes: ['paint'],
 }, (list) => {
-  entrys.value = list.getEntries()
+  entries.value = list.getEntries()
 })
 function refresh() {
   return window.location.reload()
@@ -18,5 +18,5 @@ function refresh() {
     refresh
   </button>
 
-  <pre lang="json">{{ entrys }}</pre>
+  <pre lang="json">{{ entries }}</pre>
 </template>

--- a/packages/core/usePerformanceObserver/index.md
+++ b/packages/core/usePerformanceObserver/index.md
@@ -11,10 +11,10 @@ Observe performance metrics.
 ```ts
 import { usePerformanceObserver } from '@vueuse/core'
 
-const entrys = ref<PerformanceEntry[]>([])
+const entries = ref<PerformanceEntry[]>([])
 usePerformanceObserver({
   entryTypes: ['paint'],
 }, (list) => {
-  entrys.value = list.getEntries()
+  entries.value = list.getEntries()
 })
 ```


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Confirm that this PR is based on your own understanding and review of the project, not solely generated or summarized by AI tools.

> **Note**: If this PR is deemed to be primarily generated by AI tools, it may be closed.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

The `usePerformanceObserver` documentation and demo declare the result ref as `entrys`, which is a misspelling of `entries`.

### Additional context

- since it's a doc change, no typecheck, lint or new test needed.
