### PR TITLE
fix(onKeyStroke): register listener as passive instead of capture

### DIFF
--- a/packages/core/onKeyStroke/index.browser.test.ts
+++ b/packages/core/onKeyStroke/index.browser.test.ts
@@ -54,4 +54,12 @@ describe('onKeyStroke', () => {
     await userEvent.keyboard('{a>5/}')
     expect(callBackFn).toBeCalledTimes(1)
   })
+
+  it('registers a passive listener instead of a capture listener when passive is true', () => {
+    const addSpy = vi.spyOn(window, 'addEventListener')
+
+    onKeyStroke('a', callBackFn, { passive: true })
+
+    expect(addSpy).toBeCalledWith('keydown', expect.any(Function), { passive: true })
+  })
 })

--- a/packages/core/onKeyStroke/index.browser.test.ts
+++ b/packages/core/onKeyStroke/index.browser.test.ts
@@ -55,7 +55,7 @@ describe('onKeyStroke', () => {
     expect(callBackFn).toBeCalledTimes(1)
   })
 
-  it('registers a passive listener instead of a capture listener when passive is true', () => {
+  it('pass passive option to listener', () => {
     const addSpy = vi.spyOn(window, 'addEventListener')
 
     onKeyStroke('a', callBackFn, { passive: true })

--- a/packages/core/onKeyStroke/index.ts
+++ b/packages/core/onKeyStroke/index.ts
@@ -79,7 +79,7 @@ export function onKeyStroke(...args: any[]) {
       handler(e)
   }
 
-  return useEventListener(target, eventName, listener, passive)
+  return useEventListener(target, eventName, listener, { passive })
 }
 
 /**


### PR DESCRIPTION
onKeyStroke passed the passive boolean straight through as useEventListener's options argument, and addEventListener treats a boolean there as useCapture, not passive. So passive: true silently turned the listener into a capture-phase one, letting it run before a descendant's own handler had a chance to call stopPropagation().

Wrapped it as { passive } so the browser reads it as the intended passive option and the listener stays in the default bubble phase. onKeyStroke doesn't expose any other listener option (no capture, once, etc.), so there's nothing else to forward here.

One side effect worth flagging: since passive listeners can't call preventDefault(), any handler that relied on the old (buggy) capture-mode listener actually running preventDefault() will now find it's a no-op, which is the correct passive contract but a behavior change from before.

Fixes #5620