### PR TITLE
fix(useElementVisibility): stop observing when the element first becomes visible with `once`

### DIFF
--- a/packages/core/useElementVisibility/index.browser.test.ts
+++ b/packages/core/useElementVisibility/index.browser.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
 import { useElementVisibility } from './index'
 
 describe('useElementVisibility', () => {
@@ -143,6 +144,42 @@ describe('useElementVisibility', () => {
 
       useElementVisibility(el, { window: mockWindow })
       expect(vi.mocked(useIntersectionObserver).mock.lastCall?.[2]?.window).toBe(mockWindow)
+    })
+
+    it('stops observing as soon as the element is reported visible when once is true', async () => {
+      const controls = useElementVisibility(el, { controls: true, once: true })
+      const callback = vi.mocked(useIntersectionObserver).mock.lastCall?.[1]
+
+      callback?.([{ isIntersecting: true, time: 1 }] as IntersectionObserverEntry[], {} as IntersectionObserver)
+      await nextTick()
+
+      expect(controls.isVisible.value).toBe(true)
+      expect(controls.stop).toHaveBeenCalledTimes(1)
+    })
+
+    it('keeps observing until the element becomes visible when once is true', async () => {
+      const controls = useElementVisibility(el, { controls: true, once: true })
+      const callback = vi.mocked(useIntersectionObserver).mock.lastCall?.[1]
+
+      callback?.([{ isIntersecting: false, time: 1 }] as IntersectionObserverEntry[], {} as IntersectionObserver)
+      await nextTick()
+      expect(controls.stop).not.toHaveBeenCalled()
+
+      callback?.([{ isIntersecting: true, time: 2 }] as IntersectionObserverEntry[], {} as IntersectionObserver)
+      await nextTick()
+      expect(controls.stop).toHaveBeenCalledTimes(1)
+    })
+
+    it('never stops observing when once is not set', async () => {
+      const controls = useElementVisibility(el, { controls: true })
+      const callback = vi.mocked(useIntersectionObserver).mock.lastCall?.[1]
+
+      callback?.([{ isIntersecting: true, time: 1 }] as IntersectionObserverEntry[], {} as IntersectionObserver)
+      await nextTick()
+      callback?.([{ isIntersecting: false, time: 2 }] as IntersectionObserverEntry[], {} as IntersectionObserver)
+      await nextTick()
+
+      expect(controls.stop).not.toHaveBeenCalled()
     })
 
     it('uses the given scrollTarget as the root element in useIntersectionObserver', () => {

--- a/packages/core/useElementVisibility/index.ts
+++ b/packages/core/useElementVisibility/index.ts
@@ -82,12 +82,6 @@ export function useElementVisibility(
         }
       }
       isVisible.value = isIntersecting
-
-      if (once) {
-        watchOnce(isVisible, () => {
-          observerController.stop()
-        })
-      }
     },
     {
       root: scrollTarget,
@@ -96,6 +90,14 @@ export function useElementVisibility(
       rootMargin,
     },
   )
+
+  // Registered up front: inside the observer callback the watcher would only start
+  // after the visibility change it is meant to react to had already been applied.
+  if (once) {
+    watchOnce(isVisible, () => {
+      observerController.stop()
+    })
+  }
 
   return options.controls
     ? { ...observerController, isVisible }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Confirm that this PR is based on your own understanding and review of the project, not solely generated or summarized by AI tools.

---

### Description

`useElementVisibility(el, { once: true })` is documented as "Stop tracking when element visibility changes for the first time", and `index.md` says you can "read `isActive` to tell whether tracking has already stopped after the element first became visible".

At `packages/core/useElementVisibility/index.ts:86` the `watchOnce` that calls `observerController.stop()` was registered **inside** the intersection callback, on the line after `isVisible.value = isIntersecting`. A watcher created after a value has already changed does not see that change, so the first assignment is always invisible to it.

The consequence depends on what the first observer callback reports:

| first callback | before | after |
| --- | --- | --- |
| `isIntersecting: false` (element below the fold) | works: stops when it later scrolls into view | unchanged |
| `isIntersecting: true` (element already in the viewport on mount) | does **not** stop; keeps observing until the element leaves the viewport again | stops immediately |

So the case that breaks is the one where the element is already visible when the observer attaches, which is exactly the "run this once, the element is on screen" case. `isActive` stays `true` and the `IntersectionObserver` keeps running.

Two smaller consequences of the same placement, also fixed by moving the registration out: a fresh `watchOnce` was created on **every** callback invocation, so the watchers accumulated, and only the last one could ever be the one that fires.

The fix registers the watcher once, right after the observer is created, so it starts watching from `initialValue` and reacts to the first change of `isVisible`. The "element below the fold" path is unchanged, and behaviour with `once` unset is unchanged.

No documentation change: the docs already describe the intended behaviour, the code now matches them.

### Additional context

The `once` option landed in #4577 without a behavioural test, which is why this went unnoticed. I added three tests to `index.browser.test.ts`, using the `useIntersectionObserver` mock that file already sets up:

1. one intersecting entry stops the observer (fails on `main`: `expected "vi.fn()" to be called 1 times, but got 0 times`),
2. a non-intersecting entry followed by an intersecting one still stops exactly once (passes on `main`, guards the path that already worked),
3. nothing is stopped when `once` is not set.

I checked (2) and (3) are not vacuous by mutating the source in the other direction (stopping unconditionally, and stopping immediately) and confirming each goes red.

One judgement call worth flagging: I read "visibility changes for the first time" as "the first change of `isVisible` away from `initialValue`", which is what the eager `watchOnce` now implements. That means `useElementVisibility(el, { once: true, initialValue: true })` on an element that is **not** visible stops on the first callback, because `true -> false` is a change. That is literal to the option's wording, but if you would rather `once` meant strictly "stop once the element has been seen visible", say so and I will switch it to a check on `isIntersecting` instead.

### AI usage disclosure

I used an AI assistant while working on this: to help scan the `packages/core` composables for options that are declared but never read and for teardown paths that miss a registration, and as a drafting aid for this description. The defect, the reading of the intended semantics, the fix, the tests and the counterfactual and mutation checks above are my own review of the code, and I ran the full unit and Chromium browser suites locally before opening this.
