### PR TITLE
perf(useStorage): skip unused initial serialization

### DIFF
--- a/packages/core/useStorage/index.browser.test.ts
+++ b/packages/core/useStorage/index.browser.test.ts
@@ -200,6 +200,22 @@ describe('useStorage', () => {
     expect(storage.removeItem).toBeCalledWith(KEY)
   })
 
+  it.each([true, false])('serializes defaults only when writing them (writeDefaults: %s)', async (writeDefaults) => {
+    const initial = { items: [{ name: 'a' }] }
+    const write = vi.fn(StorageSerializers.object.write)
+    const store = useStorage(KEY, initial, storage, {
+      writeDefaults,
+      serializer: { read: StorageSerializers.object.read, write },
+    })
+
+    await nextTwoTick()
+
+    expect(store.value).toEqual(initial)
+    expect(write).toHaveBeenCalledTimes(writeDefaults ? 1 : 0)
+    expect(storage.setItem).toHaveBeenCalledTimes(writeDefaults ? 1 : 0)
+    expect(storage.getItem(KEY)).toBe(writeDefaults ? JSON.stringify(initial) : undefined)
+  })
+
   it('map', async () => {
     const store = useStorage(KEY, new Map<number, string | number>([
       [1, 'a'],

--- a/packages/core/useStorage/index.ts
+++ b/packages/core/useStorage/index.ts
@@ -302,8 +302,7 @@ export function useStorage<T extends (string | number | boolean | object | null)
     pauseWatch()
 
     try {
-      const serializedData = serializer.write(data.value)
-      if (event === undefined || event?.newValue !== serializedData) {
+      if (event === undefined || event.newValue !== serializer.write(data.value)) {
         data.value = read(event)
       }
     }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Confirm that this PR is based on your own understanding and review of the project, not solely generated or summarized by AI tools.

> **Note**: If this PR is deemed to be primarily generated by AI tools, it may be closed.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

`useStorage` serializes its initial value for an event comparison even though initialization has no event. This moves serialization into the event-only branch, preserving storage reads and the comparison used for storage events.

```diff
 initialize useStorage(defaults)
-  serialize defaults for an unused event comparison
   read storage
   serialize defaults for the storage write
```

For a missing key with 10,000 object records, this reduces **2 serializations / 3,017,802 bytes to 1 / 1,508,901 bytes**, with the same single storage read and write.

Repro: [Before](https://github.com/onmax/repros/tree/repro/vueuse-storage-redundant-serialization/vueuse-storage-redundant-serialization) · [After](https://github.com/onmax/repros/tree/repro/vueuse-storage-redundant-serialization/vueuse-storage-redundant-serialization-fix), with a pnpm patch. Runs locally in Node with a Map-backed storage adapter.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
