### PR TITLE
docs: correct "an hydration" to "a hydration" in SSR notes

### DIFF
--- a/packages/core/useBreakpoints/index.md
+++ b/packages/core/useBreakpoints/index.md
@@ -90,7 +90,7 @@ const breakpoints = useBreakpoints(breakpointsTailwind, {
 
 #### Server Side Rendering and Nuxt
 
-If you are using `useBreakpoints` with SSR enabled, then you need to specify which screen size you would like to render on the server and before hydration to avoid an hydration mismatch
+If you are using `useBreakpoints` with SSR enabled, then you need to specify which screen size you would like to render on the server and before hydration to avoid a hydration mismatch
 
 ```ts
 import { breakpointsTailwind, useBreakpoints } from '@vueuse/core'

--- a/packages/core/useMediaQuery/index.md
+++ b/packages/core/useMediaQuery/index.md
@@ -17,7 +17,7 @@ const isPreferredDark = useMediaQuery('(prefers-color-scheme: dark)')
 
 #### Server Side Rendering and Nuxt
 
-If you are using `useMediaQuery` with SSR enabled, then you need to specify which screen size you would like to render on the server and before hydration to avoid an hydration mismatch
+If you are using `useMediaQuery` with SSR enabled, then you need to specify which screen size you would like to render on the server and before hydration to avoid a hydration mismatch
 
 ```ts
 import { useMediaQuery } from '@vueuse/core'


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Confirm that this PR is based on your own understanding and review of the project, not solely generated or summarized by AI tools.

### Description

The SSR notes in `useBreakpoints` and `useMediaQuery` both read "to avoid an hydration mismatch". Because "hydration" is pronounced with a consonant "h" sound, the correct indefinite article is "a", so this changes both to "a hydration mismatch". The two sentences are identical, so the same slip was copied to both pages.

### Additional context

Grammar-only fix. No code or behavior change.
