### PR TITLE
fix(useEventSource): clear pending reconnect timer on close

### DIFF
--- a/packages/core/useEventSource/index.browser.test.ts
+++ b/packages/core/useEventSource/index.browser.test.ts
@@ -37,6 +37,7 @@ describe('useEventSource', () => {
 
   afterEach(() => {
     vi.restoreAllMocks()
+    vi.useRealTimers()
   })
 
   it('should be defined', () => {
@@ -146,6 +147,35 @@ describe('useEventSource', () => {
     close()
 
     expect(status.value).toBe('CLOSED')
+  })
+
+  it('does not reconnect from a retry scheduled before close()', () => {
+    vi.useFakeTimers()
+
+    let created = 0
+    vi.stubGlobal('EventSource', class extends MockEventSource {
+      constructor() {
+        super()
+        created += 1
+      }
+    })
+
+    const { eventSource, close, open } = useEventSource('https://localhost', [], {
+      autoReconnect: { delay: 1000 },
+    })
+
+    const source = eventSource.value!
+    source.close()
+    source.onerror!(new Event('error'))
+
+    close()
+    open()
+    const reopened = eventSource.value
+
+    vi.advanceTimersByTime(1000)
+
+    expect(created).toBe(2)
+    expect(eventSource.value).toBe(reopened)
   })
 
   it('should apply custom serializer function', () => {

--- a/packages/core/useEventSource/index.ts
+++ b/packages/core/useEventSource/index.ts
@@ -1,4 +1,4 @@
-import type { Fn } from '@vueuse/shared'
+import type { Fn, TimerHandle } from '@vueuse/shared'
 import type { MaybeRefOrGetter, ShallowRef } from 'vue'
 import { isClient, toRef, tryOnScopeDispose } from '@vueuse/shared'
 import { shallowRef, watch } from 'vue'
@@ -132,6 +132,7 @@ export function useEventSource<Events extends string[], Data = any>(
 
   let explicitlyClosed = false
   let retried = 0
+  let retryTimeout: TimerHandle
 
   const {
     withCredentials = false,
@@ -143,7 +144,15 @@ export function useEventSource<Events extends string[], Data = any>(
     },
   } = options
 
+  const resetRetry = () => {
+    if (retryTimeout != null) {
+      clearTimeout(retryTimeout)
+      retryTimeout = undefined
+    }
+  }
+
   const close = () => {
+    resetRetry()
     if (isClient && eventSource.value) {
       eventSource.value.close()
       eventSource.value = null
@@ -183,9 +192,9 @@ export function useEventSource<Events extends string[], Data = any>(
         retried += 1
 
         if (typeof retries === 'number' && (retries < 0 || retried < retries))
-          setTimeout(_init, delay)
+          retryTimeout = setTimeout(_init, delay)
         else if (typeof retries === 'function' && retries())
-          setTimeout(_init, delay)
+          retryTimeout = setTimeout(_init, delay)
         else
           onFailed?.()
       }


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vueuse/vueuse/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vueuse/vueuse/blob/main/packages/guidelines.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Confirm that this PR is based on your own understanding and review of the project, not solely generated or summarized by AI tools.

---

### Description

`useEventSource` schedules a reconnect with `setTimeout(_init, delay)` but never keeps the handle, so the timer is never cancelled.

Reproduction:

1. Call `useEventSource(url, [], { autoReconnect: { delay: 1000 } })`.
2. The connection errors with `readyState === 2`, so a reconnect is scheduled.
3. Before the delay elapses, call `close()` and then `open()`.
4. `open()` creates a new `EventSource` and clears `explicitlyClosed`.
5. The timer from step 2 then fires, `_init()` passes the `explicitlyClosed` guard, and a third `EventSource` is created and assigned to `eventSource`.

The connection created by `open()` is left open and no longer reachable through the returned refs, so it can only be cleaned up by the browser. `close()` alone also leaves the timer pending until it fires.

Root cause: unlike `useWebSocket`, which stores `retryTimeout` and clears it in `resetRetry()` on `close()`, `useEventSource` discards the timeout handle. The fix stores it and clears it in `close()`, which also covers `open()` (it calls `close()` first) and `tryOnScopeDispose(close)`.

The new test stubs `EventSource` with a counting subclass, drives the sequence above under fake timers, and asserts that exactly two `EventSource` instances are constructed and that `eventSource.value` is still the one `open()` created. Without the source change it fails with `expected 3 to be 2`.

### Additional context

This is separate from #5597: that PR makes handlers ignore events from a superseded connection, but the reconnect timer is still left running and still creates the extra connection.

AI disclosure: I used AI assistance (Claude Code) while working on this change. I chose the defect, reviewed the fix against the existing `useWebSocket` implementation, and verified the test both fails without the source change and passes with it by running `vitest --project="browser (chromium)"` locally.
