### PR TITLE
fix(useIdle): update lastActive on reset

### DIFF
--- a/packages/core/useIdle/index.browser.test.ts
+++ b/packages/core/useIdle/index.browser.test.ts
@@ -144,18 +144,22 @@ describe('useIdle', () => {
     expect(lastActive.value).toBeGreaterThan(initialTime)
   })
 
-  it('should reset idle state with reset method', () => {
+  it('should update lastActive and restart timeout with reset', () => {
     const timeout = 1000
-    const { idle, reset } = useIdle(timeout)
+    const { idle, lastActive, reset } = useIdle(timeout)
+    const initialTime = lastActive.value
 
-    vi.advanceTimersByTime(timeout)
-    expect(idle.value).toBe(true)
+    vi.advanceTimersByTime(500)
 
     reset()
     expect(idle.value).toBe(false)
 
-    vi.advanceTimersByTime(timeout)
+    vi.advanceTimersByTime(timeout - 1)
+    expect(idle.value).toBe(false)
+
+    vi.advanceTimersByTime(1)
     expect(idle.value).toBe(true)
+    expect(lastActive.value).toBe(initialTime + 500)
   })
 
   it('should set isPending to true when started', () => {

--- a/packages/core/useIdle/index.md
+++ b/packages/core/useIdle/index.md
@@ -30,7 +30,7 @@ watch(idle, (idleValue) => {
   if (idleValue) {
     inc()
     console.log(`Triggered ${count.value} times`)
-    reset() // restarts the idle timer. Does not change lastActive value
+    reset() // records the reset time in lastActive and restarts the idle timer
   }
 })
 ```

--- a/packages/core/useIdle/index.ts
+++ b/packages/core/useIdle/index.ts
@@ -63,6 +63,7 @@ export function useIdle(
 
   const reset = () => {
     idle.value = false
+    lastActive.value = timestamp()
     clearTimeout(timer)
     timer = setTimeout(() => idle.value = true, timeout)
   }
@@ -70,7 +71,6 @@ export function useIdle(
   const onEvent = createFilterWrapper(
     eventFilter,
     () => {
-      lastActive.value = timestamp()
       reset()
     },
   )


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Confirm that this PR is based on my own understanding and review of the project, not solely generated or summarized by AI tools.

### Description

Fixes #5610.

`reset()` now records the current timestamp in `lastActive` before restarting the idle timeout. Activity events continue to use the same reset path, avoiding duplicate timestamp updates.

The browser regression test covers both the timestamp update and the full timeout restarting from the reset call. The `useIdle` documentation now reflects the updated reset semantics.

### Additional context

AI assistance was used during development. The bug was reproduced against the previous implementation, and the focused Chromium browser test, lint, typecheck, and full unit suite pass with this change.
