### PR TITLE
fix: correct tree-shaking annotations for overloaded and arrow functions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,13 +143,24 @@ export function useFoo(value: string | number): string | number {
 
 TypeScript removes overload signatures during compilation, so the JSDoc annotation does not reach the bundler. Keep the one-line annotation before the implementation; there is no need to duplicate the full JSDoc.
 
-For arrow functions, place the build annotation immediately before the function expression:
+### `@__NO_SIDE_EFFECTS__` with arrow functions
+
+For arrow functions, place the compact build annotation immediately before the function expression:
 
 ```ts
+/**
+ * ...
+ *
+ * This function has no side effects.
+ */
 export const useFoo: () => void = /* @__NO_SIDE_EFFECTS__ */ () => {
   // ...
 }
 ```
+
+Do not include the magic `@__NO_SIDE_EFFECTS__` tag in the leading JSDoc of a `const` declaration. Unlike overload signatures, the declaration and its JSDoc are emitted to JavaScript. The tag would then appear before the variable declaration instead of the function expression and may trigger an invalid-annotation warning from the bundler.
+
+Describe the function as having no side effects in ordinary prose instead. If the exact tag must appear in the public JSDoc, use a function declaration.
 
 ## Thanks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,22 +145,29 @@ TypeScript removes overload signatures during compilation, so the JSDoc annotati
 
 ### `@__NO_SIDE_EFFECTS__` with arrow functions
 
-For arrow functions, place the compact build annotation immediately before the function expression:
+For arrow functions, place the compact build annotation immediately before the function expression for the bundler to recognize it.
 
 ```ts
-/**
- * ...
- *
- * This function has no side effects.
- */
 export const useFoo: () => void = /* @__NO_SIDE_EFFECTS__ */ () => {
   // ...
 }
 ```
 
-Do not include the magic `@__NO_SIDE_EFFECTS__` tag in the leading JSDoc of a `const` declaration. Unlike overload signatures, the declaration and its JSDoc are emitted to JavaScript. The tag would then appear before the variable declaration instead of the function expression and may trigger an invalid-annotation warning from the bundler.
+DO NOT include the magic `@__NO_SIDE_EFFECTS__` tag in the leading JSDoc of a `const` declaration. Unlike overload signatures, the declaration and its JSDoc are emitted to JavaScript. The tag would then appear before the variable declaration instead of the function expression and may trigger an invalid-annotation warning from the bundler.
 
-Describe the function as having no side effects in ordinary prose instead. If the exact tag must appear in the public JSDoc, use a function declaration.
+If you want to present the information to human readers, consider using `@NO_SIDE_EFFECTS` (without the `__`) in ordinary prose instead. It will be ignored by the bundler so it won't trigger any warnings.
+
+```diff
+/**
+ * ...
+ *
+- * @__NO_SIDE_EFFECTS__
++ * @NO_SIDE_EFFECTS
+ */
+export const useFoo: () => void = /* @__NO_SIDE_EFFECTS__ */ () => {
+  // ...
+}
+```
 
 ## Thanks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,6 +120,37 @@ Read more about the [guidelines](https://vueuse.org/guidelines).
 
 Don't worry about the code style as long as you install the dev dependencies. Git hooks will format and fix them for you on committing.
 
+### `@__NO_SIDE_EFFECTS__` with function overloads
+
+For overloaded functions, add `@__NO_SIDE_EFFECTS__` in **two places**:
+
+1. In the public JSDoc, for API documentation.
+2. Immediately before the implementation, for build tools.
+
+```ts
+/**
+ * ...
+ *
+ * @__NO_SIDE_EFFECTS__
+ */
+export function useFoo(value: string): string
+export function useFoo(value: number): number
+/* @__NO_SIDE_EFFECTS__ */
+export function useFoo(value: string | number): string | number {
+  // ...
+}
+```
+
+TypeScript removes overload signatures during compilation, so the JSDoc annotation does not reach the bundler. Keep the one-line annotation before the implementation; there is no need to duplicate the full JSDoc.
+
+For arrow functions, place the build annotation immediately before the function expression:
+
+```ts
+export const useFoo: () => void = /* @__NO_SIDE_EFFECTS__ */ () => {
+  // ...
+}
+```
+
 ## Thanks
 
 Thank you again for being interested in this project! You are awesome!

--- a/packages/core/_configurable.ts
+++ b/packages/core/_configurable.ts
@@ -36,10 +36,10 @@ export interface ConfigurableLocation {
   location?: Location
 }
 
-export const defaultWindow = /* #__PURE__ */ isClient ? window : undefined
-export const defaultDocument = /* #__PURE__ */ isClient ? window.document : undefined
-export const defaultNavigator = /* #__PURE__ */ isClient ? window.navigator : undefined
-export const defaultLocation = /* #__PURE__ */ isClient ? window.location : undefined
+export const defaultWindow = isClient ? window : undefined
+export const defaultDocument = isClient ? window.document : undefined
+export const defaultNavigator = isClient ? window.navigator : undefined
+export const defaultLocation = isClient ? window.location : undefined
 
 export interface ConfigurableDeepRefs<D extends boolean> {
   /**

--- a/packages/core/useClipboard/index.ts
+++ b/packages/core/useClipboard/index.ts
@@ -59,6 +59,7 @@ export interface UseClipboardReturn<Optional> extends Supportable {
  */
 export function useClipboard(options?: UseClipboardOptions<undefined>): UseClipboardReturn<false>
 export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<string>>): UseClipboardReturn<true>
+/* @__NO_SIDE_EFFECTS__ */
 export function useClipboard(options: UseClipboardOptions<MaybeRefOrGetter<string> | undefined> = {}): UseClipboardReturn<boolean> {
   const {
     navigator = defaultNavigator,

--- a/packages/core/useClipboardItems/index.ts
+++ b/packages/core/useClipboardItems/index.ts
@@ -45,6 +45,7 @@ export interface UseClipboardItemsReturn<Optional> extends Supportable {
  */
 export function useClipboardItems(options?: UseClipboardItemsOptions<undefined>): UseClipboardItemsReturn<false>
 export function useClipboardItems(options: UseClipboardItemsOptions<MaybeRefOrGetter<ClipboardItems>>): UseClipboardItemsReturn<true>
+/* @__NO_SIDE_EFFECTS__ */
 export function useClipboardItems(options: UseClipboardItemsOptions<MaybeRefOrGetter<ClipboardItems> | undefined> = {}): UseClipboardItemsReturn<boolean> {
   const {
     navigator = defaultNavigator,

--- a/packages/core/useNow/index.ts
+++ b/packages/core/useNow/index.ts
@@ -25,15 +25,7 @@ export type UseNowReturn<Controls extends boolean> = Controls extends true ? ({ 
  */
 export function useNow(options?: UseNowOptions<false>): ShallowRef<Date>
 export function useNow(options: UseNowOptions<true>): { now: ShallowRef<Date> } & Pausable
-
-/**
- * Reactive current Date instance.
- *
- * @see https://vueuse.org/useNow
- * @param options
- *
- * @__NO_SIDE_EFFECTS__
- */
+/* @__NO_SIDE_EFFECTS__ */
 export function useNow(options: UseNowOptions<boolean> = {}): UseNowReturn<boolean> {
   const {
     controls: exposeControls = false,

--- a/packages/core/usePermission/index.ts
+++ b/packages/core/usePermission/index.ts
@@ -59,14 +59,7 @@ export function usePermission(
   permissionDesc: GeneralPermissionDescriptor | GeneralPermissionDescriptor['name'],
   options: UsePermissionOptions<true>,
 ): UsePermissionReturnWithControls
-
-/**
- * Reactive Permissions API.
- *
- * @see https://vueuse.org/usePermission
- *
- * @__NO_SIDE_EFFECTS__
- */
+/* @__NO_SIDE_EFFECTS__ */
 export function usePermission(
   permissionDesc: GeneralPermissionDescriptor | GeneralPermissionDescriptor['name'],
   options: UsePermissionOptions<boolean> = {},

--- a/packages/core/useStepper/index.ts
+++ b/packages/core/useStepper/index.ts
@@ -42,6 +42,13 @@ export interface UseStepperReturn<StepName, Steps, Step> {
   isAfter: (step: StepName) => boolean
 }
 
+/**
+ * Provides helpers for building a multi-step wizard interface.
+ *
+ * @see https://vueuse.org/useStepper
+ *
+ * @__NO_SIDE_EFFECTS__
+ */
 export function useStepper<T extends string | number>(steps: MaybeRef<T[]>, initialStep?: T): UseStepperReturn<T, T[], T>
 export function useStepper<T extends Record<string, any>>(steps: MaybeRef<T>, initialStep?: keyof T): UseStepperReturn<Exclude<keyof T, symbol>, T, T[keyof T]>
 /* @__NO_SIDE_EFFECTS__ */

--- a/packages/core/useTimeAgo/index.ts
+++ b/packages/core/useTimeAgo/index.ts
@@ -128,14 +128,7 @@ export type UseTimeAgoReturn<Controls extends boolean = false> = Controls extend
  */
 export function useTimeAgo<UnitNames extends string = UseTimeAgoUnitNamesDefault>(time: MaybeRefOrGetter<Date | number | string>, options?: UseTimeAgoOptions<false, UnitNames>): UseTimeAgoReturn<false>
 export function useTimeAgo<UnitNames extends string = UseTimeAgoUnitNamesDefault>(time: MaybeRefOrGetter<Date | number | string>, options: UseTimeAgoOptions<true, UnitNames>): UseTimeAgoReturn<true>
-
-/**
- * Reactive time ago formatter.
- *
- * @see https://vueuse.org/useTimeAgo
- *
- * @__NO_SIDE_EFFECTS__
- */
+/* @__NO_SIDE_EFFECTS__ */
 export function useTimeAgo<UnitNames extends string = UseTimeAgoUnitNamesDefault>(time: MaybeRefOrGetter<Date | number | string>, options: UseTimeAgoOptions<boolean, UnitNames> = {}) {
   const {
     controls: exposeControls = false,

--- a/packages/core/useVModel/index.ts
+++ b/packages/core/useVModel/index.ts
@@ -71,18 +71,7 @@ export function useVModel<P extends object, K extends keyof P, Name extends stri
   emit?: (name: Name, ...args: any[]) => void,
   options?: UseVModelOptions<P[K], true>,
 ): Ref<UnwrapRef<P[K]>>
-
-/**
- * Shorthand for v-model binding, props + emit -> ref
- *
- * @see https://vueuse.org/useVModel
- * @param props
- * @param key (default 'modelValue')
- * @param emit
- * @param options
- *
- * @__NO_SIDE_EFFECTS__
- */
+/* @__NO_SIDE_EFFECTS__ */
 export function useVModel<P extends object, K extends keyof P, Name extends string, Passive extends boolean>(
   props: P,
   key?: K,

--- a/packages/core/useVModels/index.ts
+++ b/packages/core/useVModels/index.ts
@@ -22,17 +22,7 @@ export function useVModels<P extends object, Name extends string>(
   emit?: (name: Name, ...args: any[]) => void,
   options?: UseVModelOptions<any, false>,
 ): ToRefs<P>
-
-/**
- * Shorthand for props v-model binding. Think like `toRefs(props)` but changes will also emit out.
- *
- * @see https://vueuse.org/useVModels
- * @param props
- * @param emit
- * @param options
- *
- * @__NO_SIDE_EFFECTS__
- */
+/* @__NO_SIDE_EFFECTS__ */
 export function useVModels<P extends object, Name extends string, Passive extends boolean>(
   props: P,
   emit?: (name: Name, ...args: any[]) => void,

--- a/packages/electron/useIpcRendererInvoke/index.ts
+++ b/packages/electron/useIpcRendererInvoke/index.ts
@@ -29,17 +29,7 @@ export function useIpcRendererInvoke<T>(ipcRenderer: IpcRenderer, channel: strin
  * @__NO_SIDE_EFFECTS__
  */
 export function useIpcRendererInvoke<T>(channel: string, ...args: any[]): ShallowRef<T | null>
-
-/**
- * Returns Promise<any> - Resolves with the response from the main process.
- *
- * Send a message to the main process via channel and expect a result ~~asynchronously~~. As composition-api, it makes asynchronous operations look like synchronous.
- *
- * @see https://www.electronjs.org/docs/api/ipc-renderer#ipcrendererinvokechannel-args
- * @see https://vueuse.org/useIpcRendererInvoke
- *
- * @__NO_SIDE_EFFECTS__
- */
+/* @__NO_SIDE_EFFECTS__ */
 export function useIpcRendererInvoke<T>(...args: any[]): ShallowRef<T | null> {
   let ipcRenderer: IpcRenderer | undefined
   let channel: string

--- a/packages/math/useClamp/index.ts
+++ b/packages/math/useClamp/index.ts
@@ -23,17 +23,7 @@ export function useClamp(
   min: MaybeRefOrGetter<number>,
   max: MaybeRefOrGetter<number>,
 ): Ref<number>
-
-/**
- * Reactively clamp a value between two other values.
- *
- * @see https://vueuse.org/useClamp
- * @param value number
- * @param min
- * @param max
- *
- * @__NO_SIDE_EFFECTS__
- */
+/* @__NO_SIDE_EFFECTS__ */
 export function useClamp(value: MaybeRefOrGetter<number>, min: MaybeRefOrGetter<number>, max: MaybeRefOrGetter<number>) {
   if (typeof value === 'function' || isReadonly(value))
     return computed(() => clamp(toValue(value), toValue(min), toValue(max)))

--- a/packages/shared/createInjectionState/index.ts
+++ b/packages/shared/createInjectionState/index.ts
@@ -44,6 +44,7 @@ export function createInjectionState<Arguments extends Array<any>, Return>(
   composable: (...args: Arguments) => Return,
   options?: CreateInjectionStateOptions<Return>,
 ): CreateInjectionStateReturn<Arguments, Return, Return | undefined>
+/* @__NO_SIDE_EFFECTS__ */
 export function createInjectionState<Arguments extends Array<any>, Return>(
   composable: (...args: Arguments) => Return,
   options?: CreateInjectionStateOptions<Return>,

--- a/packages/shared/injectLocal/index.ts
+++ b/packages/shared/injectLocal/index.ts
@@ -14,7 +14,7 @@ import { localProvidedStateMap } from '../provideLocal/map'
  * @__NO_SIDE_EFFECTS__
  */
 // @ts-expect-error overloads are not compatible
-export const injectLocal: typeof inject = <T>(...args) => {
+export const injectLocal: typeof inject = /* @__NO_SIDE_EFFECTS__ */ <T>(...args) => {
   const key = args[0] as InjectionKey<T> | string | number
   const instance = getCurrentInstance()?.proxy
   const owner = instance ?? getCurrentScope()

--- a/packages/shared/injectLocal/index.ts
+++ b/packages/shared/injectLocal/index.ts
@@ -11,7 +11,7 @@ import { localProvidedStateMap } from '../provideLocal/map'
  * const injectedValue = injectLocal('MyInjectionKey') // injectedValue === 1
  * ```
  *
- * This function has no side effects.
+ * @NO_SIDE_EFFECTS
  */
 // @ts-expect-error overloads are not compatible
 export const injectLocal: typeof inject = /* @__NO_SIDE_EFFECTS__ */ <T>(...args) => {

--- a/packages/shared/injectLocal/index.ts
+++ b/packages/shared/injectLocal/index.ts
@@ -11,7 +11,7 @@ import { localProvidedStateMap } from '../provideLocal/map'
  * const injectedValue = injectLocal('MyInjectionKey') // injectedValue === 1
  * ```
  *
- * @__NO_SIDE_EFFECTS__
+ * This function has no side effects.
  */
 // @ts-expect-error overloads are not compatible
 export const injectLocal: typeof inject = /* @__NO_SIDE_EFFECTS__ */ <T>(...args) => {

--- a/packages/shared/reactifyObject/index.ts
+++ b/packages/shared/reactifyObject/index.ts
@@ -22,12 +22,7 @@ export interface ReactifyObjectOptions<T extends boolean> extends ReactifyOption
  */
 export function reactifyObject<T extends object, Keys extends keyof T>(obj: T, keys?: (keyof T)[]): ReactifyObjectReturn<T, Keys, true>
 export function reactifyObject<T extends object, S extends boolean = true>(obj: T, options?: ReactifyObjectOptions<S>): ReactifyObjectReturn<T, keyof T, S>
-
-/**
- * Apply `reactify` to an object
- *
- * @__NO_SIDE_EFFECTS__
- */
+/* @__NO_SIDE_EFFECTS__ */
 export function reactifyObject<T extends object, S extends boolean = true>(obj: T, optionsOrKeys: ReactifyObjectOptions<S> | (keyof T)[] = {}): ReactifyObjectReturn<T, keyof T, S> {
   let keys: string[] = []
   let options: ReactifyOptions<S> | undefined

--- a/packages/shared/useArrayFilter/index.ts
+++ b/packages/shared/useArrayFilter/index.ts
@@ -22,18 +22,7 @@ export function useArrayFilter<T>(
   list: MaybeRefOrGetter<MaybeRefOrGetter<T>[]>,
   fn: (element: T, index: number, array: T[]) => unknown,
 ): UseArrayFilterReturn<T>
-
-/**
- * Reactive `Array.filter`
- *
- * @see https://vueuse.org/useArrayFilter
- * @param list - the array was called upon.
- * @param fn - a function that is called for every element of the given `list`. Each time `fn` executes, the returned value is added to the new array.
- *
- * @returns a shallow copy of a portion of the given array, filtered down to just the elements from the given array that pass the test implemented by the provided function. If no elements pass the test, an empty array will be returned.
- *
- * @__NO_SIDE_EFFECTS__
- */
+/* @__NO_SIDE_EFFECTS__ */
 export function useArrayFilter<T>(
   list: MaybeRefOrGetter<MaybeRefOrGetter<T>[]>,
   fn: (element: T, index: number, array: T[]) => unknown,

--- a/packages/shared/useArrayIncludes/index.ts
+++ b/packages/shared/useArrayIncludes/index.ts
@@ -39,16 +39,7 @@ export function useArrayIncludes<T, V = any>(
   value: MaybeRefOrGetter<V>,
   options?: UseArrayIncludesOptions<T, V>,
 ): UseArrayIncludesReturn
-
-/**
- * Reactive `Array.includes`
- *
- * @see https://vueuse.org/useArrayIncludes
- *
- * @returns true if the `value` is found in the array. Otherwise, false.
- *
- * @__NO_SIDE_EFFECTS__
- */
+/* @__NO_SIDE_EFFECTS__ */
 export function useArrayIncludes<T, V = any>(
   ...args: any[]
 ): UseArrayIncludesReturn {

--- a/packages/shared/useArrayReduce/index.ts
+++ b/packages/shared/useArrayReduce/index.ts
@@ -38,19 +38,7 @@ export function useArrayReduce<T, U>(
   reducer: UseArrayReducer<U, T, U>,
   initialValue: MaybeRefOrGetter<U>,
 ): UseArrayReduceReturn<U>
-
-/**
- * Reactive `Array.reduce`
- *
- * @see https://vueuse.org/useArrayReduce
- * @param list - the array was called upon.
- * @param reducer - a "reducer" function.
- * @param args
- *
- * @returns the value that results from running the "reducer" callback function to completion over the entire array.
- *
- * @__NO_SIDE_EFFECTS__
- */
+/* @__NO_SIDE_EFFECTS__ */
 export function useArrayReduce<T>(
   list: MaybeRefOrGetter<MaybeRefOrGetter<T>[]>,
   reducer: ((...p: any[]) => any),

--- a/packages/shared/useDateFormat/index.ts
+++ b/packages/shared/useDateFormat/index.ts
@@ -19,8 +19,8 @@ export interface UseDateFormatOptions {
 }
 
 // eslint-disable-next-line regexp/no-misleading-capturing-group
-const REGEX_PARSE = /* #__PURE__ */ /^(\d{4})[-/]?(\d{1,2})?[-/]?(\d{0,2})[T\s]*(\d{1,2})?:?(\d{1,2})?:?(\d{1,2})?[.:]?(\d+)?$/i
-const REGEX_FORMAT = /* #__PURE__ */ /[YMDHhms]o|\[([^\]]+)\]|Y{1,4}|M{1,4}|D{1,2}|d{1,4}|H{1,2}|h{1,2}|a{1,2}|A{1,2}|m{1,2}|s{1,2}|Z{1,2}|z{1,4}|SSS/g
+const REGEX_PARSE = /^(\d{4})[-/]?(\d{1,2})?[-/]?(\d{0,2})[T\s]*(\d{1,2})?:?(\d{1,2})?:?(\d{1,2})?[.:]?(\d+)?$/i
+const REGEX_FORMAT = /[YMDHhms]o|\[([^\]]+)\]|Y{1,4}|M{1,4}|D{1,2}|d{1,4}|H{1,2}|h{1,2}|a{1,2}|A{1,2}|m{1,2}|s{1,2}|Z{1,2}|z{1,4}|SSS/g
 
 function defaultMeridiem(hours: number, minutes: number, isLowercase?: boolean, hasPeriod?: boolean) {
   let m = (hours < 12 ? 'AM' : 'PM')


### PR DESCRIPTION
Fixed #5535
Related #5604

### Description

This PR remove some unnecessary tree-shaking annotations to avoid Rolldown warning and adds `@__NO_SIDE_EFFECTS__` to both the public JSDoc overload signature and the implementation of every side-effect-free API that uses overloads.

**Why we need to add annotations in 2 places?**
- The JSDoc annotation is intended for readers. Because it is attached to an overload signature, it is removed along with the signature during TypeScript compilation, so it never reaches the bundler or triggers an invalid-annotation warning.
- The single line annotation immediately before the implementation is preserved in the emitted JavaScript and allows bundlers to perform tree shaking.

It also establishes a convention for arrow functions and documents it in [CONTRIBUTING.md](https://github.com/serkodev/vueuse/blob/9df8944147c2be04b2493cd167406018591c316a/CONTRIBUTING.md?plain=1#L123-L170).
