### PR TITLE
fix(useFetch): reset response before a new execute

### DIFF
--- a/packages/core/useFetch/index.test.ts
+++ b/packages/core/useFetch/index.test.ts
@@ -605,6 +605,24 @@ describe('useFetch', () => {
     })
   })
 
+  it('should reset response before a new execute so onFetchError never sees a stale response', async () => {
+    const responses: (Response | null)[] = []
+    const { execute } = useFetch(`${baseUrl}?text=hello`, {
+      immediate: false,
+      onFetchError(ctx) {
+        responses.push(ctx.response)
+        return ctx
+      },
+    })
+
+    await execute()
+
+    fetchSpy.mockImplementationOnce(() => Promise.reject(new Error('Network error')))
+    await execute()
+
+    expect(responses).toEqual([null])
+  })
+
   it('should emit onFetchResponse event', async () => {
     const { onFetchResponse, onFetchError, onFetchFinally } = useFetch(baseUrl)
 

--- a/packages/core/useFetch/index.ts
+++ b/packages/core/useFetch/index.ts
@@ -422,6 +422,7 @@ export function useFetch<T>(url: MaybeRefOrGetter<string>, ...args: any[]): UseF
     loading(true)
     error.value = null
     statusCode.value = null
+    response.value = null
     aborted.value = false
 
     executeCounter += 1


### PR DESCRIPTION
### Description

`execute()` resets the per-run state at the top — `error`, `statusCode`, `aborted` — but not `response`. It stays pointing at the `Response` of the previous run until a new one arrives.

That gap is visible in `onFetchError`, which passes `response: response.value`:

```ts
.catch(async (fetchError) => {
  if (options.onFetchError) {
    ({ error: errorData, data: responseData } = await options.onFetchError({
      data: responseData,
      error: fetchError,
      response: response.value, // stale when the request failed before responding
      context,
      execute,
    }))
  }
```

When a later `execute()` rejects before a response arrives — a network error, a DNS failure, an abort — the handler receives the `Response` of the earlier successful call. Nothing marks it as stale, so an `onFetchError` that reads `ctx.response.status` or `ctx.response.ok` reports the previous request's outcome for a request that never reached the server.

The fix resets `response` alongside the other per-run state:

```ts
loading(true)
error.value = null
statusCode.value = null
response.value = null
aborted.value = false
```

`response` now follows the same lifecycle as `statusCode`, which is already cleared per run and set from the same `fetchResponse`. Callers reading `response` between the start of a request and its completion see `null` rather than the previous result, matching what `statusCode` already reported there.

### Test

The added test drives a successful fetch, then makes the next `fetch` reject, and asserts `onFetchError` sees `ctx.response === null`. It fails on `main` (receives the previous `Response`) and passes with the fix.

```
✓ packages/core/useFetch/index.test.ts (55 tests) — 55 passed
```

`eslint` on both touched files is clean.

Closes #5536

### Additional context

<!-- Add any other context or screenshots. -->

---

<!--
Thanks for your contribution!
-->
