### PR TITLE
fix(useWakeLock): clear stale sentinel when lock is revoked while visible

### DIFF
--- a/packages/core/useWakeLock/index.md
+++ b/packages/core/useWakeLock/index.md
@@ -16,6 +16,8 @@ const { isSupported, isActive, forceRequest, request, release } = useWakeLock()
 
 When `request` is called, the wake lock will be requested if the document is visible. Otherwise, the request will be queued until the document becomes visible. If the request is successful, `isActive` will be **true**. Whenever the document is hidden, the `isActive` will be **false**.
 
+The underlying lock can also be revoked by the OS or browser without the document ever becoming hidden (for example, iOS Safari can silently drop it). When that happens, `isActive` becomes **false** immediately, and the lock is transparently re-requested as long as the document is still visible.
+
 When `release` is called, the wake lock will be released. If there is a queued request, it will be canceled.
 
 To request a wake lock immediately, even if the document is hidden, use `forceRequest`. Note that this may throw an error if the document is hidden.

--- a/packages/core/useWakeLock/index.test.ts
+++ b/packages/core/useWakeLock/index.test.ts
@@ -152,4 +152,23 @@ describe('useWakeLock', () => {
 
     expect(isActive.value).toBeTruthy()
   })
+
+  it('it should become inactive if the sentinel fires release while the document stays visible', async () => {
+    const sentinel = defineWakeLockAPI()
+    const mockDocument = new MockDocument()
+    mockDocument.visibilityState = 'visible'
+
+    const { isActive, request } = useWakeLock({ document: mockDocument as Document })
+
+    await request('screen')
+
+    expect(isActive.value).toBeTruthy()
+
+    sentinel.dispatchEvent(new Event('release'))
+
+    await nextTick()
+    await nextTick()
+
+    expect(isActive.value).toBeFalsy()
+  })
 })

--- a/packages/core/useWakeLock/index.ts
+++ b/packages/core/useWakeLock/index.ts
@@ -52,6 +52,7 @@ export function useWakeLock(options: UseWakeLockOptions = {}): UseWakeLockReturn
   if (isSupported.value) {
     useEventListener(sentinel, 'release', () => {
       requestedType.value = sentinel.value?.type ?? false
+      sentinel.value = null
     }, { passive: true })
 
     whenever(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Confirm that this PR is based on your own understanding and review of the project, not solely generated or summarized by AI tools.

> **Note**: If this PR is deemed to be primarily generated by AI tools, it may be closed.

<details>
<summary><strong>⚠️ Slowing down new functions</strong></summary>
<br>

> **Warning**: **Slowing down new functions**
>
> As the VueUse audience continues to grow, we have been inundated with an overwhelming number of feature requests and pull requests. As a result, maintaining the project has become increasingly challenging and has stretched our capacity to its limits. As such, in the near future, we may need to slow down our acceptance of new features and prioritize the stability and quality of existing functions. **Please note that new features for VueUse may not be accepted at this time.** If you have any new ideas, we suggest that you first incorporate them into your own codebase, iterate on them to suit your needs, and assess their generalizability. If you strongly believe that your ideas are beneficial to the community, you may submit a pull request along with your use cases, and we would be happy to review and discuss them. Thank you for your understanding.

</details>

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
On iOS Safari, the wake lock can get dropped by the OS even while the page is still open and visible. When that happens, the sentinel fires a `release` event, but the code never cleared `sentinel.value`. So `isActive` stayed `true` forever, even though the lock was actually gone.

That's a problem because apps have no way to know the lock died, and it also meant the existing auto-recovery logic never ran — it only checks `requestedType`, not whether the sentinel is still around.

The fix is one line: clear `sentinel.value` in the release handler. Now `isActive` flips back to `false` right away, and the existing re-request logic can kick in again while the page is visible.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
Ran into this building a small app that needs the screen to stay on. Worked fine on desktop, but on iPhone the screen kept turning off even though isActive still said `true`.

Added a test: request the lock, fire `release` on the sentinel without touching document visibility, check isActive is false. Fails on main, passes with the fix. Also tested for real on an iPhone 14 and iPhone 16 — confirmed the screen actually stays on and isActive reports correctly now.